### PR TITLE
Fix between ranges in Advanced Filters for the Customers view

### DIFF
--- a/packages/js/components/changelog/56683-fix-34316-between-range-for-advanced-filters
+++ b/packages/js/components/changelog/56683-fix-34316-between-range-for-advanced-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix between ranges in Advanced Filters for the Customers view.

--- a/packages/js/components/src/advanced-filters/number-filter.js
+++ b/packages/js/components/src/advanced-filters/number-filter.js
@@ -168,14 +168,14 @@ class NumberFilter extends Component {
 		const rangeStartOnChange = ( newRangeStart ) => {
 			onFilterChange( {
 				property: 'value',
-				key: [ newRangeStart, rangeEnd ],
+				value: [ newRangeStart, rangeEnd ],
 			} );
 		};
 
 		const rangeEndOnChange = ( newRangeEnd ) => {
 			onFilterChange( {
 				property: 'value',
-				key: [ rangeStart, newRangeEnd ],
+				value: [ rangeStart, newRangeEnd ],
 			} );
 		};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a bug when using a filter with a between range on the WooCommerce > Customers page. Previously it was unable to update the values, as it was updating the `key` instead of the `value`.

This change comes from the PR https://github.com/woocommerce/woocommerce-admin/pull/8459
When calling `onFilterChange` for between ranges it was accidentally refactored to setting the `key`, updating this to `value` allows the values to be updated and the filter to be used.

Closes #34316 

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce-admin/pull/8459

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this PR and build the necessary packages: https://github.com/woocommerce/woocommerce/tree/trunk/packages/js#working-with-existing-packages
2. Generate multiple orders including customers using the [Smooth Generator plugin](https://github.com/woocommerce/wc-smooth-generator)
3. Go to WooCommerce > Customers and select "Advanced Filters"
4. Add some filters with between ranges (No. Orders, Total Spend)
5. Confirm that we are able to enter values for the input fields
6. Filter the customers and confirm we get results within the right ranges

![image](https://github.com/user-attachments/assets/bb8b45c7-cceb-4cee-80c0-e1bb83006c67)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix between ranges in Advanced Filters for the Customers view.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
