### PR TITLE
Fix duplicated "Email preview" header when managing an email

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3755-duplicated-email-preview-header-when-managing-an-email
+++ b/plugins/woocommerce/changelog/wooplug-3755-duplicated-email-preview-header-when-managing-an-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix duplicated "Email preview" header when managing an email

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-slotfill.tsx
@@ -78,7 +78,9 @@ const EmailPreviewFill = ( {
 
 	return (
 		<Fill>
-			{ ! isWide && <h2>{ __( 'Email preview', 'woocommerce' ) }</h2> }
+			{ ! isWide && ! isSingleEmail && (
+				<h2>{ __( 'Email preview', 'woocommerce' ) }</h2>
+			) }
 			<div
 				className={ `wc-settings-email-preview-container ${
 					isWide ? 'wc-settings-email-preview-container-floating' : ''


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56952, closes WOOPLUG-3755.

(For Bug Fixes) Bug introduced in PR #55923.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="645" alt="Screenshot 2025-04-02 at 10 25 10" src="https://github.com/user-attachments/assets/08f2b732-3282-4450-8f8a-9fd650505b54" />     |   <img width="646" alt="Screenshot 2025-04-02 at 10 24 43" src="https://github.com/user-attachments/assets/853ee0cc-9b16-45a9-8ab0-b1dba0157851" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Emails** and click on Manage on any email.
2. Check that there are no two `Email preview` headers.
3. Go to **WooCommerce > Settings > Emails**.
4. Reduce the browser window so the email preview is not floating next to email settings but it's below them.
5. Verify that there is still the `Email preview` title in this case.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

1. I verified that the second `Email preview` header is no longer present when managing a specific email.
2. I verified, that the `Email preview` header is present on Emails page on smaller displays (when the preview is not floating).