### PR TITLE
Deprecate: wc_current_theme_is_fse_theme in favour of wp_is_block_theme

### DIFF
--- a/plugins/woocommerce/changelog/deprecate-wc-current-theme-is-fse-theme
+++ b/plugins/woocommerce/changelog/deprecate-wc-current-theme-is-fse-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecated wc_current_theme_is_fse_theme()

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -168,7 +168,6 @@ class WC_Admin_Meta_Boxes {
 				'advanced' => '',
 			)
 		);
-
 	}
 
 	/**
@@ -283,7 +282,7 @@ class WC_Admin_Meta_Boxes {
 	 * @return string[] Templates array excluding block-based templates.
 	 */
 	public function remove_block_templates( $templates ) {
-		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() ) {
+		if ( count( $templates ) === 0 || ! wp_is_block_theme() ) {
 			return $templates;
 		}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -284,7 +284,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 		);
 
 		// Feature requires a block theme. Re-order settings if not using a block theme.
-		if ( ! wc_current_theme_is_fse_theme() ) {
+		if ( ! wp_is_block_theme() ) {
 			$account_settings = array_map(
 				function ( $setting ) {
 					if ( 'woocommerce_enable_signup_and_login_from_checkout' === $setting['id'] ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -415,7 +415,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 */
 	public function get_custom_fonts() {
 		$custom_fonts = array();
-		if ( wc_current_theme_is_fse_theme() && class_exists( 'WP_Font_Face_Resolver' ) ) {
+		if ( wp_is_block_theme() && class_exists( 'WP_Font_Face_Resolver' ) ) {
 			$theme_fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 			if ( count( $theme_fonts ) > 0 ) {
 				foreach ( $theme_fonts as $font ) {
@@ -787,7 +787,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 */
 	public function email_color_palette( $value ) {
 		$default_colors = EmailColors::get_default_colors();
-		$auto_sync = get_option( EmailStyleSync::AUTO_SYNC_OPTION, 'no' );
+		$auto_sync      = get_option( EmailStyleSync::AUTO_SYNC_OPTION, 'no' );
 
 		?>
 		<hr class="wc-settings-email-color-palette-separator" />

--- a/plugins/woocommerce/includes/blocks/class-wc-brands-block-template-utils-duplicated.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-brands-block-template-utils-duplicated.php
@@ -361,7 +361,7 @@ class BlockTemplateUtilsDuplicated {
 		$use_blockified_templates = wc_string_to_bool( get_option( Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE ) );
 
 		if ( false === $use_blockified_templates ) {
-			return function_exists( 'wc_current_theme_is_fse_theme' ) && wc_current_theme_is_fse_theme();
+			return wp_is_block_theme();
 		}
 
 		return $use_blockified_templates;

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -38,7 +38,7 @@ class WC_Brands {
 		add_action( 'woocommerce_register_taxonomy', array( __CLASS__, 'init_taxonomy' ) );
 		add_action( 'widgets_init', array( $this, 'init_widgets' ) );
 
-		if ( ! wc_current_theme_is_fse_theme() ) {
+		if ( ! wp_is_block_theme() ) {
 			add_filter( 'template_include', array( $this, 'template_loader' ) );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -89,7 +89,7 @@ class WC_Frontend_Scripts {
 					'media'   => 'all',
 					'has_rtl' => true,
 				),
-				'woocommerce-blocktheme'  => wc_current_theme_is_fse_theme() ? array(
+				'woocommerce-blocktheme'  => wp_is_block_theme() ? array(
 					'src'     => self::get_asset_url( 'assets/css/woocommerce-blocktheme.css' ),
 					'deps'    => '',
 					'version' => $version,

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -46,7 +46,7 @@ class WC_Template_Loader {
 			add_filter( 'comments_template', array( __CLASS__, 'comments_template_loader' ) );
 
 			// Loads gallery scripts on Product page for FSE themes.
-			if ( wc_current_theme_is_fse_theme() ) {
+			if ( wp_is_block_theme() ) {
 				self::add_support_for_product_page_gallery();
 			}
 		} else {
@@ -109,7 +109,7 @@ class WC_Template_Loader {
 	 * @param object $taxonomy Object taxonomy to check.
 	 * @return boolean
 	 */
-	private static function taxonomy_has_block_template( $taxonomy ) : bool {
+	private static function taxonomy_has_block_template( $taxonomy ): bool {
 		if ( taxonomy_is_product_attribute( $taxonomy->taxonomy ) ) {
 			$template_name = 'taxonomy-product_attribute';
 		} else {
@@ -134,8 +134,8 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template            = false;
-		$template_filename       = $template_name . '.html';
+		$has_template      = false;
+		$template_filename = $template_name . '.html';
 		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
 		// we should check both these possible directories for backwards-compatibility.
 		$possible_templates_dirs = array( 'templates', 'block-templates' );
@@ -192,16 +192,14 @@ class WC_Template_Loader {
 
 			if ( self::taxonomy_has_block_template( $object ) ) {
 				$default_file = '';
-			} else {
-				if ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
+			} elseif ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
 					$default_file = 'taxonomy-product-attribute.php';
-				} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-					$default_file = 'taxonomy-' . $object->taxonomy . '.php';
-				} elseif ( ! self::has_block_template( 'archive-product' ) ) {
-					$default_file = 'archive-product.php';
-				} else {
-					$default_file = '';
-				}
+			} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
+				$default_file = 'taxonomy-' . $object->taxonomy . '.php';
+			} elseif ( ! self::has_block_template( 'archive-product' ) ) {
+				$default_file = 'archive-product.php';
+			} else {
+				$default_file = '';
 			}
 		} elseif (
 			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -252,7 +252,7 @@ class WC_Tracker {
 		$theme_data           = wp_get_theme();
 		$theme_child_theme    = wc_bool_to_string( is_child_theme() );
 		$theme_wc_support     = wc_bool_to_string( current_theme_supports( 'woocommerce' ) );
-		$theme_is_block_theme = wc_bool_to_string( wc_current_theme_is_fse_theme() );
+		$theme_is_block_theme = wc_bool_to_string( wp_is_block_theme() );
 
 		return array(
 			'name'        => $theme_data->Name, // @phpcs:ignore
@@ -1188,7 +1188,7 @@ class WC_Tracker {
 	 */
 	private static function get_mini_cart_info() {
 		$mini_cart_block_name = 'woocommerce/mini-cart';
-		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? BlocksUtil::get_block_from_template_part( $mini_cart_block_name, 'header' ) : BlocksUtil::get_blocks_from_widget_area( $mini_cart_block_name );
+		$mini_cart_block_data = wp_is_block_theme() ? BlocksUtil::get_block_from_template_part( $mini_cart_block_name, 'header' ) : BlocksUtil::get_blocks_from_widget_area( $mini_cart_block_name );
 		return array(
 			'mini_cart_used'             => empty( $mini_cart_block_data[0] ) ? 'No' : 'Yes',
 			'mini_cart_block_attributes' => empty( $mini_cart_block_data[0] ) ? array() : $mini_cart_block_data[0]['attrs'],

--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -291,7 +291,6 @@ class WC_Shop_Customizer {
 			</script>
 			<?php
 		}
-
 	}
 
 	/**
@@ -955,7 +954,7 @@ global $pagenow;
 if (
 	'customize.php' === $pagenow ||
 	isset( $_REQUEST['customize_theme'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	! wc_current_theme_is_fse_theme()
+	! wp_is_block_theme()
 ) {
 	new WC_Shop_Customizer();
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1375,7 +1375,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				'version_latest'          => WC_Admin_Status::get_latest_theme_version( $active_theme ),
 				'author_url'              => esc_url_raw( $active_theme->{'Author URI'} ),
 				'is_child_theme'          => is_child_theme(),
-				'is_block_theme'          => wc_current_theme_is_fse_theme(),
+				'is_block_theme'          => wp_is_block_theme(),
 				'has_woocommerce_support' => current_theme_supports( 'woocommerce' ),
 				'has_woocommerce_file'    => ( file_exists( get_stylesheet_directory() . '/woocommerce.php' ) || file_exists( get_template_directory() . '/woocommerce.php' ) ),
 				'has_outdated_templates'  => $outdated_templates,

--- a/plugins/woocommerce/includes/tracks/events/class-wc-product-collection-block-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-product-collection-block-tracking.php
@@ -33,7 +33,7 @@ class WC_Product_Collection_Block_Tracking {
 	 */
 	public function track_collection_instances( $post_id, $post ) {
 
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! wc_current_theme_is_fse_theme() ) {
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! wp_is_block_theme() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -38,10 +38,8 @@ class WC_Theme_Tracking {
 	 * Send a Tracks event when a theme is activated so that we can track active block themes.
 	 */
 	public function track_activated_theme() {
-		$is_block_theme = false;
-		$theme_object   = wp_get_theme();
-
 		$is_block_theme = wp_is_block_theme();
+		$theme_object   = wp_get_theme();
 
 		$properties = array(
 			'block_theme'   => $is_block_theme,

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -39,11 +39,9 @@ class WC_Theme_Tracking {
 	 */
 	public function track_activated_theme() {
 		$is_block_theme = false;
-		$theme_object = wp_get_theme();
+		$theme_object   = wp_get_theme();
 
-		if ( function_exists( 'wc_current_theme_is_fse_theme' ) ) {
-			$is_block_theme = wc_current_theme_is_fse_theme();
-		}
+		$is_block_theme = wp_is_block_theme();
 
 		$properties = array(
 			'block_theme'   => $is_block_theme,

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -515,17 +515,12 @@ function wc_is_file_valid_csv( $file, $check_path = true ) {
  * Check if the current theme is a block theme.
  *
  * @since 6.0.0
+ * @deprecated 9.9.0 Use wp_is_block_theme() instead.
  * @return bool
  */
 function wc_current_theme_is_fse_theme() {
-	if ( function_exists( 'wp_is_block_theme' ) ) {
-		return (bool) wp_is_block_theme();
-	}
-	if ( function_exists( 'gutenberg_is_fse_theme' ) ) {
-		return (bool) gutenberg_is_fse_theme();
-	}
-
-	return false;
+	wc_deprecated_function( __FUNCTION__, '9.9.0', 'wp_is_block_theme' );
+	return wp_is_block_theme();
 }
 
 /**
@@ -535,7 +530,7 @@ function wc_current_theme_is_fse_theme() {
  * @return bool
  */
 function wc_current_theme_supports_woocommerce_or_fse() {
-	return (bool) current_theme_supports( 'woocommerce' ) || wc_current_theme_is_fse_theme();
+	return (bool) current_theme_supports( 'woocommerce' ) || wp_is_block_theme();
 }
 
 /**
@@ -549,7 +544,7 @@ function wc_current_theme_supports_woocommerce_or_fse() {
  * @return string
  */
 function wc_wp_theme_get_element_class_name( $element ) {
-	if ( wc_current_theme_is_fse_theme() && function_exists( 'wp_theme_get_element_class_name' ) ) {
+	if ( wp_is_block_theme() && function_exists( 'wp_theme_get_element_class_name' ) ) {
 		return wp_theme_get_element_class_name( $element );
 	}
 
@@ -570,7 +565,7 @@ function wc_wp_theme_get_element_class_name( $element ) {
  */
 function wc_block_theme_has_styles_for_element( $element ) {
 	if (
-		! wc_current_theme_is_fse_theme() ||
+		! wp_is_block_theme() ||
 		wc_wp_theme_get_element_class_name( $element ) === ''
 	) {
 		return false;

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -356,7 +356,7 @@ function wc_body_class( $classes ) {
 		}
 	}
 
-	if ( wc_current_theme_is_fse_theme() ) {
+	if ( wp_is_block_theme() ) {
 
 		$classes[] = 'woocommerce-uses-block-theme';
 
@@ -4293,7 +4293,7 @@ add_filter( 'post_type_archive_title', 'wc_update_product_archive_title', 10, 2 
  */
 function wc_set_hooked_blocks_version() {
 	// Only set the version if the current theme is a block theme.
-	if ( ! wc_current_theme_is_fse_theme() && ! current_theme_supports( 'block-template-parts' ) ) {
+	if ( ! wp_is_block_theme() && ! current_theme_supports( 'block-template-parts' ) ) {
 		return;
 	}
 
@@ -4336,7 +4336,7 @@ function wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme )
 	$enable_store_notice_in_classic_theme_option = 'woocommerce_enable_store_notice_in_classic_theme';
 	$is_store_notice_active_option               = 'woocommerce_demo_store';
 
-	if ( ! $old_theme->is_block_theme() && wc_current_theme_is_fse_theme() ) {
+	if ( ! $old_theme->is_block_theme() && wp_is_block_theme() ) {
 		/*
 		 * When switching from a classic theme to a block theme, check if the store notice is active,
 		 * if it is, disable it but set an option to re-enable it when switching back to a classic theme.
@@ -4345,7 +4345,7 @@ function wc_update_store_notice_visible_on_theme_switch( $old_name, $old_theme )
 			update_option( $is_store_notice_active_option, wc_bool_to_string( false ) );
 			add_option( $enable_store_notice_in_classic_theme_option, wc_bool_to_string( true ) );
 		}
-	} elseif ( $old_theme->is_block_theme() && ! wc_current_theme_is_fse_theme() ) {
+	} elseif ( $old_theme->is_block_theme() && ! wp_is_block_theme() ) {
 		/*
 		 * When switching from a block theme to a clasic theme, check if we have set the option to
 		 * re-enable the store notice. If so, re-enable it.
@@ -4374,7 +4374,7 @@ function wc_set_hooked_blocks_version_on_theme_switch( $old_name, $old_theme ) {
 	$option_value = get_option( $option_name, false );
 
 	// Sites with the option value set to "no" have already been migrated, and block hooks have been disabled. Checking explicitly for false to avoid setting the option again.
-	if ( ! $old_theme->is_block_theme() && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) && false === $option_value ) {
+	if ( ! $old_theme->is_block_theme() && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) && false === $option_value ) {
 		add_option( $option_name, WC()->version );
 	}
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2740,7 +2740,7 @@ function wc_update_910_add_launch_your_store_tour_option() {
  * Add woocommerce_hooked_blocks_version option for existing stores that are using a theme that supports the Block Hooks API
  */
 function wc_update_920_add_wc_hooked_blocks_version_option() {
-	if ( ! wc_current_theme_is_fse_theme() && ! current_theme_supports( 'block-template-parts' ) ) {
+	if ( ! wp_is_block_theme() && ! current_theme_supports( 'block-template-parts' ) ) {
 		return;
 	}
 
@@ -3022,7 +3022,7 @@ function wc_update_990_remove_email_notes() {
 	$wpdb->delete(
 		$wpdb->prefix . 'wc_admin_notes',
 		array(
-			'type' => 'email'
+			'type' => 'email',
 		),
 		array( '%s' )
 	);

--- a/plugins/woocommerce/patterns/coming-soon-store-only.php
+++ b/plugins/woocommerce/patterns/coming-soon-store-only.php
@@ -29,7 +29,7 @@ if ( 'twentytwentyfour' === $current_theme ) {
 <div class="wp-block-woocommerce-coming-soon woocommerce-coming-soon-store-only">
 
 <?php
-if ( wc_current_theme_is_fse_theme() ) {
+if ( wp_is_block_theme() ) {
 	echo '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->';
 }
 ?>
@@ -57,7 +57,7 @@ if ( wc_current_theme_is_fse_theme() ) {
 <!-- /wp:group -->
 
 <?php
-if ( wc_current_theme_is_fse_theme() ) {
+if ( wp_is_block_theme() ) {
 	echo '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->';
 }
 ?>

--- a/plugins/woocommerce/patterns/page-coming-soon-with-header-footer.php
+++ b/plugins/woocommerce/patterns/page-coming-soon-with-header-footer.php
@@ -20,7 +20,7 @@ $body_font_family    = $fonts['body'];
 <div class="wp-block-woocommerce-coming-soon woocommerce-coming-soon-store-only">
 
 <?php
-if ( wc_current_theme_is_fse_theme() ) {
+if ( wp_is_block_theme() ) {
 	echo '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->';
 }
 ?>
@@ -48,7 +48,7 @@ if ( wc_current_theme_is_fse_theme() ) {
 <!-- /wp:group -->
 
 <?php
-if ( wc_current_theme_is_fse_theme() ) {
+if ( wp_is_block_theme() ) {
 	echo '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->';
 }
 ?>

--- a/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
+++ b/plugins/woocommerce/src/Blocks/Assets/AssetDataRegistry.php
@@ -86,7 +86,7 @@ class AssetDataRegistry {
 			'currency'               => $this->get_currency_data(),
 			'currentUserId'          => get_current_user_id(),
 			'currentUserIsAdmin'     => current_user_can( 'manage_woocommerce' ),
-			'currentThemeIsFSETheme' => wc_current_theme_is_fse_theme(),
+			'currentThemeIsFSETheme' => wp_is_block_theme(),
 			'dateFormat'             => wc_date_format(),
 			'homeUrl'                => esc_url( home_url( '/' ) ),
 			'locale'                 => $this->get_locale_data(),

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -64,7 +64,7 @@ class BlockTemplatesRegistry {
 				MiniCartTemplate::SLUG       => new MiniCartTemplate(),
 				CheckoutHeaderTemplate::SLUG => new CheckoutHeaderTemplate(),
 			);
-			if ( Features::is_enabled( 'blockified-add-to-cart' ) && wc_current_theme_is_fse_theme() ) {
+			if ( Features::is_enabled( 'blockified-add-to-cart' ) && wp_is_block_theme() ) {
 				$product_types = wc_get_product_types();
 				if ( count( $product_types ) > 0 ) {
 					add_filter( 'default_wp_template_part_areas', array( $this, 'register_add_to_cart_with_options_template_part_area' ), 10, 1 );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -241,7 +241,7 @@ abstract class AbstractBlock {
 		 */
 		if (
 			! is_admin() &&
-			! wc_current_theme_is_fse_theme() &&
+			! wp_is_block_theme() &&
 			$block_settings['style'] &&
 			(
 				! function_exists( 'wp_should_load_separate_core_block_assets' ) ||

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Cart.php
@@ -243,7 +243,7 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ) );
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
-		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme() );
+		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 
 		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings();
 		$local_pickup_method_ids  = LocalPickupUtils::get_local_pickup_method_ids();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -226,7 +226,7 @@ class Checkout extends AbstractBlock {
 		if ( $this->is_checkout_endpoint() ) {
 			// Note: Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
 			// legacy shortcode instead and do not render block.
-			return wc_current_theme_is_fse_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
+			return wp_is_block_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
 
 		// Dequeue the core scripts when rendering this block.
@@ -441,7 +441,7 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled() );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ) );
 		$this->asset_data_registry->register_page_id( isset( $attributes['cartPageId'] ) ? $attributes['cartPageId'] : 0 );
-		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme() );
+		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 		$this->asset_data_registry->add( 'isCheckoutBlock', true );
 
 		$pickup_location_settings = LocalPickupUtils::get_local_pickup_settings();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -199,7 +199,7 @@ class MiniCart extends AbstractBlock {
 
 		if (
 			current_user_can( 'edit_theme_options' ) &&
-			( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) )
+			( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) )
 		) {
 			$theme_slug = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -54,7 +54,7 @@ class ProductButton extends AbstractBlock {
 	 */
 	protected function enqueue_assets( array $attributes, $content, $block ) {
 		parent::enqueue_assets( $attributes, $content, $block );
-		if ( wc_current_theme_is_fse_theme() ) {
+		if ( wp_is_block_theme() ) {
 			add_action(
 				'wp_enqueue_scripts',
 				array( $this, 'dequeue_add_to_cart_scripts' )

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -35,7 +35,7 @@ class ProductFilters extends AbstractBlock {
 		global $pagenow;
 		parent::enqueue_data( $attributes );
 
-		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme() );
+		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 		$this->asset_data_registry->add( 'isProductArchive', is_shop() || is_product_taxonomy() );
 		$this->asset_data_registry->add( 'isSiteEditor', 'site-editor.php' === $pagenow );
 		$this->asset_data_registry->add( 'isWidgetEditor', 'widgets.php' === $pagenow || 'customize.php' === $pagenow );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -193,7 +193,7 @@ class ProductImage extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme() );
+		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 	}
 
 

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -513,7 +513,7 @@ final class BlockTypesController {
 		// Update plugins/woocommerce/client/blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
 		// when modifying this list.
 		if ( Features::is_enabled( 'experimental-blocks' ) ) {
-			if ( Features::is_enabled( 'blockified-add-to-cart' ) && wc_current_theme_is_fse_theme() ) {
+			if ( Features::is_enabled( 'blockified-add-to-cart' ) && wp_is_block_theme() ) {
 				$block_types[] = 'AddToCartWithOptions';
 				$block_types[] = 'AddToCartWithOptionsQuantitySelector';
 				$block_types[] = 'AddToCartWithOptionsVariationSelector';

--- a/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Bootstrap.php
@@ -126,7 +126,7 @@ class Bootstrap {
 			function () {
 				$is_store_api_request = wc()->is_store_api_request();
 
-				if ( ! $is_store_api_request && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+				if ( ! $is_store_api_request && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
 					$this->container->get( BlockTemplatesRegistry::class )->init();
 					$this->container->get( BlockTemplatesController::class )->init();
 				}

--- a/plugins/woocommerce/src/Blocks/TemplateOptions.php
+++ b/plugins/woocommerce/src/Blocks/TemplateOptions.php
@@ -28,7 +28,7 @@ class TemplateOptions {
 	 * @return void
 	 */
 	public function check_should_use_blockified_product_grid_templates( $old_name, $old_theme ) {
-		if ( ! $old_theme->is_block_theme() && wc_current_theme_is_fse_theme() ) {
+		if ( ! $old_theme->is_block_theme() && wp_is_block_theme() ) {
 			$option_name = Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE;
 			// We previously stored "yes" or "no" values. This will convert them to true or false.
 			$option_value = wc_string_to_bool( get_option( $option_name ) );

--- a/plugins/woocommerce/src/Blocks/Templates/ClassicTemplatesCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ClassicTemplatesCompatibility.php
@@ -33,7 +33,7 @@ class ClassicTemplatesCompatibility {
 	 * Initialization method.
 	 */
 	protected function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingPublic
-		if ( ! wc_current_theme_is_fse_theme() ) {
+		if ( ! wp_is_block_theme() ) {
 			add_action( 'template_redirect', array( $this, 'set_classic_template_data' ) );
 			// We need to set this data on the widgets screen so the filters render previews.
 			add_action( 'load-widgets.php', array( $this, 'set_filterable_product_data' ) );

--- a/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ComingSoonTemplate.php
@@ -65,7 +65,7 @@ class ComingSoonTemplate extends AbstractPageTemplate {
 			'body'    => 'inter',
 		);
 
-		if ( ! wc_current_theme_is_fse_theme() ) {
+		if ( ! wp_is_block_theme() ) {
 			return $default_fonts;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -82,7 +82,7 @@ class ProductAttributeTemplate extends AbstractTemplate {
 	 */
 	public function update_taxonomy_template_hierarchy( $templates ) {
 		$queried_object = get_queried_object();
-		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wc_current_theme_is_fse_theme() ) {
+		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wp_is_block_theme() ) {
 			array_splice( $templates, count( $templates ) - 1, 0, self::SLUG );
 		}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -68,7 +68,7 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 	 * @param array $templates Templates that match the search hierarchy.
 	 */
 	public function update_search_template_hierarchy( $templates ) {
-		if ( ( is_search() && is_post_type_archive( 'product' ) ) && wc_current_theme_is_fse_theme() ) {
+		if ( ( is_search() && is_post_type_archive( 'product' ) ) && wp_is_block_theme() ) {
 			array_unshift( $templates, self::SLUG );
 		}
 		return $templates;

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -502,9 +502,9 @@ class BlockTemplateUtils {
 	 * @return boolean
 	 */
 	public static function supports_block_templates( $template_type = 'wp_template' ) {
-		if ( 'wp_template_part' === $template_type && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+		if ( 'wp_template_part' === $template_type && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
 			return true;
-		} elseif ( 'wp_template' === $template_type && wc_current_theme_is_fse_theme() ) {
+		} elseif ( 'wp_template' === $template_type && wp_is_block_theme() ) {
 			return true;
 		}
 		return false;
@@ -691,7 +691,7 @@ class BlockTemplateUtils {
 		$use_blockified_templates = get_option( Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE );
 
 		if ( false === $use_blockified_templates ) {
-			return wc_current_theme_is_fse_theme();
+			return wp_is_block_theme();
 		}
 
 		return wc_string_to_bool( $use_blockified_templates );

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -143,7 +143,7 @@ class CartCheckoutUtils {
 	 * @return bool true if the WC cart page is using the Cart block.
 	 */
 	public static function is_cart_block_default() {
-		if ( wc_current_theme_is_fse_theme() ) {
+		if ( wp_is_block_theme() ) {
 			// Ignore the pages and check the templates.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'cart' ), 'wp_template' );
 			foreach ( $templates_from_db as $template ) {
@@ -162,7 +162,7 @@ class CartCheckoutUtils {
 	 * @return bool true if the WC checkout page is using the Checkout block.
 	 */
 	public static function is_checkout_block_default() {
-		if ( wc_current_theme_is_fse_theme() ) {
+		if ( wp_is_block_theme() ) {
 			// Ignore the pages and check the templates.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'checkout' ), 'wp_template' );
 			foreach ( $templates_from_db as $template ) {
@@ -307,7 +307,7 @@ class CartCheckoutUtils {
 
 		$block = str_replace( 'woocommerce/', '', $block );
 
-		if ( wc_current_theme_is_fse_theme() ) {
+		if ( wp_is_block_theme() ) {
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'page-' . $block ) );
 			foreach ( $templates_from_db as $template ) {
 				if ( ! has_block( 'woocommerce/page-content-wrapper', $template->content ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
@@ -235,7 +235,7 @@ class OnboardingSetupWizard {
 		if ( $this->is_setup_wizard() ) {
 			$settings['onboarding']['pageCount']    = (int) ( wp_count_posts( 'page' ) )->publish;
 			$settings['onboarding']['postCount']    = (int) ( wp_count_posts( 'post' ) )->publish;
-			$settings['onboarding']['isBlockTheme'] = wc_current_theme_is_fse_theme();
+			$settings['onboarding']['isBlockTheme'] = wp_is_block_theme();
 		}
 
 		return apply_filters( 'woocommerce_admin_onboarding_preloaded_data', $settings );

--- a/plugins/woocommerce/src/Internal/Brands.php
+++ b/plugins/woocommerce/src/Internal/Brands.php
@@ -30,7 +30,7 @@ class Brands {
 		include_once WC_ABSPATH . 'includes/class-wc-brands-brand-settings-manager.php';
 		include_once WC_ABSPATH . 'includes/wc-brands-functions.php';
 
-		if ( wc_current_theme_is_fse_theme() ) {
+		if ( wp_is_block_theme() ) {
 			include_once WC_ABSPATH . 'includes/blocks/class-wc-brands-block-templates.php';
 			include_once WC_ABSPATH . 'includes/blocks/class-wc-brands-block-template-utils-duplicated.php';
 		}

--- a/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
+++ b/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php
@@ -58,7 +58,7 @@ class ComingSoonRequestHandler {
 	 */
 	public function possibly_init_block_templates() {
 		// No need to initialize block templates since we've already initialized them in the Block Bootstrap.
-		if ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) {
+		if ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) {
 			return;
 		}
 
@@ -83,7 +83,7 @@ class ComingSoonRequestHandler {
 		// A coming soon page needs to be displayed. Set a short cache duration to prevents ddos attacks.
 		header( 'Cache-Control: max-age=60' );
 
-		$is_fse_theme         = wc_current_theme_is_fse_theme();
+		$is_fse_theme         = wp_is_block_theme();
 		$is_store_coming_soon = $this->coming_soon_helper->is_store_coming_soon();
 		add_theme_support( 'block-templates' );
 

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -35,10 +35,7 @@ class EmailColors {
 			$body_text_color_default   = '#1e1e1e';
 			$footer_text_color_default = '#787c82';
 
-			if ( function_exists( 'wc_current_theme_is_fse_theme' ) 
-				&& wc_current_theme_is_fse_theme() 
-				&& function_exists( 'wp_get_global_styles' ) 
-			) {
+			if ( wp_is_block_theme() && function_exists( 'wp_get_global_styles' ) ) {
 				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
 				$base_color_global         = ! empty( $global_styles['elements']['button']['color']['background'] )
 					? sanitize_hex_color( $global_styles['elements']['button']['color']['background'] ) : '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Replaces all internal usages of `wc_current_theme_is_fse_theme()` with `wp_is_block_theme()`
* Updates the definition of `wc_current_theme_is_fse_theme()` with a deprecation warning, and returns the value of `wp_is_block_theme()` instead

Closes [WOOPLUG-3083](https://linear.app/a8c/issue/WOOPLUG-3083)
Closes https://github.com/woocommerce/woocommerce/issues/54930

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Manual regression testing of the store, using critical flows in both Classic and Block themes
2. Ensure all automated tests pass
3. Ensure I haven't missed any references

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
