### PR TITLE
Fix: Add a default spacing to Clear filters button

### DIFF
--- a/plugins/woocommerce/changelog/2025-03-26-09-22-44-369528
+++ b/plugins/woocommerce/changelog/2025-03-26-09-22-44-369528
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a default fallback spacing to the clear fillter button to ensure its style looks good on every theme.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/edit.tsx
@@ -16,13 +16,6 @@ const Edit = () => {
 						type: 'flex',
 						verticalAlignment: 'stretched',
 					},
-					style: {
-						spacing: {
-							margin: {
-								top: 'var:preset|spacing|10',
-							},
-						},
-					},
 				},
 				[
 					[

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/index.tsx
@@ -10,6 +10,7 @@ import { button as icon } from '@wordpress/icons';
 import metadata from './block.json';
 import Edit from './edit';
 import save from './save';
+import './style.scss';
 
 registerBlockType( metadata, {
 	icon,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/clear-button/style.scss
@@ -1,0 +1,5 @@
+.wp-block-woocommerce-product-filter-clear-button {
+	:where(.wp-block-buttons) {
+		margin-top: 1rem;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
@@ -17,15 +17,6 @@ final class ProductFilterClearButton extends AbstractBlock {
 	protected $block_name = 'product-filter-clear-button';
 
 	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return null
-	 */
-	protected function get_block_type_style() {
-		return null;
-	}
-
-	/**
 	 * Get the frontend script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR improves the styling consistency of the Product Filter Clear Button block by implementing a default fallback spacing that works across different themes. The changes:

-   Remove hardcoded margin styling from the block edit component
-   Add a new SCSS file with theme-agnostic default spacing (1rem top margin)
-   Enable style loading for the block type
-   Update block registration to include the new stylesheet

These changes ensure the Clear Filter button maintains proper spacing and visual consistency regardless of the active theme.

Previously, we used a preset value for the button margin, but not every theme uses the same set of preset values (Twenty Twenty-Four vs Twenty Twenty-Five, for example). We need to use a hardcoded value to ensure spacing between filter button and active filter chips. We set a low specificity so themes can easily override it.

### Screenshots or screen recordings:

| Before | After |
|--------|--------|
| <img width="1381" alt="image" src="https://github.com/user-attachments/assets/c8e9d5ac-ad87-4092-bf73-8f90c06f138c" /> | <img width="1381" alt="image" src="https://github.com/user-attachments/assets/cdec7eca-8196-4cef-9007-149101115c4d" /> |

### How to test the changes in this Pull Request:

1. Add Product Filters block to the Product Catalog template.
2. Verify that the Clear All Filters button has proper spacing (1rem/16px top margin) from the chips above it.
3. Verify the spacing applied on the frontend.
4. Switch between different themes (e.g., Twenty Twenty-Four, Twenty Twenty-Five) and verify the spacing remains consistent.

### Testing that has already taken place:

Testing has been conducted in a local development environment with the following setup:

-   WordPress 6.7.2
-   Tested with Twenty Twenty-Four and Twenty Twenty-Five themes
-   Verified in both block editor and front-end views
