### PR TITLE
Fix incorrect coming soon template path to editor if theme provides coming soon template

### DIFF
--- a/plugins/woocommerce/changelog/56743-fix-coming-soon-path-to-editor
+++ b/plugins/woocommerce/changelog/56743-fix-coming-soon-path-to-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the link to the coming soon template in the Site Editor

--- a/plugins/woocommerce/client/admin/client/launch-your-store/constants.ts
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/constants.ts
@@ -1,12 +1,3 @@
-/**
- * External dependencies
- */
-import { getAdminLink } from '@woocommerce/settings';
-
-export const COMING_SOON_PAGE_EDITOR_LINK = getAdminLink(
-	'site-editor.php?postType=wp_template&postId=woocommerce/woocommerce//coming-soon&canvas=edit'
-);
-
 export const SITE_VISIBILITY_DOC_LINK =
 	'https://woocommerce.com/document/configuring-woocommerce-settings/coming-soon-mode/';
 

--- a/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
@@ -19,17 +19,16 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { recordEvent } from '@woocommerce/tracks';
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, getAdminLink } from '@woocommerce/settings';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { SETTINGS_SLOT_FILL_CONSTANT } from '../../settings/settings-slots';
 import './style.scss';
-import {
-	COMING_SOON_PAGE_EDITOR_LINK,
-	SITE_VISIBILITY_DOC_LINK,
-} from '../constants';
+import { SITE_VISIBILITY_DOC_LINK } from '../constants';
 import { ConfirmationModal } from './components/confirmation-modal';
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
@@ -49,6 +48,21 @@ const SiteVisibility = () => {
 	);
 	const formRef = useRef( null );
 	const saveButtonRef = useRef( null );
+
+	const { isFetching: isFetchingComingSoonTemplateId, comingSoonTemplateId } =
+		useSelect( ( select ) => {
+			return {
+				isFetching: ! select( coreStore ).hasFinishedResolution(
+					'getDefaultTemplateId',
+					[ { slug: 'coming-soon' } ]
+				),
+				comingSoonTemplateId: select( coreStore ).getDefaultTemplateId(
+					{
+						slug: 'coming-soon',
+					}
+				),
+			};
+		}, [] );
 
 	useEffect( () => {
 		const saveButton = document.getElementsByClassName(
@@ -163,7 +177,8 @@ const SiteVisibility = () => {
 					selected={ comingSoon }
 				/>
 				<p className="site-visibility-settings-slotfill-section-description">
-					{ getSetting( 'currentThemeIsFSETheme' )
+					{ ! isFetchingComingSoonTemplateId &&
+					getSetting( 'currentThemeIsFSETheme' )
 						? createInterpolateElement(
 								__(
 									'Your site is hidden from visitors behind a “Coming soon” landing page until it’s ready for viewing. You can customize your “Coming soon” landing page via the <a>Editor</a>.',
@@ -172,7 +187,9 @@ const SiteVisibility = () => {
 								{
 									a: createElement( 'a', {
 										target: '_blank',
-										href: COMING_SOON_PAGE_EDITOR_LINK,
+										href: getAdminLink(
+											`site-editor.php?postType=wp_template&postId=${ comingSoonTemplateId }&canvas=edit`
+										),
 									} ),
 								}
 						  )

--- a/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
@@ -49,20 +49,11 @@ const SiteVisibility = () => {
 	const formRef = useRef( null );
 	const saveButtonRef = useRef( null );
 
-	const { isFetching: isFetchingComingSoonTemplateId, comingSoonTemplateId } =
-		useSelect( ( select ) => {
-			return {
-				isFetching: ! select( coreStore ).hasFinishedResolution(
-					'getDefaultTemplateId',
-					[ { slug: 'coming-soon' } ]
-				),
-				comingSoonTemplateId: select( coreStore ).getDefaultTemplateId(
-					{
-						slug: 'coming-soon',
-					}
-				),
-			};
-		}, [] );
+	const comingSoonTemplateId = useSelect( ( select ) => {
+		return select( coreStore ).getDefaultTemplateId( {
+			slug: 'coming-soon',
+		} );
+	}, [] );
 
 	useEffect( () => {
 		const saveButton = document.getElementsByClassName(
@@ -177,7 +168,7 @@ const SiteVisibility = () => {
 					selected={ comingSoon }
 				/>
 				<p className="site-visibility-settings-slotfill-section-description">
-					{ ! isFetchingComingSoonTemplateId &&
+					{ comingSoonTemplateId &&
 					getSetting( 'currentThemeIsFSETheme' )
 						? createInterpolateElement(
 								__(

--- a/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/settings/slotfill.js
@@ -168,8 +168,7 @@ const SiteVisibility = () => {
 					selected={ comingSoon }
 				/>
 				<p className="site-visibility-settings-slotfill-section-description">
-					{ comingSoonTemplateId &&
-					getSetting( 'currentThemeIsFSETheme' )
+					{ getSetting( 'currentThemeIsFSETheme' )
 						? createInterpolateElement(
 								__(
 									'Your site is hidden from visitors behind a “Coming soon” landing page until it’s ready for viewing. You can customize your “Coming soon” landing page via the <a>Editor</a>.',
@@ -178,9 +177,11 @@ const SiteVisibility = () => {
 								{
 									a: createElement( 'a', {
 										target: '_blank',
-										href: getAdminLink(
-											`site-editor.php?postType=wp_template&postId=${ comingSoonTemplateId }&canvas=edit`
-										),
+										href: comingSoonTemplateId
+											? getAdminLink(
+													`site-editor.php?postType=wp_template&postId=${ comingSoonTemplateId }&canvas=edit`
+											  )
+											: getAdminLink( 'site-editor.php' ),
 									} ),
 								}
 						  )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR enhances the Site Visibility settings by dynamically fetching the coming soon template ID using the WordPress core-data store. This improvement ensures that the link to the coming soon template in the Site Editor is correct.

Closes https://github.com/woocommerce/woocommerce/issues/53309


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a fresh site 
2. Go to the Site Visibility settings (`wp-admin/admin.php?page=wc-settings&tab=site-visibility`)
3. Confirm that the `Editor` link to the WooCommerce Coming Soon template
4. Upload and activate [twentytwentyfour-coming-soon.zip](https://github.com/user-attachments/files/19483763/twentytwentyfour-coming-soon.zip) theme
5. Go to the Site Visibility settings again
6. Confirm that the `Editor` link now points to the twentytwentyfour-coming-soon template (`/wp-admin/site-editor.php?postType=wp_template&postId=twentytwentyfour-coming-soon%2F%2Fcoming-soon&canvas=edit`)
7. Switch back to the default theme
8. Modify the coming soon template and save it
9. Switch to twentytwentyfour-coming-soon theme
10. Confirm that the `Editor` link still points to the modified coming soon template
11. Activate a classic theme, such as storefront
12. Confirm that Site Visibility settings display correctly without the `Editor` link


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix the link to the coming soon template in the Site Editor

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
