### PR TITLE
[settings] support 'single_select_page' field type

### DIFF
--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -12,8 +12,8 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
 /**
  * Internal dependencies
  */
-import type { DataFormItem } from '../../types';
-import { sanitizeHTML } from '../../utils';
+import type { DataFormItem } from '../types';
+import { sanitizeHTML } from '../utils';
 
 // https://github.com/woocommerce/woocommerce/blob/83a090f70d1f7b07325d9df9bd03fe2f753d4fd4/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L626-L636
 const PAGE_QUERY_ARGS = {

--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { createElement, useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreDataStore, Page } from '@wordpress/core-data';
+import type { DataFormControlProps } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormItem } from '../types';
+import { sanitizeHTML } from '../utils';
+
+// https://github.com/woocommerce/woocommerce/blob/83a090f70d1f7b07325d9df9bd03fe2f753d4fd4/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L626-L636
+const PAGE_QUERY_ARGS = {
+	orderby: 'menu_order',
+	order: 'asc',
+	status: [ 'publish', 'private', 'draft' ],
+	per_page: -1,
+	_fields: [ 'id', 'title' ],
+};
+
+const usePages = () => {
+	return useSelect( ( select ) => {
+		const { getEntityRecords, hasFinishedResolution } =
+			select( coreDataStore );
+
+		return {
+			pages: getEntityRecords(
+				'postType',
+				'page',
+				PAGE_QUERY_ARGS
+			) as Page[],
+			isLoading: ! hasFinishedResolution( 'getEntityRecords', [
+				'postType',
+				'page',
+				PAGE_QUERY_ARGS,
+			] ),
+		};
+	}, [] );
+};
+
+type SingleSelectPageEditProps = DataFormControlProps< DataFormItem > & {
+	help?: React.ReactNode;
+	className?: string;
+};
+
+export const SingleSelectPage = ( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	help,
+	className,
+}: SingleSelectPageEditProps ) => {
+	const { pages, isLoading } = usePages();
+
+	const { id } = field;
+
+	// DataForm will automatically use the id as the label if no label is provided so we conditionally set the label to undefined if it matches the id to avoid displaying it.
+	// We should contribute upstream to allow label to be optional.
+	const label =
+		field.label === id ? undefined : (
+			<div
+				dangerouslySetInnerHTML={ {
+					__html: sanitizeHTML( field.label ),
+				} }
+			/>
+		);
+
+	const value = field.getValue( { item: data } ) ?? '';
+	const onChangeControl = useCallback(
+		( newValue: string ) =>
+			onChange( {
+				[ id ]: newValue,
+			} ),
+		[ id, onChange ]
+	);
+
+	const elements = useMemo(
+		() => [
+			/*
+			 * Value can be undefined when:
+			 *
+			 * - the field is not required
+			 * - in bulk editing
+			 *
+			 */
+			{
+				label: isLoading
+					? __( 'Loading…', 'woocommerce' )
+					: __( 'Select a page…', 'woocommerce' ),
+				value: '',
+			},
+			...( pages ?? [] ).map( ( page ) => ( {
+				value: page.id.toString(),
+				label: page.title.rendered,
+			} ) ),
+		],
+		[ isLoading, pages ]
+	);
+
+	return (
+		<SelectControl
+			className={ className }
+			disabled={ isLoading }
+			id={ id }
+			label={ label }
+			value={ value }
+			help={ help }
+			options={ elements }
+			onChange={ onChangeControl }
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+};

--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -82,13 +82,6 @@ export const SingleSelectPage = ( {
 
 	const elements = useMemo(
 		() => [
-			/*
-			 * Value can be undefined when:
-			 *
-			 * - the field is not required
-			 * - in bulk editing
-			 *
-			 */
 			{
 				label: isLoading
 					? __( 'Loading…', 'woocommerce' )

--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { Button, SelectControl, Spinner } from '@wordpress/components';
 import { createElement, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore, Page } from '@wordpress/core-data';
+import { close } from '@wordpress/icons';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import type { DataFormItem } from '../types';
-import { sanitizeHTML } from '../utils';
+import type { DataFormItem } from '../../types';
+import { sanitizeHTML } from '../../utils';
 
 // https://github.com/woocommerce/woocommerce/blob/83a090f70d1f7b07325d9df9bd03fe2f753d4fd4/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L626-L636
 const PAGE_QUERY_ARGS = {
@@ -28,17 +29,15 @@ const usePages = () => {
 		const { getEntityRecords, hasFinishedResolution } =
 			select( coreDataStore );
 
+		const args: [ string, string, typeof PAGE_QUERY_ARGS ] = [
+			'postType',
+			'page',
+			PAGE_QUERY_ARGS,
+		];
+
 		return {
-			pages: getEntityRecords(
-				'postType',
-				'page',
-				PAGE_QUERY_ARGS
-			) as Page[],
-			isLoading: ! hasFinishedResolution( 'getEntityRecords', [
-				'postType',
-				'page',
-				PAGE_QUERY_ARGS,
-			] ),
+			pages: getEntityRecords( ...args ) as Page[],
+			isLoading: ! hasFinishedResolution( 'getEntityRecords', args ),
 		};
 	}, [] );
 };
@@ -48,7 +47,7 @@ type SingleSelectPageEditProps = DataFormControlProps< DataFormItem > & {
 	className?: string;
 };
 
-export const SingleSelectPage = ( {
+export const SingleSelectPageEdit = ( {
 	data,
 	field,
 	onChange,
@@ -97,10 +96,29 @@ export const SingleSelectPage = ( {
 		[ isLoading, pages ]
 	);
 
+	const getSuffix = () => {
+		if ( isLoading ) {
+			return <Spinner />;
+		}
+
+		if ( value ) {
+			return (
+				<Button
+					icon={ close }
+					iconSize={ 16 }
+					size="compact"
+					onClick={ () => onChangeControl( '' ) }
+				/>
+			);
+		}
+
+		return null;
+	};
+
 	return (
 		<SelectControl
 			className={ className }
-			disabled={ isLoading }
+			suffix={ getSuffix() }
 			id={ id }
 			label={ label }
 			value={ value }

--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -57,7 +57,6 @@ export const SingleSelectPage = ( {
 	className,
 }: SingleSelectPageEditProps ) => {
 	const { pages, isLoading } = usePages();
-
 	const { id } = field;
 
 	// DataForm will automatically use the id as the label if no label is provided so we conditionally set the label to undefined if it matches the id to avoid displaying it.
@@ -72,6 +71,7 @@ export const SingleSelectPage = ( {
 		);
 
 	const value = field.getValue( { item: data } ) ?? '';
+
 	const onChangeControl = useCallback(
 		( newValue: string ) =>
 			onChange( {
@@ -80,13 +80,14 @@ export const SingleSelectPage = ( {
 		[ id, onChange ]
 	);
 
-	const elements = useMemo(
+	const options = useMemo(
 		() => [
 			{
 				label: isLoading
 					? __( 'Loading…', 'woocommerce' )
 					: __( 'Select a page…', 'woocommerce' ),
 				value: '',
+				disabled: true,
 			},
 			...( pages ?? [] ).map( ( page ) => ( {
 				value: page.id.toString(),
@@ -104,7 +105,7 @@ export const SingleSelectPage = ( {
 			label={ label }
 			value={ value }
 			help={ help }
-			options={ elements }
+			options={ options }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom

--- a/packages/js/settings-editor/src/form-controls/single-select-page.tsx
+++ b/packages/js/settings-editor/src/form-controls/single-select-page.tsx
@@ -47,7 +47,7 @@ type SingleSelectPageEditProps = DataFormControlProps< DataFormItem > & {
 	className?: string;
 };
 
-export const SingleSelectPageEdit = ( {
+export const SingleSelectPage = ( {
 	data,
 	field,
 	onChange,

--- a/packages/js/settings-editor/src/hooks/utils/transformers.tsx
+++ b/packages/js/settings-editor/src/hooks/utils/transformers.tsx
@@ -18,6 +18,7 @@ import { Textarea } from '../../form-controls/textarea';
 import { Color } from '../../form-controls/color';
 import { Select } from '../../form-controls/select';
 import { Radio } from '../../form-controls/radio';
+import { SingleSelectPage } from '../../form-controls/single-select-page';
 
 export type DataItem = Record< string, BaseSettingsField[ 'value' ] >;
 
@@ -156,6 +157,18 @@ export const transformToField = (
 					} )
 				),
 				Edit: ( props ) => <Select { ...props } help={ help } />,
+			};
+		}
+		case 'single_select_page': {
+			const { label, help } = getLabelAndHelp( setting );
+
+			return {
+				id: setting.id,
+				type: 'text',
+				label,
+				Edit: ( props ) => (
+					<SingleSelectPage { ...props } help={ help } />
+				),
 			};
 		}
 		case 'textarea': {

--- a/packages/js/settings-editor/src/tests/route.test.tsx
+++ b/packages/js/settings-editor/src/tests/route.test.tsx
@@ -20,6 +20,7 @@ jest.mock( '@wordpress/hooks', () => ( {
 	removeAction: jest.fn(),
 	applyFilters: jest.fn(),
 	didFilter: jest.fn(),
+	addFilter: jest.fn(),
 } ) );
 
 jest.mock( '@automattic/site-admin', () => ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->



This PR implements support for the `single_select_page` field type in the settings editor, addressing part of issue #54592. The implementation:

- Uses WordPress core-data store to fetch and manage page data
- Maintains feature parity with the classic admin settings page functionality


### Screenshots or screen recordings:



https://github.com/user-attachments/assets/d5d8d645-b9de-48d2-813b-3af625e4b770


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `settings` feature flag via WCA tester
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=products`
3. Confirm that Shop page setting displays as a single select page field. Verify that:
   - The dropdown loads all available pages (published, private, and draft)
   - Pages are properly sorted by menu order
   - Loading state is shown while fetching pages
   - Selection changes are saved correctly



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Implements support for the `single_select_page` field type in the settings editor

</details>
