### PR TITLE
Product Gallery: Fix scrolling when multiple galleries are present

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-block-fix-scrolling-when-multiple-galleries-are-present
+++ b/plugins/woocommerce/changelog/fix-product-gallery-block-fix-scrolling-when-multiple-galleries-are-present
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Scope image scrolling to specific gallery instance

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -40,6 +40,7 @@ const scrollImageIntoView = ( imageId: number ) => {
 
 	// Get the current element that triggered the action
 	const element = getElement()?.ref as HTMLElement;
+
 	if ( ! element ) {
 		return;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -29,7 +29,7 @@ const getArrowsState = ( imageNumber: number, totalImages: number ) => ( {
  * We use getElement to get the current element that triggered the action
  * to find the closest gallery container and scroll the image into view.
  * This is necessary because if you have two galleries on the same page with the same image IDs,
- * then we could trigger the wrong gallery's image into view.
+ * then we need to query the image in the correct gallery to avoid scrolling the wrong image into view.
  *
  * @param {string} imageId - The ID of the image to scroll into view.
  */

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -24,7 +24,12 @@ const getArrowsState = ( imageNumber: number, totalImages: number ) => ( {
 } );
 
 /**
- * Scrolls an image into view.
+ * Scrolls the image into view for the main image.
+ *
+ * We use getElement to get the current element that triggered the action
+ * to find the closest gallery container and scroll the image into view.
+ * This is necessary because if you have two galleries on the same page with the same image IDs,
+ * then we could trigger the wrong gallery's image into view.
  *
  * @param {string} imageId - The ID of the image to scroll into view.
  */
@@ -32,9 +37,26 @@ const scrollImageIntoView = ( imageId: number ) => {
 	if ( ! imageId ) {
 		return;
 	}
-	const imageElement = document.querySelector(
+
+	// Get the current element that triggered the action
+	const element = getElement()?.ref as HTMLElement;
+	if ( ! element ) {
+		return;
+	}
+
+	// Find the closest gallery container
+	const galleryContainer = element.closest(
+		'.wp-block-woocommerce-product-gallery'
+	);
+
+	if ( ! galleryContainer ) {
+		return;
+	}
+
+	const imageElement = galleryContainer.querySelector(
 		`.wp-block-woocommerce-product-gallery-large-image img[data-image-id="${ imageId }"]`
 	);
+
 	if ( imageElement ) {
 		imageElement.scrollIntoView( {
 			behavior: 'smooth',
@@ -184,8 +206,15 @@ const productGallery = {
 			if ( event ) {
 				event.stopPropagation();
 			}
-
+			const context = getContext();
+			console.log(
+				'Next clicked - Product ID:',
+				context.productId,
+				'Selected Image ID:',
+				context.selectedImageId
+			);
 			const { imageData, selectedImageId } = getContext();
+			console.log( 'selectNextImage', imageData, selectedImageId );
 			const allImageIds = imageData?.image_ids || [];
 			const selectedImageNumber = getSelectedImageNumber(
 				allImageIds,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -207,15 +207,7 @@ const productGallery = {
 			if ( event ) {
 				event.stopPropagation();
 			}
-			const context = getContext();
-			console.log(
-				'Next clicked - Product ID:',
-				context.productId,
-				'Selected Image ID:',
-				context.selectedImageId
-			);
 			const { imageData, selectedImageId } = getContext();
-			console.log( 'selectNextImage', imageData, selectedImageId );
 			const allImageIds = imageData?.image_ids || [];
 			const selectedImageNumber = getSelectedImageNumber(
 				allImageIds,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When multiple product galleries are present on a page, ensure that navigation actions (next/previous) only affect the gallery where the action was triggered. This fixes an issue where clicking navigation buttons would incorrectly scroll the first gallery on the page instead of the intended gallery.

- Add gallery container scoping using closest()
- Update image query to search within specific gallery context
- Add documentation explaining the scoping behavior

Closes # .

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/55246

### Screenshots or screen recordings:

**Before**

https://github.com/user-attachments/assets/1fd4f999-d602-4623-93b2-28698d3502fd

**After**

https://github.com/user-attachments/assets/8258c959-9cc1-4a3a-8791-8f6f5b05569f

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add two Single Product blocks to the same page/post which show the same product
2. Load it on the frontend
3. Click through each gallery and ensure the correct gallery updates based on the one you interacted with

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
