### PR TITLE
Fix: Email editor compatibility with WordPress 6.8

### DIFF
--- a/packages/js/email-editor/changelog/fix-email-editor-wp68-compatibility
+++ b/packages/js/email-editor/changelog/fix-email-editor-wp68-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WordPress 6.8 compatibility

--- a/packages/js/email-editor/src/components/sidebar/sidebar.tsx
+++ b/packages/js/email-editor/src/components/sidebar/sidebar.tsx
@@ -51,7 +51,6 @@ function SidebarContent( props: Props ) {
 			}
 			icon={ drawerRight }
 			scope={ storeName }
-			smallScreenTitle={ __( 'No title', 'woocommerce' ) }
 			isActiveByDefault
 			{ ...props }
 		>

--- a/packages/js/email-editor/src/components/sidebar/style.scss
+++ b/packages/js/email-editor/src/components/sidebar/style.scss
@@ -15,4 +15,10 @@
 		box-shadow: none;
 		outline: none;
 	}
+
+	// Because we use complementary area component from the WP interface package the is visible an unwanted close icon.
+	// This style hides it.
+	.interface-complementary-area-header__small {
+		display: none;
+	}
 }

--- a/packages/js/email-editor/src/components/styles-sidebar/style.scss
+++ b/packages/js/email-editor/src/components/styles-sidebar/style.scss
@@ -4,6 +4,7 @@
 	height: 100%;
 
 	.components-panel,
+	.components-navigator,
 	.components-navigator-provider,
 	.components-navigator-screen {
 		height: 100%;

--- a/packages/js/email-editor/src/components/styles-sidebar/style.scss
+++ b/packages/js/email-editor/src/components/styles-sidebar/style.scss
@@ -52,4 +52,9 @@
 		min-height: 100px;
 		overflow: hidden;
 	}
+	// Because we use complementary area component from the WP interface package the is visible an unwanted close icon.
+	// This style hides it.
+	.interface-complementary-area-header__small {
+		display: none;
+	}
 }

--- a/packages/js/email-editor/src/components/styles-sidebar/style.scss
+++ b/packages/js/email-editor/src/components/styles-sidebar/style.scss
@@ -7,7 +7,6 @@
 	.components-navigator-provider,
 	.components-navigator-screen {
 		height: 100%;
-		overflow: hidden;
 	}
 
 	.components-navigator-screen {

--- a/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/styles-sidebar.tsx
@@ -43,7 +43,6 @@ export function RawStylesSidebar( props: Props ): JSX.Element {
 				closeLabel={ __( 'Close styles sidebar', 'woocommerce' ) }
 				icon={ styles }
 				scope={ storeName }
-				smallScreenTitle={ __( 'No title', 'woocommerce' ) }
 				{ ...props }
 			>
 				<NavigatorProvider initialPath="/">

--- a/packages/php/email-editor/changelog/fix-email-editor-wp68-compatibility
+++ b/packages/php/email-editor/changelog/fix-email-editor-wp68-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix default rendering mode for WordPress 6.8

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -170,7 +170,13 @@ class Email_Editor {
 			'show_ui'                => true,
 			'show_in_menu'           => false,
 			'show_in_nav_menus'      => false,
-			'supports'               => array( 'editor', 'title', 'custom-fields' ), // 'custom-fields' is required for loading meta fields via API.
+			'supports'               => array(
+				'editor' => array(
+					'default-mode' => 'template-locked',
+				),
+				'title',
+				'custom-fields'
+			), // 'custom-fields' is required for loading meta fields via API.
 			'has_archive'            => true,
 			'show_in_rest'           => true, // Important to enable Gutenberg editor.
 			'default_rendering_mode' => 'template-locked',

--- a/plugins/woocommerce/changelog/fix-email-editor-wp68-compatibility
+++ b/plugins/woocommerce/changelog/fix-email-editor-wp68-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The fix is related to the alpha email editor behind a feature flag
+
+

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -119,7 +119,12 @@ class Integration {
 					'search_items'  => __( 'Search Woo Emails', 'woocommerce' ),
 				),
 				'rewrite'  => array( 'slug' => self::EMAIL_POST_TYPE ),
-				'supports' => array( 'title', 'editor' ),
+				'supports' => array(
+					'title',
+					'editor' => array(
+						'default-mode' => 'template-locked',
+					),
+				),
 			),
 		);
 		return $post_types;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56272, Closes WOOPLUG-2.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1728" alt="Screenshot 2025-03-30 at 15 28 30" src="https://github.com/user-attachments/assets/8442a3a3-af02-4427-b72a-75ab5f9a43bc" /> | <img width="1728" alt="Screenshot 2025-03-30 at 15 07 29" src="https://github.com/user-attachments/assets/15e49091-2e00-418f-8084-ba403661494f" />|
|<img width="280" alt="Screenshot 2025-03-30 at 15 28 54" src="https://github.com/user-attachments/assets/f61f2063-0b9c-45ac-886d-6db9e3106218" />| <img width="279" alt="Screenshot 2025-03-30 at 15 08 06" src="https://github.com/user-attachments/assets/fe5706fa-35d5-4c98-ab8f-80523cb03efd" />|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the latest WP 6.8 (you can use the WordPress Beta Tester plugin)
2. Visit the page http://localhost:8888/wp-admin/edit.php?post_type=woo_email
3. Observe that the email editor looks as expected

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
