### PR TITLE
Update method for generating order months dropdown

### DIFF
--- a/plugins/woocommerce/changelog/update-months-filter
+++ b/plugins/woocommerce/changelog/update-months-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This makes an adjustment to another PR that is also in the 9.9 milestone.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -85,7 +85,7 @@ class ListTable extends WP_List_Table {
 	 * Init method, invoked by DI container.
 	 *
 	 * @internal This method is not intended to be used directly (except for testing).
-	 * @param PageController      $page_controller Page controller instance for this request.
+	 * @param PageController $page_controller Page controller instance for this request.
 	 */
 	final public function init( PageController $page_controller ) {
 		$this->page_controller = $page_controller;
@@ -861,7 +861,7 @@ class ListTable extends WP_List_Table {
 		if ( $start > $end ) {
 			$last_year_month_gmt = $wpdb->get_row(
 				$wpdb->prepare(
-				'
+					'
 					SELECT YEAR( t.date_created_gmt ) AS year,
 					       MONTH( t.date_created_gmt ) AS month
 					FROM %i t

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -808,7 +808,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return \stdClass[]
 	 */
-	public function get_months_filter_options(): array {
+	protected function get_months_filter_options(): array {
 		global $wpdb;
 
 		$orders_table   = esc_sql( OrdersTableDataStore::get_orders_table_name() );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Caches\OrderCountCache;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use DatePeriod;
 use WC_Order;
 use WP_List_Table;
 use WP_Screen;
@@ -811,25 +812,33 @@ class ListTable extends WP_List_Table {
 	protected function get_months_filter_options(): array {
 		global $wpdb;
 
+		$this_month = new \WC_DateTime(
+			sprintf(
+				'%s-%s-01',
+				gmdate( 'Y' ),
+				gmdate( 'm' )
+			),
+			wp_timezone()
+		);
+
 		$orders_table = esc_sql( OrdersTableDataStore::get_orders_table_name() );
 		$trash_status = esc_sql( OrderStatus::TRASH );
 
 		$first_year_month_gmt = $wpdb->get_row(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare(
 				"
 					SELECT YEAR( t.date_created_gmt ) AS year,
 					       MONTH( t.date_created_gmt ) AS month
-					FROM $orders_table t
+					FROM %i t
 					WHERE type = %s
 					AND status != %s
 					ORDER BY year ASC, month ASC
 					LIMIT 1
 				",
+				$orders_table,
 				$this->order_type,
 				$trash_status
 			)
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		);
 
 		if ( is_object( $first_year_month_gmt ) ) {
@@ -842,16 +851,41 @@ class ListTable extends WP_List_Table {
 			);
 			$start->setTimezone( wp_timezone() ); // Adjust date and time to reflect site timezone.
 		} else {
-			$start = new \WC_DateTime( 'now', wp_timezone() );
+			$start = $this_month;
 		}
 
-		$end     = new \WC_DateTime( 'now', wp_timezone() );
+		$end     = $this_month;
 		$options = array();
 
-		// If, somehow, the oldest order date is in the future, swap the start and end of the range.
+		// If, somehow, the oldest order date is in the future, we need to find the order furthest into the future as well.
 		if ( $start > $end ) {
-			$end   = $start;
-			$start = new \WC_DateTime( 'now', wp_timezone() );
+			$last_year_month_gmt = $wpdb->get_row(
+				$wpdb->prepare(
+					"
+					SELECT YEAR( t.date_created_gmt ) AS year,
+					       MONTH( t.date_created_gmt ) AS month
+					FROM %i t
+					WHERE type = %s
+					AND status != %s
+					ORDER BY year DESC, month DESC
+					LIMIT 1
+				",
+					$orders_table,
+					$this->order_type,
+					$trash_status
+				)
+			);
+
+			$end = new \WC_DateTime(
+				sprintf(
+					'%s-%s-01',
+					$last_year_month_gmt->year,
+					$last_year_month_gmt->month
+				)
+			);
+			$end->setTimezone( wp_timezone() ); // Adjust date and time to reflect site timezone.
+
+			$start = $this_month;
 		}
 
 		while (

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -813,6 +813,7 @@ class ListTable extends WP_List_Table {
 
 		$orders_table   = esc_sql( OrdersTableDataStore::get_orders_table_name() );
 		$min_max_months = $wpdb->get_row(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is escaped above.
 			$wpdb->prepare(
 				"
 					SELECT MIN( t.date_created_gmt ) as min_date_gmt,
@@ -824,6 +825,7 @@ class ListTable extends WP_List_Table {
 				$this->order_type,
 				OrderStatus::TRASH
 			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		);
 
 		/**
@@ -845,7 +847,7 @@ class ListTable extends WP_List_Table {
 				new \DateTimeZone( 'UTC' )
 			);
 			$start->setTimezone( wp_timezone() );
-			$start->setDate( $start->format( 'Y'), $start->format( 'm' ), 1 );
+			$start->setDate( $start->format( 'Y' ), $start->format( 'm' ), 1 );
 			$start->setTime( 0, 0 );
 
 			$end = new \WC_DateTime(
@@ -853,7 +855,7 @@ class ListTable extends WP_List_Table {
 				new \DateTimeZone( 'UTC' )
 			);
 			$end->setTimezone( wp_timezone() );
-			$end->setDate( $end->format( 'Y'), $end->format( 'm' ), 1 );
+			$end->setDate( $end->format( 'Y' ), $end->format( 'm' ), 1 );
 			$end->setTime( 0, 0 );
 
 			if ( $start > $this_month ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Caches\OrderCountCache;
 use Automattic\WooCommerce\Utilities\OrderUtil;
-use DatePeriod;
 use WC_Order;
 use WP_List_Table;
 use WP_Screen;
@@ -809,102 +808,83 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return \stdClass[]
 	 */
-	protected function get_months_filter_options(): array {
+	public function get_months_filter_options(): array {
 		global $wpdb;
 
-		$this_month = new \WC_DateTime(
-			sprintf(
-				'%s-%s-01',
-				gmdate( 'Y' ),
-				gmdate( 'm' )
-			),
-			wp_timezone()
-		);
-
-		$orders_table = esc_sql( OrdersTableDataStore::get_orders_table_name() );
-		$trash_status = esc_sql( OrderStatus::TRASH );
-
-		$first_year_month_gmt = $wpdb->get_row(
+		$orders_table   = esc_sql( OrdersTableDataStore::get_orders_table_name() );
+		$min_max_months = $wpdb->get_row(
 			$wpdb->prepare(
-				'
-					SELECT YEAR( t.date_created_gmt ) AS year,
-					       MONTH( t.date_created_gmt ) AS month
-					FROM %i t
+				"
+					SELECT MIN( t.date_created_gmt ) as min_date_gmt,
+					       MAX( t.date_created_gmt ) as max_date_gmt
+					FROM `{$orders_table}` t
 					WHERE type = %s
 					AND status != %s
-					ORDER BY year ASC, month ASC
-					LIMIT 1
-				',
-				$orders_table,
+				",
 				$this->order_type,
-				$trash_status
+				OrderStatus::TRASH
 			)
 		);
 
-		if ( is_object( $first_year_month_gmt ) ) {
-			$start = new \WC_DateTime(
-				sprintf(
-					'%s-%s-01',
-					$first_year_month_gmt->year,
-					$first_year_month_gmt->month
-				)
-			);
-			$start->setTimezone( wp_timezone() ); // Adjust date and time to reflect site timezone.
-		} else {
-			$start = $this_month;
-		}
+		/**
+		 * Normalize "this month" to be the first day of the month in the current timezone of the site.
+		 */
+		$this_month = new \WC_DateTime(
+			'now',
+			new \DateTimeZone( 'UTC' )
+		);
+		$this_month->setTimezone( wp_timezone() );
+		$this_month->setDate( $this_month->format( 'Y' ), $this_month->format( 'm' ), 1 );
+		$this_month->setTime( 0, 0 );
 
-		$end     = $this_month;
 		$options = array();
 
-		// If, somehow, the oldest order date is in the future, we need to find the order furthest into the future as well.
-		if ( $start > $end ) {
-			$last_year_month_gmt = $wpdb->get_row(
-				$wpdb->prepare(
-					'
-					SELECT YEAR( t.date_created_gmt ) AS year,
-					       MONTH( t.date_created_gmt ) AS month
-					FROM %i t
-					WHERE type = %s
-					AND status != %s
-					ORDER BY year DESC, month DESC
-					LIMIT 1
-				',
-					$orders_table,
-					$this->order_type,
-					$trash_status
-				)
+		if ( isset( $min_max_months ) && ! is_null( $min_max_months->min_date_gmt ) ) {
+			$start = new \WC_DateTime(
+				$min_max_months->min_date_gmt,
+				new \DateTimeZone( 'UTC' )
 			);
+			$start->setTimezone( wp_timezone() );
+			$start->setDate( $start->format( 'Y'), $start->format( 'm' ), 1 );
+			$start->setTime( 0, 0 );
 
 			$end = new \WC_DateTime(
-				sprintf(
-					'%s-%s-01',
-					$last_year_month_gmt->year,
-					$last_year_month_gmt->month
-				)
+				$min_max_months->max_date_gmt,
+				new \DateTimeZone( 'UTC' )
 			);
-			$end->setTimezone( wp_timezone() ); // Adjust date and time to reflect site timezone.
+			$end->setTimezone( wp_timezone() );
+			$end->setDate( $end->format( 'Y'), $end->format( 'm' ), 1 );
+			$end->setTime( 0, 0 );
 
-			$start = $this_month;
-		}
+			if ( $start > $this_month ) {
+				$start = $this_month;
+			}
 
-		while (
-			$start->date( 'Y' ) < $end->date( 'Y' )
-			|| $start->date( 'n' ) < $end->date( 'n' )
-		) {
+			if ( $end < $this_month ) {
+				$end = $this_month;
+			}
+
+			$intervals = new \DatePeriod( $start, new \DateInterval( 'P1M' ), $end );
+
+			foreach ( $intervals as $interval ) {
+				$option        = new \stdClass();
+				$option->year  = $interval->format( 'Y' );
+				$option->month = $interval->format( 'n' );
+				$options[]     = $option;
+			}
+
 			$option        = new \stdClass();
-			$option->year  = $start->date( 'Y' );
-			$option->month = $start->date( 'n' );
+			$option->year  = $end->format( 'Y' );
+			$option->month = $end->format( 'n' );
 			$options[]     = $option;
-
-			$start->add( new \DateInterval( 'P1M' ) );
 		}
 
-		// Add in the current year-month.
-		$option        = new \stdClass();
-		$option->year  = $end->date( 'Y' );
-		$option->month = $end->date( 'n' );
-		$options[]     = $option;
+		if ( count( $options ) < 1 ) {
+			$option        = new \stdClass();
+			$option->year  = $this_month->format( 'Y' );
+			$option->month = $this_month->format( 'n' );
+			$options[]     = $option;
+		}
 
 		return array_reverse( $options );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -826,7 +826,7 @@ class ListTable extends WP_List_Table {
 
 		$first_year_month_gmt = $wpdb->get_row(
 			$wpdb->prepare(
-				"
+				'
 					SELECT YEAR( t.date_created_gmt ) AS year,
 					       MONTH( t.date_created_gmt ) AS month
 					FROM %i t
@@ -834,7 +834,7 @@ class ListTable extends WP_List_Table {
 					AND status != %s
 					ORDER BY year ASC, month ASC
 					LIMIT 1
-				",
+				',
 				$orders_table,
 				$this->order_type,
 				$trash_status
@@ -861,7 +861,7 @@ class ListTable extends WP_List_Table {
 		if ( $start > $end ) {
 			$last_year_month_gmt = $wpdb->get_row(
 				$wpdb->prepare(
-					"
+				'
 					SELECT YEAR( t.date_created_gmt ) AS year,
 					       MONTH( t.date_created_gmt ) AS month
 					FROM %i t
@@ -869,7 +869,7 @@ class ListTable extends WP_List_Table {
 					AND status != %s
 					ORDER BY year DESC, month DESC
 					LIMIT 1
-				",
+				',
 					$orders_table,
 					$this->order_type,
 					$trash_status

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
@@ -292,9 +292,7 @@ test(
 
 				const expectedRegularPrice = product.regular_price;
 
-				await expect
-					.soft( await page.locator( 'ins' ).count() )
-					.toBe( 0 );
+				await expect( page.locator( 'ins' ) ).toHaveCount( 0 );
 
 				await expect
 					.soft( page.locator( 'bdi' ).first() )

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
@@ -130,26 +130,30 @@ class ListTableTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The months filter options works as expected when the oldest order has a future date.
+	 * @testdox The months filter options works as expected when all orders have a future date.
+	 *
+	 * When all orders have a future date, the month options range should go from the current date to
+	 * the order date farthest in the future.
 	 */
 	public function test_get_months_filter_options_only_future_orders() {
-		$start_date     = new \WC_DateTime( '+ 2 years' );
-		$current_date   = new \WC_DateTime();
-		$expected_count = $this->get_months_count( $current_date, $start_date );
+		$current_date   = new \WC_DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$start_date     = new \WC_DateTime( '+ 1 years', new \DateTimeZone( 'UTC' ) );
+		$end_date       = new \WC_DateTime( '+ 2 years', new \DateTimeZone( 'UTC' ) );
+		$expected_count = $this->get_months_count( $current_date, $end_date );
 
 		$order = \WC_Helper_Order::create_order();
 		$order->set_date_created( $start_date );
 		$order->save();
 
 		$order = \WC_Helper_Order::create_order();
-		$order->set_date_created( new \WC_DateTime( '+ 1 year' ) );
+		$order->set_date_created( $end_date );
 		$order->save();
 
 		$year_months = $this->call_get_months_filter_options( $this->sut );
 
 		$this->assertCount( $expected_count, $year_months );
-		$this->assertEquals( $start_date->format( 'Y' ), $year_months[0]->year );
-		$this->assertEquals( $start_date->format( 'n' ), $year_months[0]->month );
+		$this->assertEquals( $end_date->format( 'Y' ), $year_months[0]->year );
+		$this->assertEquals( $end_date->format( 'n' ), $year_months[0]->month );
 		$this->assertEquals( gmdate( 'Y', time() ), end( $year_months )->year );
 		$this->assertEquals( gmdate( 'n', time() ), end( $year_months )->month );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/ListTableTest.php
@@ -133,7 +133,7 @@ class ListTableTest extends \WC_Unit_Test_Case {
 	 * @testdox The months filter options works as expected when the oldest order has a future date.
 	 */
 	public function test_get_months_filter_options_only_future_orders() {
-		$start_date     = new \WC_DateTime( '+ 1 year' );
+		$start_date     = new \WC_DateTime( '+ 2 years' );
 		$current_date   = new \WC_DateTime();
 		$expected_count = $this->get_months_count( $current_date, $start_date );
 
@@ -142,7 +142,7 @@ class ListTableTest extends \WC_Unit_Test_Case {
 		$order->save();
 
 		$order = \WC_Helper_Order::create_order();
-		$order->set_date_created( new \WC_DateTime( '+ 2 years' ) );
+		$order->set_date_created( new \WC_DateTime( '+ 1 year' ) );
 		$order->save();
 
 		$year_months = $this->call_get_months_filter_options( $this->sut );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #55510 we changed how the Months filter dropdown on the Orders list table is generated so that it uses a much more efficient query. However, it introduced a bug that could happen at the end of the month when the following month had fewer days in it. This was surfaced via a unit test, fortunately. In this PR we are making the method more robust so that the number of days in the month doesn't matter, and also improving the behavior during an edge case where all existing orders are in the future, so that the _furthest_ future order date is represented in the dropdown, and not just the _closest_ future date.

Bug introduced in PR #55510

### How to test the changes in this Pull Request:

It probably isn't realistic to try and spoof the current date on your local dev environment in order to test this. Instead, just follow the testing instructions in #55510 and make sure there aren't any regressions. Also ensure the unit tests pass.

### Testing that has already taken place:

* Tested in a wp-env environment running WP 6.7 and PHP 8.1
* Unit test that caught the failure was updated to take into account the changes in this PR. All unit tests in the file are passing in the local environment.
