### PR TITLE
registerProductBlockType: Use toBeAttached instead of toBeVisible in dataviews E2E test

### DIFF
--- a/plugins/woocommerce/changelog/fix-register-product-block-type-data-views
+++ b/plugins/woocommerce/changelog/fix-register-product-block-type-data-views
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use .toBeAttached instead of .toBeVisible when asserting product blocks exist in dataviews page

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -148,14 +148,13 @@ test.describe( 'registerProductBlockType registers', () => {
 
 		await expect( singleProductTemplate ).toBeVisible();
 
-		const iframe = page.frameLocator(
-			'button[aria-label="Single Product"] iframe[title="Editor canvas"]'
+		const previewCanvas = singleProductTemplate.frameLocator(
+			'iframe[title="Editor canvas"]'
 		);
-
 		for ( const blockType of productBlockTypes ) {
-			const block = iframe?.locator( `[data-type="${ blockType }"]` );
-			// We are not using toBeVisible() because it never scrolls the block into view.
-			// Presumably because its in a locked iframe.
+			const block = previewCanvas.locator(
+				`[data-type="${ blockType }"]`
+			);
 			await expect( block.first() ).toBeAttached();
 		}
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -151,26 +151,12 @@ test.describe( 'registerProductBlockType registers', () => {
 		const iframe = page.frameLocator(
 			'button[aria-label="Single Product"] iframe[title="Editor canvas"]'
 		);
+
 		for ( const blockType of productBlockTypes ) {
 			const block = iframe?.locator( `[data-type="${ blockType }"]` );
-			await expect( block ).toBeVisible();
-		}
-
-		await admin.page.reload();
-
-		const singleProductTemplateAfterReload = page.getByRole( 'button', {
-			name: 'Single Product',
-		} );
-
-		await expect( singleProductTemplateAfterReload ).toBeVisible();
-		const iframeAfterReload = page.frameLocator(
-			'button[aria-label="Single Product"] iframe[title="Editor canvas"]'
-		);
-		for ( const blockType of productBlockTypes ) {
-			const block = iframeAfterReload?.locator(
-				`[data-type="${ blockType }"]`
-			);
-			await expect( block ).toBeVisible();
+			// We are not using toBeVisible() because it never scrolls the block into view.
+			// Presumably because its in a locked iframe.
+			await expect( block.first() ).toBeAttached();
 		}
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use `toBeAttached` to verify product blocks exist in the Single Product template in the dataviews templates view. Also dropped the page reload since directly loading the URL instead of going via the menu items simulates a reload in itself.

Closes # .

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56759

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure CI passes

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
