### PR TITLE
Dev/blockified Display add to cart block template custom product types

### DIFF
--- a/plugins/woocommerce/changelog/dev-blockified-add-to-cart-custom-product-types
+++ b/plugins/woocommerce/changelog/dev-blockified-add-to-cart-custom-product-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Introduce "__experimental_woocommerce_{$product_type}_add_to_cart_with_options_block_template_part" filter for front end rendering of custom product types in the add to cart with options block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -242,13 +242,17 @@ class AddToCartWithOptions extends AbstractBlock {
 			ob_start();
 
 			if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+
 				$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
+				remove_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
+
 				/**
 				 * Trigger the single product add to cart action that prints the markup.
 				 *
 				 * @since 9.9.0
 				 */
 				do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
+				add_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
 			}
 
 			$form_html = $form_html . ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -158,20 +158,6 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 1.5.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_button' );
-				} elseif ( ProductType::EXTERNAL === $product_type ) {
-					/**
-					 * Hook: woocommerce_before_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_before_add_to_cart_button' );
-				} elseif ( ProductType::GROUPED === $product_type ) {
-					/**
-					 * Hook: woocommerce_before_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_before_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_variations_form.
@@ -179,6 +165,13 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 2.4.0
 					 */
 					do_action( 'woocommerce_before_variations_form' );
+				} else {
+					/**
+					 * Hook: woocommerce_before_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_button' );
 				}
 				$hooks_before = ob_get_clean();
 
@@ -196,20 +189,6 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 1.5.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_button' );
-				} elseif ( ProductType::EXTERNAL === $product_type ) {
-					/**
-					 * Hook: woocommerce_after_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_after_add_to_cart_button' );
-				} elseif ( ProductType::GROUPED === $product_type ) {
-					/**
-					 * Hook: woocommerce_after_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_after_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_after_variations_form.
@@ -217,7 +196,15 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 2.4.0
 					 */
 					do_action( 'woocommerce_after_variations_form' );
+				} else {
+					/**
+					 * Hook: woocommerce_after_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_after_add_to_cart_button' );
 				}
+				
 				$hooks_after = ob_get_clean();
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -87,9 +87,9 @@ class AddToCartWithOptions extends AbstractBlock {
 		 * @param boolean $supports Is the type supported
 		 * @param string $product_type The product type 
 		 */
-		$template_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
+		$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
 
-		if ( file_exists( $template_path ) ) {
+		if ( file_exists( $template_part_path ) ) {
 
 			$template_part_contents = '';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.
@@ -108,7 +108,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			if ( '' === $template_part_contents ) {
-				$template_part_contents = file_get_contents( $template_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$template_part_contents = file_get_contents( $template_part_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
 
 			$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -80,14 +80,18 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$slug = $product_type . '-product-add-to-cart-with-options';
 
-		/**
-		 * Filter to declare product type's cart block template is supported.
-		 * 
-		 * @since x.x.x
-		 * @param boolean $supports Is the type supported
-		 * @param string $product_type The product type 
-		 */
-		$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
+		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+			$template_part_path = Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html';
+		} else {
+			/**
+			 * Filter to declare product type's cart block template is supported.
+			 * 
+			 * @since x.x.x
+			 * @param boolean $supports Is the type supported
+			 * @param string $product_type The product type 
+			 */
+			$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
+		}
 
 		if ( file_exists( $template_part_path ) ) {
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -90,7 +90,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			 * @param boolean $supports Is the type supported
 			 * @param string $product_type The product type 
 			 */
-			$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
+			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}
 
 		if ( file_exists( $template_part_path ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -93,7 +93,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}
 
-		if ( file_exists( $template_part_path ) ) {
+		if ( is_string( $template_part_path) && file_exists( $template_part_path ) ) {
 
 			$template_part_contents = '';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -86,7 +86,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			/**
 			 * Filter to declare product type's cart block template is supported.
 			 * 
-			 * @since x.x.x
+			 * @since 9.9.0
 			 * @param mixed string|boolean The template part path if it exists
 			 * @param string $product_type The product type 
 			 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -90,7 +90,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			 * @param boolean $supports Is the type supported
 			 * @param string $product_type The product type 
 			 */
-			$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
+			$template_part_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}
 
 		if ( file_exists( $template_part_path ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -158,6 +158,20 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 1.5.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_button' );
+				} elseif ( ProductType::EXTERNAL === $product_type ) {
+					/**
+					 * Hook: woocommerce_before_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_button' );
+				} elseif ( ProductType::GROUPED === $product_type ) {
+					/**
+					 * Hook: woocommerce_before_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_variations_form.
@@ -165,13 +179,6 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 2.4.0
 					 */
 					do_action( 'woocommerce_before_variations_form' );
-				} else {
-					/**
-					 * Hook: woocommerce_before_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_before_add_to_cart_button' );
 				}
 				$hooks_before = ob_get_clean();
 
@@ -189,6 +196,20 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 1.5.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_button' );
+				} elseif ( ProductType::EXTERNAL === $product_type ) {
+					/**
+					 * Hook: woocommerce_after_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_after_add_to_cart_button' );
+				} elseif ( ProductType::GROUPED === $product_type ) {
+					/**
+					 * Hook: woocommerce_after_add_to_cart_button.
+					 *
+					 * @since 1.5.0
+					 */
+					do_action( 'woocommerce_after_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_after_variations_form.
@@ -196,15 +217,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					 * @since 2.4.0
 					 */
 					do_action( 'woocommerce_after_variations_form' );
-				} else {
-					/**
-					 * Hook: woocommerce_after_add_to_cart_button.
-					 *
-					 * @since 1.5.0
-					 */
-					do_action( 'woocommerce_after_add_to_cart_button' );
 				}
-				
 				$hooks_after = ob_get_clean();
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -241,17 +241,14 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			ob_start();
 
-			$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
-			remove_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
-
-			/**
-			 * Trigger the single product add to cart action that prints the markup.
-			 *
-			 * @since 9.9.0
-			 */
-			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
-			if ( function_exists( $add_to_cart_fn ) ) {
-				add_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
+			if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+				$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
+				/**
+				 * Trigger the single product add to cart action that prints the markup.
+				 *
+				 * @since 9.9.0
+				 */
+				do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
 			}
 
 			$form_html = $form_html . ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -85,10 +85,10 @@ class AddToCartWithOptions extends AbstractBlock {
 		} else {
 			/**
 			 * Filter to declare product type's cart block template is supported.
-			 * 
+			 *
 			 * @since 9.9.0
 			 * @param mixed string|boolean The template part path if it exists
-			 * @param string $product_type The product type 
+			 * @param string $product_type The product type
 			 */
 			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -224,14 +224,18 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			ob_start();
 
-			remove_action( 'woocommerce_' . $product_type . '_add_to_cart', 'woocommerce_' . $product_type . '_add_to_cart', 30 );
+			$add_to_cart_fn = 'woocommerce_' . $product_type . '_add_to_cart';
+			remove_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
+
 			/**
 			 * Trigger the single product add to cart action that prints the markup.
 			 *
 			 * @since 9.9.0
 			 */
 			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
-			add_action( 'woocommerce_' . $product_type . '_add_to_cart', 'woocommerce_' . $product_type . '_add_to_cart', 30 );
+			if ( function_exists( $add_to_cart_fn ) ) {
+				add_action( 'woocommerce_' . $product_type . '_add_to_cart', $add_to_cart_fn, 30 );
+			}
 
 			$form_html = $form_html . ob_get_clean();
 		} else {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -78,11 +78,23 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$product_type = $product->get_type();
 
-		if ( in_array( $product_type, array( ProductType::SIMPLE, ProductType::EXTERNAL, ProductType::VARIABLE, ProductType::GROUPED ), true ) ) {
+		$slug = $product_type . '-product-add-to-cart-with-options';
+
+		/**
+		 * Filter to declare product type's cart block template is supported.
+		 * 
+		 * @since x.x.x
+		 * @param boolean $supports Is the type supported
+		 * @param string $product_type The product type 
+		 */
+		$template_path = apply_filters( 'woocommerce_' . $product_type . '_add_to_cart_block_template_part', Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html', $product_type );
+
+		if ( file_exists( $template_path ) ) {
+
 			$template_part_contents = '';
-			$slug                   = $product_type . '-product-add-to-cart-with-options';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.
 			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( $slug ), 'wp_template_part' );
+
 			if ( is_countable( $templates_from_db ) && count( $templates_from_db ) > 0 ) {
 				$template_slug_to_load = $templates_from_db[0]->theme;
 			} else {
@@ -96,7 +108,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			if ( '' === $template_part_contents ) {
-				$template_part_contents = file_get_contents( Package::get_path() . 'templates/' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $slug . '.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$template_part_contents = file_get_contents( $template_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
 
 			$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -87,7 +87,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			 * Filter to declare product type's cart block template is supported.
 			 * 
 			 * @since x.x.x
-			 * @param boolean $supports Is the type supported
+			 * @param mixed string|boolean The template part path if it exists
 			 * @param string $product_type The product type 
 			 */
 			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -93,7 +93,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}
 
-		if ( is_string( $template_part_path) && file_exists( $template_part_path ) ) {
+		if ( is_string( $template_part_path ) && file_exists( $template_part_path ) ) {
 
 			$template_part_contents = '';
 			// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.


### PR DESCRIPTION
This introduces a filter for plugins to declare a template part for blockified add to cart for custom product types. It would be used like so from another plugin:

```
add_filter( 'woocommerce_taco_add_to_cart_block_template_part', function() {
	return plugin_dir_path( __FILE__ ) . '/templates/taco-product-add-to-cart-with-options.html';
}, 10, 2 );
```

*Update* with the `__experimental_` prefix

```
add_filter( '__experimental_woocommerce_taco_add_to_cart_with_options_block_template_part', function() {
	return plugin_dir_path( __FILE__ ) . '/templates/taco-product-add-to-cart-with-options.html';
}, 10, 2 );
```

NB: This is _only_ related to the front-end display.

here's a [complete mini-plugin](https://gist.github.com/helgatheviking/f49ebaf44b1fe70b4ab8e993336491f9) that creates a custom product type and it's relevant block template for testing this PR. (updated with the experimental filter prefix)

Result for the display of my "taco" type product is the custom taco add to cart template!
![image](https://github.com/user-attachments/assets/40d254f5-02cf-4ee9-a18a-d6a3c12c0f03)


related to #55700 cc @Aljullu 