### PR TITLE
Hide Product Element: Title from Single Product block

### DIFF
--- a/plugins/woocommerce/changelog/fix-hide-title-from-single-product
+++ b/plugins/woocommerce/changelog/fix-hide-title-from-single-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Single Product: hide duplicated Product Title block from inserter

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -21,9 +21,9 @@ import { Save } from './save';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
-	// Product Title is not expected to be available in Product Collection
-	// nor Products (Beta). They use core/post-title variation.
-	ancestor: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
+	// Product Title is not expected to be available anywhere than in All Products.
+	// Everywhere else we use core/post-title variation.
+	ancestor: [ 'woocommerce/all-products' ],
 	title,
 	description,
 	icon: { src: icon },

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -21,7 +21,7 @@ import { Save } from './save';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
-	// Product Title is not expected to be available anywhere than in All Products.
+	// Product Title is not expected to be available anywhere other than in All Products.
 	// Everywhere else we use core/post-title variation.
 	ancestor: [ 'woocommerce/all-products' ],
 	title,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In majority of the blocks we use and default to Product Title which is a core's Post Title variation. But there's also WooCommerce's Product Title block in Product Elements. It's purpose is mainly for All Products block.

I spotted it's exposed in Single Product block as well even though the variation one is used there by default. If you wanted to insert Product Title block in Single Product, this situation results in two Product Title blocks so I'm this PR hides unwanted one. Especially that it doesn't render on the frontend.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Case| Before 1 | After |
| -- | ------ | ----- | 
| Before inserting |    Two blocks: <img width="761" alt="image" src="https://github.com/user-attachments/assets/890ff1f7-198b-4bbe-975d-efc0b195ce7a" />  | <img width="791" alt="image" src="https://github.com/user-attachments/assets/319ae9f7-c3f3-48b6-b39d-8297cad05e99" />  
| After inserting | Both blocks: <img width="861" alt="image" src="https://github.com/user-attachments/assets/859dc8f0-90d9-4eaa-9dbe-7b3a189db7ab" /> | <img width="798" alt="image" src="https://github.com/user-attachments/assets/567cf15d-514d-4d24-9d29-38110b8fb165" /> |



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Add Single Product block 
3. Choose some product
4. Inside Single Product block try inserting Product Title
5. **Expected:** Make sure there's only ONE Product Title.
6. When inserted, enter the Code Editor
7. **Expected:** Verify it's Post Title variation

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/2b4393b8-e022-40df-820f-c050558191ac" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
