### PR TITLE
Remove isDescendentOf attributes from Product SKU block

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-is-descedent-of-attributes-from-product-sku
+++ b/plugins/woocommerce/changelog/fix-remove-is-descedent-of-attributes-from-product-sku
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove isDescendentOf attributes from Product SKU block

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
@@ -9,23 +9,14 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 const Edit = () => {
-	const isDescendentOfSingleProductTemplate =
-		useIsDescendentOfSingleProductTemplate();
-
 	const TEMPLATE: InnerBlockTemplate[] = [
 		[
 			'core/group',
 			{ layout: { type: 'flex', flexWrap: 'nowrap' } },
 			[
-				[
-					'woocommerce/product-sku',
-					{
-						isDescendentOfSingleProductTemplate,
-					},
-				],
+				[ 'woocommerce/product-sku' ],
 				[
 					'core/post-terms',
 					{

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
@@ -9,18 +9,6 @@
 			"type": "number",
 			"default": 0
 		},
-		"isDescendentOfQueryLoop": {
-			"type": "boolean",
-			"default": false
-		},
-		"isDescendentOfSingleProductTemplate": {
-			"type": "boolean",
-			"default": false
-		},
-		"isDescendentOfSingleProductBlock": {
-			"type": "boolean",
-			"default": false
-		},
 		"isDescendantOfAllProducts": {
 			"type": "boolean",
 			"default": false

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -19,7 +19,11 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import type { Attributes } from './types';
 
-type Props = BlockEditProps< Attributes > & HTMLAttributes< HTMLDivElement >;
+type Props = BlockEditProps< Attributes > &
+	HTMLAttributes< HTMLDivElement > & {
+		isDescendantOfAllProducts: boolean;
+		isDescendentOfSingleProductTemplate: boolean;
+	};
 
 const Preview = ( {
 	setAttributes,

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -5,7 +5,6 @@ import { useBlockProps } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,7 +12,6 @@ import { useEffect } from '@wordpress/element';
 import './editor.scss';
 import Block from './block';
 import type { Attributes } from './types';
-import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
 import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 const Edit = ( {
@@ -30,8 +28,6 @@ const Edit = ( {
 		...context,
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
-	const { isDescendentOfSingleProductBlock } =
-		useIsDescendentOfSingleProductBlock( { blockClientId: blockProps.id } );
 
 	let { isDescendentOfSingleProductTemplate } =
 		useIsDescendentOfSingleProductTemplate();
@@ -39,21 +35,6 @@ const Edit = ( {
 	if ( isDescendentOfQueryLoop ) {
 		isDescendentOfSingleProductTemplate = false;
 	}
-
-	useEffect(
-		() =>
-			setAttributes( {
-				isDescendentOfQueryLoop,
-				isDescendentOfSingleProductTemplate,
-				isDescendentOfSingleProductBlock,
-			} ),
-		[
-			setAttributes,
-			isDescendentOfQueryLoop,
-			isDescendentOfSingleProductTemplate,
-			isDescendentOfSingleProductBlock,
-		]
-	);
 
 	return (
 		<>
@@ -69,7 +50,16 @@ const Edit = ( {
 					attributes.isDescendantOfAllProducts ? undefined : style
 				}
 			>
-				<Block { ...blockAttrs } setAttributes={ setAttributes } />
+				<Block
+					{ ...blockAttrs }
+					setAttributes={ setAttributes }
+					isDescendentOfSingleProductTemplate={
+						isDescendentOfSingleProductTemplate
+					}
+					isDescendantOfAllProducts={
+						attributes.isDescendantOfAllProducts
+					}
+				/>
 			</div>
 		</>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/types.ts
@@ -1,8 +1,5 @@
 export interface Attributes {
 	productId: number;
-	isDescendentOfQueryLoop: boolean;
-	isDescendentOfSingleProductTemplate: boolean;
-	isDescendentOfSingleProductBlock: boolean;
 	showProductSelector: boolean;
 	isDescendantOfAllProducts: boolean;
 	prefix: string;

--- a/plugins/woocommerce/templates/templates/blockified/single-product.html
+++ b/plugins/woocommerce/templates/templates/blockified/single-product.html
@@ -29,7 +29,7 @@
 			<div class="wp-block-woocommerce-product-meta">
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:woocommerce/product-sku {"isDescendentOfSingleProductTemplate":true} /-->
+					<!-- wp:woocommerce/product-sku /-->
 
 					<!-- wp:post-terms {"term":"product_cat","prefix":"Category: "} /-->
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateTests.php
@@ -338,7 +338,7 @@ class SingleProductTemplateTests extends WP_UnitTestCase {
 					<div class="wp-block-woocommerce-product-meta">
 						<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 						<div class="wp-block-group">
-							<!-- wp:woocommerce/product-sku {"isDescendentOfSingleProductTemplate":true} /-->
+							<!-- wp:woocommerce/product-sku /-->
 
 							<!-- wp:post-terms {"term":"product_cat","prefix":"Category: "} /-->
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes several `isDesecendentOf` attributes from the Product SKU block.

Part of #48936.
Part of WOOPLUG-2348.

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions related to the Product SKU block. Go through all the steps with your browser devtools console open to make sure there are no JS errors.

#### Single Product and Product Collection blocks

1. Create a post or page.
2. Add the Single Product block.
3. Verify the Product SKU block is rendered correctly.

![Captura de pantalla de 2025-04-02 17-00-01](https://github.com/user-attachments/assets/74b4ba41-b04e-4538-aedc-504607f14ad6)

4. Add the Product Collection block and inside it insert the Product SKU block.
5. Verify it's rendered correctly.
6. Publish the post and view it in the frontend. Verify the Product SKU block is rendered correctly.

![imatge](https://github.com/user-attachments/assets/6285fb3c-1b8c-4e00-967b-73a46c21c441)

#### Single Product template

7. Go to the Single Product template in the frontend.
8. Verify the Product SKU block is rendered correctly.
9. Click on _Edit Site_ in the top bar to edit the _Single Product_ template.
10. Verify the Product SKU block is rendered correctly in the editor too.
11. Try adding the _Product Meta_ block and verify it works well too.

#### Product Catalog template

12. Go to Appearance > Editor > Templates > Product Catalog and add the Product SKU block inside the _Product Collection_ block.
13. Verify it renders correctly in the editor and in the frontend (`/shop` page).

![imatge](https://github.com/user-attachments/assets/e644ac1d-52b0-44b9-acc1-d0d692743fcc)

#### All Products

14. Create a post or page and insert the _All Products_ block by copy and pasting this snippet:

```HTML
<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image",{"imageSizing":"cropped"}],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;,{&quot;imageSizing&quot;:&quot;cropped&quot;}],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"><!-- wp:woocommerce/product-image {"imageSizing":"thumbnail"} -->
<div class="is-loading"></div>
<!-- /wp:woocommerce/product-image -->

<!-- wp:woocommerce/product-title -->
<div class="wp-block-woocommerce-product-title is-loading"></div>
<!-- /wp:woocommerce/product-title -->

<!-- wp:woocommerce/product-price -->
<div class="is-loading"></div>
<!-- /wp:woocommerce/product-price -->

<!-- wp:woocommerce/product-rating -->
<div class="is-loading"></div>
<!-- /wp:woocommerce/product-rating -->

<!-- wp:woocommerce/product-button /--></div>
<!-- /wp:woocommerce/all-products -->
```

15. Edit the _All Products_ block and insert the _Product SKU_ block inside.

![imatge](https://github.com/user-attachments/assets/6eed89c7-b587-429f-be74-24375e61c39e)

16. Click on _Done_ and verify the block shows up in the editor and the frontend.