### PR TITLE
Reset analytics settings at setup in `analytics-data.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-reset-analytics-settings-to-default-at-setup
+++ b/plugins/woocommerce/changelog/dev-e2e-reset-analytics-settings-to-default-at-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Reset analytics settings to defaults as a setup step in analytics-data.spec.js.

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -165,18 +165,22 @@ test.beforeAll( async ( { browser, restApi } ) => {
 		} );
 
 	// Reset Analytics Settings to their default values.
-	// Setting options can be found at plugins/woocommerce/src/Internal/Admin/Settings.php.
-	await wcAdminApi.post( 'options', {
-		woocommerce_excluded_report_order_statuses: [
-			'pending',
-			'cancelled',
-			'failed',
-		],
-	} );
-	await wcAdminApi.post( 'options', {
+	await wcAdminApi
+		.put( 'options', {
+			woocommerce_excluded_report_order_statuses: [
+				'pending',
+				'cancelled',
+				'failed',
+			],
+		} )
+		.then( ( response ) => {
+			console.log( response );
+		} )
+		.catch( ( error ) => console.log( error ) );
+	await wcAdminApi.put( 'options', {
 		woocommerce_actionable_order_statuses: [ 'processing', 'on-hold' ],
 	} );
-	await wcAdminApi.post( 'options', {
+	await wcAdminApi.put( 'options', {
 		woocommerce_default_date_range: 'period=month&compare=previous_year',
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -4,6 +4,7 @@
 import { expect, tags, test as baseTest } from '../../fixtures/fixtures';
 import { WC_ADMIN_API_PATH, WC_API_PATH } from '../../utils/api-client';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+import { describe } from 'node:test';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -165,24 +166,31 @@ test.beforeAll( async ( { browser, restApi } ) => {
 		} );
 
 	// Reset Analytics Settings to their default values.
-	await wcAdminApi
-		.put( 'options', {
-			woocommerce_excluded_report_order_statuses: [
-				'pending',
-				'cancelled',
-				'failed',
-			],
-		} )
-		.then( ( response ) => {
-			console.log( response );
-		} )
-		.catch( ( error ) => console.log( error ) );
-	await wcAdminApi.put( 'options', {
-		woocommerce_actionable_order_statuses: [ 'processing', 'on-hold' ],
-	} );
-	await wcAdminApi.put( 'options', {
-		woocommerce_default_date_range: 'period=month&compare=previous_year',
-	} );
+	await restApi
+		.post(
+			'wc-analytics/settings/wc_admins/woocommerce_excluded_report_order_statuses',
+			{
+				value: [ 'pending', 'cancelled', 'failed' ],
+			}
+		)
+		.catch( ( error ) => {
+			console.log( 'Caught' );
+			throw new Error(
+				`Something went wrong when resetting 'Excluded statuses' to default values.\n${ JSON.stringify(
+					error,
+					null,
+					2
+				) }`
+			);
+		} );
+
+	// TODO implement the same strategy as above.
+	// await wcAdminApi.put( 'options', {
+	// 	woocommerce_actionable_order_statuses: [ 'processing', 'on-hold' ],
+	// } );
+	// await wcAdminApi.put( 'options', {
+	// 	woocommerce_default_date_range: 'period=month&compare=previous_year',
+	// } );
 
 	// process the Action Scheduler tasks
 	setupPage = await browser.newPage();
@@ -641,6 +649,7 @@ test(
 	}
 );
 
+// TODO remove .only()
 test.only(
 	'analytics settings',
 	{

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -4,7 +4,6 @@
 import { expect, tags, test as baseTest } from '../../fixtures/fixtures';
 import { WC_ADMIN_API_PATH, WC_API_PATH } from '../../utils/api-client';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
-import { describe } from 'node:test';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -166,16 +165,24 @@ test.beforeAll( async ( { browser, restApi } ) => {
 		} );
 
 	// Reset Analytics Settings to their default values.
+	// Reset 'Excluded statuses' to default values.
 	await restApi
 		.post(
-			'wc-analytics/settings/wc_admins/woocommerce_excluded_report_order_statuses',
+			'wc-analytics/settings/wc_admin/woocommerce_excluded_report_order_statuses',
 			{
 				value: [ 'pending', 'cancelled', 'failed' ],
 			}
 		)
+		.then( ( response ) => {
+			expect( response.data.value ).toEqual( [
+				'pending',
+				'cancelled',
+				'failed',
+			] );
+		} )
 		.catch( ( error ) => {
 			throw new Error(
-				`Something went wrong when resetting 'Excluded statuses' to default values.\n${ JSON.stringify(
+				`Error occurred while resetting 'Excluded statuses' to defaults.\n${ JSON.stringify(
 					error,
 					null,
 					2
@@ -183,13 +190,53 @@ test.beforeAll( async ( { browser, restApi } ) => {
 			);
 		} );
 
-	// TODO implement the same strategy as above.
-	// await wcAdminApi.put( 'options', {
-	// 	woocommerce_actionable_order_statuses: [ 'processing', 'on-hold' ],
-	// } );
-	// await wcAdminApi.put( 'options', {
-	// 	woocommerce_default_date_range: 'period=month&compare=previous_year',
-	// } );
+	// Reset 'Actionable statuses' to default values.
+	await restApi
+		.post(
+			'wc-analytics/settings/wc_admin/woocommerce_actionable_order_statuses',
+			{
+				value: [ 'processing', 'on-hold' ],
+			}
+		)
+		.then( ( response ) => {
+			expect( response.data.value ).toEqual( [
+				'processing',
+				'on-hold',
+			] );
+		} )
+		.catch( ( error ) => {
+			throw new Error(
+				`Error occurred while resetting 'Actionable statuses' to defaults.\n${ JSON.stringify(
+					error,
+					null,
+					2
+				) }`
+			);
+		} );
+
+	// Reset 'Default date range' to default values.
+	await restApi
+		.post(
+			'wc-analytics/settings/wc_admin/woocommerce_default_date_range',
+			{
+				value: 'period=month&compare=previous_year',
+			}
+		)
+		.then( ( response ) => {
+			// '&' is encoded as '&amp;' in the response.
+			expect( response.data.value ).toEqual(
+				'period=month&amp;compare=previous_year'
+			);
+		} )
+		.catch( ( error ) => {
+			throw new Error(
+				`Error occurred while resetting 'Default date range' to defaults.\n${ JSON.stringify(
+					error,
+					null,
+					2
+				) }`
+			);
+		} );
 
 	// process the Action Scheduler tasks
 	setupPage = await browser.newPage();
@@ -648,8 +695,7 @@ test(
 	}
 );
 
-// TODO remove .only()
-test.only(
+test(
 	'analytics settings',
 	{
 		tag: [ tags.PAYMENTS, tags.SERVICES ],

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -174,7 +174,6 @@ test.beforeAll( async ( { browser, restApi } ) => {
 			}
 		)
 		.catch( ( error ) => {
-			console.log( 'Caught' );
 			throw new Error(
 				`Something went wrong when resetting 'Excluded statuses' to default values.\n${ JSON.stringify(
 					error,

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -164,6 +164,22 @@ test.beforeAll( async ( { browser, restApi } ) => {
 			orderIds = response.data.create.map( ( order ) => order.id );
 		} );
 
+	// Reset Analytics Settings to their default values.
+	// Setting options can be found at plugins/woocommerce/src/Internal/Admin/Settings.php.
+	await wcAdminApi.post( 'options', {
+		woocommerce_excluded_report_order_statuses: [
+			'pending',
+			'cancelled',
+			'failed',
+		],
+	} );
+	await wcAdminApi.post( 'options', {
+		woocommerce_actionable_order_statuses: [ 'processing', 'on-hold' ],
+	} );
+	await wcAdminApi.post( 'options', {
+		woocommerce_default_date_range: 'period=month&compare=previous_year',
+	} );
+
 	// process the Action Scheduler tasks
 	setupPage = await browser.newPage();
 	// eslint-disable-next-line playwright/no-wait-for-timeout

--- a/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js
@@ -621,7 +621,7 @@ test(
 	}
 );
 
-test(
+test.only(
 	'analytics settings',
 	{
 		tag: [ tags.PAYMENTS, tags.SERVICES ],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes `analytics-data.spec.js`, particularly the `analytics settings` test, more stable on external environments by resetting the analytics settings during test setup. One reason why this test is failing on external environments is because the Analytics > Settings page is sometimes left with non-default values, resulting to Playwright not being able to locate objects that have default values (such as the Default Date Range setting) and failing assertions.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Log in to our Pressable and WPCOM test sites.
2. Go to their Analytics > Settings pages.
3. The image below shows the defaults of the three Analytics settings touched by the test. In the Pressable & WPCOM test sites, check and uncheck values such that they don't match the defaults anymore. Easiest way would be to uncheck all the options.
    <img width="800" alt="Screenshot 2025-03-26 at 2 30 52 PM" src="https://github.com/user-attachments/assets/25c1e07d-ef9a-4ac9-9cd6-e12cef3e1589" />
4. Run the following test against our Pressable and WPCOM test sites, and make sure they both pass:
    ```bash
    # Set the E2E_ENV_KEY
    pnpm test:e2e:pressable analytics-data.spec.js -g 'analytics settings'
    pnpm test:e2e:wpcom analytics-data.spec.js -g 'analytics settings'
    ```
    Without this fix, they would fail.

<!-- End testing instructions -->

### Testing that has already taken place:

Ran the entire `analytics-data.spec.js` file (not just the 'analytics settings' test) against the following environments:
- localhost (wp-env) with WP 6.7
- localhost (wp-env) with WP 6.8-RC1 (installed the WP version by setting `core` to the download url of WP 6.8 RC1) 
- Pressable site
- WPCOM site

Tested the error reporting of the API requests I added by:
- Changing [this](https://github.com/woocommerce/woocommerce/blob/638abf7d11ca8fcca4df98d9370f5d4baf79c83f/plugins/woocommerce/tests/e2e-pw/tests/analytics/analytics-data.spec.js#L171) request URL to get a 404 error and see if the Playwright HTML report could display an understandable error message. It didn't at first, but it did when I added a catch block to make the error message more readable and easier to point to the failing step.


<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
