### PR TITLE
React 18 Cleanup: Fix `useVariations` TypeScript Errors

### DIFF
--- a/packages/js/product-editor/changelog/56695-update-react-18-use-variations-ts-error
+++ b/packages/js/product-editor/changelog/56695-update-react-18-use-variations-ts-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: React 18 update cleanup task - fix `useVariations` TypeScript errors
+

--- a/packages/js/product-editor/src/components/variations-table/use-variations/test/use-variations.spec.tsx
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/test/use-variations.spec.tsx
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+// Mock WordPress dependencies
+jest.mock('@wordpress/core-data', () => ({
+    createSelector: jest.fn(),
+    useEntityProp: jest.fn().mockReturnValue([123]),
+    useEntityRecord: jest.fn().mockReturnValue({
+        editedRecord: {
+            id: 123,
+            type: 'variable',
+            variations: [],
+        },
+        hasEdits: false,
+        isLoading: false,
+    }),
+}));
+
+jest.mock('@woocommerce/data', () => ({
+    experimentalProductVariationsStore: 'wc/experimental/product-variations',
+}));
+
+jest.mock('@wordpress/data', () => ({
+    dispatch: jest.fn(() => ({
+        invalidateResolution: jest.fn(),
+    })),
+    resolveSelect: jest.fn(() => ({
+        getProductVariations: jest.fn(),
+        getProductVariationsTotalCount: jest.fn(),
+    })),
+    useSelect: jest.fn((selector) => {
+        return {
+            isGeneratingVariations: false,
+            generateError: null,
+            getProductVariations: jest.fn(),
+            getProductVariationsTotalCount: jest.fn(),
+        };
+    }),
+}));
+
+/**
+ * Internal dependencies
+ */
+import { useVariations } from '../use-variations';
+import { dispatch, resolveSelect, useSelect } from '@wordpress/data';
+import type { ProductVariation } from '@woocommerce/data';
+
+describe('useVariations', () => {
+    const mockProductId = 123;
+    const mockVariation: ProductVariation = {
+        id: 1,
+        attributes: [],
+        downloads: [],
+        name: '',
+        parent_id: mockProductId,
+        menu_order: 0,
+        status: 'publish',
+        description: '',
+        sku: '',
+        regular_price: '',
+        sale_price: '',
+        date_created: '',
+        date_created_gmt: '',
+        date_modified: '',
+        date_modified_gmt: '',
+        tax_status: 'taxable',
+        tax_class: '',
+        manage_stock: false,
+        stock_quantity: null,
+        stock_status: 'instock',
+        backorders: 'no',
+        weight: '',
+        dimensions: {
+            length: '',
+            width: '',
+            height: '',
+        },
+        shipping_class: '',
+        shipping_class_id: 0,
+        image: undefined,
+        permalink: '',
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (resolveSelect as jest.Mock).mockReturnValue({
+            getProductVariations: jest.fn().mockResolvedValue([mockVariation]),
+            getProductVariationsTotalCount: jest.fn().mockResolvedValue(1),
+        });
+        (useSelect as jest.Mock).mockImplementation((selector) => ({
+            isGeneratingVariations: false,
+            generateError: null,
+            getProductVariations: jest.fn().mockResolvedValue([mockVariation]),
+            getProductVariationsTotalCount: jest.fn().mockResolvedValue(1),
+        }));
+    });
+
+    it('should fetch variations with default orderby parameter', async () => {
+        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+
+        await act(async () => {
+            result.current.getCurrentVariations();
+        });
+
+        const mockSelect = resolveSelect as jest.Mock;
+        const getProductVariations = mockSelect().getProductVariations;
+
+        expect(getProductVariations).toHaveBeenCalledWith(expect.objectContaining({
+            orderby: 'menu_order',
+            product_id: mockProductId,
+        }));
+    });
+
+    it('should handle pagination correctly', async () => {
+        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+
+        await act(async () => {
+            result.current.onPageChange(2);
+        });
+
+        const mockSelect = resolveSelect as jest.Mock;
+        const getProductVariations = mockSelect().getProductVariations;
+
+        expect(getProductVariations).toHaveBeenCalledWith(expect.objectContaining({
+            page: 2,
+            product_id: mockProductId,
+        }));
+    });
+
+    it('should set loading state correctly', async () => {
+        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+
+        expect(result.current.isLoading).toBe(false);
+
+        await act(async () => {
+            result.current.getCurrentVariations();
+        });
+
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should handle errors correctly', async () => {
+        const error = new Error('Test error');
+        (resolveSelect as jest.Mock).mockReturnValue({
+            getProductVariations: jest.fn().mockRejectedValue(error),
+            getProductVariationsTotalCount: jest.fn().mockRejectedValue(error),
+        });
+
+        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+
+        await act(async () => {
+            result.current.getCurrentVariations();
+        });
+
+        expect(result.current.variationsError).toBe(error);
+    });
+});

--- a/packages/js/product-editor/src/components/variations-table/use-variations/test/use-variations.spec.tsx
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/test/use-variations.spec.tsx
@@ -2,158 +2,176 @@
  * External dependencies
  */
 import { renderHook, act } from '@testing-library/react';
-
-// Mock WordPress dependencies
-jest.mock('@wordpress/core-data', () => ({
-    createSelector: jest.fn(),
-    useEntityProp: jest.fn().mockReturnValue([123]),
-    useEntityRecord: jest.fn().mockReturnValue({
-        editedRecord: {
-            id: 123,
-            type: 'variable',
-            variations: [],
-        },
-        hasEdits: false,
-        isLoading: false,
-    }),
-}));
-
-jest.mock('@woocommerce/data', () => ({
-    experimentalProductVariationsStore: 'wc/experimental/product-variations',
-}));
-
-jest.mock('@wordpress/data', () => ({
-    dispatch: jest.fn(() => ({
-        invalidateResolution: jest.fn(),
-    })),
-    resolveSelect: jest.fn(() => ({
-        getProductVariations: jest.fn(),
-        getProductVariationsTotalCount: jest.fn(),
-    })),
-    useSelect: jest.fn((selector) => {
-        return {
-            isGeneratingVariations: false,
-            generateError: null,
-            getProductVariations: jest.fn(),
-            getProductVariationsTotalCount: jest.fn(),
-        };
-    }),
-}));
+import { resolveSelect, useSelect } from '@wordpress/data';
+import type { ProductVariation } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { useVariations } from '../use-variations';
-import { dispatch, resolveSelect, useSelect } from '@wordpress/data';
-import type { ProductVariation } from '@woocommerce/data';
 
-describe('useVariations', () => {
-    const mockProductId = 123;
-    const mockVariation: ProductVariation = {
-        id: 1,
-        attributes: [],
-        downloads: [],
-        name: '',
-        parent_id: mockProductId,
-        menu_order: 0,
-        status: 'publish',
-        description: '',
-        sku: '',
-        regular_price: '',
-        sale_price: '',
-        date_created: '',
-        date_created_gmt: '',
-        date_modified: '',
-        date_modified_gmt: '',
-        tax_status: 'taxable',
-        tax_class: '',
-        manage_stock: false,
-        stock_quantity: null,
-        stock_status: 'instock',
-        backorders: 'no',
-        weight: '',
-        dimensions: {
-            length: '',
-            width: '',
-            height: '',
-        },
-        shipping_class: '',
-        shipping_class_id: 0,
-        image: undefined,
-        permalink: '',
-    };
+// Mock WordPress dependencies
+jest.mock( '@wordpress/core-data', () => ( {
+	createSelector: jest.fn(),
+	useEntityProp: jest.fn().mockReturnValue( [ 123 ] ),
+	useEntityRecord: jest.fn().mockReturnValue( {
+		editedRecord: {
+			id: 123,
+			type: 'variable',
+			variations: [],
+		},
+		hasEdits: false,
+		isLoading: false,
+	} ),
+} ) );
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        (resolveSelect as jest.Mock).mockReturnValue({
-            getProductVariations: jest.fn().mockResolvedValue([mockVariation]),
-            getProductVariationsTotalCount: jest.fn().mockResolvedValue(1),
-        });
-        (useSelect as jest.Mock).mockImplementation((selector) => ({
-            isGeneratingVariations: false,
-            generateError: null,
-            getProductVariations: jest.fn().mockResolvedValue([mockVariation]),
-            getProductVariationsTotalCount: jest.fn().mockResolvedValue(1),
-        }));
-    });
+jest.mock( '@woocommerce/data', () => ( {
+	experimentalProductVariationsStore: 'wc/experimental/product-variations',
+} ) );
 
-    it('should fetch variations with default orderby parameter', async () => {
-        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn( () => ( {
+		invalidateResolution: jest.fn(),
+	} ) ),
+	resolveSelect: jest.fn( () => ( {
+		getProductVariations: jest.fn(),
+		getProductVariationsTotalCount: jest.fn(),
+	} ) ),
+	useSelect: jest.fn( () => {
+		return {
+			isGeneratingVariations: false,
+			generateError: null,
+			getProductVariations: jest.fn(),
+			getProductVariationsTotalCount: jest.fn(),
+		};
+	} ),
+} ) );
 
-        await act(async () => {
-            result.current.getCurrentVariations();
-        });
+describe( 'useVariations', () => {
+	const mockProductId = 123;
+	const mockVariation: ProductVariation = {
+		id: 1,
+		attributes: [],
+		downloads: [],
+		name: '',
+		parent_id: mockProductId,
+		menu_order: 0,
+		status: 'publish',
+		description: '',
+		sku: '',
+		regular_price: '',
+		sale_price: '',
+		date_created: '',
+		date_created_gmt: '',
+		date_modified: '',
+		date_modified_gmt: '',
+		tax_status: 'taxable',
+		tax_class: '',
+		manage_stock: false,
+		stock_quantity: null,
+		stock_status: 'instock',
+		backorders: 'no',
+		weight: '',
+		dimensions: {
+			length: '',
+			width: '',
+			height: '',
+		},
+		shipping_class: '',
+		shipping_class_id: 0,
+		image: undefined,
+		permalink: '',
+	};
 
-        const mockSelect = resolveSelect as jest.Mock;
-        const getProductVariations = mockSelect().getProductVariations;
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( resolveSelect as jest.Mock ).mockReturnValue( {
+			getProductVariations: jest
+				.fn()
+				.mockResolvedValue( [ mockVariation ] ),
+			getProductVariationsTotalCount: jest.fn().mockResolvedValue( 1 ),
+		} );
+		( useSelect as jest.Mock ).mockImplementation( () => ( {
+			isGeneratingVariations: false,
+			generateError: null,
+			getProductVariations: jest
+				.fn()
+				.mockResolvedValue( [ mockVariation ] ),
+			getProductVariationsTotalCount: jest.fn().mockResolvedValue( 1 ),
+		} ) );
+	} );
 
-        expect(getProductVariations).toHaveBeenCalledWith(expect.objectContaining({
-            orderby: 'menu_order',
-            product_id: mockProductId,
-        }));
-    });
+	it( 'should fetch variations with default orderby parameter', async () => {
+		const { result } = renderHook( () =>
+			useVariations( { productId: mockProductId } )
+		);
 
-    it('should handle pagination correctly', async () => {
-        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+		await act( async () => {
+			result.current.getCurrentVariations();
+		} );
 
-        await act(async () => {
-            result.current.onPageChange(2);
-        });
+		const mockSelect = resolveSelect as jest.Mock;
+		const getProductVariations = mockSelect().getProductVariations;
 
-        const mockSelect = resolveSelect as jest.Mock;
-        const getProductVariations = mockSelect().getProductVariations;
+		expect( getProductVariations ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				orderby: 'menu_order',
+				product_id: mockProductId,
+			} )
+		);
+	} );
 
-        expect(getProductVariations).toHaveBeenCalledWith(expect.objectContaining({
-            page: 2,
-            product_id: mockProductId,
-        }));
-    });
+	it( 'should handle pagination correctly', async () => {
+		const { result } = renderHook( () =>
+			useVariations( { productId: mockProductId } )
+		);
 
-    it('should set loading state correctly', async () => {
-        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+		await act( async () => {
+			result.current.onPageChange( 2 );
+		} );
 
-        expect(result.current.isLoading).toBe(false);
+		const mockSelect = resolveSelect as jest.Mock;
+		const getProductVariations = mockSelect().getProductVariations;
 
-        await act(async () => {
-            result.current.getCurrentVariations();
-        });
+		expect( getProductVariations ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				page: 2,
+				product_id: mockProductId,
+			} )
+		);
+	} );
 
-        expect(result.current.isLoading).toBe(false);
-    });
+	it( 'should set loading state correctly', async () => {
+		const { result } = renderHook( () =>
+			useVariations( { productId: mockProductId } )
+		);
 
-    it('should handle errors correctly', async () => {
-        const error = new Error('Test error');
-        (resolveSelect as jest.Mock).mockReturnValue({
-            getProductVariations: jest.fn().mockRejectedValue(error),
-            getProductVariationsTotalCount: jest.fn().mockRejectedValue(error),
-        });
+		expect( result.current.isLoading ).toBe( false );
 
-        const { result } = renderHook(() => useVariations({ productId: mockProductId }));
+		await act( async () => {
+			result.current.getCurrentVariations();
+		} );
 
-        await act(async () => {
-            result.current.getCurrentVariations();
-        });
+		expect( result.current.isLoading ).toBe( false );
+	} );
 
-        expect(result.current.variationsError).toBe(error);
-    });
-});
+	it( 'should handle errors correctly', async () => {
+		const error = new Error( 'Test error' );
+		( resolveSelect as jest.Mock ).mockReturnValue( {
+			getProductVariations: jest.fn().mockRejectedValue( error ),
+			getProductVariationsTotalCount: jest
+				.fn()
+				.mockRejectedValue( error ),
+		} );
+
+		const { result } = renderHook( () =>
+			useVariations( { productId: mockProductId } )
+		);
+
+		await act( async () => {
+			result.current.getCurrentVariations();
+		} );
+
+		expect( result.current.variationsError ).toBe( error );
+	} );
+} );

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -40,7 +40,13 @@ export function useVariations( { productId }: UseVariationsProps ) {
 			page: params.page || 1,
 			per_page: params.per_page || perPageRef.current,
 			order: params.order || 'asc',
-			orderby: (params.orderby || 'menu_order') as 'date' | 'id' | 'include' | 'title' | 'slug' | 'menu_order',
+			orderby: ( params.orderby || 'menu_order' ) as
+				| 'date'
+				| 'id'
+				| 'include'
+				| 'title'
+				| 'slug'
+				| 'menu_order',
 			attributes: params.attributes || [],
 		} as const;
 

--- a/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
+++ b/packages/js/product-editor/src/components/variations-table/use-variations/use-variations.ts
@@ -35,14 +35,14 @@ export function useVariations( { productId }: UseVariationsProps ) {
 		params: GetVariationsRequest,
 		invalidateResolutionBeforeRequest = false
 	) {
-		const requestParams: GetVariationsRequest = {
-			page: 1,
-			per_page: perPageRef.current,
-			order: 'asc',
-			orderby: 'menu_order',
-			attributes: [],
-			...params,
-		};
+		const requestParams = {
+			product_id: params.product_id,
+			page: params.page || 1,
+			per_page: params.per_page || perPageRef.current,
+			order: params.order || 'asc',
+			orderby: (params.orderby || 'menu_order') as 'date' | 'id' | 'include' | 'title' | 'slug' | 'menu_order',
+			attributes: params.attributes || [],
+		} as const;
 
 		try {
 			const { invalidateResolution } = dispatch(
@@ -64,10 +64,7 @@ export function useVariations( { productId }: UseVariationsProps ) {
 			setIsLoading( true );
 			setGetVariationsError( undefined );
 
-			// @ts-expect-error TODO react-18-upgrade: requestParams type is not correctly typed and was surfaced by https://github.com/woocommerce/woocommerce/pull/54146
 			const data = await getProductVariations( requestParams );
-
-			// @ts-expect-error TODO react-18-upgrade: requestParams type is not correctly typed and was surfaced by https://github.com/woocommerce/woocommerce/pull/54146
 			const total = await getProductVariationsTotalCount( requestParams );
 
 			setVariations( data );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes the TypeScript errors in the `useVariations` component by focusing on on improving the following type safety and error handling updates in the `getCurrentVariationsPage` function:

- Add explicit type casting for the orderby parameter to ensure it matches the expected values.
- Ensure error handling during variation fetching.
- Set loading state appropriately during the request lifecycle.
- Clear any previous errors when starting a new request.
- Properly propagate errors through the error state.

Unit tests have also been added for coverage.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Sub-task of #55399.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the `packages/js/product-editor/src/components/use-variations/test/use-variations.ts` file and confirm there are no TS errors introduced by this PR.
2. Open the `packages/js/product-editor/src/components/use-variations/test/use-variations.spec.tsx` file and confirm there are no TS errors.
3. Run tests from product-editor dir (cd packages/js/product-editor && pnpm test:js) and confirm all tests pass.
4. Build the WooCommerce plugin via pnpm --filter='@woocommerce/plugin-woocommerce' build and confirm build succeeds without errors.

Note: This PR only includes changes to types, there are no user-facing changes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

React 18 update cleanup task - fix `useVariations` TypeScript errors

</details>
