### PR TITLE
Add pickup location required field indicator

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
@@ -53,6 +53,7 @@ const Form = ( {
 				onChange={ setLocationField( 'name' ) }
 				autoComplete="off"
 				required={ true }
+				aria-required={ true }
 				onInvalid={ (
 					event: React.InvalidEvent< HTMLInputElement >
 				) => {

--- a/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
@@ -47,7 +47,7 @@ const Form = ( {
 	return (
 		<form ref={ formRef }>
 			<TextControl
-				label={ __( 'Location name', 'woocommerce' ) }
+				label={ __( 'Location name', 'woocommerce' ) + ' *' }
 				name={ 'location_name' }
 				value={ values.name }
 				onChange={ setLocationField( 'name' ) }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Closes #54978 (Closes WOOPLUG-3091)

- Add the required field indicator following existing implementation conventions.
- Add `aria-required`  true

I've checked existing implementations to ensure we keep them consistent. Here are [a React based case](https://github.com/woocommerce/woocommerce/blob/9276274e671ab81095659a994b37ef4c2c8586d7/plugins/woocommerce/client/admin/client/dashboard/components/settings/general/store-address.tsx#L376) and [a PHP one](https://github.com/woocommerce/woocommerce/blob/9276274e671ab81095659a994b37ef4c2c8586d7/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-classes.php#L64) as reference.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|<img width="558" alt="Screenshot 2025-03-31 at 14 11 37" src="https://github.com/user-attachments/assets/910d3ab0-755c-4197-be4e-175781c8ff6c" />|<img width="558" alt="Screenshot 2025-03-31 at 14 11 16" src="https://github.com/user-attachments/assets/3eb0a15a-e8b3-47cc-8954-df7bdaf2a80e" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce Settings → Shipping → Local pickup**
2. Click on **Add pickup location**
3. Confirm that the first label contains the asterisk, and `aria-required` attribute.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
There is no significant change, just a asterisk indicating that a field is required.
</details>
