### PR TITLE
Remove declare(strict_types=1) from wc-product-functions.php

### DIFF
--- a/plugins/woocommerce/changelog/remove-declare-strict-types-wc-product-functions
+++ b/plugins/woocommerce/changelog/remove-declare-strict-types-wc-product-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove strict types from wc-product-functions.php

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -8,8 +8,6 @@
  * @version 3.0.0
  */
 
-declare(strict_types=1);
-
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes `declare(strict_types=1);` from `wc-product-functions.php` to prevent fatal TypeError exceptions when non-numeric values are passed to `wc_get_related_products()`. This declaration was causing PHP to enforce strict type checking, which would fail when performing arithmetic operations on the `$limit` parameter if it was passed as a string.

Closes https://github.com/woocommerce/woocommerce/issues/56485

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/55843

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit `wc_get_related_products()` in `wc-product-functions.php` 
2. As the first line _within_ the function add `$limit = '5';` as shown below.
3. Ensure no fatal error occurs on the product page.

```php
function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(), $related_by = array() ) {
	$limit          = '5';
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
