### PR TITLE
Fix types in blocks/package/compponents

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/notices.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/notices.ts
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import type { Notice } from '@wordpress/notices';
+import type { WPNotice } from '@wordpress/notices/build-types/store/selectors';
 
-export interface NoticeType extends Partial< Omit< Notice, 'status' > > {
+export type StoreNoticeStatus =
+	| 'success'
+	| 'error'
+	| 'info'
+	| 'warning'
+	| 'default';
+export interface NoticeType extends Partial< Omit< WPNotice, 'status' > > {
 	id: string;
 	content: string;
-	status: 'success' | 'error' | 'info' | 'warning' | 'default';
+	status: StoreNoticeStatus;
 	isDismissible: boolean;
 	context?: string | undefined;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/notices.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/notices.ts
@@ -3,16 +3,11 @@
  */
 import type { WPNotice } from '@wordpress/notices/build-types/store/selectors';
 
-export type StoreNoticeStatus =
-	| 'success'
-	| 'error'
-	| 'info'
-	| 'warning'
-	| 'default';
+export type NoticeStatus = 'success' | 'error' | 'info' | 'warning' | 'default';
 export interface NoticeType extends Partial< Omit< WPNotice, 'status' > > {
 	id: string;
 	content: string;
-	status: StoreNoticeStatus;
+	status: NoticeStatus;
 	isDismissible: boolean;
 	context?: string | undefined;
 }

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
@@ -3,7 +3,7 @@
  */
 import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
-import type { ReactNode } from 'react';
+import type { ReactNode, InputHTMLAttributes } from 'react';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -12,17 +12,23 @@ import { forwardRef } from '@wordpress/element';
 import './style.scss';
 
 export type CheckboxControlProps = {
-	className?: string;
 	label?: string | React.ReactNode;
-	id?: string;
 	onChange: ( value: boolean ) => void;
 	children?: ReactNode | null | undefined;
 	hasError?: boolean;
-	checked?: boolean;
-	disabled?: boolean;
 	errorId?: string;
 	errorMessage?: string;
-};
+} & Pick<
+	InputHTMLAttributes< HTMLInputElement >,
+	| 'value'
+	| 'name'
+	| 'aria-label'
+	| 'aria-describedby'
+	| 'className'
+	| 'id'
+	| 'disabled'
+	| 'checked'
+>;
 
 /**
  * Component used to show a checkbox control with styles.
@@ -43,6 +49,7 @@ export const CheckboxControl = forwardRef<
 			disabled = false,
 			errorId,
 			errorMessage,
+			value,
 			...rest
 		}: CheckboxControlProps,
 		forwardedRef

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
@@ -19,7 +19,9 @@ export type CheckboxControlProps = {
 	children?: ReactNode | null | undefined;
 	hasError?: boolean;
 	checked?: boolean;
-	disabled?: string | boolean | undefined;
+	disabled?: boolean;
+	errorId?: string;
+	errorMessage?: string;
 };
 
 /**
@@ -42,7 +44,7 @@ export const CheckboxControl = forwardRef<
 			errorId,
 			errorMessage,
 			...rest
-		}: CheckboxControlProps & Record< string, unknown >,
+		}: CheckboxControlProps,
 		forwardedRef
 	): JSX.Element => {
 		const instanceId = useInstanceId( CheckboxControl );
@@ -69,7 +71,7 @@ export const CheckboxControl = forwardRef<
 						}
 						aria-invalid={ hasError === true }
 						checked={ checked }
-						disabled={ !! disabled }
+						disabled={ disabled }
 						{ ...rest }
 					/>
 					<svg

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
@@ -79,6 +79,7 @@ export const CheckboxControl = forwardRef<
 						aria-invalid={ hasError === true }
 						checked={ checked }
 						disabled={ disabled }
+						value={ value }
 						{ ...rest }
 					/>
 					<svg

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import { useEffect, useState } from '@wordpress/element';
 
 /**
@@ -19,7 +19,7 @@ export default {
 	},
 } as Meta< CheckboxControlProps >;
 
-const Template: Story< CheckboxControlProps > = ( args ) => {
+const Template: StoryFn< CheckboxControlProps > = ( args ) => {
 	const [ checked, setChecked ] = useState( args.checked );
 	useEffect( () => {
 		setChecked( args.checked );
@@ -33,5 +33,5 @@ const Template: Story< CheckboxControlProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< CheckboxControlProps > = Template.bind( {} );
 Default.args = {};

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/validated-checkbox-control.tsx
@@ -74,6 +74,7 @@ const ValidatedCheckboxControl = forwardRef<
 			label,
 			validateOnMount = true,
 			instanceId: preferredInstanceId = '',
+			disabled = false,
 			...rest
 		},
 		forwardedRef
@@ -214,6 +215,7 @@ const ValidatedCheckboxControl = forwardRef<
 				checked={ checked }
 				title="" // This prevents the same error being shown on hover.
 				label={ label }
+				disabled={ disabled }
 				{ ...rest }
 			>
 				<ValidationInputError propertyName={ errorIdString } />

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-list/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-list/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import { useArgs } from '@storybook/client-api';
 
 /**
@@ -83,7 +83,7 @@ export default {
 	},
 } as Meta< CheckboxListProps >;
 
-const Template: Story< CheckboxListProps > = ( args ) => {
+const Template: StoryFn< CheckboxListProps > = ( args ) => {
 	const [ { checked, onChange: argsOnChange }, updateArgs ] = useArgs();
 	const onChange = ( checkedOption: string ) => {
 		argsOnChange( checkedOption );
@@ -102,7 +102,7 @@ const Template: Story< CheckboxListProps > = ( args ) => {
 	return <CheckboxList { ...args } onChange={ onChange } />;
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< CheckboxListProps > = Template.bind( {} );
 Default.args = {
 	options: [
 		{ label: '🍏 Apple', value: 'apple' },

--- a/plugins/woocommerce/client/blocks/packages/components/chip/chip.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/chip.tsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import type { ElementType, HTMLAttributes } from 'react';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-export interface ChipProps {
+export interface ChipProps extends HTMLAttributes< HTMLElement > {
 	/**
 	 * Text for chip content.
 	 */
@@ -20,7 +21,7 @@ export interface ChipProps {
 	/**
 	 * The element type for the chip. Default 'li'.
 	 */
-	element?: string;
+	element?: ElementType;
 	/**
 	 * CSS class used.
 	 */

--- a/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
@@ -4,6 +4,14 @@
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
+import type { HTMLAttributes } from 'react';
+
+declare module '@wordpress/icons' {
+	interface IconProps extends HTMLAttributes< HTMLElement > {
+		icon: JSX.Element;
+		size?: number;
+	}
+}
 
 /**
  * Internal dependencies
@@ -94,13 +102,12 @@ export const RemovableChip = ( {
 				className="wc-block-components-chip__remove"
 				{ ...removeProps }
 			>
+				{ /* @ts-expect-error - TS wants the Icon component to define svg specific props, but it's not always SVG */ }
 				<Icon
 					className="wc-block-components-chip__remove-icon"
 					icon={ closeSmall }
 					size={ 16 }
 					role="img"
-					onPointerEnterCapture={ undefined } // onPointerEnterCapture required by SVG types.
-					onPointerLeaveCapture={ undefined } // onPointerLeaveCapture required by SVG types.
 				/>
 			</RemoveElement>
 		</Chip>

--- a/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
@@ -86,7 +86,7 @@ export const RemovableChip = ( {
 			{ ...props }
 			{ ...chipProps }
 			className={ clsx( className, 'is-removable' ) }
-			element={ removeOnAnyClick ? 'button' : props.element }
+			element={ removeOnAnyClick ? 'button' : props.element || 'span' }
 			screenReaderText={ screenReaderText }
 			text={ text }
 		>
@@ -99,6 +99,8 @@ export const RemovableChip = ( {
 					icon={ closeSmall }
 					size={ 16 }
 					role="img"
+					onPointerEnterCapture={ undefined } // onPointerEnterCapture required by SVG types.
+					onPointerLeaveCapture={ undefined } // onPointerLeaveCapture required by SVG types.
 				/>
 			</RemoveElement>
 		</Chip>

--- a/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
@@ -94,7 +94,7 @@ export const RemovableChip = ( {
 			{ ...props }
 			{ ...chipProps }
 			className={ clsx( className, 'is-removable' ) }
-			element={ removeOnAnyClick ? 'button' : props.element || 'span' }
+			element={ removeOnAnyClick ? 'button' : props.element || 'li' }
 			screenReaderText={ screenReaderText }
 			text={ text }
 		>

--- a/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/removable-chip.tsx
@@ -4,10 +4,10 @@
 import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
-import type { HTMLAttributes } from 'react';
+import type { ComponentProps } from 'react';
 
 declare module '@wordpress/icons' {
-	interface IconProps extends HTMLAttributes< HTMLElement > {
+	interface IconProps extends Partial< ComponentProps< 'div' > > {
 		icon: JSX.Element;
 		size?: number;
 	}

--- a/plugins/woocommerce/client/blocks/packages/components/chip/stories/chip.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/stories/chip.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 
 /**
  * Internal dependencies
@@ -28,9 +28,9 @@ export default {
 	},
 } as Meta< ChipProps >;
 
-const Template: Story< ChipProps > = ( args ) => <Chip { ...args } />;
+const Template: StoryFn< ChipProps > = ( args ) => <Chip { ...args } />;
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< ChipProps > = Template.bind( {} );
 Default.args = {
 	element: 'li',
 	text: 'Take me to the casino!',

--- a/plugins/woocommerce/client/blocks/packages/components/chip/stories/removable-chip.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/stories/removable-chip.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 
 /**
  * Internal dependencies
@@ -21,11 +21,11 @@ export default {
 	},
 } as Meta< RemovableChipProps >;
 
-const Template: Story< RemovableChipProps > = ( args ) => (
+const Template: StoryFn< RemovableChipProps > = ( args ) => (
 	<RemovableChip { ...args } />
 );
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< RemovableChipProps > = Template.bind( {} );
 Default.args = {
 	element: 'li',
 	text: 'Take me to the casino',

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/index.tsx
@@ -11,7 +11,7 @@ import Title from '../title';
 
 interface StepHeadingProps {
 	title: string;
-	stepHeadingContent?: JSX.Element;
+	stepHeadingContent?: JSX.Element | undefined;
 }
 
 const StepHeading = ( { title, stepHeadingContent }: StepHeadingProps ) => (

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/stories/index.stories.tsx
@@ -117,7 +117,7 @@ const Template: StoryFn< FormStepProps > = ( args ) => (
 	</div>
 );
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< FormStepProps > = Template.bind( {} );
 
 Default.args = {
 	stepHeadingContent: () => <span>Step heading content</span>,

--- a/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useArgs } from '@storybook/client-api';
 
 /**
@@ -95,7 +95,7 @@ export default {
 	},
 } as Meta< FormattedMonetaryAmountProps >;
 
-const Template: Story< FormattedMonetaryAmountProps > = ( args ) => {
+const Template: StoryFn< FormattedMonetaryAmountProps > = ( args ) => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ _, updateArgs ] = useArgs();
 	const onValueChange = ( unit: number ) => {
@@ -107,7 +107,9 @@ const Template: Story< FormattedMonetaryAmountProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< FormattedMonetaryAmountProps > = Template.bind(
+	{}
+);
 Default.args = {
 	currency: {
 		minorUnit: 2,

--- a/plugins/woocommerce/client/blocks/packages/components/label/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/label/stories/index.stories.tsx
@@ -42,7 +42,7 @@ export default {
 
 const Template: StoryFn = ( args ) => <Label { ...args } />;
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< LabelProps > = Template.bind( {} );
 Default.args = {
 	label: 'I am a label',
 	screenReaderLabel: 'I am a screen reader label',

--- a/plugins/woocommerce/client/blocks/packages/components/panel/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/panel/index.tsx
@@ -67,6 +67,8 @@ const Panel = ( {
 					aria-hidden="true"
 					className="wc-block-components-panel__button-icon"
 					icon={ isOpen ? chevronUp : chevronDown }
+					onPointerEnterCapture={ undefined } // onPointerEnterCapture required by SVG types.
+					onPointerLeaveCapture={ undefined } // onPointerLeaveCapture required by SVG types.
 				/>
 				{ title }
 			</Button>

--- a/plugins/woocommerce/client/blocks/packages/components/panel/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/panel/index.tsx
@@ -63,12 +63,11 @@ const Panel = ( {
 				className="wc-block-components-panel__button"
 				onClick={ () => setIsOpen( ! isOpen ) }
 			>
+				{ /* @ts-expect-error - TS wants the Icon component to define svg specific props, but it's not always SVG */ }
 				<Icon
 					aria-hidden="true"
 					className="wc-block-components-panel__button-icon"
 					icon={ isOpen ? chevronUp : chevronDown }
-					onPointerEnterCapture={ undefined } // onPointerEnterCapture required by SVG types.
-					onPointerLeaveCapture={ undefined } // onPointerLeaveCapture required by SVG types.
 				/>
 				{ title }
 			</Button>

--- a/plugins/woocommerce/client/blocks/packages/components/panel/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/panel/stories/index.stories.tsx
@@ -91,7 +91,7 @@ const Template: StoryFn< PanelProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< PanelProps > = Template.bind( {} );
 Default.args = {
 	title: (
 		<div style={ { paddingBottom: '.375em', marginBottom: '.375em' } }>
@@ -102,7 +102,7 @@ Default.args = {
 	initialOpen: false,
 };
 
-export const InitialOpen = Template.bind( {} );
+export const InitialOpen: StoryFn< PanelProps > = Template.bind( {} );
 InitialOpen.args = {
 	title: (
 		<div style={ { paddingBottom: '.375em', marginBottom: '.375em' } }>

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control-accordion/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control-accordion/stories/index.stories.tsx
@@ -55,7 +55,9 @@ const Template: StoryFn< RadioControlAccordionProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< RadioControlAccordionProps > = Template.bind(
+	{}
+);
 Default.args = {
 	options: [
 		{

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/stories/index.stories.tsx
@@ -55,7 +55,7 @@ const Template: StoryFn< RadioControlProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< RadioControlProps > = Template.bind( {} );
 Default.args = {
 	options: [
 		{

--- a/plugins/woocommerce/client/blocks/packages/components/sort-select/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/sort-select/stories/index.stories.tsx
@@ -93,7 +93,7 @@ const Template: StoryFn< SortSelectProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< SortSelectProps > = Template.bind( {} );
 Default.args = {
 	label: 'Choose one of the options',
 	options: [

--- a/plugins/woocommerce/client/blocks/packages/components/spinner/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/spinner/stories/index.stories.tsx
@@ -15,6 +15,6 @@ export default {
 
 const Template: StoryFn = () => <Spinner />;
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn = Template.bind( {} );
 Default.args = {};
 Default.parameters = { controls: { hideNoControlsWarning: true } };

--- a/plugins/woocommerce/client/blocks/packages/components/store-notice/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notice/stories/index.stories.tsx
@@ -60,7 +60,7 @@ const Template: StoryFn< NoticeBannerProps > = ( { children, ...args } ) => {
 	return <StoreNotice { ...args }>{ children }</StoreNotice>;
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< NoticeBannerProps > = Template.bind( {} );
 Default.args = {
 	children: 'This is a default notice',
 	status: 'default',
@@ -68,35 +68,35 @@ Default.args = {
 	politeness: 'polite',
 };
 
-export const Error = Template.bind( {} );
+export const Error: StoryFn< NoticeBannerProps > = Template.bind( {} );
 Error.args = {
 	children: 'This is an error notice',
 	status: 'error',
 	politeness: 'assertive',
 };
 
-export const Warning = Template.bind( {} );
+export const Warning: StoryFn< NoticeBannerProps > = Template.bind( {} );
 Warning.args = {
 	children: 'This is a warning notice',
 	status: 'warning',
 	politeness: 'polite',
 };
 
-export const Info = Template.bind( {} );
+export const Info: StoryFn< NoticeBannerProps > = Template.bind( {} );
 Info.args = {
 	children: 'This is an informational notice',
 	status: 'info',
 	politeness: 'polite',
 };
 
-export const Success = Template.bind( {} );
+export const Success: StoryFn< NoticeBannerProps > = Template.bind( {} );
 Success.args = {
 	children: 'This is a success notice',
 	status: 'success',
 	politeness: 'polite',
 };
 
-export const ErrorSummary = Template.bind( {} );
+export const ErrorSummary: StoryFn< NoticeBannerProps > = Template.bind( {} );
 ErrorSummary.args = {
 	summary: 'Please fix the following errors',
 	children: (

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -8,7 +8,7 @@ import { sanitizeHTML } from '@woocommerce/utils';
 import { useDispatch } from '@wordpress/data';
 import { usePrevious } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import type { NoticeType, StoreNoticeStatus } from '@woocommerce/types';
+import type { NoticeStatus, NoticeType } from '@woocommerce/types';
 import type { NoticeBannerProps } from '@woocommerce/base-components/notice-banner';
 
 /**
@@ -124,7 +124,7 @@ const StoreNotices = ( {
 							),
 						} ) );
 					const noticeProps: Omit< NoticeBannerProps, 'children' > = {
-						status: status as StoreNoticeStatus,
+						status: status as NoticeStatus,
 						onRemove: () => {
 							noticeGroup.forEach( ( notice ) => {
 								removeNotice( notice.id, notice.context );

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -8,7 +8,7 @@ import { sanitizeHTML } from '@woocommerce/utils';
 import { useDispatch } from '@wordpress/data';
 import { usePrevious } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import type { NoticeType } from '@woocommerce/types';
+import type { NoticeType, StoreNoticeStatus } from '@woocommerce/types';
 import type { NoticeBannerProps } from '@woocommerce/base-components/notice-banner';
 
 /**
@@ -124,7 +124,7 @@ const StoreNotices = ( {
 							),
 						} ) );
 					const noticeProps: Omit< NoticeBannerProps, 'children' > = {
-						status,
+						status: status as StoreNoticeStatus,
 						onRemove: () => {
 							noticeGroup.forEach( ( notice ) => {
 								removeNotice( notice.id, notice.context );

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/stories/text-input.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/stories/text-input.stories.tsx
@@ -163,7 +163,7 @@ const Template: StoryFn< TextInputProps > = ( args ) => {
 	return <TextInput { ...args } onChange={ onChange } />;
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< TextInputProps > = Template.bind( {} );
 Default.args = {
 	id: 'unique-id',
 	label: 'Enter your value',

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/stories/validated-text-input.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/stories/validated-text-input.stories.tsx
@@ -222,14 +222,16 @@ const Template: StoryFn< ValidatedTextInputProps > = ( args ) => {
 	return <ValidatedTextInput { ...args } onChange={ onChange } />;
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< ValidatedTextInputProps > = Template.bind( {} );
 Default.args = {
 	id: 'unique-id',
 	label: 'Enter your value',
 	value: '',
 };
 
-export const WithError = Template.bind( {} );
+export const WithError: StoryFn< ValidatedTextInputProps > = Template.bind(
+	{}
+);
 WithError.args = {
 	id: 'unique-id',
 	showError: true,
@@ -238,7 +240,8 @@ WithError.args = {
 	value: 'Lorem ipsum',
 };
 
-export const WithCustomFormatter = Template.bind( {} );
+export const WithCustomFormatter: StoryFn< ValidatedTextInputProps > =
+	Template.bind( {} );
 WithCustomFormatter.args = {
 	id: 'unique-id',
 	label: 'Enter your value',

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/stories/index.stories.tsx
@@ -67,7 +67,7 @@ const Template: StoryFn< TextareaProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< TextareaProps > = Template.bind( {} );
 
 Default.args = {
 	className: '',

--- a/plugins/woocommerce/client/blocks/packages/components/title/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/title/stories/index.stories.tsx
@@ -51,7 +51,7 @@ const Template: StoryFn< TitleProps > = ( args ) => {
 	return <Title { ...rest }>{ children }</Title>;
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< TitleProps > = Template.bind( {} );
 
 Default.args = {
 	headingLevel: '1',

--- a/plugins/woocommerce/client/blocks/packages/components/totals/fees/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/fees/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import {
 	currenciesAPIShape,
 	currencies,
@@ -38,7 +38,7 @@ export default {
 
 type StorybookTotalFeesProps = TotalsFeesProps & { total: string };
 
-const Template: Story< StorybookTotalFeesProps > = ( args ) => {
+const Template: StoryFn< StorybookTotalFeesProps > = ( args ) => {
 	return (
 		<Fees
 			{ ...args }
@@ -55,13 +55,14 @@ const Template: Story< StorybookTotalFeesProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< StorybookTotalFeesProps > = Template.bind( {} );
 Default.args = {
 	currency: currencies.USD,
 	total: '1000',
 };
 
-export const AlternativeCurrency = Template.bind( {} );
+export const AlternativeCurrency: StoryFn< StorybookTotalFeesProps > =
+	Template.bind( {} );
 AlternativeCurrency.args = {
 	currency: currencies.EUR,
 	total: '1000',

--- a/plugins/woocommerce/client/blocks/packages/components/totals/item/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/item/index.tsx
@@ -36,7 +36,7 @@ const TotalsItemValue = ( {
 	return Number.isFinite( value ) ? (
 		<FormattedMonetaryAmount
 			className="wc-block-components-totals-item__value"
-			currency={ currency || {} }
+			currency={ currency || undefined }
 			value={ value as number }
 		/>
 	) : null;

--- a/plugins/woocommerce/client/blocks/packages/components/totals/item/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/item/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import { currencies, currencyControl } from '@woocommerce/storybook-controls';
 
 /**
@@ -23,9 +23,9 @@ export default {
 	},
 } as Meta< TotalsItemProps >;
 
-const Template: Story< TotalsItemProps > = ( args ) => <Item { ...args } />;
+const Template: StoryFn< TotalsItemProps > = ( args ) => <Item { ...args } />;
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< TotalsItemProps > = Template.bind( {} );
 Default.args = {
 	currency: currencies.USD,
 	description: 'This item is so interesting',

--- a/plugins/woocommerce/client/blocks/packages/components/totals/subtotal/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/subtotal/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import { currencies, currencyControl } from '@woocommerce/storybook-controls';
 
 /**
@@ -25,7 +25,7 @@ export default {
 
 type StorybookSubtotalProps = SubtotalProps & { total_items: string };
 
-const Template: Story< StorybookSubtotalProps > = ( args ) => {
+const Template: StoryFn< StorybookSubtotalProps > = ( args ) => {
 	const totalItems = args.total_items;
 	const values = {
 		total_items: totalItems,
@@ -37,7 +37,7 @@ const Template: Story< StorybookSubtotalProps > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< StorybookSubtotalProps > = Template.bind( {} );
 Default.args = {
 	currency: currencies.USD,
 	total_items: '1000',

--- a/plugins/woocommerce/client/blocks/packages/components/totals/taxes/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/totals/taxes/stories/index.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Story, Meta } from '@storybook/react';
+import type { StoryFn, Meta } from '@storybook/react';
 import { currencies, currencyControl } from '@woocommerce/storybook-controls';
 
 /**
@@ -32,9 +32,9 @@ export default {
 	},
 } as Meta< TotalsTaxesProps >;
 
-const Template: Story< TotalsTaxesProps > = ( args ) => <Taxes { ...args } />;
+const Template: StoryFn< TotalsTaxesProps > = ( args ) => <Taxes { ...args } />;
 
-export const Default = Template.bind( {} );
+export const Default: StoryFn< TotalsTaxesProps > = Template.bind( {} );
 Default.args = {
 	currency: currencies.USD,
 };

--- a/plugins/woocommerce/client/blocks/packages/components/validation-input-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/validation-input-error/index.tsx
@@ -44,11 +44,8 @@ export const ValidationInputError = ( {
 	return (
 		<div className="wc-block-components-validation-error" role="alert">
 			<p id={ validationErrorId }>
-				<Icon
-					icon={ warning }
-					onPointerEnterCapture={ undefined }
-					onPointerLeaveCapture={ undefined }
-				/>
+				{ /* @ts-expect-error - TS wants the Icon component to define svg specific props, but it's not always SVG */ }
+				<Icon icon={ warning } />
 				<span>{ errorMessage }</span>
 			</p>
 		</div>

--- a/plugins/woocommerce/client/blocks/packages/components/validation-input-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/validation-input-error/index.tsx
@@ -21,13 +21,17 @@ export const ValidationInputError = ( {
 	propertyName = '',
 	elementId = '',
 }: ValidationInputErrorProps ): JSX.Element | null => {
-	const { validationError, validationErrorId } = useSelect( ( select ) => {
-		const store = select( validationStore );
-		return {
-			validationError: store.getValidationError( propertyName ),
-			validationErrorId: store.getValidationErrorId( elementId ),
-		};
-	} );
+	const { validationError, validationErrorId } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+
+			return {
+				validationError: store.getValidationError( propertyName ),
+				validationErrorId: store.getValidationErrorId( elementId ),
+			};
+		},
+		[ propertyName, elementId ]
+	);
 
 	if ( ! errorMessage || typeof errorMessage !== 'string' ) {
 		if ( validationError?.message && ! validationError?.hidden ) {
@@ -40,7 +44,11 @@ export const ValidationInputError = ( {
 	return (
 		<div className="wc-block-components-validation-error" role="alert">
 			<p id={ validationErrorId }>
-				<Icon icon={ warning } />
+				<Icon
+					icon={ warning }
+					onPointerEnterCapture={ undefined }
+					onPointerLeaveCapture={ undefined }
+				/>
 				<span>{ errorMessage }</span>
 			</p>
 		</div>


### PR DESCRIPTION
### Submission Review Guidelines:

This PR fixes all but 2 typescript errors in `client/blocks/packages/components`. The remaining 2 errors are related to the fact that we are referencing properties onloy available in the `@woocommerce/notices` package, but we are instead using the `@wordpress/notices` package. This should be fixed separately, as it will need thoughtful consideration around notices, out of scope for this PR.

Note I did not fix any errors in the test files

The issue is recorded in https://github.com/woocommerce/woocommerce/issues/56690

Closes https://github.com/woocommerce/woocommerce/issues/55975.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is only testable by developers and has no impact on the end user.

1. In your terminal `cd plugins/woocommerce/client/blocks`
2. `npx tsc --noEmit | grep -i "packages/components" | grep -iv "test"`
3. Check that there are only 2 type errors, related to the `explicitDismiss` property.
4. All Ci should pass

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR only fixes some types and has no impact outside of developer experience.

</details>
