### PR TITLE
Fix flaky test Product Gallery: Show button inside of the image

### DIFF
--- a/plugins/woocommerce/changelog/fix-56710
+++ b/plugins/woocommerce/changelog/fix-56710
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
@@ -138,20 +138,22 @@ test.describe( `${ blockData.name }`, () => {
 				{ clientId: parentClientId }
 			);
 
-			const editorBoundingClientRect = await getBoundingClientRect( {
-				pageObject,
-				leftArrowSelector: blockData.selectors.editor.leftArrow,
-				rightArrowSelector: blockData.selectors.editor.rightArrow,
-				isFrontend: false,
-			} );
+			await expect( async () => {
+				const editorBoundingClientRect = await getBoundingClientRect( {
+					pageObject,
+					leftArrowSelector: blockData.selectors.editor.leftArrow,
+					rightArrowSelector: blockData.selectors.editor.rightArrow,
+					isFrontend: false,
+				} );
 
-			expect( editorBoundingClientRect.leftArrow.left ).toBeGreaterThan(
-				editorBoundingClientRect.gallery.left
-			);
+				expect(
+					editorBoundingClientRect.leftArrow.left
+				).toBeGreaterThan( editorBoundingClientRect.gallery.left );
 
-			expect( editorBoundingClientRect.rightArrow.right ).toBeLessThan(
-				editorBoundingClientRect.gallery.right
-			);
+				expect(
+					editorBoundingClientRect.rightArrow.right
+				).toBeLessThan( editorBoundingClientRect.gallery.right );
+			} ).toPass( { timeout: 3_000 } );
 
 			await editor.saveSiteEditorEntities( {
 				isOnlyCurrentEntityDirty: true,
@@ -159,20 +161,25 @@ test.describe( `${ blockData.name }`, () => {
 
 			await page.goto( blockData.productPage );
 
-			const frontendBoundingClientRect = await getBoundingClientRect( {
-				pageObject,
-				leftArrowSelector: blockData.selectors.editor.leftArrow,
-				rightArrowSelector: blockData.selectors.editor.rightArrow,
-				isFrontend: true,
-			} );
+			await expect( async () => {
+				const frontendBoundingClientRect = await getBoundingClientRect(
+					{
+						pageObject,
+						leftArrowSelector: blockData.selectors.editor.leftArrow,
+						rightArrowSelector:
+							blockData.selectors.editor.rightArrow,
+						isFrontend: true,
+					}
+				);
 
-			expect( frontendBoundingClientRect.leftArrow.left ).toBeGreaterThan(
-				frontendBoundingClientRect.gallery.left
-			);
+				expect(
+					frontendBoundingClientRect.leftArrow.left
+				).toBeGreaterThan( frontendBoundingClientRect.gallery.left );
 
-			expect( frontendBoundingClientRect.rightArrow.right ).toBeLessThan(
-				frontendBoundingClientRect.gallery.right
-			);
+				expect(
+					frontendBoundingClientRect.rightArrow.right
+				).toBeLessThan( frontendBoundingClientRect.gallery.right );
+			} ).toPass( { timeout: 3_000 } );
 		} );
 
 		test( 'Show buttons at the bottom of the image by default', async ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fix flaky test `
woocommerce/product-gallery-large-image-next-previous > woocommerce/product-gallery-large-image-next-previous > Settings > Show button inside of the image`. It's been flaky probably due to the image loading time. I couldn't reproduce the failing test when testing locally. Hence adding `expect( ... ).toPasss()` which is helpful in such cases to retry particular step that may rely on DOM loading time.

Closes https://github.com/woocommerce/woocommerce/issues/56710

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI passes and the test actual test (suite: Block 8/10) passes at the first time

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
