### PR TITLE
[E2E] Fix flakiness in `product/product-edit.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/dev-e2e-fix-trunk-product-edit
+++ b/plugins/woocommerce/changelog/dev-e2e-fix-trunk-product-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flakiness in `product/product-edit.spec.js`

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
@@ -225,9 +225,9 @@ test(
 				.selectOption( 'Edit' );
 			await page.locator( '#doaction' ).click();
 
-			await expect(
-				await page.locator( '#bulk-titles-list li' ).count()
-			).toEqual( products.length );
+			await expect( page.locator( '#bulk-titles-list li' ) ).toHaveCount(
+				products.length
+			);
 		} );
 
 		await test.step( 'update the sale price', async () => {
@@ -256,14 +256,17 @@ test(
 					( 1 - salePriceDecrease / 100 )
 				).toFixed( 2 );
 
-				await expect
-					.soft(
-						await page
-							.locator( 'ins' )
-							.getByText( `$${ expectedSalePrice }` )
-							.count()
-					)
-					.toBeGreaterThan( 0 );
+				const productPriceLocator = page
+					.locator( `[data-block-name="woocommerce/product-price"]` )
+					.first();
+
+				await expect( productPriceLocator ).toContainText(
+					'$' + expectedRegularPrice
+				);
+
+				await expect( productPriceLocator ).toContainText(
+					'$' + expectedSalePrice
+				);
 			}
 		} );
 
@@ -290,20 +293,13 @@ test(
 			for ( const product of products ) {
 				await page.goto( `product/${ product.slug }` );
 
-				const expectedRegularPrice = product.regular_price;
+				const productPriceLocator = page
+					.locator( `[data-block-name="woocommerce/product-price"]` )
+					.first();
 
-				await expect
-					.soft(
-						page
-							.locator( '.wc-block-components-product-price' )
-							.first()
-							.locator( 'ins' )
-					)
-					.toHaveCount( 0 );
-
-				await expect
-					.soft( page.locator( 'bdi' ).first() )
-					.toContainText( expectedRegularPrice );
+				await expect( productPriceLocator ).toHaveText(
+					'$' + product.regular_price
+				);
 			}
 		} );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
@@ -293,8 +293,13 @@ test(
 				const expectedRegularPrice = product.regular_price;
 
 				await expect
-					.soft( await page.locator( 'ins' ).count() )
-					.toBe( 0 );
+					.soft(
+						page
+							.locator( '.wc-block-components-product-price' )
+							.first()
+							.locator( 'ins' )
+					)
+					.toHaveCount( 0 );
 
 				await expect
 					.soft( page.locator( 'bdi' ).first() )

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-linked-products.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-linked-products.spec.js
@@ -232,7 +232,10 @@ test.describe(
 				await page
 					.getByRole( 'button', { name: 'Add to cart', exact: true } )
 					.click();
-				await page.getByRole( 'link', { name: 'View cart' } ).click();
+				await page
+					.getByRole( 'link', { name: 'View cart' } )
+					.first()
+					.click();
 
 				// check for cross-sells
 				const sectionLocator = page.locator( 'div' ).filter( {
@@ -290,7 +293,10 @@ test.describe(
 				await page
 					.getByRole( 'button', { name: 'Add to cart', exact: true } )
 					.click();
-				await page.getByRole( 'link', { name: 'View cart' } ).click();
+				await page
+					.getByRole( 'link', { name: 'View cart' } )
+					.first()
+					.click();
 
 				// check for cross-sells
 				await expect(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/56899.

`product/product-edit.spec.js` fails when there are other on-sale items in the "Related products" section of the product page.

Currently, the test is expecting that there are no `locator( 'ins' )` in the entire page when the test product is no longer on sale. This approach would fail in the event that there are on-sale products in the  "Related products" section. Each on-sale product has its own `ins` tag, as you can see from below:

<img width="700" alt="Screenshot 2025-04-01 at 5 31 20 PM" src="https://github.com/user-attachments/assets/6b230fe6-b773-4e66-813c-508bc22f2cd1" />

To solve this, this PR limits the search to the parent element `locator('.wc-block-components-product-price').first()`. Unfortunately I couldn't find any user-facing locator for it.
 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Just make sure the `product/product-edit.spec.js` test passes on CI. THere's another e2e test that's currently failing on trunk and it could fail here too, `product-linked-products.spec.js`. That failure is unrelated to the changes in this PR, and will be fixed separately.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested locally by running `pnpm test:e2e product/product-edit.spec.js`.

Also locally ran the test as part of shard 5/6 since that's the shard in CI that this test belongs to, and to make sure it passes despite the other possible on-sale items created by other tests in the shard.

<img width="1016" alt="Screenshot 2025-04-01 at 6 03 39 PM" src="https://github.com/user-attachments/assets/01b8056b-ce66-42cc-9778-6b3cd3366774" />


<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
