### PR TITLE
[Checkout] Improve Delivery selector styling and spacing

### DIFF
--- a/plugins/woocommerce/changelog/update-shipping-selector-style-56010
+++ b/plugins/woocommerce/changelog/update-shipping-selector-style-56010
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updated delivery selector styling on block checkout to improve spacing.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -4,7 +4,7 @@
 // Bright colors
 $discount-color: $alert-green;
 
-$input-text-active: #2b2d2f;
+$input-text-light: #2b2d2f;
 $input-text-dark: #fff;
 $input-placeholder-dark: rgba(255, 255, 255, 0.6);
 $input-border-dark: rgba(255, 255, 255, 0.4);

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_colors.scss
@@ -4,16 +4,12 @@
 // Bright colors
 $discount-color: $alert-green;
 
-$input-border-gray: #50575e;
-$input-border-dark: rgba(255, 255, 255, 0.4);
-$controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
-$input-placeholder-dark: rgba(255, 255, 255, 0.6);
 $input-text-dark: #fff;
+$input-placeholder-dark: rgba(255, 255, 255, 0.6);
+$input-border-dark: rgba(255, 255, 255, 0.4);
+$input-background-light: #fff;
 $input-background-dark: rgba(0, 0, 0, 0.1);
-$select-dropdown-dark: #1e1e1e;
-$select-dropdown-light: #fff;
-$select-item-dark: rgba(0, 0, 0, 0.4);
 $image-placeholder-border-color: #f2f2f2;
 
 // Universal colors for use on the frontend, currently being applied to checkout blocks.

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -105,7 +105,7 @@ $fontSizes: (
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	clip-path: none;
-	color: $input-text-active;
+	color: $input-text-light;
 	display: block;
 	font-size: 0.875rem;
 	font-weight: 700;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -33,7 +33,7 @@
 		appearance: none;
 		background: none;
 		padding: em($gap) em($gap-smaller) 0;
-		color: $input-text-active;
+		color: $input-text-light;
 		border: 1px solid $universal-border-strong;
 
 		&:focus {
@@ -63,7 +63,7 @@
 		top: 2px;
 		transform-origin: top left;
 		transition: all 200ms ease;
-		color: $input-text-active;
+		color: $input-text-light;
 		z-index: 1;
 		margin: 0;
 		overflow: hidden;
@@ -92,7 +92,7 @@
 		top: 50%;
 		right: $gap-small;
 		pointer-events: none;
-		fill: $input-text-active;
+		fill: $input-text-light;
 
 		.has-dark-controls & {
 			fill: $input-text-dark;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -4,7 +4,7 @@
 	.wc-blocks-components-select__container {
 		border-radius: $universal-border-radius;
 		box-sizing: border-box;
-		background: #fff;
+		background: $input-background-light;
 		width: 100%;
 		height: 3.125em;
 		position: relative;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -47,7 +47,7 @@
 		margin: 0;
 		box-sizing: border-box;
 		height: 3em;
-		color: $input-text-active;
+		color: $input-text-light;
 		cursor: text;
 
 		&:focus {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -41,7 +41,7 @@
 		background-color: #fff;
 		padding: em($gap-small) 0 em($gap-small) $gap;
 		border-radius: $universal-border-radius;
-		border: 1px solid $input-border-gray;
+		border: 1px solid $universal-border-strong;
 		width: 100%;
 		font-family: inherit;
 		margin: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
@@ -14,10 +14,10 @@
 	margin-top: $gap;
 
 	&:focus {
-		background-color: #fff;
+		background-color: $input-background-light;
 		color: $input-text-active;
 		outline: 0;
-		box-shadow: 0 0 0 1px $input-border-gray;
+		box-shadow: 0 0 0 1px $input-text-active;
 	}
 
 	.has-dark-controls & {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
@@ -15,9 +15,9 @@
 
 	&:focus {
 		background-color: $input-background-light;
-		color: $input-text-active;
+		color: $input-text-light;
 		outline: 0;
-		box-shadow: 0 0 0 1px $input-text-active;
+		box-shadow: 0 0 0 1px $input-text-light;
 	}
 
 	.has-dark-controls & {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -53,15 +53,17 @@ const LocalPickupSelector = ( {
 					checked === 'pickup',
 			} ) }
 		>
-			{ showIcon === true && (
-				<Icon
-					icon={ store }
-					size={ 28 }
-					className="wc-block-checkout__shipping-method-option-icon"
-				/>
-			) }
-			<span className="wc-block-checkout__shipping-method-option-title">
-				{ toggleText }
+			<span className="wc-block-checkout__shipping-method-option-title-wrapper">
+				{ showIcon === true && (
+					<Icon
+						icon={ store }
+						size={ 28 }
+						className="wc-block-checkout__shipping-method-option-icon"
+					/>
+				) }
+				<span className="wc-block-checkout__shipping-method-option-title">
+					{ toggleText }
+				</span>
 			</span>
 			{ showPrice === true && (
 				<RatePrice
@@ -140,15 +142,17 @@ const ShippingSelector = ( {
 					checked === 'shipping',
 			} ) }
 		>
-			{ showIcon === true && (
-				<Icon
-					icon={ shipping }
-					size={ 28 }
-					className="wc-block-checkout__shipping-method-option-icon"
-				/>
-			) }
-			<span className="wc-block-checkout__shipping-method-option-title">
-				{ toggleText }
+			<span className="wc-block-checkout__shipping-method-option-title-wrapper">
+				{ showIcon === true && (
+					<Icon
+						icon={ shipping }
+						size={ 28 }
+						className="wc-block-checkout__shipping-method-option-icon"
+					/>
+				) }
+				<span className="wc-block-checkout__shipping-method-option-title">
+					{ toggleText }
+				</span>
 			</span>
 			{ showPrice === true && Price }
 		</Button>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -30,6 +30,11 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 	border-radius: $universal-border-radius;
 	border: 2px solid transparent;
 	background-color: transparent;
+	color: $input-text-light;
+
+	.has-dark-controls & {
+		color: $input-text-dark;
+	}
 
 	&:hover,
 	&:focus-within {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -40,18 +40,32 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 	&.wc-block-checkout__shipping-method-option--selected {
 		border: 2px solid currentColor;
 		background: $input-background-light;
+
+		.has-dark-controls & {
+			background: $input-background-dark;
+		}
 	}
+}
+
+.wc-block-checkout__shipping-method-option-title-wrapper {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+	flex-wrap: nowrap;
+	gap: $gap-smallest;
 }
 
 .wc-block-checkout__shipping-method-option-icon {
 	fill: currentColor;
-	margin: 0 $gap-smallest;
+	flex-shrink: 0;
+	vertical-align: middle;
 }
 
 .wc-block-checkout__shipping-method-option-title {
 	@include reset-typography();
 	@include font-size(regular, 1rem);
 	font-weight: bold;
+	line-height: 28px; // Match the icon size
 }
 
 .wc-block-checkout__shipping-method-option-price {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -1,18 +1,16 @@
+$component-background: color-mix(in srgb, currentColor 6%, transparent);
+$component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
+
 .wc-block-checkout__shipping-method .wc-block-checkout__shipping-method-container {
 	width: 100%;
 	display: flex;
-	gap: $gap;
 	justify-content: space-between;
-}
-
-// This nested selector is solely for specificity to override a quite specific style set in the button component.
-// We have avoided nesting all the styles in case specificity changes introduce regressions elsewhere.
-.edit-post-visual-editor {
-	.wc-block-checkout__shipping-method-container {
-		.wc-block-checkout__shipping-method-option {
-			min-height: 80px;
-		}
-	}
+	align-items: stretch;
+	flex-direction: row;
+	border-radius: $universal-border-radius * 2;
+	background-color: $component-background;
+	gap: $gap-smallest;
+	padding: $gap-smallest;
 }
 
 .edit-post-visual-editor .wc-block-checkout__shipping-method-option,
@@ -23,63 +21,41 @@
 	justify-content: center;
 	flex-wrap: wrap;
 	align-items: center;
-	height: 100%;
-	min-height: 80px;
 	box-sizing: border-box;
 	flex-basis: 0;
-	gap: 4px;
-	padding: 16px 12px;
-	background-color: transparent;
-	outline: 1px solid $universal-border-light;
-	border-radius: $universal-border-radius;
+	gap: 0;
 	cursor: pointer;
 	position: relative; // Add this for pseudo-element positioning
+	padding: $gap-small;
+	border-radius: $universal-border-radius;
+	border: 2px solid transparent;
+	background-color: transparent;
 
-	.has-dark-controls & {
-		outline: 1px solid $input-border-dark;
-	}
-
-	&::after {
-		content: "";
-		position: absolute;
-		top: -3px;
-		right: -3px;
-		bottom: -3px;
-		left: -3px;
-		border-radius: calc(#{$universal-border-radius} + 2px);
-		pointer-events: none;
-	}
-
+	&:hover,
 	&:focus-within {
-		outline: 1.5px solid currentColor;
-		&::after {
-			outline: 1px solid currentColor;
-		}
-	}
-
-	&:hover {
-		background-color: $universal-background;
+		background-color: $component-background-hover;
+		outline: none;
 	}
 
 	&.wc-block-checkout__shipping-method-option--selected {
-		outline: 1.5px solid currentColor;
-		background-color: $universal-background;
-		&:focus-within::after {
-			outline: 1px solid currentColor;
-		}
+		border: 2px solid currentColor;
+		background: $input-background-light;
 	}
 }
 
 .wc-block-checkout__shipping-method-option-icon {
 	fill: currentColor;
+	margin: 0 $gap-smallest;
 }
 
 .wc-block-checkout__shipping-method-option-title {
+	@include reset-typography();
 	@include font-size(regular, 1rem);
 	font-weight: bold;
 }
 
 .wc-block-checkout__shipping-method-option-price {
+	@include reset-typography();
 	@include font-size(small, 1rem);
 	flex-basis: 100%;
 	text-align: center;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -71,6 +71,7 @@ $component-background-hover: color-mix(in srgb, currentColor 12%, transparent);
 	@include font-size(regular, 1rem);
 	font-weight: bold;
 	line-height: 28px; // Match the icon size
+	text-wrap: balance;
 }
 
 .wc-block-checkout__shipping-method-option-price {

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
@@ -43,10 +43,10 @@
 		overflow: hidden;
 		position: static;
 		vertical-align: middle;
-		background-color: #fff;
+		background-color: $input-background-light;
 
 		&:checked {
-			background: #fff;
+			background: $input-background-light;
 		}
 
 		&:focus {
@@ -64,7 +64,7 @@
 		}
 
 		.has-dark-controls & {
-			border-color: $controls-border-dark;
+			border-color: $input-border-dark;
 			background-color: $input-background-dark;
 			color: $input-text-dark;
 
@@ -110,7 +110,7 @@
 		pointer-events: none;
 
 		.has-dark-controls & {
-			fill: #fff;
+			fill: $input-text-dark;
 		}
 	}
 
@@ -124,14 +124,14 @@
 .theme-twentytwentyone {
 	.wc-block-components-checkbox__input[type="checkbox"],
 	.has-dark-controls .wc-block-components-checkbox__input[type="checkbox"] {
-		background-color: #fff;
+		background-color: $input-background-light;
 		border-color: var(--form--border-color);
 		position: relative;
 	}
 
 	.wc-block-components-checkbox__input[type="checkbox"]:checked,
 	.has-dark-controls .wc-block-components-checkbox__input[type="checkbox"]:checked {
-		background-color: #fff;
+		background-color: $input-background-light;
 		border-color: var(--form--border-color);
 	}
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -203,7 +203,7 @@
 .wc-block-components-radio-control {
 	.wc-block-components-radio-control__input {
 		appearance: none;
-		background: #fff;
+		background: $input-background-light;
 		border: 1px solid $universal-border-medium;
 		border-radius: 50%;
 		display: inline-block;
@@ -244,7 +244,7 @@
 		}
 
 		.has-dark-controls & {
-			border-color: $controls-border-dark;
+			border-color: $input-border-dark;
 			background-color: $input-background-dark;
 
 			&:checked {

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -25,8 +25,16 @@ const StoreNotices = ( {
 } ): JSX.Element => {
 	const ref = useRef< HTMLDivElement >( null );
 	const { removeNotice } = useDispatch( 'core/notices' );
-	const noticeIds = notices.map( ( notice ) => notice.id );
-	const previousNoticeIds = usePrevious( noticeIds );
+	// Only scroll to the container when an error notice is added, not info notices.
+	const errorIds = notices
+		.map( ( notice ) => {
+			if ( notice.status === 'error' || notice.status === 'warning' ) {
+				return notice.id;
+			}
+			return null;
+		} )
+		.filter( Boolean );
+	const previousErrorIds = usePrevious( errorIds );
 
 	useEffect( () => {
 		// Scroll to container when an error is added here.
@@ -48,17 +56,18 @@ const StoreNotices = ( {
 			return;
 		}
 
-		const newNoticeIds = noticeIds.filter(
+		const newErrorIds = errorIds.filter(
 			( value ) =>
-				! previousNoticeIds || ! previousNoticeIds.includes( value )
+				! previousErrorIds || ! previousErrorIds.includes( value )
 		);
 
-		if ( newNoticeIds.length && containerRef?.scrollIntoView ) {
+		if ( newErrorIds.length && containerRef?.scrollIntoView ) {
 			containerRef.scrollIntoView( {
 				behavior: 'smooth',
 			} );
 		}
 	}, [ noticeIds, previousNoticeIds, ref ] );
+	}, [ errorIds, previousErrorIds, ref ] );
 
 	// Group notices by whether or not they are dismissible. Dismissible notices can be grouped.
 	const dismissibleNotices = notices.filter(

--- a/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/store-notices-container/store-notices.tsx
@@ -66,7 +66,6 @@ const StoreNotices = ( {
 				behavior: 'smooth',
 			} );
 		}
-	}, [ noticeIds, previousNoticeIds, ref ] );
 	}, [ errorIds, previousErrorIds, ref ] );
 
 	// Group notices by whether or not they are dismissible. Dismissible notices can be grouped.

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -58,11 +58,11 @@
 		min-height: 0;
 		height: 3.125em;
 		background-color: $input-background-light;
-		color: $input-text-active;
+		color: $input-text-light;
 
 		&:focus {
 			background-color: $input-background-light;
-			color: $input-text-active;
+			color: $input-text-light;
 			border: 1.5px solid currentColor;
 		}
 

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -57,11 +57,11 @@
 		box-sizing: border-box;
 		min-height: 0;
 		height: 3.125em;
-		background-color: #fff;
+		background-color: $input-background-light;
 		color: $input-text-active;
 
 		&:focus {
-			background-color: #fff;
+			background-color: $input-background-light;
 			color: $input-text-active;
 			border: 1.5px solid currentColor;
 		}

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -3,7 +3,7 @@
 	background-color: $input-background-light;
 	border: 1px solid $universal-border-strong;
 	border-radius: $universal-border-radius;
-	color: $input-text-active;
+	color: $input-text-light;
 	font-family: inherit;
 	line-height: 1.375; // =22px when font-size is 16px.
 	margin: 0;

--- a/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/textarea/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-textarea {
 	@include font-size(regular);
-	background-color: #fff;
+	background-color: $input-background-light;
 	border: 1px solid $universal-border-strong;
 	border-radius: $universal-border-radius;
 	color: $input-text-active;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements design changes to the shipping/pickup selector to optimise spacing, and make it more obviously a toggle vs a pair of buttons.

Closes #56010

### Screenshots or screen recordings:

Note that when testing dark themes, I enabled "dark mode" at block level to give the inputs (and these new styles) a darker background instead of white. 

| Setup | Light theme | Dark theme |
|------------|------------|-----------|
| Desktop | ![Screenshot 2025-03-28 at 12 31 54](https://github.com/user-attachments/assets/3be3999e-3d15-4c12-add7-f3379b71a0a3) | ![Screenshot 2025-03-28 at 12 41 11](https://github.com/user-attachments/assets/eea5b24b-2a9a-4052-9d5f-c0b10a4fe87b) |
| Desktop w/o labels | ![Screenshot 2025-03-28 at 12 30 47](https://github.com/user-attachments/assets/4f6371ba-9246-4e75-b0c7-6a6bde6e10f8) | ![Screenshot 2025-03-28 at 12 52 14](https://github.com/user-attachments/assets/e9942b31-be97-4608-a085-3b10be086583) |
| Mobile | ![Screenshot 2025-03-28 at 12 31 42](https://github.com/user-attachments/assets/b08b3caf-3fdd-4597-956f-f723c8901170) | ![Screenshot 2025-03-28 at 12 53 51](https://github.com/user-attachments/assets/508c5f3e-1047-4872-b85f-a836f3ecd0c0)
| Mobile w/o labels | ![Screenshot 2025-03-28 at 12 31 22](https://github.com/user-attachments/assets/c3a875fa-4e18-47a3-9540-29337b6916ba) | ![Screenshot 2025-03-28 at 12 53 15](https://github.com/user-attachments/assets/7cf45133-5782-4d02-b598-1af2bd901388) |

Wrapping long lines:

![Screenshot 2025-03-28 at 13 12 41](https://github.com/user-attachments/assets/a31e9494-52d2-4bf2-82e7-5b82f285393b)

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build the project and go to your block checkout page. To see the selectors ensure Local Pickup and Shipping Methods are both enabled, and you have a cart at requires shipping.
2. Check designs against screenshots. Test hover states work and toggling works as expected. 
3. Test with mobile view as well as desktop view.
4. Edit the checkout block. Select the shipping selector. Test it works as expected with labels hidden or visible in a variety of setups.
5. Check with a light theme and a dark theme. Note that to get good results, you may have to toggle dark mode inputs on/off by editing the checkout block.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
