### PR TITLE
registerProductBlockType: Capture exceptions when they are thrown

### DIFF
--- a/plugins/woocommerce/changelog/add-remote-error-logging-register-product-blocktype
+++ b/plugins/woocommerce/changelog/add-remote-error-logging-register-product-blocktype
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Capture exceptions for registerProductBlockType failures

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -241,6 +241,7 @@ export class BlockRegistrationManager {
 				`Failed to unregister block ${ blockName }:`,
 				error
 			);
+			// @ts-expect-error - remoteLogging is not typed
 			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
@@ -304,7 +305,6 @@ export class BlockRegistrationManager {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );
-
 			// @ts-expect-error - remoteLogging is not typed
 			window?.wc?.remoteLogging?.captureException( error );
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -228,6 +228,7 @@ export class BlockRegistrationManager {
 		const { blockName, isVariationBlock, variationName } = config;
 
 		try {
+			throw new Error( 'Testing the remote error logging' );
 			if ( isVariationBlock && variationName ) {
 				unregisterBlockVariation( blockName, variationName );
 				this.attemptedRegisteredBlocks.delete( variationName );
@@ -241,7 +242,6 @@ export class BlockRegistrationManager {
 				`Failed to unregister block ${ blockName }:`,
 				error
 			);
-			// @ts-expect-error - remoteLogging is not typed
 			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
@@ -305,8 +305,6 @@ export class BlockRegistrationManager {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );
-			// @ts-expect-error - remoteLogging is not typed
-			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -228,7 +228,6 @@ export class BlockRegistrationManager {
 		const { blockName, isVariationBlock, variationName } = config;
 
 		try {
-			throw new Error( 'Testing the remote error logging' );
 			if ( isVariationBlock && variationName ) {
 				unregisterBlockVariation( blockName, variationName );
 				this.attemptedRegisteredBlocks.delete( variationName );

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -304,6 +304,9 @@ export class BlockRegistrationManager {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );
+
+			// @ts-expect-error - remoteLogging is not typed
+			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -241,6 +241,8 @@ export class BlockRegistrationManager {
 				`Failed to unregister block ${ blockName }:`,
 				error
 			);
+			// @ts-expect-error - remoteLogging is not typed
+			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
 
@@ -264,6 +266,7 @@ export class BlockRegistrationManager {
 		} = config;
 
 		try {
+			throw new Error( 'Testing the remote error logging' );
 			// Check if block is already registered
 			const key = variationName || blockName;
 			if ( this.hasAttemptedRegistration( key ) ) {
@@ -303,6 +306,8 @@ export class BlockRegistrationManager {
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( `Failed to register block ${ blockName }:`, error );
+			// @ts-expect-error - remoteLogging is not typed
+			window?.wc?.remoteLogging?.captureException( error );
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-product-block-type.ts
@@ -266,7 +266,6 @@ export class BlockRegistrationManager {
 		} = config;
 
 		try {
-			throw new Error( 'Testing the remote error logging' );
 			// Check if block is already registered
 			const key = variationName || blockName;
 			if ( this.hasAttemptedRegistration( key ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As mentioned here https://github.com/woocommerce/woocommerce/pull/53788#issuecomment-2549031791 we want a way to monitor block registration failures since this logic is critical for WooCommerce stores to ensure correct blocks are registered in the correct context.

This PR captures exceptions when registering/unregistering product block types for sites that have opted into tracking.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set the following localStorage item in your browser `window.localStorage.setItem('debug', 'wc:remote-logging')` to enable debug logging and ensure you have opted into tracking for your store.
2. Edit the `registerBlock` method in the `BlockRegistrationManager` class and throw an error.
3. Load the Single Product template in the Editor.
4. Check your console to see that the errors are present here.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
