### PR TITLE
Add product name field and registry/hook for DataForm field registry

### DIFF
--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -21,6 +21,9 @@ import { Header } from '../../../components/header';
 import { ValidationProvider } from '../../../contexts/validation-context';
 import { EditorProps } from './types';
 import { ProductTabs } from '../tabs';
+import { initFields } from '../fields';
+
+initFields();
 
 export function Editor( { productId, postType = 'product' }: EditorProps ) {
 	const query = getQuery() as Record< string, string >;

--- a/packages/js/product-editor/src/data-form/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/data-form/components/editor/editor.tsx
@@ -54,9 +54,11 @@ export function Editor( { productId, postType = 'product' }: EditorProps ) {
 							productType={ postType }
 							selectedTab={ selectedTab }
 						/>
+						{ /* @ts-expect-error Type definitions are missing */ }
 						{ layoutTemplate?.blockTemplates && (
 							<ProductTabs
 								sectionTemplate={
+									// @ts-expect-error Type definitions are missing
 									layoutTemplate?.blockTemplates
 								}
 								postType={ postType }

--- a/packages/js/product-editor/src/data-form/components/fields/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { initNameField } from './name';
+
+export function initFields() {
+	initNameField();
+}
+
+export * from './registration';

--- a/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
@@ -110,6 +110,7 @@ export function NameBlockEdit( {
 		'product_name'
 	) as string;
 
+	// @todo: This relies on attribute settings from the block information, we need to find a way to get this into the DataForm.
 	// useEffect( () => {
 	// 	if ( field.attributes.autoFocus ) {
 	// 		selectBlock( clientId );

--- a/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
@@ -26,10 +26,9 @@ import { useValidation } from '../../../../contexts/validation-context';
 import { useProductEdits } from '../../../../hooks/use-product-edits';
 import { AUTO_DRAFT_NAME, getPermalinkParts } from '../../../../utils';
 
-/**
- * @todo: This is a temporary solution and close to a copy of the block name field.
- * We need refactor this to use this Edit in the current block name field.
- */
+// @todo: This is a temporary solution and close to a copy of the block name field.
+// We need refactor this to use this Edit in the current block name field.
+
 export function NameBlockEdit( {
 	data,
 	onChange,

--- a/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
@@ -1,0 +1,210 @@
+/**
+ * External dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+import { createElement, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { DataFormControlProps } from '@wordpress/dataviews';
+import { starEmpty, starFilled } from '@wordpress/icons';
+import { cleanForSlug } from '@wordpress/url';
+import { Product } from '@woocommerce/data';
+import classNames from 'classnames';
+import {
+	Button,
+	BaseControl,
+	Tooltip,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { EditProductLinkModal } from '../../../../components/edit-product-link-modal';
+import { Label } from '../../../../components/label/label';
+import { useValidation } from '../../../../contexts/validation-context';
+import { useProductEdits } from '../../../../hooks/use-product-edits';
+import { AUTO_DRAFT_NAME, getPermalinkParts } from '../../../../utils';
+
+export function NameBlockEdit( {
+	data,
+	onChange,
+}: DataFormControlProps< Product > ) {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
+
+	const { hasEdit } = useProductEdits();
+
+	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
+		useState( false );
+
+	const productId = data.id;
+	const sku = data.sku;
+	const name = data.name;
+	const featured = data.featured;
+
+	const { prefix: permalinkPrefix, suffix: permalinkSuffix } =
+		getPermalinkParts( data );
+
+	const {
+		ref: nameRef,
+		error: nameValidationError,
+		validate: validateName,
+	} = useValidation< Product >(
+		'name',
+		async function nameValidator() {
+			if ( ! name || name === AUTO_DRAFT_NAME ) {
+				return {
+					message: __( 'Product name is required.', 'woocommerce' ),
+				};
+			}
+
+			if ( name.length > 120 ) {
+				return {
+					message: __(
+						'Please enter a product name shorter than 120 characters.',
+						'woocommerce'
+					),
+				};
+			}
+		},
+		[ name ]
+	);
+
+	const setSkuIfEmpty = () => {
+		if ( sku || nameValidationError ) {
+			return;
+		}
+		onChange( { sku: cleanForSlug( name ) } );
+	};
+
+	const help =
+		nameValidationError ??
+		( productId &&
+			[ 'publish', 'draft' ].includes( data.status ) &&
+			permalinkPrefix && (
+				<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
+					{ __( 'Product link', 'woocommerce' ) }
+					:&nbsp;
+					<a href={ data.permalink } target="_blank" rel="noreferrer">
+						{ permalinkPrefix }
+						{ data.slug || cleanForSlug( name ) }
+						{ permalinkSuffix }
+					</a>
+					<Button
+						variant="link"
+						onClick={ () => setShowProductLinkEditModal( true ) }
+					>
+						{ __( 'Edit', 'woocommerce' ) }
+					</Button>
+				</span>
+			) );
+
+	const nameControlId = useInstanceId(
+		BaseControl,
+		'product_name'
+	) as string;
+
+	// useEffect( () => {
+	// 	if ( field.attributes.autoFocus ) {
+	// 		selectBlock( clientId );
+	// 	}
+	// }, [] );
+
+	function handleSuffixClick() {
+		onChange( { featured: ! featured } );
+	}
+
+	function renderFeaturedSuffix() {
+		const markedText = __( 'Mark as featured', 'woocommerce' );
+		const unmarkedText = __( 'Unmark as featured', 'woocommerce' );
+		const tooltipText = featured ? unmarkedText : markedText;
+
+		return (
+			<Tooltip text={ tooltipText } placement="top">
+				{ featured ? (
+					<Button
+						icon={ starFilled }
+						aria-label={ unmarkedText }
+						onClick={ handleSuffixClick }
+					/>
+				) : (
+					<Button
+						icon={ starEmpty }
+						aria-label={ markedText }
+						onClick={ handleSuffixClick }
+					/>
+				) }
+			</Tooltip>
+		);
+	}
+
+	return (
+		<div>
+			<BaseControl
+				id={ nameControlId }
+				label={
+					<Label label={ __( 'Name', 'woocommerce' ) } required />
+				}
+				className={ classNames( {
+					'has-error': nameValidationError,
+				} ) }
+				help={ help }
+			>
+				<InputControl
+					id={ nameControlId }
+					ref={ nameRef }
+					name="name"
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					// autoFocus={ attributes.autoFocus }
+					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
+					onChange={ ( nextValue ) => {
+						onChange( { name: nextValue ?? '' } );
+					} }
+					value={ name && name !== AUTO_DRAFT_NAME ? name : '' }
+					autoComplete="off"
+					data-1p-ignore
+					onBlur={ () => {
+						if ( hasEdit( 'name' ) ) {
+							setSkuIfEmpty();
+							validateName();
+						}
+					} }
+					suffix={ renderFeaturedSuffix() }
+				/>
+			</BaseControl>
+
+			{ showProductLinkEditModal && (
+				<EditProductLinkModal
+					permalinkPrefix={ permalinkPrefix || '' }
+					permalinkSuffix={ permalinkSuffix || '' }
+					product={ data }
+					onCancel={ () => setShowProductLinkEditModal( false ) }
+					onSaved={ () => setShowProductLinkEditModal( false ) }
+					saveHandler={ async ( updatedSlug: string ) => {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						const { slug, permalink }: Product =
+							await saveEntityRecord( 'postType', 'product', {
+								id: data.id,
+								slug: updatedSlug,
+							} );
+
+						if ( slug && permalink ) {
+							editEntityRecord( 'postType', 'product', data.id, {
+								slug,
+								permalink,
+							} );
+
+							return {
+								slug,
+								permalink,
+							};
+						}
+					} }
+				/>
+			) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
+++ b/packages/js/product-editor/src/data-form/components/fields/name/field.tsx
@@ -26,6 +26,10 @@ import { useValidation } from '../../../../contexts/validation-context';
 import { useProductEdits } from '../../../../hooks/use-product-edits';
 import { AUTO_DRAFT_NAME, getPermalinkParts } from '../../../../utils';
 
+/**
+ * @todo: This is a temporary solution and close to a copy of the block name field.
+ * We need refactor this to use this Edit in the current block name field.
+ */
 export function NameBlockEdit( {
 	data,
 	onChange,

--- a/packages/js/product-editor/src/data-form/components/fields/name/index.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/name/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductField } from '../registration';
+import { NameBlockEdit } from './field';
+
+export function initNameField() {
+	return registerProductField( 'woocommerce/product-name-field', {
+		id: 'name',
+		label: 'Name',
+		type: 'text',
+		Edit: NameBlockEdit,
+	} );
+}

--- a/packages/js/product-editor/src/data-form/components/fields/registration.ts
+++ b/packages/js/product-editor/src/data-form/components/fields/registration.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import type { Product } from '@woocommerce/data';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+
+const productFields: Record< string, Field< Product > > = {};
+
+export function registerProductField( id: string, field: Field< Product > ) {
+	productFields[ id ] = field;
+}
+
+export function getProductField( id: string ) {
+	return productFields[ id ];
+}

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -13,26 +13,13 @@ import { DataForm } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { SectionHeader } from '../../../components/section-header';
+import { useDataFormProductFields } from '../use-data-form-product-fields';
 
 type ProductSectionProps = {
 	sectionTemplate: Template;
 	postType: string;
 	productId: number;
 };
-
-/**
- * @todo: This is a temporary solution to get the fields for the DataForm.
- * We need to move this into a hook with a useMemo or something as we did have to generate some of this on the fly.
- * For example, label comes from the sectionTemplate. Also things like the id which matches the product key comes from the config as well.
- * You can see an example here: https://github.com/woocommerce/woocommerce/blob/89068601d334953e2904ecf56f528fc271c7b9ec/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php#L192
- */
-const fields = [
-	{
-		id: 'name',
-		type: 'text',
-		label: 'Title',
-	},
-];
 
 export function ProductSection( {
 	sectionTemplate,
@@ -45,6 +32,7 @@ export function ProductSection( {
 		blockGap: string;
 	};
 
+	const fields = useDataFormProductFields( sectionTemplate[ 2 ] );
 	const { editEntityRecord } = useDispatch( coreDataStore );
 	const { record, hasFinishedResolution } = useSelect(
 		( select ) => {

--- a/packages/js/product-editor/src/data-form/components/section/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/section/index.tsx
@@ -43,7 +43,9 @@ export function ProductSection( {
 
 			const args = [ 'postType', postType, productId ];
 			return {
+				// @ts-expect-error Type definitions are missing
 				record: getEditedEntityRecord( ...args ) as Product,
+				// @ts-expect-error Type definitions are missing
 				hasFinishedResolution: hasFinished(
 					'getEditedEntityRecord',
 					args
@@ -63,7 +65,7 @@ export function ProductSection( {
 		return {
 			type: 'regular' as const,
 			fields: sectionTemplate[ 2 ]
-				.filter(
+				?.filter(
 					( field ) => field[ 0 ] === 'woocommerce/product-name-field'
 				)
 				.map( () => 'name' ),
@@ -87,7 +89,6 @@ export function ProductSection( {
 			<div className={ nestedClassNames }>
 				{ hasFinishedResolution && (
 					<DataForm
-						// @ts-expect-error fields is not typed
 						fields={ fields }
 						form={ form }
 						onChange={ onChange }

--- a/packages/js/product-editor/src/data-form/components/tabs/index.tsx
+++ b/packages/js/product-editor/src/data-form/components/tabs/index.tsx
@@ -4,8 +4,6 @@
 import { createElement, useMemo } from '@wordpress/element';
 import { Template } from '@wordpress/blocks';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-// @ts-expect-error missing types.
-// eslint-disable-next-line @woocommerce/dependency-group
 import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { Field } from '@wordpress/dataviews';
+import { Product } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { getProductField } from './fields';
+
+type FieldDefinition = [
+	string,
+	{
+		type?: string;
+		label?: string;
+		description?: string;
+		property?: string;
+		metadata?: {
+			bindings?: {
+				value?: {
+					source?: string;
+					args?: {
+						prop?: string;
+					};
+				};
+			};
+		};
+		[ key: string ]: unknown;
+	}
+];
+
+function getFieldKey( field: FieldDefinition ): string {
+	const attributes = field[ 1 ];
+	if (
+		attributes.metadata?.bindings?.value?.source ===
+			'woocommerce/entity-product' &&
+		attributes.metadata?.bindings?.value?.args?.prop
+	) {
+		return attributes.metadata?.bindings?.value?.args?.prop;
+	} else if ( attributes.property ) {
+		return attributes.property;
+	}
+	return field[ 0 ];
+}
+
+/**
+ * Hook that transforms field definitions into DataForm compatible field objects.
+ * Each field definition is an array where:
+ * - First item is the field name (matching a block definition)
+ * - Second item is an object with field parameters
+ *
+ * @param fields - Array of field definitions
+ * @return Array of DataForm compatible field objects
+ */
+export function useDataFormProductFields(
+	fields: FieldDefinition[] = []
+): Field< Product >[] {
+	return useMemo( () => {
+		return fields.map( ( [ fieldName, params ] ) => {
+			const getFieldDefinition = getProductField( fieldName );
+			console.log( fieldName, getFieldDefinition );
+			// Convert the field definition to a DataForm field format
+			const field: Field< Product > = {
+				...getFieldDefinition,
+				id: getFieldKey( [ fieldName, params ] ),
+			};
+
+			// Note: In practice, you'd want to:
+			// 1. Have a mapping of fieldNames to their respective Edit components
+			// 2. Or use React.lazy with dynamic imports for code splitting
+			// Example with React.lazy:
+			// field.Edit = React.lazy(() => import(`../../blocks/${fieldName}/edit`));
+
+			return field;
+		} );
+	}, [ fields ] );
+}

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -13,6 +13,7 @@ import { getProductField } from './fields';
 
 /**
  * Get the property key for a field definition
+ *
  * @param field - The field definition
  * @return The key for the field
  */

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -31,8 +31,14 @@ type FieldDefinition = [
 	}
 ];
 
+/**
+ * Get the property key for a field definition
+ * @param field - The field definition
+ * @return The key for the field
+ */
 function getFieldKey( field: FieldDefinition ): string {
 	const attributes = field[ 1 ];
+	// We support the block binding structure.
 	if (
 		attributes.metadata?.bindings?.value?.source ===
 			'woocommerce/entity-product' &&
@@ -60,18 +66,11 @@ export function useDataFormProductFields(
 	return useMemo( () => {
 		return fields.map( ( [ fieldName, params ] ) => {
 			const getFieldDefinition = getProductField( fieldName );
-			console.log( fieldName, getFieldDefinition );
 			// Convert the field definition to a DataForm field format
 			const field: Field< Product > = {
 				...getFieldDefinition,
 				id: getFieldKey( [ fieldName, params ] ),
 			};
-
-			// Note: In practice, you'd want to:
-			// 1. Have a mapping of fieldNames to their respective Edit components
-			// 2. Or use React.lazy with dynamic imports for code splitting
-			// Example with React.lazy:
-			// field.Edit = React.lazy(() => import(`../../blocks/${fieldName}/edit`));
 
 			return field;
 		} );

--- a/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
+++ b/packages/js/product-editor/src/data-form/components/use-data-form-product-fields.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useMemo } from '@wordpress/element';
+import { Template, TemplateArray } from '@wordpress/blocks';
 import { Field } from '@wordpress/dataviews';
 import { Product } from '@woocommerce/data';
 
@@ -10,34 +11,13 @@ import { Product } from '@woocommerce/data';
  */
 import { getProductField } from './fields';
 
-type FieldDefinition = [
-	string,
-	{
-		type?: string;
-		label?: string;
-		description?: string;
-		property?: string;
-		metadata?: {
-			bindings?: {
-				value?: {
-					source?: string;
-					args?: {
-						prop?: string;
-					};
-				};
-			};
-		};
-		[ key: string ]: unknown;
-	}
-];
-
 /**
  * Get the property key for a field definition
  * @param field - The field definition
  * @return The key for the field
  */
-function getFieldKey( field: FieldDefinition ): string {
-	const attributes = field[ 1 ];
+function getFieldKey( field: Template ): string {
+	const attributes = field[ 1 ] || {};
 	// We support the block binding structure.
 	if (
 		attributes.metadata?.bindings?.value?.source ===
@@ -61,7 +41,7 @@ function getFieldKey( field: FieldDefinition ): string {
  * @return Array of DataForm compatible field objects
  */
 export function useDataFormProductFields(
-	fields: FieldDefinition[] = []
+	fields: TemplateArray = []
 ): Field< Product >[] {
 	return useMemo( () => {
 		return fields.map( ( [ fieldName, params ] ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets up some initial DataForm field migration work and started with the name field.
In particular I have:
- Created a basic registration for DataForm fields ( key, DataFieldObject ), where the key is the block name as passed in through the template.
- A `useDataFormProductFields` hook that takes a list of fields from the template and generates the field list needed for DataForm
- The name field, which is a near copy of the current name field from the `edit` function. I currently copied it and made some small modifications. I did have to do a follow up to restructure the block version to use the DataForm version under the hood.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<img width="1138" alt="Screenshot 2025-03-31 at 09 06 47" src="https://github.com/user-attachments/assets/f499a5ad-afa6-4cf0-99b9-5584184ba4f6" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta Tester plugin and go to **Tools > WCA Test Helper > Features** and enable **product-data-views**
3. Refresh the page, it should now show a new menu item under **Products** called **Add new product ( data forms )**
4. Make sure the name field is rendered
5. You should be able to type a name and save it, once saved the slug should also show up correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
