### PR TITLE
[e2e tests] Enhance stability of order details resend check

### DIFF
--- a/plugins/woocommerce/changelog/e2e-wooplug-3457-flaky-test-merchant-can-resend-order-details-to-customer
+++ b/plugins/woocommerce/changelog/e2e-wooplug-3457-flaky-test-merchant-can-resend-order-details-to-customer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: improve test stability

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
@@ -133,6 +133,9 @@ test( 'Merchant can resend order details to customer', async ( {
 		.locator( 'li#actions > select' )
 		.selectOption( 'send_order_details' );
 	await page.locator( 'button.wc-reload' ).click();
+	await expect(
+		page.locator( '#message' ).filter( { hasText: 'Order updated' } )
+	).toBeVisible();
 
 	await expectEmail(
 		page,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56428

Add a check for order update before navigating away to a new page to avoid `Error: page.goto: net::ERR_ABORTED`

### How to test the changes in this Pull Request:

Run the test multiple times

```
pnpm test:e2e -g "Merchant can resend order details to customer"
```

### Testing that has already taken place:

Ran the test multiple times:

```
pnpm test:e2e -g "Merchant can resend order details to customer" --repeat-each=100 --max-failures=1
```

Ran the spec multiple times:

```
pnpm test:e2e order-emails.spec --repeat-each=100 --max-failures=1
```
