### PR TITLE
Poc/product editor with dataform

### DIFF
--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
-import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { getNewPath, getQuery, navigateTo } from '@woocommerce/navigation';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useDispatch } from '@wordpress/data';
@@ -32,7 +32,15 @@ export function PreviewButton( {
 		},
 		onSaveSuccess( savedProduct: Product ) {
 			if ( productStatus === 'auto-draft' ) {
-				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				const query = getQuery() as { path?: string; page: string };
+				let urlPrefix = '/product/';
+				if ( query.path?.includes( 'data-forms' ) ) {
+					urlPrefix = '/product-data-forms/';
+				}
+				const url = getNewPath(
+					{},
+					`${ urlPrefix }${ savedProduct.id }`
+				);
 				navigateTo( { url } );
 			}
 		},

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -7,7 +7,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { type Product } from '@woocommerce/data';
-import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { getNewPath, navigateTo, getQuery } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -58,7 +58,15 @@ export function PublishButton( {
 			maybeShowFeedbackBar();
 
 			if ( prevStatus === 'auto-draft' || prevStatus === 'draft' ) {
-				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				const query = getQuery() as { path?: string; page: string };
+				let urlPrefix = '/product/';
+				if ( query.path?.includes( 'data-forms' ) ) {
+					urlPrefix = '/product-data-forms/';
+				}
+				const url = getNewPath(
+					{},
+					`${ urlPrefix }${ savedProduct.id }`
+				);
 				navigateTo( { url } );
 			}
 		},

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
-import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { getNewPath, navigateTo, getQuery } from '@woocommerce/navigation';
 import { Product } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
 
@@ -44,7 +44,15 @@ export function SaveDraftButton( {
 			maybeShowFeedbackBar();
 
 			if ( productStatus === 'auto-draft' ) {
-				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				const query = getQuery() as { path?: string; page: string };
+				let urlPrefix = '/product/';
+				if ( query.path?.includes( 'data-forms' ) ) {
+					urlPrefix = '/product-data-forms/';
+				}
+				const url = getNewPath(
+					{},
+					`${ urlPrefix }${ savedProduct.id }`
+				);
 				navigateTo( { url } );
 			}
 		},

--- a/packages/js/product-editor/src/data-form/components/column/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/column/index.tsx
@@ -26,7 +26,7 @@ export function ProductColumn( {
 }: ProductColumnProps ) {
 	const innerBlocks = columnTemplate[ 2 ] || [];
 	const { editEntityRecord } = useDispatch( coreDataStore );
-	const fields = useDataFormProductFields( innerBlocks );
+	const fieldGroups = useDataFormProductFields( innerBlocks );
 
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -49,24 +49,19 @@ export function ProductColumn( {
 		[ postType, productId ]
 	);
 
+	const flattenedFieldGroups = useMemo( () => {
+		return fieldGroups.flatMap( ( group ) =>
+			group.type === 'fields' ? group.content : []
+		);
+	}, [ fieldGroups ] );
+
 	// Convert the fields to DataForm compatible format
 	const form = useMemo( () => {
 		return {
 			type: 'regular' as const,
-			fields: columnTemplate[ 2 ]
-				?.filter(
-					( field ) =>
-						field[ 0 ] ===
-							'woocommerce/product-regular-price-field' ||
-						field[ 0 ] === 'woocommerce/product-sale-price-field'
-				)
-				.map( ( field ) =>
-					field[ 0 ] === 'woocommerce/product-regular-price-field'
-						? 'regular_price'
-						: 'woocommerce/product-sale-price-field'
-				),
+			fields: flattenedFieldGroups.map( ( field ) => field.id ),
 		};
-	}, [ columnTemplate ] );
+	}, [ flattenedFieldGroups ] );
 
 	const onChange = ( edits: Partial< Product > ) => {
 		editEntityRecord( 'postType', postType, productId, edits );
@@ -78,7 +73,7 @@ export function ProductColumn( {
 		<div style={ { flex: 1, marginTop: '16px' } }>
 			{ hasFinishedResolution && (
 				<DataForm
-					fields={ fields }
+					fields={ flattenedFieldGroups }
 					form={ form }
 					data={ record }
 					onChange={ onChange }

--- a/packages/js/product-editor/src/data-form/components/column/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/column/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Template } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { createElement, useMemo } from '@wordpress/element';
+import { DataForm } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { useDataFormProductFields } from '../use-data-form-product-fields';
+
+type ProductColumnProps = {
+	columnTemplate: Template;
+	postType: string;
+	productId: number;
+};
+
+export function ProductColumn( {
+	columnTemplate,
+	postType,
+	productId,
+}: ProductColumnProps ) {
+	const innerBlocks = columnTemplate[ 2 ] || [];
+	const { editEntityRecord } = useDispatch( coreDataStore );
+	const fields = useDataFormProductFields( innerBlocks );
+
+	const { record, hasFinishedResolution } = useSelect(
+		( select ) => {
+			const {
+				getEditedEntityRecord,
+				hasFinishedResolution: hasFinished,
+			} = select( coreDataStore );
+
+			const args = [ 'postType', postType, productId ];
+			return {
+				// @ts-expect-error Type definitions are missing
+				record: getEditedEntityRecord( ...args ) as Product,
+				// @ts-expect-error Type definitions are missing
+				hasFinishedResolution: hasFinished(
+					'getEditedEntityRecord',
+					args
+				),
+			};
+		},
+		[ postType, productId ]
+	);
+
+	// Convert the fields to DataForm compatible format
+	const form = useMemo( () => {
+		return {
+			type: 'regular' as const,
+			fields: columnTemplate[ 2 ]
+				?.filter(
+					( field ) =>
+						field[ 0 ] ===
+							'woocommerce/product-regular-price-field' ||
+						field[ 0 ] === 'woocommerce/product-sale-price-field'
+				)
+				.map( ( field ) =>
+					field[ 0 ] === 'woocommerce/product-regular-price-field'
+						? 'regular_price'
+						: 'woocommerce/product-sale-price-field'
+				),
+		};
+	}, [ columnTemplate ] );
+
+	const onChange = ( edits: Partial< Product > ) => {
+		editEntityRecord( 'postType', postType, productId, edits );
+	};
+
+	// Basic container for a column, styling might be needed later
+	// The flex: 1 assumes columns should share space equally by default
+	return (
+		<div style={ { flex: 1, marginTop: '16px' } }>
+			{ hasFinishedResolution && (
+				<DataForm
+					fields={ fields }
+					form={ form }
+					data={ record }
+					onChange={ onChange }
+				/>
+			) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/columns/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/columns/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { Template } from '@wordpress/blocks';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ProductColumn } from '../column';
+
+type ProductColumnsProps = {
+	columnsTemplate: Template;
+	postType: string;
+	productId: number;
+};
+
+export function ProductColumns( {
+	columnsTemplate,
+	postType,
+	productId,
+}: ProductColumnsProps ) {
+	const columns = columnsTemplate[ 2 ] || [];
+
+	// Basic container for columns, styling might be needed later
+	return (
+		<div style={ { display: 'flex', gap: '16px' } }>
+			{ columns.map( ( columnTemplate, index ) => {
+				if ( columnTemplate[ 0 ] === 'core/column' ) {
+					return (
+						<ProductColumn
+							key={
+								columnTemplate[ 1 ]?._templateBlockId || index
+							}
+							columnTemplate={ columnTemplate }
+							postType={ postType }
+							productId={ productId }
+						/>
+					);
+				}
+				return null;
+			} ) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -21,6 +21,9 @@ import { Header } from '../../../components/header';
 import { ValidationProvider } from '../../../contexts/validation-context';
 import { EditorProps } from './types';
 import { ProductTabs } from '../tabs';
+import { initFields } from '../fields';
+
+initFields();
 
 export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	const query = getQuery() as Record< string, string >;
@@ -51,9 +54,11 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 							productType={ postType }
 							selectedTab={ selectedTab }
 						/>
+						{ /* @ts-expect-error Type definitions are missing */ }
 						{ layoutTemplate?.blockTemplates && (
 							<ProductTabs
 								sectionTemplate={
+									// @ts-expect-error Type definitions are missing
 									layoutTemplate?.blockTemplates
 								}
 								postType={ postType }

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { createElement, StrictMode, useCallback } from '@wordpress/element';
+import {
+	LayoutContextProvider,
+	useExtendLayout,
+} from '@woocommerce/admin-layout';
+import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
+import { Popover } from '@wordpress/components';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { EntityProvider } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { Header } from '../../../components/header';
+import { ValidationProvider } from '../../../contexts/validation-context';
+import { EditorProps } from './types';
+
+export function Editor( { productId, postType = 'product' }: EditorProps ) {
+	const query = getQuery() as Record< string, string >;
+	const selectedTab = query.tab || null;
+
+	const setSelectedTab = useCallback( ( tabId: string ) => {
+		navigateTo( { url: getNewPath( { tab: tabId } ) } );
+	}, [] );
+
+	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
+
+	return (
+		<LayoutContextProvider value={ updatedLayoutContext }>
+			<StrictMode>
+				<EntityProvider
+					kind="postType"
+					type={ postType }
+					id={ productId }
+				>
+					<ValidationProvider
+						postType={ postType }
+						productId={ productId }
+					>
+						<Header
+							onTabSelect={ setSelectedTab }
+							productType={ postType }
+							selectedTab={ selectedTab }
+						/>
+						<p>Data Form Editor</p>
+						{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }
+						<Popover.Slot />
+					</ValidationProvider>
+				</EntityProvider>
+			</StrictMode>
+		</LayoutContextProvider>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -33,7 +33,7 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 		navigateTo( { url: getNewPath( { tab: tabId } ) } );
 	}, [] );
 
-	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
+	const updatedLayoutContext = useExtendLayout( 'product-editor' );
 
 	const { layoutTemplate } = useLayoutTemplate( 'simple-product' );
 

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -1,20 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	StrictMode,
-	useCallback,
-	useMemo,
-	useState,
-} from '@wordpress/element';
+import { createElement, StrictMode, useCallback } from '@wordpress/element';
 import {
 	LayoutContextProvider,
 	useExtendLayout,
 } from '@woocommerce/admin-layout';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { useLayoutTemplate } from '@woocommerce/block-templates';
-import { Product } from '@woocommerce/data';
 import { Popover } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -41,8 +34,6 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 
 	const { layoutTemplate } = useLayoutTemplate( 'simple-product' );
 
-	const [ edits, setEdits ] = useState< Product >( {} as Product );
-
 	return (
 		<LayoutContextProvider value={ updatedLayoutContext }>
 			<StrictMode>
@@ -66,9 +57,7 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 									layoutTemplate?.blockTemplates
 								}
 								postType={ postType }
-								data={ edits }
-								// @ts-expect-error onChange is not typed
-								onChange={ setEdits }
+								productId={ productId }
 							/>
 						) }
 						{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -6,6 +6,7 @@ import {
 	StrictMode,
 	useCallback,
 	useMemo,
+	useState,
 } from '@wordpress/element';
 import {
 	LayoutContextProvider,
@@ -13,6 +14,7 @@ import {
 } from '@woocommerce/admin-layout';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { useLayoutTemplate } from '@woocommerce/block-templates';
+import { Product } from '@woocommerce/data';
 import { Popover } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -26,7 +28,6 @@ import { Header } from '../../../components/header';
 import { ValidationProvider } from '../../../contexts/validation-context';
 import { EditorProps } from './types';
 import { ProductTabs } from '../tabs';
-import { useProductTemplate } from '../../../hooks/use-product-template';
 
 export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	const query = getQuery() as Record< string, string >;
@@ -38,8 +39,9 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 
 	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
 
-	const { productTemplate } = useProductTemplate( null, null );
 	const { layoutTemplate } = useLayoutTemplate( 'simple-product' );
+
+	const [ edits, setEdits ] = useState< Product >( {} as Product );
 
 	return (
 		<LayoutContextProvider value={ updatedLayoutContext }>
@@ -64,6 +66,9 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 									layoutTemplate?.blockTemplates
 								}
 								postType={ postType }
+								data={ edits }
+								// @ts-expect-error onChange is not typed
+								onChange={ setEdits }
 							/>
 						) }
 						{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import { createElement, StrictMode, useCallback } from '@wordpress/element';
+import {
+	createElement,
+	StrictMode,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import {
 	LayoutContextProvider,
 	useExtendLayout,
 } from '@woocommerce/admin-layout';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
+import { useLayoutTemplate } from '@woocommerce/block-templates';
 import { Popover } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -19,6 +25,8 @@ import { EntityProvider } from '@wordpress/core-data';
 import { Header } from '../../../components/header';
 import { ValidationProvider } from '../../../contexts/validation-context';
 import { EditorProps } from './types';
+import { ProductTabs } from '../tabs';
+import { useProductTemplate } from '../../../hooks/use-product-template';
 
 export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	const query = getQuery() as Record< string, string >;
@@ -29,6 +37,9 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	}, [] );
 
 	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
+
+	const { productTemplate } = useProductTemplate( null, null );
+	const { layoutTemplate } = useLayoutTemplate( 'simple-product' );
 
 	return (
 		<LayoutContextProvider value={ updatedLayoutContext }>
@@ -47,7 +58,14 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 							productType={ postType }
 							selectedTab={ selectedTab }
 						/>
-						<p>Data Form Editor</p>
+						{ layoutTemplate?.blockTemplates && (
+							<ProductTabs
+								sectionTemplate={
+									layoutTemplate?.blockTemplates
+								}
+								postType={ postType }
+							/>
+						) }
 						{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }
 						<Popover.Slot />
 					</ValidationProvider>

--- a/packages/js/product-editor/src/data-form/components/editor/index.ts
+++ b/packages/js/product-editor/src/data-form/components/editor/index.ts
@@ -1,0 +1,2 @@
+export * from './editor';
+export * from './types';

--- a/packages/js/product-editor/src/data-form/components/editor/style.scss
+++ b/packages/js/product-editor/src/data-form/components/editor/style.scss
@@ -1,0 +1,4 @@
+@import "@wordpress/interface/src/components/complementary-area-header/style.scss";
+@import "@wordpress/interface/src/components/complementary-area/style.scss";
+@import "@wordpress/interface/src/components/interface-skeleton/style.scss";
+@import "@wordpress/interface/src/components/pinned-items/style.scss";

--- a/packages/js/product-editor/src/data-form/components/editor/types.ts
+++ b/packages/js/product-editor/src/data-form/components/editor/types.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import {
+	EditorSettings,
+	EditorBlockListSettings,
+} from '@wordpress/block-editor';
+import { Template } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { ProductTemplate } from '../../../types';
+
+export type LayoutTemplate = {
+	id: string;
+	title: string;
+	description: string;
+	area: string;
+	blockTemplates: Template[];
+};
+
+export type ProductEditorSettings = Partial<
+	EditorSettings & EditorBlockListSettings
+> & {
+	productTemplates: ProductTemplate[];
+	productTemplate?: ProductTemplate;
+};
+
+export type EditorProps = {
+	productId: number;
+	postType?: string;
+};

--- a/packages/js/product-editor/src/data-form/components/fields/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/index.ts
@@ -5,12 +5,14 @@ import { initNameField } from './name';
 import { initRegularPriceField } from './regular-price';
 import { initSalePriceField } from './sale-price';
 import { initScheduleSaleField } from './schedule-sale';
+import { initTextAreaField } from './text-area';
 
 export function initFields() {
 	initNameField();
 	initRegularPriceField();
 	initSalePriceField();
 	initScheduleSaleField();
+	initTextAreaField();
 }
 
 export * from './registration';

--- a/packages/js/product-editor/src/data-form/components/fields/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/index.ts
@@ -4,11 +4,13 @@
 import { initNameField } from './name';
 import { initRegularPriceField } from './regular-price';
 import { initSalePriceField } from './sale-price';
+import { initScheduleSaleField } from './schedule-sale';
 
 export function initFields() {
 	initNameField();
 	initRegularPriceField();
 	initSalePriceField();
+	initScheduleSaleField();
 }
 
 export * from './registration';

--- a/packages/js/product-editor/src/data-form/components/fields/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { initNameField } from './name';
+
+export function initFields() {
+	initNameField();
+}
+
+export * from './registration';

--- a/packages/js/product-editor/src/data-form/components/fields/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/index.ts
@@ -2,9 +2,13 @@
  * Internal dependencies
  */
 import { initNameField } from './name';
+import { initRegularPriceField } from './regular-price';
+import { initSalePriceField } from './sale-price';
 
 export function initFields() {
 	initNameField();
+	initRegularPriceField();
+	initSalePriceField();
 }
 
 export * from './registration';

--- a/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
@@ -1,0 +1,214 @@
+/**
+ * External dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+import { createElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { DataFormControlProps } from '@wordpress/dataviews';
+import { starEmpty, starFilled } from '@wordpress/icons';
+import { cleanForSlug } from '@wordpress/url';
+import { Product } from '@woocommerce/data';
+import classNames from 'classnames';
+import {
+	Button,
+	BaseControl,
+	Tooltip,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { EditProductLinkModal } from '../../../../components/edit-product-link-modal';
+import { Label } from '../../../../components/label/label';
+import { useValidation } from '../../../../contexts/validation-context';
+import { useProductEdits } from '../../../../hooks/use-product-edits';
+import { AUTO_DRAFT_NAME, getPermalinkParts } from '../../../../utils';
+
+// @todo: This is a temporary solution and close to a copy of the block name field.
+// We need refactor this to use this Edit in the current block name field.
+
+export function NameBlockEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< Product > ) {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
+
+	const { hasEdit } = useProductEdits();
+
+	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
+		useState( false );
+
+	const productId = data.id;
+	const sku = data.sku;
+	const name = data.name;
+	const featured = data.featured;
+
+	const { prefix: permalinkPrefix, suffix: permalinkSuffix } =
+		getPermalinkParts( data );
+
+	const {
+		ref: nameRef,
+		error: nameValidationError,
+		validate: validateName,
+	} = useValidation< Product >(
+		'name',
+		async function nameValidator() {
+			if ( ! name || name === AUTO_DRAFT_NAME ) {
+				return {
+					message: __( 'Product name is required.', 'woocommerce' ),
+				};
+			}
+
+			if ( name.length > 120 ) {
+				return {
+					message: __(
+						'Please enter a product name shorter than 120 characters.',
+						'woocommerce'
+					),
+				};
+			}
+		},
+		[ name ]
+	);
+
+	const setSkuIfEmpty = () => {
+		if ( sku || nameValidationError ) {
+			return;
+		}
+		onChange( { sku: cleanForSlug( name ) } );
+	};
+
+	const help =
+		nameValidationError ??
+		( productId &&
+			[ 'publish', 'draft' ].includes( data.status ) &&
+			permalinkPrefix && (
+				<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
+					{ __( 'Product link', 'woocommerce' ) }
+					:&nbsp;
+					<a href={ data.permalink } target="_blank" rel="noreferrer">
+						{ permalinkPrefix }
+						{ data.slug || cleanForSlug( name ) }
+						{ permalinkSuffix }
+					</a>
+					<Button
+						variant="link"
+						onClick={ () => setShowProductLinkEditModal( true ) }
+					>
+						{ __( 'Edit', 'woocommerce' ) }
+					</Button>
+				</span>
+			) );
+
+	const nameControlId = useInstanceId(
+		BaseControl,
+		'product_name'
+	) as string;
+
+	// @todo: This relies on attribute settings from the block information, we need to find a way to get this into the DataForm.
+	// useEffect( () => {
+	// 	if ( field.attributes.autoFocus ) {
+	// 		selectBlock( clientId );
+	// 	}
+	// }, [] );
+
+	function handleSuffixClick() {
+		onChange( { featured: ! featured } );
+	}
+
+	function renderFeaturedSuffix() {
+		const markedText = __( 'Mark as featured', 'woocommerce' );
+		const unmarkedText = __( 'Unmark as featured', 'woocommerce' );
+		const tooltipText = featured ? unmarkedText : markedText;
+
+		return (
+			<Tooltip text={ tooltipText } placement="top">
+				{ featured ? (
+					<Button
+						icon={ starFilled }
+						aria-label={ unmarkedText }
+						onClick={ handleSuffixClick }
+					/>
+				) : (
+					<Button
+						icon={ starEmpty }
+						aria-label={ markedText }
+						onClick={ handleSuffixClick }
+					/>
+				) }
+			</Tooltip>
+		);
+	}
+
+	return (
+		<div>
+			<BaseControl
+				id={ nameControlId }
+				label={
+					<Label label={ __( 'Name', 'woocommerce' ) } required />
+				}
+				className={ classNames( {
+					'has-error': nameValidationError,
+				} ) }
+				help={ help }
+			>
+				<InputControl
+					id={ nameControlId }
+					ref={ nameRef }
+					name="name"
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					// autoFocus={ attributes.autoFocus }
+					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
+					onChange={ ( nextValue ) => {
+						onChange( { name: nextValue ?? '' } );
+					} }
+					value={ name && name !== AUTO_DRAFT_NAME ? name : '' }
+					autoComplete="off"
+					data-1p-ignore
+					onBlur={ () => {
+						if ( hasEdit( 'name' ) ) {
+							setSkuIfEmpty();
+							validateName();
+						}
+					} }
+					suffix={ renderFeaturedSuffix() }
+				/>
+			</BaseControl>
+
+			{ showProductLinkEditModal && (
+				<EditProductLinkModal
+					permalinkPrefix={ permalinkPrefix || '' }
+					permalinkSuffix={ permalinkSuffix || '' }
+					product={ data }
+					onCancel={ () => setShowProductLinkEditModal( false ) }
+					onSaved={ () => setShowProductLinkEditModal( false ) }
+					saveHandler={ async ( updatedSlug: string ) => {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						const { slug, permalink }: Product =
+							await saveEntityRecord( 'postType', 'product', {
+								id: data.id,
+								slug: updatedSlug,
+							} );
+
+						if ( slug && permalink ) {
+							editEntityRecord( 'postType', 'product', data.id, {
+								slug,
+								permalink,
+							} );
+
+							return {
+								slug,
+								permalink,
+							};
+						}
+					} }
+				/>
+			) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/name/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/name/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { NameBlockEdit } from './field';
+
+export function initNameField() {
+	return registerProductField( 'woocommerce/product-name-field', {
+		id: 'name',
+		label: 'Name',
+		type: 'text',
+		Edit: NameBlockEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/registration.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/registration.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import type { Product } from '@woocommerce/data';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+
+const productFields: Record< string, Field< Product > > = {};
+
+export function registerProductField( id: string, field: Field< Product > ) {
+	productFields[ id ] = field;
+}
+
+export function getProductField( id: string ) {
+	return productFields[ id ];
+}

--- a/packages/js/product-editor/src/data-form/components/fields/regular-price/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/regular-price/field.tsx
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useInstanceId } from '@wordpress/compose';
+import { Product } from '@woocommerce/data';
+import { createElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { DataFormControlProps } from '@wordpress/dataviews';
+import {
+	BaseControl,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Label } from '../../../../components/label/label';
+import { useValidation } from '../../../../contexts/validation-context';
+import { useCurrencyInputProps } from '../../../../hooks/use-currency-input-props';
+import { sanitizeHTML } from '../../../../utils/sanitize-html';
+
+export function RegularPriceBlockEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< Product > ) {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	const salePrice = data.sale_price;
+	const regularPrice = data.regular_price;
+	const isRequired = true;
+	const label = __( 'Regular Price', 'woocommerce' );
+
+	const inputProps = useCurrencyInputProps( {
+		value: data.regular_price,
+		onChange: ( nextValue ) => {
+			onChange( {
+				regular_price: nextValue ?? '',
+			} );
+		},
+	} );
+
+	const regularPriceId = useInstanceId(
+		BaseControl,
+		'wp-block-woocommerce-product-regular-price-field'
+	) as string;
+
+	const {
+		ref: regularPriceRef,
+		error: regularPriceValidationError,
+		validate: validateRegularPrice,
+	} = useValidation< Product >(
+		`regular_price`,
+		async function regularPriceValidator() {
+			const listPrice = Number.parseFloat( regularPrice );
+			if ( listPrice ) {
+				if ( listPrice < 0 ) {
+					return {
+						message: __(
+							'Regular price must be greater than or equals to zero.',
+							'woocommerce'
+						),
+					};
+				}
+				if (
+					salePrice &&
+					listPrice <= Number.parseFloat( salePrice )
+				) {
+					return {
+						message: __(
+							'Regular price must be greater than the sale price.',
+							'woocommerce'
+						),
+					};
+				}
+			} else if ( isRequired ) {
+				return {
+					message: sprintf(
+						/* translators: label of required field. */
+						__( '%s is required.', 'woocommerce' ),
+						label
+					),
+				};
+			}
+		},
+		[ regularPrice, salePrice ]
+	);
+
+	function renderHelp() {
+		if ( regularPriceValidationError ) {
+			return (
+				<span
+					dangerouslySetInnerHTML={ sanitizeHTML(
+						regularPriceValidationError
+					) }
+				/>
+			);
+		}
+	}
+
+	return (
+		<div>
+			<BaseControl
+				id={ regularPriceId }
+				label={ <Label label={ label } required /> }
+				help={
+					regularPriceValidationError
+						? regularPriceValidationError
+						: renderHelp()
+				}
+				className={ classNames( {
+					'has-error': regularPriceValidationError,
+				} ) }
+			>
+				<InputControl
+					{ ...inputProps }
+					id={ regularPriceId }
+					name={ 'regular_price' }
+					inputMode="decimal"
+					ref={ regularPriceRef }
+					onChange={ ( nextValue ) => {
+						onChange( {
+							regular_price: nextValue ?? '',
+						} );
+					} }
+					value={ regularPrice }
+					// disabled={ disabled }
+					onBlur={ () => validateRegularPrice() }
+				/>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/regular-price/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/regular-price/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { RegularPriceBlockEdit } from './field';
+
+export function initRegularPriceField() {
+	return registerProductField( 'woocommerce/product-regular-price-field', {
+		id: 'regular_price',
+		label: 'Regular price',
+		type: 'integer',
+		Edit: RegularPriceBlockEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/sale-price/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/sale-price/field.tsx
@@ -24,7 +24,6 @@ export function SalePriceBlockEdit( {
 }: DataFormControlProps< Product > ) {
 	const salePrice = data.sale_price;
 	const regularPrice = data.regular_price;
-	const isRequired = true;
 	const label = __( 'Sale Price', 'woocommerce' );
 
 	// const { label, help, tooltip, disabled } = attributes;

--- a/packages/js/product-editor/src/data-form/components/fields/sale-price/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/sale-price/field.tsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { Product } from '@woocommerce/data';
+import { useInstanceId } from '@wordpress/compose';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { DataFormControlProps } from '@wordpress/dataviews';
+import {
+	BaseControl,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useValidation } from '../../../../contexts/validation-context';
+import { useCurrencyInputProps } from '../../../../hooks/use-currency-input-props';
+
+export function SalePriceBlockEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< Product > ) {
+	const salePrice = data.sale_price;
+	const regularPrice = data.regular_price;
+	const isRequired = true;
+	const label = __( 'Sale Price', 'woocommerce' );
+
+	// const { label, help, tooltip, disabled } = attributes;
+	// const [ regularPrice ] = useEntityProp< string >(
+	// 	'postType',
+	// 	context.postType || 'product',
+	// 	'regular_price'
+	// );
+	// const [ salePrice, setSalePrice ] = useEntityProp< string >(
+	// 	'postType',
+	// 	context.postType || 'product',
+	// 	'sale_price'
+	// );
+
+	const inputProps = useCurrencyInputProps( {
+		value: salePrice,
+		onChange: ( nextValue ) => {
+			onChange( {
+				sale_price: nextValue ?? '',
+			} );
+		},
+	} );
+
+	const salePriceId = useInstanceId(
+		BaseControl,
+		'wp-block-woocommerce-product-sale-price-field'
+	) as string;
+
+	const {
+		ref: salePriceRef,
+		error: salePriceValidationError,
+		validate: validateSalePrice,
+	} = useValidation< Product >(
+		`sale-price`,
+		async function salePriceValidator() {
+			if ( salePrice ) {
+				if ( Number.parseFloat( salePrice ) < 0 ) {
+					return {
+						message: __(
+							'Sale price must be greater than or equals to zero.',
+							'woocommerce'
+						),
+					};
+				}
+				const listPrice = Number.parseFloat( regularPrice );
+				if (
+					! listPrice ||
+					listPrice <= Number.parseFloat( salePrice )
+				) {
+					return {
+						message: __(
+							'Sale price must be lower than the regular price.',
+							'woocommerce'
+						),
+					};
+				}
+			}
+		},
+		[ regularPrice, salePrice ]
+	);
+
+	return (
+		<div>
+			<BaseControl
+				id={ salePriceId }
+				help={ salePriceValidationError ?? '' }
+				className={ classNames( {
+					'has-error': salePriceValidationError,
+				} ) }
+				label={ label }
+			>
+				<InputControl
+					{ ...inputProps }
+					id={ salePriceId }
+					name={ 'sale_price' }
+					inputMode="decimal"
+					ref={ salePriceRef }
+					// disabled={ disabled }
+					onBlur={ () => validateSalePrice() }
+				/>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/sale-price/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/sale-price/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { SalePriceBlockEdit } from './field';
+
+export function initSalePriceField() {
+	return registerProductField( 'woocommerce/product-sale-price-field', {
+		id: 'sale_price',
+		label: 'Sale price',
+		type: 'integer',
+		Edit: SalePriceBlockEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/schedule-sale/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/schedule-sale/field.tsx
@@ -1,0 +1,226 @@
+/**
+ * External dependencies
+ */
+import { DateTimePickerControl } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+import { ToggleControl } from '@wordpress/components';
+import {
+	createElement,
+	useCallback,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import { DataFormControlProps } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import moment from 'moment';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore We need this to get the datetime format for the DateTimePickerControl.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { getSettings } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import { useProductEdits } from '../../../../hooks/use-product-edits';
+import { useValidation } from '../../../../contexts/validation-context';
+
+export function ScheduleSaleFieldEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< Product > ) {
+	const salePrice = data.sale_price;
+	const dateOnSaleFromGmt = data.date_on_sale_from_gmt;
+	const dateOnSaleToGmt = data.date_on_sale_to_gmt;
+
+	const { hasEdit } = useProductEdits();
+
+	const dateTimeFormat = getSettings().formats.datetime;
+
+	const [ showScheduleSale, setShowScheduleSale ] = useState( false );
+
+	const isSalePriceGreaterThanZero =
+		Number.parseFloat( salePrice || '0' ) > 0;
+
+	const today = moment().startOf( 'minute' ).toISOString();
+
+	const setDateOnSaleFromGmt = useCallback(
+		( value: string ) => {
+			onChange( {
+				date_on_sale_from_gmt: value,
+			} );
+		},
+		[ onChange ]
+	);
+
+	const setDateOnSaleToGmt = useCallback(
+		( value: string ) => {
+			onChange( {
+				date_on_sale_to_gmt: value,
+			} );
+		},
+		[ onChange ]
+	);
+
+	function handleToggleChange( value: boolean ) {
+		recordEvent( 'product_pricing_schedule_sale_toggle_click', {
+			enabled: value,
+		} );
+
+		setShowScheduleSale( value );
+
+		if ( value ) {
+			setDateOnSaleFromGmt( today );
+			setDateOnSaleToGmt( '' );
+		} else {
+			setDateOnSaleFromGmt( '' );
+			setDateOnSaleToGmt( '' );
+		}
+	}
+
+	// Hide and clean date fields if the user manually changes
+	// the sale price to zero or less.
+	useEffect( () => {
+		if ( hasEdit( 'sale_price' ) && ! isSalePriceGreaterThanZero ) {
+			setShowScheduleSale( false );
+			setDateOnSaleFromGmt( '' );
+			setDateOnSaleToGmt( '' );
+		}
+	}, [ isSalePriceGreaterThanZero ] );
+
+	// Automatically show date fields if `from` or `to` dates have
+	// any value.
+	useEffect( () => {
+		if ( dateOnSaleFromGmt || dateOnSaleToGmt ) {
+			setShowScheduleSale( true );
+		}
+	}, [ dateOnSaleFromGmt, dateOnSaleToGmt ] );
+
+	const _dateOnSaleFrom = moment( dateOnSaleFromGmt, moment.ISO_8601, true );
+	const _dateOnSaleTo = moment( dateOnSaleToGmt, moment.ISO_8601, true );
+
+	const {
+		ref: dateOnSaleFromGmtRef,
+		error: dateOnSaleFromGmtValidationError,
+		validate: validateDateOnSaleFromGmt,
+	} = useValidation< Product >(
+		`date_on_sale_from_gmt`,
+		async function dateOnSaleFromValidator() {
+			if ( showScheduleSale && dateOnSaleFromGmt ) {
+				if ( ! _dateOnSaleFrom.isValid() ) {
+					return {
+						message: __(
+							'Please enter a valid date.',
+							'woocommerce'
+						),
+					};
+				}
+
+				if ( _dateOnSaleFrom.isAfter( _dateOnSaleTo ) ) {
+					return {
+						message: __(
+							'The start date of the sale must be before the end date.',
+							'woocommerce'
+						),
+					};
+				}
+			}
+		},
+		[ showScheduleSale, dateOnSaleFromGmt, _dateOnSaleFrom, _dateOnSaleTo ]
+	);
+
+	const {
+		ref: dateOnSaleToGmtRef,
+		error: dateOnSaleToGmtValidationError,
+		validate: validateDateOnSaleToGmt,
+	} = useValidation< Product >(
+		`date_on_sale_to_gmt`,
+		async function dateOnSaleToValidator() {
+			if ( showScheduleSale && dateOnSaleToGmt ) {
+				if ( ! _dateOnSaleTo.isValid() ) {
+					return {
+						message: __(
+							'Please enter a valid date.',
+							'woocommerce'
+						),
+					};
+				}
+
+				if ( _dateOnSaleTo.isBefore( _dateOnSaleFrom ) ) {
+					return {
+						message: __(
+							'The end date of the sale must be after the start date.',
+							'woocommerce'
+						),
+					};
+				}
+			}
+		},
+		[ showScheduleSale, dateOnSaleFromGmt, _dateOnSaleFrom, _dateOnSaleTo ]
+	);
+
+	return (
+		<div style={ { marginTop: '16px' } }>
+			<ToggleControl
+				label={ __( 'Schedule sale', 'woocommerce' ) }
+				checked={ showScheduleSale }
+				onChange={ handleToggleChange }
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore disabled prop exists
+				disabled={ ! isSalePriceGreaterThanZero }
+			/>
+
+			{ showScheduleSale && (
+				<div className="wp-block-columns wp-block-woocommerce-product-schedule-sale-fields__content">
+					<div className="wp-block-column">
+						<DateTimePickerControl
+							ref={
+								dateOnSaleFromGmtRef as React.Ref< HTMLInputElement >
+							}
+							label={ __( 'From', 'woocommerce' ) }
+							placeholder={ __(
+								'Sale start date and time (optional)',
+								'woocommerce'
+							) }
+							dateTimeFormat={ dateTimeFormat }
+							currentDate={ dateOnSaleFromGmt }
+							onChange={ setDateOnSaleFromGmt }
+							className={
+								dateOnSaleFromGmtValidationError && 'has-error'
+							}
+							help={ dateOnSaleFromGmtValidationError as string }
+							onBlur={ () => validateDateOnSaleFromGmt() }
+						/>
+					</div>
+
+					<div className="wp-block-column">
+						<DateTimePickerControl
+							ref={
+								dateOnSaleToGmtRef as React.Ref< HTMLInputElement >
+							}
+							label={ __( 'To', 'woocommerce' ) }
+							placeholder={ __(
+								'Sale end date and time (optional)',
+								'woocommerce'
+							) }
+							dateTimeFormat={ dateTimeFormat }
+							currentDate={ dateOnSaleToGmt }
+							onChange={ ( value ) =>
+								setDateOnSaleToGmt(
+									moment( value )
+										.startOf( 'minute' )
+										.toISOString()
+								)
+							}
+							onBlur={ () => validateDateOnSaleToGmt() }
+							className={
+								dateOnSaleToGmtValidationError && 'has-error'
+							}
+							help={ dateOnSaleToGmtValidationError as string }
+						/>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/schedule-sale/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/schedule-sale/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { ScheduleSaleFieldEdit } from './field';
+
+export function initScheduleSaleField() {
+	return registerProductField( 'woocommerce/product-schedule-sale-fields', {
+		id: 'woocommerce/product-schedule-sale-fields',
+		label: 'Schedule sale',
+		type: 'text',
+		Edit: ScheduleSaleFieldEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/schedule-sale/style.scss
+++ b/packages/js/product-editor/src/data-form/components/fields/schedule-sale/style.scss
@@ -1,0 +1,11 @@
+.woocommerce-product-form__schedule-sale-field {
+	&-dates {
+		display: flex;
+		gap: $gap-large;
+		margin-top: $gap-large;
+	}
+
+	&-date {
+		flex: 1;
+	}
+}

--- a/packages/js/product-editor/src/data-form/components/fields/text-area/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/text-area/field.tsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { createElement, useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
+import { BaseControl, TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Label } from '../../../../components/label/label';
+import { ProductDataFormControlProps } from '../types';
+import { TextAreaBlockEditAttributes } from '../../../../blocks/generic/text-area/types';
+import RichTextEditor from './rich-text';
+
+export function TextAreaBlockEdit( {
+	data,
+	onChange,
+	field,
+	attributes,
+}: ProductDataFormControlProps<
+	TextAreaBlockEditAttributes & { note?: string; tooltip?: string }
+> ) {
+	const { id, label } = field;
+	const {
+		placeholder,
+		help,
+		required,
+		note,
+		tooltip,
+		disabled = false,
+		align,
+		allowedFormats,
+		direction,
+		mode = 'rich-text',
+	} = attributes || {};
+	const value = field.getValue( { item: data } ) ?? '';
+	const textAreaRef = useRef< HTMLTextAreaElement >( null );
+	const contentId = useInstanceId(
+		TextAreaBlockEdit,
+		'wp-block-woocommerce-product-content-field__content'
+	);
+	const labelId = contentId.toString() + '__label';
+
+	function focusTextArea() {
+		textAreaRef.current?.focus();
+	}
+
+	if ( mode === 'plain-text' ) {
+		return (
+			<BaseControl
+				id={ contentId.toString() }
+				label={
+					<Label
+						label={ label || '' }
+						labelId={ labelId }
+						required={ required }
+						note={ note }
+						tooltip={ tooltip }
+						onClick={ focusTextArea }
+					/>
+				}
+				help={ help }
+			>
+				<TextareaControl
+					ref={ textAreaRef }
+					aria-labelledby={ labelId }
+					value={ value || '' }
+					onChange={ ( nextValue: string ) => {
+						onChange( {
+							[ id ]: nextValue,
+						} );
+					} }
+					placeholder={ placeholder }
+					required={ required }
+					disabled={ disabled }
+				/>
+			</BaseControl>
+		);
+	}
+
+	return (
+		<div>
+			<RichTextEditor
+				contentId={ contentId }
+				label={ label }
+				value={ value }
+				onChange={ onChange }
+				id={ id }
+				allowedFormats={ allowedFormats }
+				placeholder={ placeholder }
+				required={ required }
+				disabled={ disabled }
+				defaultAlign={ align }
+				defaultDirection={ direction }
+			/>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/text-area/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/text-area/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { TextAreaBlockEdit } from './field';
+
+export function initTextAreaField() {
+	return registerProductField( 'woocommerce/product-text-area-field', {
+		id: 'summary',
+		label: 'Summary',
+		type: 'text',
+		Edit: TextAreaBlockEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/text-area/rich-text.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/text-area/rich-text.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { createElement, useEffect } from '@wordpress/element';
+import { SlotFillProvider } from '@wordpress/components';
+import { unregisterBlockType } from '@wordpress/blocks';
+import {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	BlockTools,
+	BlockEditorProvider,
+	BlockList,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { TextAreaBlockEditAttributes } from '../../../../blocks/generic/text-area/types';
+import { init as initTextArea } from '../../../../blocks/generic/text-area';
+
+export type RichTextEditorProps = {
+	contentId: string;
+	label: string;
+	value: string;
+	onChange: ( value: Record< string, unknown > ) => void;
+	id: string;
+	allowedFormats?: string[];
+	placeholder?: string;
+	required?: boolean;
+	disabled?: boolean;
+	defaultAlign?: TextAreaBlockEditAttributes[ 'align' ];
+	defaultDirection?: 'ltr' | 'rtl';
+};
+
+export default function RichTextEditorWrapper( props: RichTextEditorProps ) {
+	useEffect( () => {
+		const textAreaBlock = initTextArea();
+
+		return () => {
+			if ( textAreaBlock ) {
+				unregisterBlockType( textAreaBlock.name );
+			}
+		};
+	}, [] );
+	return (
+		<SlotFillProvider>
+			<BlockEditorProvider
+				useSubRegistry={ true }
+				settings={ {
+					templateLock: 'all',
+					hasFixedToolbar: false,
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore This property was recently added in the block editor data store.
+					__experimentalClearBlockSelection: false,
+				} }
+				value={ [
+					{
+						name: 'woocommerce/product-text-area-field',
+						innerBlocks: [],
+						attributes: {
+							...props,
+							property: props.id,
+							lock: { move: true },
+						},
+						clientId: props.contentId,
+						isValid: true,
+					},
+				] }
+			>
+				<BlockTools>
+					<BlockList />
+				</BlockTools>
+			</BlockEditorProvider>
+		</SlotFillProvider>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/types.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/types.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import type { Product } from '@woocommerce/data';
+import type { DataFormControlProps } from '@wordpress/dataviews';
+
+export type ProductDataFormControlProps<
+	Attributes = Record< string, unknown >
+> = DataFormControlProps< Product > & { attributes?: Attributes };

--- a/packages/js/product-editor/src/data-form/components/index.ts
+++ b/packages/js/product-editor/src/data-form/components/index.ts
@@ -1,0 +1,1 @@
+export { Editor as __experimentalDataFormEditor } from './editor';

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { Template } from '@wordpress/blocks';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { SectionHeader } from '../../../components/section-header';
+
+type ProductSectionProps = {
+	sectionTemplate: Template;
+	postType: string;
+};
+
+export function ProductSection( {
+	sectionTemplate,
+	postType,
+}: ProductSectionProps ) {
+	const { description, title, blockGap } = sectionTemplate[ 1 ] as {
+		description: string;
+		title: string;
+		blockGap: string;
+	};
+
+	const nestedClassNames = classNames(
+		'wp-block-woocommerce-product-section-header__content',
+		`wp-block-woocommerce-product-section-header__content--block-gap-${ blockGap }`
+	);
+	const SectionTagName = title ? 'fieldset' : 'div';
+
+	return (
+		<SectionTagName>
+			{ title && (
+				<SectionHeader
+					description={ description }
+					sectionTagName={ SectionTagName }
+					title={ title }
+				/>
+			) }
+
+			<div className={ nestedClassNames }>
+				<p>
+					Render DataForm with { sectionTemplate[ 2 ]?.length } fields
+				</p>
+				<ul>
+					{ sectionTemplate[ 2 ]?.map( ( field ) => (
+						<li key={ field[ 0 ] }>{ field[ 0 ] }</li>
+					) ) }
+				</ul>
+			</div>
+		</SectionTagName>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -14,7 +14,7 @@ import { DataForm } from '@wordpress/dataviews';
  */
 import { SectionHeader } from '../../../components/section-header';
 import { useDataFormProductFields } from '../use-data-form-product-fields';
-
+import { ProductColumns } from '../columns';
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
@@ -56,6 +56,7 @@ export function ProductSection( {
 	);
 
 	const nestedClassNames = classNames(
+		'woocommerce-product-block-editor',
 		'wp-block-woocommerce-product-section-header__content',
 		`wp-block-woocommerce-product-section-header__content--block-gap-${ blockGap }`
 	);
@@ -87,14 +88,32 @@ export function ProductSection( {
 			) }
 
 			<div className={ nestedClassNames }>
-				{ hasFinishedResolution && (
-					<DataForm
-						fields={ fields }
-						form={ form }
-						onChange={ onChange }
-						data={ record }
-					/>
-				) }
+				{ hasFinishedResolution &&
+					sectionTemplate[ 2 ]?.map( ( field ) => {
+						if ( field[ 0 ] === 'core/columns' ) {
+							return (
+								<ProductColumns
+									key={ field[ 1 ]?._templateBlockId }
+									columnsTemplate={ field }
+									postType={ postType }
+									productId={ productId }
+								/>
+							);
+						} else if (
+							field[ 0 ] === 'woocommerce/product-name-field'
+						) {
+							return (
+								<DataForm
+									key={ field[ 1 ]?._templateBlockId }
+									fields={ fields }
+									form={ form }
+									onChange={ onChange }
+									data={ record }
+								/>
+							);
+						}
+						return null;
+					} ) }
 				<p>
 					Render DataForm with { sectionTemplate[ 2 ]?.length } fields
 				</p>

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -3,9 +3,11 @@
  */
 import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import classNames from 'classnames';
 import { Product } from '@woocommerce/data';
-import { DataForm, DataFormProps } from '@wordpress/dataviews';
+import { DataForm } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -15,11 +17,18 @@ import { SectionHeader } from '../../../components/section-header';
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
-} & Omit< DataFormProps< Product >, 'fields' | 'form' >;
+	productId: number;
+};
 
+/**
+ * @todo: This is a temporary solution to get the fields for the DataForm.
+ * We need to move this into a hook with a useMemo or something as we did have to generate some of this on the fly.
+ * For example, label comes from the sectionTemplate. Also things like the id which matches the product key comes from the config as well.
+ * You can see an example here: https://github.com/woocommerce/woocommerce/blob/89068601d334953e2904ecf56f528fc271c7b9ec/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php#L192
+ */
 const fields = [
 	{
-		id: 'product-name-field',
+		id: 'name',
 		type: 'text',
 		label: 'Title',
 	},
@@ -27,15 +36,34 @@ const fields = [
 
 export function ProductSection( {
 	sectionTemplate,
+	productId,
 	postType,
-	data,
-	onChange,
 }: ProductSectionProps ) {
 	const { description, title, blockGap } = sectionTemplate[ 1 ] as {
 		description: string;
 		title: string;
 		blockGap: string;
 	};
+
+	const { editEntityRecord } = useDispatch( coreDataStore );
+	const { record, hasFinishedResolution } = useSelect(
+		( select ) => {
+			const {
+				getEditedEntityRecord,
+				hasFinishedResolution: hasFinished,
+			} = select( coreDataStore );
+
+			const args = [ 'postType', postType, productId ];
+			return {
+				record: getEditedEntityRecord( ...args ) as Product,
+				hasFinishedResolution: hasFinished(
+					'getEditedEntityRecord',
+					args
+				),
+			};
+		},
+		[ postType, productId ]
+	);
 
 	const nestedClassNames = classNames(
 		'wp-block-woocommerce-product-section-header__content',
@@ -50,9 +78,13 @@ export function ProductSection( {
 				.filter(
 					( field ) => field[ 0 ] === 'woocommerce/product-name-field'
 				)
-				.map( ( field ) => field[ 0 ].split( '/' )[ 1 ] ),
+				.map( () => 'name' ),
 		};
 	}, [ sectionTemplate ] );
+
+	const onChange = ( edits: Partial< Product > ) => {
+		editEntityRecord( 'postType', postType, productId, edits );
+	};
 
 	return (
 		<SectionTagName>
@@ -65,6 +97,15 @@ export function ProductSection( {
 			) }
 
 			<div className={ nestedClassNames }>
+				{ hasFinishedResolution && (
+					<DataForm
+						// @ts-expect-error fields is not typed
+						fields={ fields }
+						form={ form }
+						onChange={ onChange }
+						data={ record }
+					/>
+				) }
 				<p>
 					Render DataForm with { sectionTemplate[ 2 ]?.length } fields
 				</p>
@@ -73,13 +114,6 @@ export function ProductSection( {
 						<li key={ field[ 0 ] }>{ field[ 0 ] }</li>
 					) ) }
 				</ul>
-				<DataForm
-					// @ts-expect-error fields is not typed
-					fields={ fields }
-					form={ form }
-					onChange={ onChange }
-					data={ data }
-				/>
 			</div>
 		</SectionTagName>
 	);

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, useMemo } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -15,6 +15,7 @@ import { DataForm } from '@wordpress/dataviews';
 import { SectionHeader } from '../../../components/section-header';
 import { useDataFormProductFields } from '../use-data-form-product-fields';
 import { ProductColumns } from '../columns';
+
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
@@ -32,7 +33,7 @@ export function ProductSection( {
 		blockGap: string;
 	};
 
-	const fields = useDataFormProductFields( sectionTemplate[ 2 ] );
+	const fieldGroups = useDataFormProductFields( sectionTemplate[ 2 ] );
 	const { editEntityRecord } = useDispatch( coreDataStore );
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -62,17 +63,6 @@ export function ProductSection( {
 	);
 	const SectionTagName = title ? 'fieldset' : 'div';
 
-	const form = useMemo( () => {
-		return {
-			type: 'regular' as const,
-			fields: sectionTemplate[ 2 ]
-				?.filter(
-					( field ) => field[ 0 ] === 'woocommerce/product-name-field'
-				)
-				.map( () => 'name' ),
-		};
-	}, [ sectionTemplate ] );
-
 	const onChange = ( edits: Partial< Product > ) => {
 		editEntityRecord( 'postType', postType, productId, edits );
 	};
@@ -89,30 +79,32 @@ export function ProductSection( {
 
 			<div className={ nestedClassNames }>
 				{ hasFinishedResolution &&
-					sectionTemplate[ 2 ]?.map( ( field ) => {
-						if ( field[ 0 ] === 'core/columns' ) {
-							return (
-								<ProductColumns
-									key={ field[ 1 ]?._templateBlockId }
-									columnsTemplate={ field }
-									postType={ postType }
-									productId={ productId }
-								/>
-							);
-						} else if (
-							field[ 0 ] === 'woocommerce/product-name-field'
-						) {
+					fieldGroups.map( ( group, index ) => {
+						if ( group.type === 'fields' ) {
+							const form = {
+								type: 'regular' as const,
+								fields: group.content.map(
+									( field ) => field.id
+								),
+							};
 							return (
 								<DataForm
-									key={ field[ 1 ]?._templateBlockId }
-									fields={ fields }
+									key={ index }
+									fields={ group.content }
 									form={ form }
 									onChange={ onChange }
 									data={ record }
 								/>
 							);
 						}
-						return null;
+						return (
+							<ProductColumns
+								key={ index }
+								columnsTemplate={ group.content }
+								postType={ postType }
+								productId={ productId }
+							/>
+						);
 					} ) }
 				<p>
 					Render DataForm with { sectionTemplate[ 2 ]?.length } fields

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -57,7 +57,7 @@ export function ProductSection( {
 	);
 
 	const nestedClassNames = classNames(
-		'woocommerce-product-block-editor',
+		'woocommerce-product-editor',
 		'wp-block-woocommerce-product-section-header__content',
 		`wp-block-woocommerce-product-section-header__content--block-gap-${ blockGap }`
 	);
@@ -68,7 +68,7 @@ export function ProductSection( {
 	};
 
 	return (
-		<SectionTagName>
+		<SectionTagName className="woocommerce-product-section">
 			{ title && (
 				<SectionHeader
 					description={ description }
@@ -106,14 +106,6 @@ export function ProductSection( {
 							/>
 						);
 					} ) }
-				<p>
-					Render DataForm with { sectionTemplate[ 2 ]?.length } fields
-				</p>
-				<ul>
-					{ sectionTemplate[ 2 ]?.map( ( field ) => (
-						<li key={ field[ 0 ] }>{ field[ 0 ] }</li>
-					) ) }
-				</ul>
 			</div>
 		</SectionTagName>
 	);

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -13,26 +13,13 @@ import { DataForm } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { SectionHeader } from '../../../components/section-header';
+import { useDataFormProductFields } from '../use-data-form-product-fields';
 
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
 	productId: number;
 };
-
-/**
- * @todo: This is a temporary solution to get the fields for the DataForm.
- * We need to move this into a hook with a useMemo or something as we did have to generate some of this on the fly.
- * For example, label comes from the sectionTemplate. Also things like the id which matches the product key comes from the config as well.
- * You can see an example here: https://github.com/woocommerce/woocommerce/blob/89068601d334953e2904ecf56f528fc271c7b9ec/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php#L192
- */
-const fields = [
-	{
-		id: 'name',
-		type: 'text',
-		label: 'Title',
-	},
-];
 
 export function ProductSection( {
 	sectionTemplate,
@@ -45,6 +32,7 @@ export function ProductSection( {
 		blockGap: string;
 	};
 
+	const fields = useDataFormProductFields( sectionTemplate[ 2 ] );
 	const { editEntityRecord } = useDispatch( coreDataStore );
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {
@@ -55,7 +43,9 @@ export function ProductSection( {
 
 			const args = [ 'postType', postType, productId ];
 			return {
+				// @ts-expect-error Type definitions are missing
 				record: getEditedEntityRecord( ...args ) as Product,
+				// @ts-expect-error Type definitions are missing
 				hasFinishedResolution: hasFinished(
 					'getEditedEntityRecord',
 					args
@@ -75,7 +65,7 @@ export function ProductSection( {
 		return {
 			type: 'regular' as const,
 			fields: sectionTemplate[ 2 ]
-				.filter(
+				?.filter(
 					( field ) => field[ 0 ] === 'woocommerce/product-name-field'
 				)
 				.map( () => 'name' ),
@@ -99,7 +89,6 @@ export function ProductSection( {
 			<div className={ nestedClassNames }>
 				{ hasFinishedResolution && (
 					<DataForm
-						// @ts-expect-error fields is not typed
 						fields={ fields }
 						form={ form }
 						onChange={ onChange }

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
 import classNames from 'classnames';
+import { Product } from '@woocommerce/data';
+import { DataForm, DataFormProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -13,11 +15,21 @@ import { SectionHeader } from '../../../components/section-header';
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
-};
+} & Omit< DataFormProps< Product >, 'fields' | 'form' >;
+
+const fields = [
+	{
+		id: 'product-name-field',
+		type: 'text',
+		label: 'Title',
+	},
+];
 
 export function ProductSection( {
 	sectionTemplate,
 	postType,
+	data,
+	onChange,
 }: ProductSectionProps ) {
 	const { description, title, blockGap } = sectionTemplate[ 1 ] as {
 		description: string;
@@ -30,6 +42,17 @@ export function ProductSection( {
 		`wp-block-woocommerce-product-section-header__content--block-gap-${ blockGap }`
 	);
 	const SectionTagName = title ? 'fieldset' : 'div';
+
+	const form = useMemo( () => {
+		return {
+			type: 'regular' as const,
+			fields: sectionTemplate[ 2 ]
+				.filter(
+					( field ) => field[ 0 ] === 'woocommerce/product-name-field'
+				)
+				.map( ( field ) => field[ 0 ].split( '/' )[ 1 ] ),
+		};
+	}, [ sectionTemplate ] );
 
 	return (
 		<SectionTagName>
@@ -50,6 +73,13 @@ export function ProductSection( {
 						<li key={ field[ 0 ] }>{ field[ 0 ] }</li>
 					) ) }
 				</ul>
+				<DataForm
+					// @ts-expect-error fields is not typed
+					fields={ fields }
+					form={ form }
+					onChange={ onChange }
+					data={ data }
+				/>
 			</div>
 		</SectionTagName>
 	);

--- a/packages/js/product-editor/src/data-form/components/section/style.scss
+++ b/packages/js/product-editor/src/data-form/components/section/style.scss
@@ -1,0 +1,13 @@
+.woocommerce-product-section {
+	margin: calc(3 * $gap) 0 0;
+	padding: 0 0 calc(3 * $gap);
+	border-bottom: 1px solid #ddd;
+
+	&:first-child {
+		margin-top: calc(4 * $gap);
+	}
+
+	&:last-child {
+		border-bottom: none;
+	}
+}

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -4,8 +4,6 @@
 import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-// @ts-expect-error missing types.
-// eslint-disable-next-line @woocommerce/dependency-group
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -57,13 +57,15 @@ export function ProductTabs( {
 			// onKeyDown={ handleKeyDown }
 			className="woocommerce-product-tabs"
 		>
-			<Tabs.TabList className="woocommerce-product-tabs__tablist">
-				{ tabs.map( ( tab ) => (
-					<Tabs.Tab key={ tab.id } tabId={ tab.id }>
-						{ tab.title }
-					</Tabs.Tab>
-				) ) }
-			</Tabs.TabList>
+			<div className="woocommerce-product-tabs__tablist-container">
+				<Tabs.TabList className="woocommerce-product-tabs__tablist">
+					{ tabs.map( ( tab ) => (
+						<Tabs.Tab key={ tab.id } tabId={ tab.id }>
+							{ tab.title }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.TabList>
+			</div>
 			{ tabs.map( ( tab ) => (
 				<Tabs.TabPanel
 					key={ tab.id }

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { createElement, useMemo } from '@wordpress/element';
+import { Template } from '@wordpress/blocks';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+// @ts-expect-error missing types.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductSection } from '../section';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/edit-site' // The module name must be in the list of allowed, so for now I used the package name of the post editor
+);
+
+const { Tabs } = unlock( componentsPrivateApis );
+
+type ProductSectionProps = {
+	sectionTemplate: Template[];
+	postType: string;
+}; // & Omit< DataFormProps< Product >, 'fields' | 'form' >;
+
+type Tab = {
+	id: string;
+	title: string;
+	children: Template[];
+};
+
+export function ProductTabs( {
+	sectionTemplate,
+	postType,
+}: ProductSectionProps ) {
+	const tabs = useMemo( () => {
+		return sectionTemplate
+			.map( ( template ) => {
+				if ( template[ 0 ] === 'woocommerce/product-tab' ) {
+					return {
+						...template[ 1 ],
+						children: template[ 2 ],
+					};
+				}
+				return null;
+			} )
+			.filter( ( tab ): tab is Tab => !! tab );
+	}, [ sectionTemplate ] );
+
+	return (
+		<Tabs
+			// onNavigate={ selectTabOnNavigate }
+			// onKeyDown={ handleKeyDown }
+			className="woocommerce-product-tabs"
+		>
+			<Tabs.TabList className="woocommerce-product-tabs__tablist">
+				{ tabs.map( ( tab ) => (
+					<Tabs.Tab key={ tab.id } tabId={ tab.id }>
+						{ tab.title }
+					</Tabs.Tab>
+				) ) }
+			</Tabs.TabList>
+			{ tabs.map( ( tab ) => (
+				<Tabs.TabPanel
+					key={ tab.id }
+					tabId={ tab.id }
+					className="woocommerce-product-tabs__tabpanel"
+				>
+					{ tab.children.map( ( child, index ) => {
+						if ( child[ 0 ] === 'woocommerce/product-section' ) {
+							return (
+								<ProductSection
+									key={
+										child[ 1 ]?._templateBlockId || index
+									}
+									postType={ postType }
+									sectionTemplate={ child }
+								/>
+							);
+						}
+						return null;
+					} ) }
+				</Tabs.TabPanel>
+			) ) }
+		</Tabs>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -3,8 +3,6 @@
  */
 import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
-import { DataFormProps } from '@wordpress/dataviews';
-import { Product } from '@woocommerce/data';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 // @ts-expect-error missing types.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -25,7 +23,8 @@ const { Tabs } = unlock( componentsPrivateApis );
 type ProductSectionProps = {
 	sectionTemplate: Template[];
 	postType: string;
-} & Omit< DataFormProps< Product >, 'fields' | 'form' >;
+	productId: number;
+};
 
 type Tab = {
 	id: string;
@@ -36,7 +35,7 @@ type Tab = {
 export function ProductTabs( {
 	sectionTemplate,
 	postType,
-	...dataFormProps
+	productId,
 }: ProductSectionProps ) {
 	const tabs = useMemo( () => {
 		return sectionTemplate
@@ -80,7 +79,7 @@ export function ProductTabs( {
 									}
 									postType={ postType }
 									sectionTemplate={ child }
-									{ ...dataFormProps }
+									productId={ productId }
 								/>
 							);
 						}

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -3,6 +3,8 @@
  */
 import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
+import { DataFormProps } from '@wordpress/dataviews';
+import { Product } from '@woocommerce/data';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 // @ts-expect-error missing types.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -23,7 +25,7 @@ const { Tabs } = unlock( componentsPrivateApis );
 type ProductSectionProps = {
 	sectionTemplate: Template[];
 	postType: string;
-}; // & Omit< DataFormProps< Product >, 'fields' | 'form' >;
+} & Omit< DataFormProps< Product >, 'fields' | 'form' >;
 
 type Tab = {
 	id: string;
@@ -34,6 +36,7 @@ type Tab = {
 export function ProductTabs( {
 	sectionTemplate,
 	postType,
+	...dataFormProps
 }: ProductSectionProps ) {
 	const tabs = useMemo( () => {
 		return sectionTemplate
@@ -77,6 +80,7 @@ export function ProductTabs( {
 									}
 									postType={ postType }
 									sectionTemplate={ child }
+									{ ...dataFormProps }
 								/>
 							);
 						}

--- a/packages/js/product-editor/src/data-form/components/tabs/style.scss
+++ b/packages/js/product-editor/src/data-form/components/tabs/style.scss
@@ -12,3 +12,7 @@
 		margin-right: auto;
 	}
 }
+
+.woocommerce-product-block-editor {
+	padding-top: 0px;
+}

--- a/packages/js/product-editor/src/data-form/components/tabs/style.scss
+++ b/packages/js/product-editor/src/data-form/components/tabs/style.scss
@@ -1,0 +1,10 @@
+.woocommerce-product-tabs {
+	&__tablist {
+		margin: 0 auto;
+	}
+	&__tabpanel {
+		max-width: 650px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+}

--- a/packages/js/product-editor/src/data-form/components/tabs/style.scss
+++ b/packages/js/product-editor/src/data-form/components/tabs/style.scss
@@ -1,4 +1,8 @@
 .woocommerce-product-tabs {
+	&__tablist-container {
+		display: flex;
+		flex-direction: column;
+	}
 	&__tablist {
 		margin: 0 auto;
 	}

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -1,15 +1,17 @@
 /**
  * External dependencies
  */
-import { useMemo } from '@wordpress/element';
+import type { ComponentType } from 'react';
+import { useMemo, createElement } from '@wordpress/element';
 import { Template, TemplateArray } from '@wordpress/blocks';
-import { Field } from '@wordpress/dataviews';
+import { Field, DataFormControlProps } from '@wordpress/dataviews';
 import { Product } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { getProductField } from './fields';
+import { ProductDataFormControlProps } from './fields/types';
 
 /**
  * Get the property key for a field definition
@@ -26,6 +28,8 @@ function getFieldKey( field: Template ): string {
 		attributes.metadata?.bindings?.value?.args?.prop
 	) {
 		return attributes.metadata?.bindings?.value?.args?.prop;
+	} else if ( attributes.property ) {
+		return attributes.property;
 	} else if ( attributes.name ) {
 		return attributes.name;
 	}
@@ -42,6 +46,17 @@ type ColumnGroup = {
 	content: Template;
 };
 
+function addAttributesToEdit(
+	Edit: string | ComponentType< ProductDataFormControlProps >,
+	attributes: Record< string, unknown >
+): string | ComponentType< DataFormControlProps< Product > > {
+	if ( typeof Edit === 'string' ) {
+		return Edit;
+	}
+	return function EditWithAttributes( props ) {
+		return <Edit { ...props } attributes={ attributes } />;
+	};
+}
 /**
  * Hook that transforms field definitions into DataForm compatible field objects,
  * grouping fields that appear before and after column blocks.
@@ -67,7 +82,7 @@ export function useDataFormProductFields(
 		};
 
 		fields.forEach( ( field ) => {
-			const [ fieldName ] = field;
+			const [ fieldName, params ] = field;
 
 			// If this is a columns block
 			if ( fieldName === 'core/columns' ) {
@@ -78,10 +93,18 @@ export function useDataFormProductFields(
 				} );
 			} else {
 				// Convert regular field
-				const getFieldDefinition = getProductField( fieldName );
+				const fieldDefinition = getProductField( fieldName );
 				const convertedField: Field< Product > = {
-					...getFieldDefinition,
-					id: getFieldKey( field ),
+					...fieldDefinition,
+					label: params?.label || fieldDefinition?.label,
+					Edit:
+						fieldDefinition?.Edit && params
+							? addAttributesToEdit(
+									fieldDefinition.Edit,
+									params
+							  )
+							: fieldDefinition?.Edit,
+					id: getFieldKey( [ fieldName, params ] ),
 				};
 				currentFields.push( convertedField );
 			}

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { Template, TemplateArray } from '@wordpress/blocks';
+import { Field } from '@wordpress/dataviews';
+import { Product } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { getProductField } from './fields';
+
+/**
+ * Get the property key for a field definition
+ *
+ * @param field - The field definition
+ * @return The key for the field
+ */
+function getFieldKey( field: Template ): string {
+	const attributes = field[ 1 ] || {};
+	// We support the block binding structure.
+	if (
+		attributes.metadata?.bindings?.value?.source ===
+			'woocommerce/entity-product' &&
+		attributes.metadata?.bindings?.value?.args?.prop
+	) {
+		return attributes.metadata?.bindings?.value?.args?.prop;
+	} else if ( attributes.property ) {
+		return attributes.property;
+	}
+	return field[ 0 ];
+}
+
+/**
+ * Hook that transforms field definitions into DataForm compatible field objects.
+ * Each field definition is an array where:
+ * - First item is the field name (matching a block definition)
+ * - Second item is an object with field parameters
+ *
+ * @param fields - Array of field definitions
+ * @return Array of DataForm compatible field objects
+ */
+export function useDataFormProductFields(
+	fields: TemplateArray = []
+): Field< Product >[] {
+	return useMemo( () => {
+		return fields.map( ( [ fieldName, params ] ) => {
+			const getFieldDefinition = getProductField( fieldName );
+			// Convert the field definition to a DataForm field format
+			const field: Field< Product > = {
+				...getFieldDefinition,
+				id: getFieldKey( [ fieldName, params ] ),
+			};
+
+			return field;
+		} );
+	}, [ fields ] );
+}

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -26,8 +26,8 @@ function getFieldKey( field: Template ): string {
 		attributes.metadata?.bindings?.value?.args?.prop
 	) {
 		return attributes.metadata?.bindings?.value?.args?.prop;
-	} else if ( attributes.property ) {
-		return attributes.property;
+	} else if ( attributes.name ) {
+		return attributes.name;
 	}
 	return field[ 0 ];
 }

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -32,28 +32,64 @@ function getFieldKey( field: Template ): string {
 	return field[ 0 ];
 }
 
+type FieldGroup = {
+	type: 'fields';
+	content: Field< Product >[];
+};
+
+type ColumnGroup = {
+	type: 'column';
+	content: Template;
+};
+
 /**
- * Hook that transforms field definitions into DataForm compatible field objects.
- * Each field definition is an array where:
- * - First item is the field name (matching a block definition)
- * - Second item is an object with field parameters
+ * Hook that transforms field definitions into DataForm compatible field objects,
+ * grouping fields that appear before and after column blocks.
  *
  * @param fields - Array of field definitions
- * @return Array of DataForm compatible field objects
+ * @return Array of grouped fields and columns
  */
 export function useDataFormProductFields(
 	fields: TemplateArray = []
-): Field< Product >[] {
+): ( FieldGroup | ColumnGroup )[] {
 	return useMemo( () => {
-		return fields.map( ( [ fieldName, params ] ) => {
-			const getFieldDefinition = getProductField( fieldName );
-			// Convert the field definition to a DataForm field format
-			const field: Field< Product > = {
-				...getFieldDefinition,
-				id: getFieldKey( [ fieldName, params ] ),
-			};
+		const result: ( FieldGroup | ColumnGroup )[] = [];
+		let currentFields: Field< Product >[] = [];
 
-			return field;
+		const flushCurrentFields = () => {
+			if ( currentFields.length > 0 ) {
+				result.push( {
+					type: 'fields',
+					content: currentFields,
+				} );
+				currentFields = [];
+			}
+		};
+
+		fields.forEach( ( field ) => {
+			const [ fieldName ] = field;
+
+			// If this is a columns block
+			if ( fieldName === 'core/columns' ) {
+				flushCurrentFields();
+				result.push( {
+					type: 'column',
+					content: field,
+				} );
+			} else {
+				// Convert regular field
+				const getFieldDefinition = getProductField( fieldName );
+				const convertedField: Field< Product > = {
+					...getFieldDefinition,
+					id: getFieldKey( field ),
+				};
+				currentFields.push( convertedField );
+			}
 		} );
+
+		// Don't forget remaining fields
+		flushCurrentFields();
+
+		return result;
 	}, [ fields ] );
 }

--- a/packages/js/product-editor/src/index.ts
+++ b/packages/js/product-editor/src/index.ts
@@ -5,6 +5,7 @@ import registerProductEditorUiStore from './store/product-editor-ui';
 import registerProductEditorHooks from './wp-hooks';
 
 export * from './components';
+export * from './data-form/components';
 export { DETAILS_SECTION_ID, TAB_GENERAL_ID, TRACKS_SOURCE } from './constants';
 
 /**

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -63,3 +63,6 @@
 @import "hooks/use-draggable/styles.scss";
 
 @import "products.scss";
+
+/* DataForm Styles */
+@import "data-form/components/tabs/style.scss";

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -66,3 +66,4 @@
 
 /* DataForm Styles */
 @import "data-form/components/tabs/style.scss";
+@import "data-form/components/section/style.scss";

--- a/packages/js/product-editor/src/utils/is-product-editor.ts
+++ b/packages/js/product-editor/src/utils/is-product-editor.ts
@@ -7,8 +7,11 @@ export const isProductEditor = () => {
 	const query: { page?: string; path?: string } = getQuery();
 	return (
 		query?.page === 'wc-admin' &&
-		[ '/add-product', '/product/' ].some( ( path ) =>
-			query?.path?.startsWith( path )
-		)
+		[
+			'/add-product',
+			'/product/',
+			'/product-data-forms/',
+			'/add-product-data-forms',
+		].some( ( path ) => query?.path?.startsWith( path ) )
 	);
 };

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -38,6 +38,11 @@ const ProductVariationPage = lazy( () =>
 const ProductPage = lazy( () =>
 	import( /* webpackChunkName: "product-page" */ '../products/product-page' )
 );
+const ProductDataFormsPage = lazy( () =>
+	import(
+		/* webpackChunkName: "product-data-forms-page" */ '../products/product-data-forms-page'
+	)
+);
 const AnalyticsReport = lazy( () =>
 	import( /* webpackChunkName: "analytics-report" */ '../analytics/report' )
 );
@@ -228,6 +233,44 @@ export const getPages = () => {
 			],
 			navArgs: {
 				id: 'woocommerce-edit-product',
+			},
+		} );
+	}
+
+	if (
+		isFeatureEnabled( 'product_block_editor' ) &&
+		window.wcAdminFeatures[ 'product-data-views' ]
+	) {
+		const productPage = {
+			container: ProductDataFormsPage,
+			layout: {
+				header: false,
+			},
+			wpOpenMenu: 'menu-posts-product',
+			capability: 'manage_woocommerce',
+		};
+
+		pages.push( {
+			...productPage,
+			path: '/add-product-data-forms',
+			breadcrumbs: [
+				[ '/add-product-data-forms', __( 'Product', 'woocommerce' ) ],
+				__( 'Add New Product (Data Forms)', 'woocommerce' ),
+			],
+			navArgs: {
+				id: 'woocommerce-add-product-data-forms',
+			},
+		} );
+
+		pages.push( {
+			...productPage,
+			path: '/product-data-forms/:productId',
+			breadcrumbs: [
+				[ '/edit-product-data-forms', __( 'Product', 'woocommerce' ) ],
+				__( 'Edit Product (Data Forms)', 'woocommerce' ),
+			],
+			navArgs: {
+				id: 'woocommerce-edit-product-data-forms',
 			},
 		} );
 	}

--- a/plugins/woocommerce/client/admin/client/products/product-data-forms-page.tsx
+++ b/plugins/woocommerce/client/admin/client/products/product-data-forms-page.tsx
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import {
+	__experimentalDataFormEditor as Editor,
+	__experimentalWooProductMoreMenuItem as WooProductMoreMenuItem,
+	productApiFetchMiddleware,
+	productEditorHeaderApiFetchMiddleware,
+	TRACKS_SOURCE,
+	__experimentalProductMVPCESFooter as FeedbackBar,
+	__experimentalEditorLoadingContext as EditorLoadingContext,
+} from '@woocommerce/product-editor';
+import { Spinner } from '@woocommerce/components';
+import { recordEvent } from '@woocommerce/tracks';
+import { lazy, Suspense, useContext, useEffect } from 'react';
+import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
+import { useParams } from 'react-router-dom';
+import { WooFooterItem } from '@woocommerce/admin-layout';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useProductEntityRecord } from './hooks/use-product-entity-record';
+import { MoreMenuFill } from './fills/product-block-editor-fills';
+import './product-page.scss';
+
+productEditorHeaderApiFetchMiddleware();
+productApiFetchMiddleware();
+
+// Lazy load components
+const BlockEditorTourWrapper = lazy(
+	() => import( './tour/block-editor/block-editor-tour-wrapper' )
+);
+const ProductMVPFeedbackModalContainer = lazy( () =>
+	import( '@woocommerce/product-editor' ).then( ( module ) => ( {
+		default: module.__experimentalProductMVPFeedbackModalContainer,
+	} ) )
+);
+
+export default function ProductPage() {
+	const { productId: productIdSearchParam } = useParams();
+
+	/**
+	 * Only register blocks and unregister them when the product page is being rendered or unmounted.
+	 * Note: Dependency array should stay empty.
+	 */
+	useEffect( () => {
+		document.body.classList.add( 'is-product-editor' );
+
+		return () => {
+			document.body.classList.remove( 'is-product-editor' );
+		};
+	}, [] );
+
+	useEffect( () => {
+		registerPlugin( 'wc-admin-product-editor', {
+			scope: 'woocommerce-product-block-editor',
+			render: () => {
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				const isEditorLoading = useContext( EditorLoadingContext );
+
+				if ( isEditorLoading ) {
+					return null;
+				}
+
+				return (
+					<>
+						<WooProductMoreMenuItem>
+							{ ( { onClose } ) => (
+								<MoreMenuFill onClose={ onClose } />
+							) }
+						</WooProductMoreMenuItem>
+
+						<WooFooterItem>
+							<>
+								<FeedbackBar productType="product" />
+								<Suspense fallback={ <Spinner /> }>
+									<ProductMVPFeedbackModalContainer
+										productId={
+											productIdSearchParam
+												? Number.parseInt(
+														productIdSearchParam,
+														10
+												  )
+												: undefined
+										}
+									/>
+								</Suspense>
+							</>
+						</WooFooterItem>
+
+						<Suspense fallback={ <Spinner /> }>
+							<BlockEditorTourWrapper />
+						</Suspense>
+					</>
+				);
+			},
+		} );
+
+		return () => {
+			unregisterPlugin( 'wc-admin-product-editor' );
+		};
+	}, [ productIdSearchParam ] );
+
+	useEffect(
+		function trackViewEvents() {
+			if ( productIdSearchParam ) {
+				recordEvent( 'product_edit_view', {
+					source: TRACKS_SOURCE,
+					product_id: productIdSearchParam,
+				} );
+			} else {
+				recordEvent( 'product_add_view', {
+					source: TRACKS_SOURCE,
+				} );
+			}
+		},
+		[ productIdSearchParam ]
+	);
+
+	const productId = useProductEntityRecord( productIdSearchParam );
+
+	if ( ! productId ) {
+		return (
+			<div className="woocommerce-layout__loading">
+				<Spinner
+					aria-label={ __( 'Creating the product', 'woocommerce' ) }
+				/>
+			</div>
+		);
+	}
+
+	return <Editor productId={ productId } />;
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
@@ -103,11 +103,19 @@ class Init {
 	 * Replaces the default posts menu item with the new posts dashboard.
 	 */
 	public function woocommerce_add_new_products_dashboard() {
-		$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-		if ( ! $gutenberg_experiments ) {
-			return;
-		}
 		$ptype_obj = get_post_type_object( 'product' );
+		global $submenu;
+		$permalink = 'admin.php?page=wc-admin&path=/add-product-data-forms';
+		array_splice(
+			$submenu['edit.php?post_type=product'],
+			2,
+			0,
+			array(
+				array( 'Add new product ( data forms )', 'manage_options', $permalink )
+			)
+		);
+
+		// Adds the dataviews product page.
 		add_submenu_page(
 			'edit.php?post_type=product',
 			$ptype_obj->labels->name,

--- a/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductDataViews/Init.php
@@ -111,7 +111,7 @@ class Init {
 			2,
 			0,
 			array(
-				array( 'Add new product ( data forms )', 'manage_options', $permalink )
+				array( 'Add new product ( data forms )', 'manage_options', $permalink ),
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is the base PR we can use for the POC for using DataForm's to render the new product editor.
Some of the initial setup is based off of this PR that I created late last year: https://github.com/woocommerce/woocommerce/pull/53504

Tasks:

- [x] @louwie17  Create new route and page for rendering the form using DataForms
- [x] @louwie17 Set up the initial DataForm rendering passing the product data down and the `onChange` method ( with a single text field )
- [x] @louwie17 Create re-usable hook that generates the DataForm field definition from a passed in template array ( which has the format of: `[ [ field/block name, { ... custom attributes }, [ nested fields ] ]`. We shouldn't need to worry about the third param. For most of the cases we will have to include the `Edit` function, which we can use the registered blocks `Edit` function for. ( see the current hardcoded definition: https://github.com/woocommerce/woocommerce/blob/ddc17e48567dba2603ea289857639a13a6cf706f/packages/js/product-editor/src/data-form/components/section/index.tsx#L29-L35 
- [x] Migrate the name field over
- [x] Migrate the regular and sale price over
- [x] Migrate the summary field over ( note the block toolbar here )
- [ ] Migrate the Description field over and the full editor
- [ ] Integrate the current validation, and/or use something similar as done here: https://github.com/Automattic/wp-calypso/pull/100771 
- [x] Hook up the save/update buttons to allow for saving
- [ ] Migrate Images over
- [ ] ..... Continue migrating each remaining field

### Screenshots or screen recordings:

<img width="1512" alt="Screenshot 2025-03-25 at 21 03 26" src="https://github.com/user-attachments/assets/78e3d8c0-fc9c-48c1-8f24-86e4f12cc06e" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta Tester plugin and go to **Tools > WCA Test Helper > Features** and enable **product-data-views**
3. Refresh the page, it should now show a new menu item under **Products** called **Add new product ( data forms )**

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
