### PR TITLE
Product Image: add aspectRatio support

### DIFF
--- a/plugins/woocommerce/changelog/56991-wooplug-2232-add-aspect-ratio-and-other-image-controls-to-the-product
+++ b/plugins/woocommerce/changelog/56991-wooplug-2232-add-aspect-ratio-and-other-image-controls-to-the-product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enhance Product Image block with aspect ratio support.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
@@ -14,6 +14,7 @@ import { withProductDataContext } from '@woocommerce/shared-hocs';
 import { useStoreEvents } from '@woocommerce/base-context/hooks';
 import type { HTMLAttributes } from 'react';
 import { decodeEntities } from '@wordpress/html-entities';
+import { isString, objectHasProp } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -98,7 +99,8 @@ const Image = ( {
 	);
 };
 
-type Props = BlockAttributes & HTMLAttributes< HTMLDivElement >;
+type Props = BlockAttributes &
+	HTMLAttributes< HTMLDivElement > & { style: Record< string, unknown > };
 
 export const Block = ( props: Props ): JSX.Element | null => {
 	const {
@@ -111,6 +113,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		width,
 		scale,
 		aspectRatio,
+		style,
 		...restProps
 	} = props;
 	const styleProps = useStyleProps( props );
@@ -154,9 +157,6 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		},
 	};
 
-	// Remove parent block custom styles from sale badge.
-	delete restProps.style;
-
 	return (
 		<div
 			className={ clsx(
@@ -184,7 +184,13 @@ export const Block = ( props: Props ): JSX.Element | null => {
 					width={ width }
 					height={ height }
 					scale={ scale }
-					aspectRatio={ aspectRatio }
+					aspectRatio={
+						objectHasProp( style, 'dimensions' ) &&
+						objectHasProp( style.dimensions, 'aspectRatio' ) &&
+						isString( style.dimensions.aspectRatio )
+							? style.dimensions.aspectRatio
+							: aspectRatio
+					}
 				/>
 			</ParentComponent>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/block.tsx
@@ -100,7 +100,7 @@ const Image = ( {
 };
 
 type Props = BlockAttributes &
-	HTMLAttributes< HTMLDivElement > & { style: Record< string, unknown > };
+	HTMLAttributes< HTMLDivElement > & { style?: Record< string, unknown > };
 
 export const Block = ( props: Props ): JSX.Element | null => {
 	const {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -25,4 +25,8 @@ export const supports = {
 		},
 	} ),
 	__experimentalSelector: '.wc-block-components-product-image',
+	dimensions: {
+		aspectRatio: true,
+		__experimentalSkipSerialization: true,
+	},
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -162,8 +162,18 @@ class ProductImage extends AbstractBlock {
 		if ( ! empty( $attributes['scale'] ) ) {
 			$image_style .= sprintf( 'object-fit:%s;', $attributes['scale'] );
 		}
+
+		// Keep this aspect ratio for backward compatibility.
 		if ( ! empty( $attributes['aspectRatio'] ) ) {
 			$image_style .= sprintf( 'aspect-ratio:%s;', $attributes['aspectRatio'] );
+		}
+
+		if ( ! empty( $attributes['style']['dimensions']['aspectRatio'] ) ) {
+			$image_style .= sprintf( 'aspect-ratio:%s;', $attributes['style']['dimensions']['aspectRatio'] );
+		}
+
+		if ( ! empty( $attributes['style']['dimensions']['minHeight'] ) ) {
+			$image_style .= sprintf( 'min-height:%s;', $attributes['style']['dimensions']['minHeight'] );
 		}
 
 		$image_id = $product->get_image_id();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR enhances the Product Image block by improving aspect ratio using Supports API.

### How to test the changes in this Pull Request:

1. Edit the Product Catalog template that contain the Product Collection block.
2. Focus the Product Image block.
3. See the Aspect Ratio setting in the Styles tab.
4. Change the setting, see the editor preview react.
5. Save and see the style applied on the frontend.

### Testing that has already taken place:

Testing has been conducted in a local development environment with:

-   WordPress 6.7.2
-   Twenty Twenty-Five theme

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor
-   [ ] Patch
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Enhancement - Improvement to existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues

#### Message

Enhance Product Image block with aspect ratio support.

</details>
