### PR TITLE
Re-enable Blueprint feature UI in features settings page and enable the feature by default

### DIFF
--- a/plugins/woocommerce/changelog/enable-blueprint-feature-ui
+++ b/plugins/woocommerce/changelog/enable-blueprint-feature-ui
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Dev - Re-enable Blueprint feature UI in features settings page. 
+Dev - Re-enable Blueprint feature UI in features settings page and make it enabled by default. 

--- a/plugins/woocommerce/changelog/enable-blueprint-feature-ui
+++ b/plugins/woocommerce/changelog/enable-blueprint-feature-ui
@@ -1,0 +1,1 @@
+Dev - Re-enable Blueprint feature UI in features settings page. 

--- a/plugins/woocommerce/changelog/enable-blueprint-feature-ui
+++ b/plugins/woocommerce/changelog/enable-blueprint-feature-ui
@@ -1,1 +1,4 @@
+Significance: patch
+Type: fix
+
 Dev - Re-enable Blueprint feature UI in features settings page. 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -379,7 +379,7 @@ class FeaturesController {
 						'Enable blueprint to import and export settings in bulk',
 						'woocommerce'
 					),
-					'enabled_by_default' => false,
+					'enabled_by_default' => true,
 					'disable_ui'         => false,
 
 					/*

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -380,7 +380,7 @@ class FeaturesController {
 						'woocommerce'
 					),
 					'enabled_by_default' => false,
-					'disable_ui'         => true,
+					'disable_ui'         => false,
 
 					/*
 					* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This reverts the temporary changes from #56545 to re-enable the Blueprint feature UI in the features settings page.
We're also enabling the Blueprints feature by default for WC 9.9

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->
| Before | After |
| ------ | ----- |
|  <img width="789" alt="image" src="https://github.com/user-attachments/assets/2410784a-60fd-45e7-acfc-b5cfa6f3f1b8" />| 
![image](https://github.com/user-attachments/assets/ded80725-b36d-4ae3-a0e7-56895c58c672)
![image](https://github.com/user-attachments/assets/563eabaa-2def-4d9b-8a7e-53d90a688ffb)

  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Advanced > Features
2. In the list of features, ensure `Blueprint (beta)` is listed and enabled by default


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
