### PR TITLE
[e2e tests] Fix shipping zones test by using stricter locator on zone selection

### DIFF
--- a/plugins/woocommerce/changelog/e2e-wooplug-3221-flaky-test-can-add-and-use-shipping-zone-for-canada-with
+++ b/plugins/woocommerce/changelog/e2e-wooplug-3221-flaky-test-can-add-and-use-shipping-zone-for-canada-with
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: enhance shipping zones test

--- a/plugins/woocommerce/tests/e2e-pw/tests/shipping/shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shipping/shipping-zones.spec.js
@@ -185,7 +185,10 @@ async function checkShippingRateInCart( page, product, checks ) {
 			input.click();
 			input.fill( zone );
 
-			await page.getByText( zone ).last().click();
+			await page
+				.locator( 'label' )
+				.filter( { hasText: new RegExp( `^${ zone }$` ) } )
+				.click();
 
 			// Close dropdown
 			await page.getByPlaceholder( 'Zone name' ).click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/55721

Fixes an issue with a loose locator when selecting the shipping zone. When searching for Canada, all the states are displayed, and the last on containing the text (`Canada`) was being selected (`Yukon Teritorry, Canada`). Using a strict text locator ensures the right item is selected (`Canada`).

### How to test the changes in this Pull Request:

Run the test multiple times

```
pnpm test:e2e -g "can add and use shipping zone"
```

### Testing that has already taken place:

Ran the test multiple times

```
pnpm test:e2e -g "can add and use shipping zone" --repeat-each=100 --max-failures=1
```

Ran the spec multiple times

```
pnpm test:e2e shipping-zones.spec --repeat-each=100 --max-failures=1
```


