### PR TITLE
Update some block dependencies to allow DataViews to work

### DIFF
--- a/plugins/woocommerce/changelog/update-blocks_dependencies
+++ b/plugins/woocommerce/changelog/update-blocks_dependencies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update @wordpress/components and @wordpress/server-side-render dependencies in block package.

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
@@ -82,22 +82,28 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="inspector-checkbox-control-54"
-                      type="checkbox"
-                      value="1"
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-54"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="inspector-checkbox-control-0"
+                        type="checkbox"
+                        value="1"
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="inspector-checkbox-control-0"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>
@@ -113,23 +119,29 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-11-5"
-                      name="search-list-item-11"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-55"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-11-5"
+                        name="search-list-item-11"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-11-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -145,23 +157,29 @@ exports[`SearchListControl should render a search box and list of hierarchical o
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-11-6"
-                      name="search-list-item-11"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-56"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-11-6"
+                        name="search-list-item-11"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-11-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -224,22 +242,28 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="inspector-checkbox-control-54"
-                    type="checkbox"
-                    value="1"
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-54"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="inspector-checkbox-control-0"
+                      type="checkbox"
+                      value="1"
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="inspector-checkbox-control-0"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </div>
@@ -255,23 +279,29 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-11-5"
-                    name="search-list-item-11"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-55"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-11-5"
+                      name="search-list-item-11"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-11-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -287,23 +317,29 @@ exports[`SearchListControl should render a search box and list of hierarchical o
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-11-6"
-                    name="search-list-item-11"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-56"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-11-6"
+                      name="search-list-item-11"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-11-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -446,23 +482,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-1"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-0"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-1"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -478,23 +520,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-2"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-1"
-                  >
-                    Clementine
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-2"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -510,23 +558,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-3"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-2"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-3"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -542,23 +596,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-4"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-3"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-4"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -574,23 +634,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-5"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-4"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-5"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -606,23 +672,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-0-6"
-                      name="search-list-item-0"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-5"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-0-6"
+                        name="search-list-item-0"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-0-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -684,23 +756,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-1"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-0"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-1"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -716,23 +794,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-2"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-1"
-                >
-                  Clementine
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-2"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -748,23 +832,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-3"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-2"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-3"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -780,23 +870,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-4"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-3"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-4"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -812,23 +908,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-5"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-4"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-5"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -844,23 +946,29 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-0-6"
-                    name="search-list-item-0"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-5"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-0-6"
+                      name="search-list-item-0"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-0-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1003,23 +1111,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-1"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-6"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-1"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1035,23 +1149,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-2"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-7"
-                  >
-                    Clementine
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-2"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1067,23 +1187,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-3"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-8"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-3"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1099,23 +1225,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-4"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-9"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-4"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1131,23 +1263,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-5"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-10"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-5"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1163,23 +1301,29 @@ exports[`SearchListControl should render a search box and list of options with a
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-1-6"
-                      name="search-list-item-1"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-11"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-1-6"
+                        name="search-list-item-1"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-1-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1241,23 +1385,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-1"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-6"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-1"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1273,23 +1423,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-2"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-7"
-                >
-                  Clementine
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-2"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1305,23 +1461,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-3"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-8"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-3"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1337,23 +1499,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-4"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-9"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-4"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1369,23 +1537,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-5"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-10"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-5"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1401,23 +1575,29 @@ exports[`SearchListControl should render a search box and list of options with a
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-1-6"
-                    name="search-list-item-1"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-11"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-1-6"
+                      name="search-list-item-1"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-1-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -1805,23 +1985,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-1"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-48"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-1"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1837,23 +2023,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-2"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-49"
-                  >
-                    Clementine
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-2"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1869,23 +2061,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-3"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-50"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-3"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1901,23 +2099,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-4"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-51"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-4"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1933,23 +2137,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-5"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-52"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-5"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -1965,23 +2175,29 @@ exports[`SearchListControl should render a search box and list of options, with 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-9-6"
-                      name="search-list-item-9"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-53"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-9-6"
+                        name="search-list-item-9"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-9-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2043,23 +2259,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-1"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-48"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-1"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2075,23 +2297,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-2"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-49"
-                >
-                  Clementine
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-2"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2107,23 +2335,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-3"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-50"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-3"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2139,23 +2373,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-4"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-51"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-4"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2171,23 +2411,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-5"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-52"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-5"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2203,23 +2449,29 @@ exports[`SearchListControl should render a search box and list of options, with 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-9-6"
-                    name="search-list-item-9"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-53"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-9-6"
+                      name="search-list-item-9"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-9-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2579,23 +2831,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-1"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-42"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-1"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2611,23 +2869,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-2"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-43"
-                  >
-                    Clementine
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-2"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2643,23 +2907,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-3"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-44"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-3"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2675,23 +2945,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-4"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-45"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-4"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2707,23 +2983,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-5"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-46"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-5"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2739,23 +3021,29 @@ exports[`SearchListControl should render a search box with a search term, and no
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-8-6"
-                      name="search-list-item-8"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-47"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-8-6"
+                        name="search-list-item-8"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-8-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -2817,23 +3105,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-1"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-42"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-1"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2849,23 +3143,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-2"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-43"
-                >
-                  Clementine
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-2"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2881,23 +3181,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-3"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-44"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-3"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2913,23 +3219,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-4"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-45"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-4"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2945,23 +3257,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-5"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-46"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-5"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -2977,23 +3295,29 @@ exports[`SearchListControl should render a search box with a search term, and no
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-8-6"
-                    name="search-list-item-8"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-47"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-8-6"
+                      name="search-list-item-8"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-8-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3136,23 +3460,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-1"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-24"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-1"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3168,23 +3498,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-2"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-25"
-                  >
-                    Clementine
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-2"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3200,23 +3536,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-3"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-26"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-3"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3232,23 +3574,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-4"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-27"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-4"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3264,23 +3612,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-5"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-28"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-5"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3296,23 +3650,29 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-5-6"
-                      name="search-list-item-5"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-29"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-5-6"
+                        name="search-list-item-5"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-5-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3374,23 +3734,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-1"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-24"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-1"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3406,23 +3772,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-2"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-25"
-                >
-                  Clementine
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-2"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3438,23 +3810,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-3"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-26"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-3"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3470,23 +3848,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-4"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-27"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-4"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3502,23 +3886,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-5"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-28"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-5"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3534,23 +3924,29 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-5-6"
-                    name="search-list-item-5"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-29"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-5-6"
+                      name="search-list-item-5"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-5-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3693,26 +4089,32 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-6-3"
-                      name="search-list-item-6"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-32"
-                  >
-                    Elder
-                    <strong>
-                      berry
-                    </strong>
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-6-3"
+                        name="search-list-item-6"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-6-3"
+                    >
+                      Elder
+                      <strong>
+                        berry
+                      </strong>
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3728,26 +4130,32 @@ exports[`SearchListControl should render a search box with a search term, and on
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-6-6"
-                      name="search-list-item-6"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-35"
-                  >
-                    Mul
-                    <strong>
-                      berry
-                    </strong>
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-6-6"
+                        name="search-list-item-6"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-6-6"
+                    >
+                      Mul
+                      <strong>
+                        berry
+                      </strong>
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -3809,26 +4217,32 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-6-3"
-                    name="search-list-item-6"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-32"
-                >
-                  Elder
-                  <strong>
-                    berry
-                  </strong>
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-6-3"
+                      name="search-list-item-6"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-6-3"
+                  >
+                    Elder
+                    <strong>
+                      berry
+                    </strong>
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -3844,26 +4258,32 @@ exports[`SearchListControl should render a search box with a search term, and on
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-6-6"
-                    name="search-list-item-6"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-35"
-                >
-                  Mul
-                  <strong>
-                    berry
-                  </strong>
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-6-6"
+                      name="search-list-item-6"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-6-6"
+                  >
+                    Mul
+                    <strong>
+                      berry
+                    </strong>
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4057,23 +4477,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-1"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-12"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-1"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4089,38 +4515,44 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      checked=""
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-2"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="components-checkbox-control__checked"
-                      focusable="false"
-                      height="24"
-                      role="presentation"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      class="components-checkbox-control__input-container"
                     >
-                      <path
-                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      <input
+                        checked=""
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-2"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
                       />
-                    </svg>
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-13"
-                  >
-                    Clementine
-                  </label>
+                      <svg
+                        aria-hidden="true"
+                        class="components-checkbox-control__checked"
+                        focusable="false"
+                        height="24"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                        />
+                      </svg>
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4136,23 +4568,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-3"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-14"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-3"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4168,23 +4606,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-4"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-15"
-                  >
-                    Guava
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-4"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4200,23 +4644,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-5"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-16"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-5"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4232,23 +4682,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-2-6"
-                      name="search-list-item-2"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-17"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-2-6"
+                        name="search-list-item-2"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-2-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4361,23 +4817,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-1"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-12"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-1"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4393,38 +4855,44 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    checked=""
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-2"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="components-checkbox-control__checked"
-                    focusable="false"
-                    height="24"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    class="components-checkbox-control__input-container"
                   >
-                    <path
-                      d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                    <input
+                      checked=""
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-2"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
                     />
-                  </svg>
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-13"
-                >
-                  Clementine
-                </label>
+                    <svg
+                      aria-hidden="true"
+                      class="components-checkbox-control__checked"
+                      focusable="false"
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      />
+                    </svg>
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4440,23 +4908,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-3"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-14"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-3"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4472,23 +4946,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-4"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-15"
-                >
-                  Guava
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-4"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4504,23 +4984,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-5"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-16"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-5"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4536,23 +5022,29 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-2-6"
-                    name="search-list-item-2"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-17"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-2-6"
+                      name="search-list-item-2"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-2-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -4788,23 +5280,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-1"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-18"
-                  >
-                    Apricots
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-1"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-1"
+                    >
+                      Apricots
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4820,38 +5318,44 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      checked=""
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-2"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="components-checkbox-control__checked"
-                      focusable="false"
-                      height="24"
-                      role="presentation"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      class="components-checkbox-control__input-container"
                     >
-                      <path
-                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      <input
+                        checked=""
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-2"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
                       />
-                    </svg>
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-19"
-                  >
-                    Clementine
-                  </label>
+                      <svg
+                        aria-hidden="true"
+                        class="components-checkbox-control__checked"
+                        focusable="false"
+                        height="24"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                        />
+                      </svg>
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-2"
+                    >
+                      Clementine
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4867,23 +5371,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-3"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-20"
-                  >
-                    Elderberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-3"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-3"
+                    >
+                      Elderberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4899,38 +5409,44 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      checked=""
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-4"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="components-checkbox-control__checked"
-                      focusable="false"
-                      height="24"
-                      role="presentation"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      class="components-checkbox-control__input-container"
                     >
-                      <path
-                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      <input
+                        checked=""
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-4"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
                       />
-                    </svg>
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-21"
-                  >
-                    Guava
-                  </label>
+                      <svg
+                        aria-hidden="true"
+                        class="components-checkbox-control__checked"
+                        focusable="false"
+                        height="24"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                        />
+                      </svg>
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-4"
+                    >
+                      Guava
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4946,23 +5462,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-5"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-22"
-                  >
-                    Lychee
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-5"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-5"
+                    >
+                      Lychee
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -4978,23 +5500,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
                 >
-                  <span
-                    class="components-checkbox-control__input-container"
+                  <div
+                    class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
                   >
-                    <input
-                      class="components-checkbox-control__input"
-                      id="search-list-item-3-6"
-                      name="search-list-item-3"
-                      type="checkbox"
-                      value=""
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-23"
-                  >
-                    Mulberry
-                  </label>
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        class="components-checkbox-control__input"
+                        id="search-list-item-3-6"
+                        name="search-list-item-3"
+                        type="checkbox"
+                        value=""
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="search-list-item-3-6"
+                    >
+                      Mulberry
+                    </label>
+                  </div>
                 </div>
               </div>
             </label>
@@ -5149,23 +5677,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-1"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-18"
-                >
-                  Apricots
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-1"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-1"
+                  >
+                    Apricots
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -5181,38 +5715,44 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    checked=""
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-2"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="components-checkbox-control__checked"
-                    focusable="false"
-                    height="24"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    class="components-checkbox-control__input-container"
                   >
-                    <path
-                      d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                    <input
+                      checked=""
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-2"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
                     />
-                  </svg>
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-19"
-                >
-                  Clementine
-                </label>
+                    <svg
+                      aria-hidden="true"
+                      class="components-checkbox-control__checked"
+                      focusable="false"
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      />
+                    </svg>
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-2"
+                  >
+                    Clementine
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -5228,23 +5768,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-3"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-20"
-                >
-                  Elderberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-3"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-3"
+                  >
+                    Elderberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -5260,38 +5806,44 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    checked=""
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-4"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="components-checkbox-control__checked"
-                    focusable="false"
-                    height="24"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    class="components-checkbox-control__input-container"
                   >
-                    <path
-                      d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                    <input
+                      checked=""
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-4"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
                     />
-                  </svg>
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-21"
-                >
-                  Guava
-                </label>
+                    <svg
+                      aria-hidden="true"
+                      class="components-checkbox-control__checked"
+                      focusable="false"
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      />
+                    </svg>
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-4"
+                  >
+                    Guava
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -5307,23 +5859,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-5"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-22"
-                >
-                  Lychee
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-5"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-5"
+                  >
+                    Lychee
+                  </label>
+                </div>
               </div>
             </div>
           </label>
@@ -5339,23 +5897,29 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
               >
-                <span
-                  class="components-checkbox-control__input-container"
+                <div
+                  class="components-flex components-h-stack css-urm3j0-PolymorphicDiv-Flex-base-ItemsRow e19lxcc00"
+                  data-wp-c16t="true"
+                  data-wp-component="HStack"
                 >
-                  <input
-                    class="components-checkbox-control__input"
-                    id="search-list-item-3-6"
-                    name="search-list-item-3"
-                    type="checkbox"
-                    value=""
-                  />
-                </span>
-                <label
-                  class="components-checkbox-control__label"
-                  for="inspector-checkbox-control-23"
-                >
-                  Mulberry
-                </label>
+                  <span
+                    class="components-checkbox-control__input-container"
+                  >
+                    <input
+                      class="components-checkbox-control__input"
+                      id="search-list-item-3-6"
+                      name="search-list-item-3"
+                      type="checkbox"
+                      value=""
+                    />
+                  </span>
+                  <label
+                    class="components-checkbox-control__label"
+                    for="search-list-item-3-6"
+                  >
+                    Mulberry
+                  </label>
+                </div>
               </div>
             </div>
           </label>

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -276,7 +276,7 @@
 		"@wordpress/notices": "5.15.1",
 		"@wordpress/plugins": "4.10.0",
 		"@wordpress/primitives": "4.11.0",
-		"@wordpress/server-side-render": "3.10.0",
+		"@wordpress/server-side-render": "wp-6.6",
 		"@wordpress/style-engine": "^1.30.0",
 		"@wordpress/url": "3.13.0",
 		"@wordpress/wordcount": "3.47.0",

--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -163,7 +163,7 @@
 		"@wordpress/block-library": "wp-6.6",
 		"@wordpress/blocks": "wp-6.6",
 		"@wordpress/browserslist-config": "next",
-		"@wordpress/components": "19.17.0",
+		"@wordpress/components": "wp-6.6",
 		"@wordpress/core-data": "wp-6.6",
 		"@wordpress/data-controls": "2.2.7",
 		"@wordpress/date": "4.44.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         version: 10.5.0(sass@1.69.5)(webpack@5.89.0)
       ts-jest:
         specifier: 29.1.x
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)))(typescript@5.7.2)
+        version: 29.1.1(@babel/core@7.25.7)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)))(typescript@5.7.2)
       typescript:
         specifier: 5.7.x
         version: 5.7.2
@@ -4339,8 +4339,8 @@ importers:
         specifier: 4.11.0
         version: 4.11.0(react@18.3.1)
       '@wordpress/server-side-render':
-        specifier: 3.10.0
-        version: 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: wp-6.6
+        version: 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/style-engine':
         specifier: ^1.30.0
         version: 1.30.0
@@ -7055,23 +7055,11 @@ packages:
   '@financial-times/origami-service-makefile@7.0.3':
     resolution: {integrity: sha512-aKe65sZ3XgZ/0Sm0MDLbGrcO3G4DRv/bVW4Gpmw68cRZV9IBE7h/pwfR3Rs7njNSZMFkjS4rPG/YySv9brQByA==}
 
-  '@floating-ui/core@0.6.2':
-    resolution: {integrity: sha512-jktYRmZwmau63adUG3GKOAVCofBXkk55S/zQ94XOorAHhwqFIOFAy1rSp2N0Wp6/tGbe9V3u/ExlGZypyY17rg==}
-
   '@floating-ui/core@1.5.2':
     resolution: {integrity: sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==}
 
-  '@floating-ui/dom@0.4.5':
-    resolution: {integrity: sha512-b+prvQgJt8pieaKYMSJBXHxX/DYwdLsAWxKYqnO5dO2V4oo/TYBZJAUQCVNjTWWsrs6o4VDrNcP9+E70HAhJdw==}
-
   '@floating-ui/dom@1.5.3':
     resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
-
-  '@floating-ui/react-dom@0.6.3':
-    resolution: {integrity: sha512-hC+pS5D6AgS2wWjbmSQ6UR6Kpy+drvWGJIri6e1EDGADTPsCaa4KzCgmCczHrQeInx9tqs81EyDmbKJYY2swKg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
 
   '@floating-ui/react-dom@2.0.9':
     resolution: {integrity: sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==}
@@ -7545,24 +7533,6 @@ packages:
 
   '@mdx-js/util@1.6.22':
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
-
-  '@motionone/animation@10.16.3':
-    resolution: {integrity: sha512-QUGWpLbMFLhyqKlngjZhjtxM8IqiJQjLK0DF+XOF6od9nhSvlaeEpOY/UMCRVcZn/9Tr2rZO22EkuCIjYdI74g==}
-
-  '@motionone/dom@10.12.0':
-    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
-
-  '@motionone/easing@10.16.3':
-    resolution: {integrity: sha512-HWTMZbTmZojzwEuKT/xCdvoMPXjYSyQvuVM6jmM0yoGU6BWzsmYMeB4bn38UFf618fJCNtP9XeC/zxtKWfbr0w==}
-
-  '@motionone/generators@10.16.4':
-    resolution: {integrity: sha512-geFZ3w0Rm0ZXXpctWsSf3REGywmLLujEjxPYpBR0j+ymYwof0xbV6S5kGqqsDKgyWKVWpUInqQYvQfL6fRbXeg==}
-
-  '@motionone/types@10.16.3':
-    resolution: {integrity: sha512-W4jkEGFifDq73DlaZs3HUfamV2t1wM35zN/zX7Q79LfZ2sc6C0R1baUHZmqc/K5F3vSw3PavgQ6HyHLd/MXcWg==}
-
-  '@motionone/utils@10.16.3':
-    resolution: {integrity: sha512-WNWDksJIxQkaI9p9Z9z0+K27xdqISGNFy1SsWVGaiedTHq0iaT6iZujby8fT/ZnZxj1EOaxJtSfUPCFNU5CRoA==}
 
   '@mrmlnc/readdir-enhanced@2.2.1':
     resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}
@@ -11211,13 +11181,6 @@ packages:
     peerDependencies:
       reakit-utils: ^0.15.1
 
-  '@wordpress/components@19.17.0':
-    resolution: {integrity: sha512-6FsLq1WS924fjZjRGSuen3Tzaa4mEWRtCTHM2JS5eE5+rnuhddiHNNgvw26IZCwhQYQwIvIKq9m9in0F0fSOzg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: ^17.0.0
-      react-dom: ^17.0.0
-
   '@wordpress/components@25.16.0':
     resolution: {integrity: sha512-voQuMsO5JbH+JW33TnWurwwvpSb8IQ4XU5wyVMubX4TUwadt+/2ToNJbZIDXoaJPei7vbM81Ft+pH+zGlN8CyA==}
     engines: {node: '>=12'}
@@ -12208,12 +12171,6 @@ packages:
     resolution: {integrity: sha512-e+wfrkKtZIcFZJZLxkrikiXbxlr6nuGg+V94uKMLrzJEWdw7w/8l3dNhWHRGPkldXIEGrF/mV40ibjUa2p3Sfg==}
     engines: {node: '>=12'}
 
-  '@wordpress/rich-text@5.20.0':
-    resolution: {integrity: sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: ^17.0.0
-
   '@wordpress/rich-text@6.35.0':
     resolution: {integrity: sha512-h6/XftSqo9UQZebuNZyLfOVu+ButBLITW/BILsKeJhSpmM19VNdz8UhVGLp+xQPE+/GPCIMJrhhqipISDfc2Ig==}
     engines: {node: '>=12'}
@@ -12267,16 +12224,16 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/server-side-render@3.10.0':
-    resolution: {integrity: sha512-RVm/QSaJ1KtMIFu1T5Ywi84QSorlsb1ryLg6h9lqI+Jmt22Bg3kDUBbfL4MfmadqrEH4u9ObD+WKMLjGa9OsWA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: ^17.0.0
-      react-dom: ^17.0.0
-
   '@wordpress/server-side-render@4.35.0':
     resolution: {integrity: sha512-yTbq31iGFc9VaRMtdCLlyZtbwCN+WdiECEqY6MsMXf31/TDmUcdZPxRTORy3Rz2HxEpFfUMjpRz7A8wn1QZmzA==}
     engines: {node: '>=12'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/server-side-render@5.0.3':
+    resolution: {integrity: sha512-/8bP+uTqX/9lU7fvRuq5D0RmYPu48mN4vdEdA7HNifrm+2v7lLHA66aq+1gCfwhxxOowuvaw+ZGnpGXB0wRx1g==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -16600,15 +16557,6 @@ packages:
       react-dom:
         optional: true
 
-  framer-motion@6.5.1:
-    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
-    peerDependencies:
-      react: '>=16.8 || ^17.0.0 || ^18.0.0'
-      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
-
-  framesync@6.0.1:
-    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
-
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -17282,9 +17230,6 @@ packages:
   hexoid@1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
     engines: {node: '>=8'}
-
-  hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
   highlight-words-core@1.2.2:
     resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
@@ -21162,9 +21107,6 @@ packages:
     resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
     engines: {node: '>=10'}
 
-  popmotion@11.0.3:
-    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
-
   portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
     engines: {node: '>= 0.12.0'}
@@ -23924,9 +23866,6 @@ packages:
 
   style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
-
-  style-value-types@5.0.0:
-    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
 
   stylehacks@4.0.3:
     resolution: {integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==}
@@ -28066,29 +28005,14 @@ snapshots:
 
   '@financial-times/origami-service-makefile@7.0.3': {}
 
-  '@floating-ui/core@0.6.2': {}
-
   '@floating-ui/core@1.5.2':
     dependencies:
       '@floating-ui/utils': 0.1.6
-
-  '@floating-ui/dom@0.4.5':
-    dependencies:
-      '@floating-ui/core': 0.6.2
 
   '@floating-ui/dom@1.5.3':
     dependencies:
       '@floating-ui/core': 1.5.2
       '@floating-ui/utils': 0.1.6
-
-  '@floating-ui/react-dom@0.6.3(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 0.4.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.3.16)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@floating-ui/react-dom@2.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29302,41 +29226,6 @@ snapshots:
       react: 18.3.1
 
   '@mdx-js/util@1.6.22': {}
-
-  '@motionone/animation@10.16.3':
-    dependencies:
-      '@motionone/easing': 10.16.3
-      '@motionone/types': 10.16.3
-      '@motionone/utils': 10.16.3
-      tslib: 2.8.1
-
-  '@motionone/dom@10.12.0':
-    dependencies:
-      '@motionone/animation': 10.16.3
-      '@motionone/generators': 10.16.4
-      '@motionone/types': 10.16.3
-      '@motionone/utils': 10.16.3
-      hey-listen: 1.0.8
-      tslib: 2.8.1
-
-  '@motionone/easing@10.16.3':
-    dependencies:
-      '@motionone/utils': 10.16.3
-      tslib: 2.8.1
-
-  '@motionone/generators@10.16.4':
-    dependencies:
-      '@motionone/types': 10.16.3
-      '@motionone/utils': 10.16.3
-      tslib: 2.8.1
-
-  '@motionone/types@10.16.3': {}
-
-  '@motionone/utils@10.16.3':
-    dependencies:
-      '@motionone/types': 10.16.3
-      hey-listen: 1.0.8
-      tslib: 2.8.1
 
   '@mrmlnc/readdir-enhanced@2.2.1':
     dependencies:
@@ -34955,7 +34844,6 @@ snapshots:
       - bufferutil
       - react
       - react-dom
-      - react-with-direction
       - supports-color
       - utf-8-validate
 
@@ -36617,7 +36505,7 @@ snapshots:
       '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
-      '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.0.1
       '@wordpress/viewport': 6.0.2(react@18.3.1)
       '@wordpress/wordcount': 4.10.0
@@ -36672,7 +36560,7 @@ snapshots:
       '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
-      '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.0.1
       '@wordpress/viewport': 6.0.2(react@18.3.1)
       '@wordpress/wordcount': 4.10.0
@@ -36727,7 +36615,7 @@ snapshots:
       '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
-      '@wordpress/server-side-render': 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.0.1
       '@wordpress/viewport': 6.0.2(react@18.3.1)
       '@wordpress/wordcount': 3.47.0
@@ -36747,7 +36635,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - bufferutil
-      - react-with-direction
       - supports-color
       - utf-8-validate
 
@@ -37014,55 +36901,6 @@ snapshots:
       - '@types/react'
       - react
       - react-dom
-      - react-with-direction
-      - supports-color
-
-  '@wordpress/components@19.17.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@emotion/cache': 11.11.0
-      '@emotion/css': 11.11.2
-      '@emotion/react': 11.11.1(@types/react@18.3.16)(react@18.3.1)
-      '@emotion/serialize': 1.1.2
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.1(@types/react@18.3.16)(react@18.3.1))(@types/react@18.3.16)(react@18.3.1)
-      '@emotion/utils': 1.0.0
-      '@floating-ui/react-dom': 0.6.3(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@use-gesture/react': 10.3.0(react@18.3.1)
-      '@wordpress/a11y': 3.58.0
-      '@wordpress/compose': 5.20.0(react@18.3.1)
-      '@wordpress/date': 4.44.0
-      '@wordpress/deprecated': 3.41.0
-      '@wordpress/dom': 3.27.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/escape-html': 2.47.0
-      '@wordpress/hooks': 3.58.0
-      '@wordpress/i18n': 4.45.0
-      '@wordpress/icons': 9.36.0
-      '@wordpress/is-shallow-equal': 4.24.0
-      '@wordpress/keycodes': 3.58.0
-      '@wordpress/primitives': 3.56.0
-      '@wordpress/rich-text': 5.20.0(react@18.3.1)
-      '@wordpress/warning': 2.58.0
-      classnames: 2.3.2
-      colord: 2.9.3
-      dom-scroll-into-view: 1.2.1
-      downshift: 6.1.12(react@18.3.1)
-      framer-motion: 6.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 0.1.5
-      highlight-words-core: 1.2.2
-      lodash: 4.17.21
-      memize: 1.1.0
-      moment: 2.29.4
-      re-resizable: 6.9.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dates: 21.8.0(@babel/runtime@7.26.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      reakit: 1.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      remove-accents: 0.4.4
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - '@types/react'
       - react-with-direction
       - supports-color
 
@@ -38393,7 +38231,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - bufferutil
-      - react-with-direction
       - supports-color
       - utf-8-validate
 
@@ -38481,7 +38318,7 @@ snapshots:
       '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
-      '@wordpress/server-side-render': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.0.1
       '@wordpress/warning': 3.0.1
       '@wordpress/wordcount': 4.10.0
@@ -38539,7 +38376,7 @@ snapshots:
       '@wordpress/private-apis': 1.16.0
       '@wordpress/reusable-blocks': 5.10.0(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.3.0)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
-      '@wordpress/server-side-render': 3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.0.1
       '@wordpress/warning': 3.0.1
       '@wordpress/wordcount': 3.47.0
@@ -38561,7 +38398,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - bufferutil
-      - react-with-direction
       - supports-color
       - utf-8-validate
 
@@ -40197,21 +40033,6 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@wordpress/rich-text@5.20.0(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@wordpress/a11y': 3.58.0
-      '@wordpress/compose': 5.20.0(react@18.3.1)
-      '@wordpress/data': 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
-      '@wordpress/deprecated': 3.41.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/escape-html': 2.58.0
-      '@wordpress/i18n': 4.45.0
-      '@wordpress/keycodes': 3.58.0
-      memize: 1.1.0
-      react: 18.3.1
-      rememo: 4.0.2
-
   '@wordpress/rich-text@6.35.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -40705,26 +40526,6 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@wordpress/server-side-render@3.10.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@wordpress/api-fetch': 6.21.0
-      '@wordpress/blocks': 11.21.0(react@18.3.1)
-      '@wordpress/components': 19.17.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 5.20.0(react@18.3.1)
-      '@wordpress/data': 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
-      '@wordpress/deprecated': 3.41.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/i18n': 4.45.0
-      '@wordpress/url': 3.13.0
-      lodash: 4.17.21
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-with-direction
-      - supports-color
-
   '@wordpress/server-side-render@4.35.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -40737,6 +40538,26 @@ snapshots:
       '@wordpress/element': 5.35.0
       '@wordpress/i18n': 4.58.0
       '@wordpress/url': 3.59.0
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+
+  '@wordpress/server-side-render@5.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@wordpress/api-fetch': 7.0.1
+      '@wordpress/blocks': 13.0.3(react@18.3.1)
+      '@wordpress/components': 28.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.0.1(react@18.3.1)
+      '@wordpress/data': 10.0.2(patch_hash=xjmezqav3jkhcz5453svqnw2p4)(react@18.3.1)
+      '@wordpress/deprecated': 4.0.1
+      '@wordpress/element': 6.0.1
+      '@wordpress/i18n': 5.0.1
+      '@wordpress/url': 4.0.1
       fast-deep-equal: 3.1.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -46815,23 +46636,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  framer-motion@6.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@motionone/dom': 10.12.0
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      popmotion: 11.0.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      style-value-types: 5.0.0
-      tslib: 2.6.3
-    optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-
-  framesync@6.0.1:
-    dependencies:
-      tslib: 2.8.1
-
   fresh@0.5.2: {}
 
   from2@2.3.0:
@@ -47692,8 +47496,6 @@ snapshots:
   hex-color-regex@1.1.0: {}
 
   hexoid@1.0.0: {}
-
-  hey-listen@1.0.8: {}
 
   highlight-words-core@1.2.2: {}
 
@@ -53722,13 +53524,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.7
 
-  popmotion@11.0.3:
-    dependencies:
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      style-value-types: 5.0.0
-      tslib: 2.8.1
-
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
@@ -55041,28 +54836,6 @@ snapshots:
       react-with-styles: 4.2.0(@babel/runtime@7.25.7)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react-with-styles-interface-css: 6.0.0(@babel/runtime@7.25.7)(react-with-styles@4.2.0(@babel/runtime@7.25.7)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))
 
-  react-dates@21.8.0(@babel/runtime@7.26.0)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      airbnb-prop-types: 2.16.0(react@18.3.1)
-      consolidated-events: 2.0.2
-      enzyme-shallow-equal: 1.0.5
-      is-touch-device: 1.0.1
-      lodash: 4.17.21
-      moment: 2.29.4
-      object.assign: 4.1.5
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      raf: 3.4.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-moment-proptypes: 1.8.1(moment@2.29.4)
-      react-outside-click-handler: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-portal: 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-with-direction: 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-with-styles: 4.2.0(@babel/runtime@7.26.0)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      react-with-styles-interface-css: 6.0.0(@babel/runtime@7.26.0)(react-with-styles@4.2.0(@babel/runtime@7.26.0)(react@18.3.1))
-
   react-devtools-core@4.28.5:
     dependencies:
       shell-quote: 1.8.1
@@ -55487,13 +55260,6 @@ snapshots:
       global-cache: 1.2.1
       react-with-styles: 4.2.0(@babel/runtime@7.25.7)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
 
-  react-with-styles-interface-css@6.0.0(@babel/runtime@7.26.0)(react-with-styles@4.2.0(@babel/runtime@7.26.0)(react@18.3.1)):
-    dependencies:
-      '@babel/runtime': 7.26.0
-      array.prototype.flat: 1.3.2
-      global-cache: 1.2.1
-      react-with-styles: 4.2.0(@babel/runtime@7.26.0)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-
   react-with-styles@3.2.3(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       hoist-non-react-statics: 3.3.2
@@ -55505,16 +55271,6 @@ snapshots:
   react-with-styles@4.2.0(@babel/runtime@7.25.7)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.7
-      airbnb-prop-types: 2.16.0(react@18.3.1)
-      hoist-non-react-statics: 3.3.2
-      object.assign: 4.1.5
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-with-direction: 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
-  react-with-styles@4.2.0(@babel/runtime@7.26.0)(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.26.0
       airbnb-prop-types: 2.16.0(react@18.3.1)
       hoist-non-react-statics: 3.3.2
       object.assign: 4.1.5
@@ -57215,11 +56971,6 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  style-value-types@5.0.0:
-    dependencies:
-      hey-listen: 1.0.8
-      tslib: 2.8.1
-
   stylehacks@4.0.3:
     dependencies:
       browserslist: 4.19.3
@@ -58208,23 +57959,6 @@ snapshots:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.7.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-
-  ts-jest@29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)))(typescript@5.7.2):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,7 +1801,7 @@ importers:
         version: 2.17.0(wp-prettier@3.0.3)
       '@wordpress/scripts':
         specifier: wp-6.6
-        version: 28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(encoding@0.1.13)(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
+        version: 28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)
       '@wordpress/stylelint-config':
         specifier: ^21.36.0
         version: 21.36.0(postcss@8.4.32)(stylelint@14.16.1)
@@ -4623,8 +4623,8 @@ importers:
         specifier: next
         version: 6.13.1-next.a9f418477.0
       '@wordpress/components':
-        specifier: 19.17.0
-        version: 19.17.0(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react-with-direction@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: wp-6.6
+        version: 28.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/core-data':
         specifier: wp-6.6
         version: 7.0.7(@emotion/is-prop-valid@1.2.1)(@types/react-dom@18.0.10)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -28848,7 +28848,9 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@jest/reporters@25.5.1':
     dependencies:
@@ -29050,7 +29052,9 @@ snapshots:
       jest-runner: 24.9.0
       jest-runtime: 24.9.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@jest/test-sequencer@25.5.4':
     dependencies:
@@ -29060,12 +29064,9 @@ snapshots:
       jest-runner: 25.5.4
       jest-runtime: 25.5.4
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - utf-8-validate
 
-  '@jest/test-sequencer@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))':
+  '@jest/test-sequencer@26.6.3':
     dependencies:
       '@jest/test-result': 26.6.2
       graceful-fs: 4.2.11
@@ -29073,11 +29074,7 @@ snapshots:
       jest-runner: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
       jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   '@jest/test-sequencer@27.5.1':
     dependencies:
@@ -35125,6 +35122,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 4.33.0
+      debug: 4.4.0
+      eslint: 8.55.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.3.0
+      regexpp: 3.2.0
+      semver: 7.6.3
+      tsutils: 3.21.0(typescript@5.7.2)
+    optionalDependencies:
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
@@ -37236,7 +37250,7 @@ snapshots:
   '@wordpress/components@28.0.3(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.25.7
       '@emotion/cache': 11.11.0
       '@emotion/css': 11.11.2
       '@emotion/react': 11.11.1(@types/react@18.3.16)(react@18.3.1)
@@ -37253,14 +37267,14 @@ snapshots:
       '@wordpress/deprecated': 4.0.1
       '@wordpress/dom': 4.0.1
       '@wordpress/element': 6.0.1
-      '@wordpress/escape-html': 3.10.0
+      '@wordpress/escape-html': 3.16.0
       '@wordpress/hooks': 4.0.1
       '@wordpress/html-entities': 4.0.1
       '@wordpress/i18n': 5.0.1
       '@wordpress/icons': 10.0.2(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.0.1
       '@wordpress/keycodes': 4.0.1
-      '@wordpress/primitives': 4.11.0(react@18.3.1)
+      '@wordpress/primitives': 4.0.1
       '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/warning': 3.0.1
@@ -37292,7 +37306,7 @@ snapshots:
   '@wordpress/components@28.0.3(@emotion/is-prop-valid@1.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.25.7
       '@emotion/cache': 11.11.0
       '@emotion/css': 11.11.2
       '@emotion/react': 11.11.1(@types/react@18.3.16)(react@18.3.1)
@@ -37309,14 +37323,14 @@ snapshots:
       '@wordpress/deprecated': 4.0.1
       '@wordpress/dom': 4.0.1
       '@wordpress/element': 6.0.1
-      '@wordpress/escape-html': 3.10.0
+      '@wordpress/escape-html': 3.16.0
       '@wordpress/hooks': 4.0.1
       '@wordpress/html-entities': 4.0.1
       '@wordpress/i18n': 5.0.1
       '@wordpress/icons': 10.0.2(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.0.1
       '@wordpress/keycodes': 4.0.1
-      '@wordpress/primitives': 4.11.0(react@18.3.1)
+      '@wordpress/primitives': 4.0.1
       '@wordpress/private-apis': 1.16.0
       '@wordpress/rich-text': 7.0.2(react@18.3.1)
       '@wordpress/warning': 3.0.1
@@ -38954,7 +38968,7 @@ snapshots:
   '@wordpress/eslint-plugin@9.3.0(@babel/core@7.25.7)(eslint@7.32.0)(typescript@5.7.2)':
     dependencies:
       '@babel/eslint-parser': 7.23.3(@babel/core@7.25.7)(eslint@7.32.0)
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@wordpress/prettier-config': 1.4.0(wp-prettier@2.2.1-beta-1)
       cosmiconfig: 7.1.0
@@ -40286,7 +40300,7 @@ snapshots:
       expect-puppeteer: 4.4.0
       filenamify: 4.3.0
       jest: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
-      jest-circus: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
+      jest-circus: 26.6.3
       jest-dev-server: 5.0.3(debug@4.3.4)
       jest-environment-node: 26.6.2
       markdownlint: 0.23.1
@@ -40365,7 +40379,7 @@ snapshots:
       expect-puppeteer: 4.4.0
       filenamify: 4.3.0
       jest: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
-      jest-circus: 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
+      jest-circus: 26.6.3
       jest-dev-server: 5.0.3(debug@4.3.4)
       jest-environment-node: 26.6.2
       markdownlint: 0.23.1
@@ -40416,7 +40430,7 @@ snapshots:
       - utf-8-validate
       - webpack-dev-server
 
-  '@wordpress/scripts@28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(encoding@0.1.13)(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)':
+  '@wordpress/scripts@28.0.2(@playwright/test@1.50.1)(@swc/core@1.3.100)(@types/eslint@8.44.8)(@types/node@20.17.8)(@types/webpack@4.41.38)(file-loader@6.2.0(webpack@5.91.0(@swc/core@1.3.100)))(node-notifier@8.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2))(type-fest@3.13.1)(typescript@5.7.2)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/core': 7.25.7
       '@playwright/test': 1.50.1
@@ -40462,7 +40476,7 @@ snapshots:
       postcss: 8.4.32
       postcss-loader: 6.2.1(postcss@8.4.32)(webpack@5.91.0(@swc/core@1.3.100))
       prettier: wp-prettier@3.0.3
-      puppeteer-core: 13.7.0(encoding@0.1.13)
+      puppeteer-core: 13.7.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
@@ -45382,7 +45396,7 @@ snapshots:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       eslint: 7.32.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -48790,7 +48804,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-circus@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)):
+  jest-circus@26.6.3:
     dependencies:
       '@babel/traverse': 7.25.9
       '@jest/environment': 26.6.2
@@ -48814,11 +48828,7 @@ snapshots:
       stack-utils: 2.0.6
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-circus@27.5.1:
     dependencies:
@@ -49076,7 +49086,7 @@ snapshots:
   jest-config@26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.25.7
-      '@jest/test-sequencer': 26.6.3(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@22.9.1)(typescript@5.7.2))
+      '@jest/test-sequencer': 26.6.3
       '@jest/types': 26.6.2
       babel-jest: 26.6.3(@babel/core@7.25.7)
       chalk: 4.1.2
@@ -54744,7 +54754,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@13.7.0(encoding@0.1.13):
+  puppeteer-core@13.7.0:
     dependencies:
       cross-fetch: 3.1.5(encoding@0.1.13)
       debug: 4.3.4(supports-color@9.4.0)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This updates two dependencies with the blocks package to prevent the build process from using an older version of `@floating-ui/react-dom`. As this broke the use of dataviews in this PR: https://github.com/woocommerce/woocommerce/pull/56641

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all the GH actions are green
2. Create a new post and change the editor to **Code Editor**
3. Paste `<!-- wp:woocommerce/handpicked-products {"editMode":false,"products":[]} /-->`
4. Select a product and change some of the settings, the block should work correctly
5. Now also remove the product afterwards, it should display a list of sample products and work correctly

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
