### PR TITLE
[e2e tests] Fix flaky checkout spec and improve error handling in update functions

### DIFF
--- a/plugins/woocommerce/changelog/e2e-wooplug-3242-flaky-test-guest-can-checkout-paying-with-cash-on-delivery
+++ b/plugins/woocommerce/changelog/e2e-wooplug-3242-flaky-test-guest-can-checkout-paying-with-cash-on-delivery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: fix checkout spec fixture failing on first run

--- a/plugins/woocommerce/tests/e2e-pw/tests/checkout/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/checkout/checkout.spec.js
@@ -197,12 +197,12 @@ const test = baseTest.extend( {
 		await resetValue( 'general/woocommerce_calc_taxes', calcTaxesState );
 
 		await resetValue(
-			'general/woocommerce_enable_checkout_login_reminder',
+			'account/woocommerce_enable_checkout_login_reminder',
 			loginAtCheckoutState
 		);
 
 		await resetValue(
-			'general/woocommerce_enable_signup_and_login_from_checkout',
+			'account/woocommerce_enable_signup_and_login_from_checkout',
 			signUpAtCheckoutState
 		);
 

--- a/plugins/woocommerce/tests/e2e-pw/utils/settings.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/settings.js
@@ -17,7 +17,12 @@ function resolvePath( path ) {
  * @return {Promise<void>} A promise that resolves when the update is complete.
  */
 export async function updateValue( path, desiredValue ) {
-	await apiClient.put( resolvePath( path ), { value: desiredValue } );
+	await apiClient
+		.put( resolvePath( path ), { value: desiredValue } )
+		.catch( ( err ) => {
+			console.error( `Error updating ${ path }` );
+			throw err;
+		} );
 }
 
 /**
@@ -30,7 +35,11 @@ export async function updateValue( path, desiredValue ) {
 export async function updateIfNeeded( path, desiredValue ) {
 	const initialValue = await apiClient
 		.get( resolvePath( path ) )
-		.then( ( r ) => r.data.value );
+		.then( ( r ) => r.data.value )
+		.catch( ( err ) => {
+			console.log( `Error checking ${ path }` );
+			throw err;
+		} );
 	if ( initialValue !== desiredValue ) {
 		await updateValue( path, desiredValue );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/55828
Closes https://github.com/woocommerce/woocommerce/issues/56329

The rest api path used to reset the values was incorrect (`general` instead of `account`). Because of this the first test in the spec was always marked as failing in the first try, but passed on retry.

### How to test the changes in this Pull Request:

On a fresh environment, run the checkout spec

```
pnpm test:e2e checkout.spec
```


### Testing that has already taken place:

Ran the checkout spec multiple times.
