### PR TITLE
Dev/e2e fix settings email style sync external sites

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-fix-settings-email-style-sync-external-sites
+++ b/plugins/woocommerce/changelog/dev-e2e-fix-settings-email-style-sync-external-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix conflicting page reloads in `settings-email-style-sync.spec.js`.

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -76,7 +76,9 @@ test.describe( 'Email Style Sync', () => {
 		await expect( autoSyncToggle ).toBeChecked();
 
 		// Save settings
-		await page.locator( 'button.woocommerce-save-button' ).click();
+		const saveButton = page.getByRole( 'button', { name: 'Save changes' } );
+		await saveButton.click();
+		await expect( saveButton ).toBeDisabled();
 
 		// Reload page and check if setting persisted
 		await page.reload();

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -58,12 +58,15 @@ test.describe( 'Email Style Sync', () => {
 	test( 'Auto-sync toggle in email settings works correctly', async ( {
 		page,
 	} ) => {
-		// Navigate to WooCommerce email settings
-		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
-
 		const autoSyncToggle = page.locator(
 			'.wc-settings-email-color-palette-auto-sync input[type="checkbox"]'
 		);
+		const saveButton = page.getByRole( 'button', {
+			name: 'Save changes',
+		} );
+
+		// Navigate to WooCommerce email settings
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 		// Auto-sync is not available when theme is not in sync
 		await expect( autoSyncToggle ).toBeHidden();
@@ -75,13 +78,9 @@ test.describe( 'Email Style Sync', () => {
 		await expect( autoSyncToggle ).toBeVisible();
 		await expect( autoSyncToggle ).toBeChecked();
 
-		// Save settings
-		const saveButton = page.getByRole( 'button', { name: 'Save changes' } );
-		await saveButton.click();
-		await expect( saveButton ).toBeDisabled();
-
-		// Reload page and check if setting persisted
-		await page.reload();
+		// Save settings and check if setting persisted.
+		await saveButton.click(); // Triggers page reload.
+		await expect( saveButton ).toBeDisabled(); // Page reload done.
 		await expect( autoSyncToggle ).toBeVisible();
 		await expect( autoSyncToggle ).toBeChecked();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56841.

`email/settings-email-style-sync.spec.js` is failing on external sites because `page.reload()` is being called while the site is still being reloaded by the previous click on the save button.

![Screenshot 2025-03-28 at 6 20 54 PM](https://github.com/user-attachments/assets/e56078d4-57c7-4223-aa5c-18be47d651e5)

To fix this, this PR removes the `page.reload()` call and instead added a web assertion to check if the Save button is disabled as a signal that the page was done refreshing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the test against Pressable and WPCOM and make sure it passes.
    ```bash
    # Set up E2E_ENV_KEY
    pnpm test:e2e:pressable settings-email-style-sync.spec.js
    
    # When testing against WPCOM, set CI to true to extend the navigation timeout to 20s.
    # The default 10s wasn't enough in my own testing.
    export CI=true
    pnpm test:e2e:wpcom settings-email-style-sync.spec.js
    ```

<!-- End testing instructions -->

### Testing that has already taken place:

I ran `email/settings-email-style-sync.spec.js` 10 consecutive times against Pressable using this script:
```bash
for i in $(seq 1 10);
do
    pnpm test:e2e:pressable email/settings-email-style-sync.spec.js
done
```
I did the same against WPCOM but only 5 times because WPCOM's quite slow, not sure if it's just on my end.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
