### PR TITLE
Combine flaky mini-cart test, reduce E2E runs and improve flakiness

### DIFF
--- a/plugins/woocommerce/changelog/fix-disable-flaky-mini-cart-test
+++ b/plugins/woocommerce/changelog/fix-disable-flaky-mini-cart-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Test change only
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.classic_theme.spec.ts
@@ -48,24 +48,23 @@ test.describe( 'Merchant → Mini Cart', () => {
 				await editor.getBlockByName( blockData.slug )
 			).toBeVisible();
 		} );
-		test( 'can only be inserted once', async ( {
-			page,
-			admin,
-			editor,
-		} ) => {
-			await admin.visitWidgetEditor();
-			await editor.openGlobalBlockInserter();
+		test.fixme(
+			'can only be inserted once',
+			async ( { page, admin, editor } ) => {
+				await admin.visitWidgetEditor();
+				await editor.openGlobalBlockInserter();
 
-			await editor.page
-				.getByRole( 'searchbox', { name: 'Search' } )
-				.fill( blockData.slug );
+				await editor.page
+					.getByRole( 'searchbox', { name: 'Search' } )
+					.fill( blockData.slug );
 
-			const miniCartButton = page.getByRole( 'option', {
-				name: blockData.name,
-				exact: true,
-			} );
+				const miniCartButton = page.getByRole( 'option', {
+					name: blockData.name,
+					exact: true,
+				} );
 
-			await expect( miniCartButton ).toBeHidden();
-		} );
+				await expect( miniCartButton ).toBeHidden();
+			}
+		);
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.classic_theme.spec.ts
@@ -24,10 +24,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 	} );
 
 	test.describe( 'in widget editor', () => {
-		test( 'can be inserted in a widget area', async ( {
-			admin,
-			editor,
-		} ) => {
+		test( 'can be inserted only once', async ( { admin, editor } ) => {
 			await admin.visitWidgetEditor();
 			await editor.openGlobalBlockInserter();
 
@@ -47,24 +44,14 @@ test.describe( 'Merchant → Mini Cart', () => {
 			await expect(
 				await editor.getBlockByName( blockData.slug )
 			).toBeVisible();
+
+			await editor.openGlobalBlockInserter();
+
+			await editor.page
+				.getByRole( 'searchbox', { name: 'Search' } )
+				.fill( blockData.slug );
+
+			await expect( miniCartButton ).toBeDisabled();
 		} );
-		test.fixme(
-			'can only be inserted once',
-			async ( { page, admin, editor } ) => {
-				await admin.visitWidgetEditor();
-				await editor.openGlobalBlockInserter();
-
-				await editor.page
-					.getByRole( 'searchbox', { name: 'Search' } )
-					.fill( blockData.slug );
-
-				const miniCartButton = page.getByRole( 'option', {
-					name: blockData.name,
-					exact: true,
-				} );
-
-				await expect( miniCartButton ).toBeHidden();
-			}
-		);
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Combines the the Merchant → Mini Cart -> in widget editor -> can only be inserted once into the "can be inserted in a widget area" test.

These tests are very closely related and since we're already _in_ the widget editor in test 1, checking if the block can be inserted at the same time seems sensibe.

I also noticed that the first test was barely ever reported as flaky whereas the second (can only be inserted once) was regularly flaky.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #48186

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check CI passes, run it a few times and check it's passing each time.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally multiple times and it's passing each time.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
