### PR TITLE
Product Filter: comparing URLs before navigation

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filter-navigation
+++ b/plugins/woocommerce/changelog/fix-product-filter-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: client navigation issue of Product Filters with server context

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -91,9 +91,8 @@ class ProductFilters extends AbstractBlock {
 			''
 		);
 		$interactivity_context = array(
-			'params'         => $filter_params,
-			'originalParams' => $filter_params,
-			'activeFilters'  => $active_filters,
+			'params'        => $filter_params,
+			'activeFilters' => $active_filters,
 		);
 
 		$classes = '';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Due to an issue with `getServerContext()` as discussed in p1742965843021159-slack-C05GY7MD3ST, we need to use another approach to check if we need to do navigation. This PR remove the unnecessary `originalParams` context and use the current URL to compare and check if we need to navigate.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Reproduce the issue first without this PR
  1. Add `Product Filters` block to the `Product Catalog` template.
  2. Import sample products if you haven't done it.
  3. On the Shop page, set the min price to 19, see the navigation.
  4. Select Red color, see the navigation.
  5. Unselect Red color, see the navigation.
  6. Select Red color again, don't see the navigation.
2. Checkout this PR, repeat steps above, verify that the navigation always happens once the filters change.

<!-- End testing instructions -->
