### PR TITLE
[e2e tests] Enhance email settings spec to verify success message after saving settings

### DIFF
--- a/plugins/woocommerce/changelog/e2e-wooplug-3460-flaky-test-auto-sync-toggle-in-email-settings-works
+++ b/plugins/woocommerce/changelog/e2e-wooplug-3460-flaky-test-auto-sync-toggle-in-email-settings-works
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests: enhance email settings test to verify success message after saving settings

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -78,6 +78,12 @@ test.describe( 'Email Style Sync', () => {
 		// Save settings
 		await page.locator( 'button.woocommerce-save-button' ).click();
 
+		await expect(
+			page
+				.locator( '#message' )
+				.filter( { hasText: 'Your settings have been saved' } )
+		).toBeVisible();
+
 		// Reload page and check if setting persisted
 		await page.reload();
 		await expect( autoSyncToggle ).toBeVisible();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/56433

Enhances email settings spec to check for the success message after saving email settings. This avoids the `net::ERR_ABORTED` error that happens if the page tries to navigate before the save was complete.

### How to test the changes in this Pull Request:

Run the test multiple times:

```
pnpm test:e2e -g "Auto-sync toggle in email settings works correctly"
```

### Testing that has already taken place:

Ran the test multiple times:

```
pnpm test:e2e -g "Auto-sync toggle in email settings works correctly" --repeat-each=100 --max-failures=1
```

Ran the spec multiple times:

```
pnpm test:e2e settings-email-style-sync --repeat-each=100 --max-failures=1
```