### PR TITLE
Fix block registration errors in the editor when no payment methods are enabled

### DIFF
--- a/plugins/woocommerce/changelog/56994-fix-js-errors-when-no-payments
+++ b/plugins/woocommerce/changelog/56994-fix-js-errors-when-no-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix block registration problems in the editor when no payment methods enabled.

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/default-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/default-state.ts
@@ -29,7 +29,7 @@ const savedPaymentMethods = getSetting<
 >( 'customerPaymentMethods', {} );
 
 const defaultPaymentMethod = isEditor()
-	? globalPaymentMethods[ 0 ].id
+	? globalPaymentMethods[ 0 ]?.id || ''
 	: checkoutData?.payment_method;
 
 function getDefaultPaymentMethod() {
@@ -37,7 +37,7 @@ function getDefaultPaymentMethod() {
 		return '';
 	}
 
-	return defaultPaymentMethod;
+	return defaultPaymentMethod as string;
 }
 
 /**

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/test/default-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/test/default-state.ts
@@ -1,0 +1,200 @@
+/**
+ * External dependencies
+ */
+import type { GlobalPaymentMethod } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import type { PaymentState } from '../default-state';
+
+// Helper function to get a fresh instance of defaultPaymentState for each test
+const getDefaultPaymentStateWithMocks = ( {
+	isEditorMode = false,
+	checkoutData = {
+		payment_method: 'stripe',
+	},
+	customerPaymentMethods = {},
+	globalPaymentMethods = [],
+}: {
+	isEditorMode?: boolean;
+	checkoutData?: { payment_method: string };
+	customerPaymentMethods?: Record< string, any >;
+	globalPaymentMethods?: GlobalPaymentMethod[];
+} = {} ): PaymentState => {
+	let state: PaymentState | undefined;
+
+	// IsolateModules is used to ensure that the module is not cached between tests
+	jest.isolateModules( () => {
+		// Set up mocks before requiring the module
+		// Using doMock as calls to `mock` are hoisted to the top of the file
+		jest.doMock( '../../utils', () => ( {
+			isEditor: () => isEditorMode,
+		} ) );
+
+		jest.doMock( '../../checkout/constants', () => ( {
+			checkoutData,
+		} ) );
+
+		jest.doMock( '@woocommerce/settings', () => ( {
+			getSetting: ( setting: string ) => {
+				switch ( setting ) {
+					case 'globalPaymentMethods':
+						return globalPaymentMethods;
+					case 'customerPaymentMethods':
+						return customerPaymentMethods;
+					default:
+						return {};
+				}
+			},
+		} ) );
+
+		// Get a fresh copy of the state
+		state = require( '../default-state' ).defaultPaymentState;
+	} );
+
+	// TypeScript needs this check, but isolateModules will always set the state
+	if ( ! state ) {
+		throw new Error( 'Failed to initialize state' );
+	}
+
+	return state;
+};
+
+describe( 'defaultPaymentState', () => {
+	describe( 'Initial state', () => {
+		it( 'should initialize with correct default values', () => {
+			const state = getDefaultPaymentStateWithMocks();
+			expect( state ).toEqual( {
+				status: 'idle',
+				activePaymentMethod: 'stripe',
+				availablePaymentMethods: {},
+				availableExpressPaymentMethods: {},
+				savedPaymentMethods: {},
+				paymentMethodData: {},
+				paymentResult: null,
+				paymentMethodsInitialized: false,
+				expressPaymentMethodsInitialized: false,
+				shouldSavePaymentMethod: false,
+			} );
+		} );
+	} );
+
+	describe( 'In editor mode, activePaymentMethod', () => {
+		it( 'should be an empty string when no global payment methods exist', () => {
+			const state = getDefaultPaymentStateWithMocks( {
+				isEditorMode: true,
+				globalPaymentMethods: [],
+			} );
+			expect( state.activePaymentMethod ).toBe( '' );
+		} );
+
+		it( 'should be equal to the first payment method id from globalPaymentMethods when payment methods exist', () => {
+			const mockGlobalPaymentMethods: GlobalPaymentMethod[] = [
+				{
+					id: 'stripe',
+					title: 'Stripe',
+					description: 'Pay with Stripe',
+				},
+				{
+					id: 'paypal',
+					title: 'PayPal',
+					description: 'Pay with PayPal',
+				},
+			];
+
+			const state = getDefaultPaymentStateWithMocks( {
+				isEditorMode: true,
+				globalPaymentMethods: mockGlobalPaymentMethods,
+			} );
+			expect( state.activePaymentMethod ).toBe( 'stripe' );
+		} );
+	} );
+
+	describe( 'Frontend', () => {
+		it( 'should set activePaymentMethod to value from checkoutData.payment_method', () => {
+			const state = getDefaultPaymentStateWithMocks( {
+				checkoutData: { payment_method: 'stripe' },
+			} );
+			expect( state.activePaymentMethod ).toBe( 'stripe' );
+		} );
+
+		describe( 'Payment method data', () => {
+			it( 'should be empty when no default payment method exists', () => {
+				const state = getDefaultPaymentStateWithMocks( {
+					checkoutData: { payment_method: '' },
+					customerPaymentMethods: {},
+					globalPaymentMethods: [],
+				} );
+				expect( state.paymentMethodData ).toEqual( {} );
+			} );
+
+			it( 'should be empty when default payment method does not match saved methods', () => {
+				const mockSavedPaymentMethods = {
+					cc: [
+						{
+							method: {
+								gateway: 'stripe',
+							},
+							tokenId: '123',
+						},
+					],
+				};
+
+				const state = getDefaultPaymentStateWithMocks( {
+					checkoutData: { payment_method: 'paypal' },
+					customerPaymentMethods: mockSavedPaymentMethods,
+				} );
+				expect( state.paymentMethodData ).toEqual( {} );
+			} );
+
+			it( 'should be equal to the payment method data for the default payment method', () => {
+				const customerPaymentMethods = {
+					cc: [
+						{
+							method: {
+								gateway: 'stripe',
+								brand: 'visa',
+								last4: '1234',
+							},
+							tokenId: '123',
+							is_default: true,
+						},
+					],
+				};
+
+				const state = getDefaultPaymentStateWithMocks( {
+					checkoutData: { payment_method: 'stripe' },
+					customerPaymentMethods,
+				} );
+				expect( state.paymentMethodData ).toEqual( {
+					token: '123',
+					payment_method: 'stripe',
+					'wc-stripe-payment-token': '123',
+				} );
+			} );
+		} );
+
+		describe( 'Saved payment methods', () => {
+			it( 'should handle saved payment methods correctly', () => {
+				const mockSavedPaymentMethods = {
+					cc: [
+						{
+							method: {
+								gateway: 'stripe',
+							},
+							tokenId: '123',
+						},
+					],
+				};
+
+				const state = getDefaultPaymentStateWithMocks( {
+					customerPaymentMethods: mockSavedPaymentMethods,
+				} );
+				expect( state.savedPaymentMethods ).toEqual(
+					mockSavedPaymentMethods
+				);
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/test/default-state.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/test/default-state.ts
@@ -7,6 +7,7 @@ import type { GlobalPaymentMethod } from '@woocommerce/types';
  * Internal dependencies
  */
 import type { PaymentState } from '../default-state';
+import { SavedPaymentMethod } from '../types';
 
 // Helper function to get a fresh instance of defaultPaymentState for each test
 const getDefaultPaymentStateWithMocks = ( {
@@ -19,7 +20,7 @@ const getDefaultPaymentStateWithMocks = ( {
 }: {
 	isEditorMode?: boolean;
 	checkoutData?: { payment_method: string };
-	customerPaymentMethods?: Record< string, any >;
+	customerPaymentMethods?: Record< string, SavedPaymentMethod[] >;
 	globalPaymentMethods?: GlobalPaymentMethod[];
 } = {} ): PaymentState => {
 	let state: PaymentState | undefined;
@@ -50,6 +51,7 @@ const getDefaultPaymentStateWithMocks = ( {
 		} ) );
 
 		// Get a fresh copy of the state
+		// eslint-disable-next-line @typescript-eslint/no-var-requires -- Cloning using structuredClone is not supported in jsdom and Object.assign won't work as the state contains objects that need to be reset too. This is a clean way to get a fresh copy of the state.
 		state = require( '../default-state' ).defaultPaymentState;
 	} );
 
@@ -130,13 +132,26 @@ describe( 'defaultPaymentState', () => {
 			} );
 
 			it( 'should be empty when default payment method does not match saved methods', () => {
-				const mockSavedPaymentMethods = {
+				const mockSavedPaymentMethods: Record<
+					string,
+					SavedPaymentMethod[]
+				> = {
 					cc: [
 						{
 							method: {
 								gateway: 'stripe',
+								brand: 'visa',
+								last4: '1234',
 							},
-							tokenId: '123',
+							tokenId: 123,
+							is_default: true,
+							expires: '10/99',
+							actions: {
+								default: {
+									name: 'Delete',
+									url: 'https://example.com',
+								},
+							},
 						},
 					],
 				};
@@ -149,7 +164,10 @@ describe( 'defaultPaymentState', () => {
 			} );
 
 			it( 'should be equal to the payment method data for the default payment method', () => {
-				const customerPaymentMethods = {
+				const customerPaymentMethods: Record<
+					string,
+					SavedPaymentMethod[]
+				> = {
 					cc: [
 						{
 							method: {
@@ -157,8 +175,15 @@ describe( 'defaultPaymentState', () => {
 								brand: 'visa',
 								last4: '1234',
 							},
-							tokenId: '123',
+							tokenId: 123,
 							is_default: true,
+							expires: '10/99',
+							actions: {
+								default: {
+									name: 'Delete',
+									url: 'https://example.com',
+								},
+							},
 						},
 					],
 				};
@@ -177,13 +202,26 @@ describe( 'defaultPaymentState', () => {
 
 		describe( 'Saved payment methods', () => {
 			it( 'should handle saved payment methods correctly', () => {
-				const mockSavedPaymentMethods = {
+				const mockSavedPaymentMethods: Record<
+					string,
+					SavedPaymentMethod[]
+				> = {
 					cc: [
 						{
 							method: {
 								gateway: 'stripe',
+								brand: 'visa',
+								last4: '1234',
 							},
-							tokenId: '123',
+							tokenId: 123,
+							is_default: true,
+							expires: '10/99',
+							actions: {
+								default: {
+									name: 'Delete',
+									url: 'https://example.com',
+								},
+							},
 						},
 					],
 				};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses a bug found on trunk, where blocks would not render in the editor if there are no payment methods configured. There was an assumption [here](https://github.com/woocommerce/woocommerce/blob/master/plugins/woocommerce/client/blocks/assets/js/data/payment/default-state.ts#L32) that the array of payment methods will never be empty. We set the activePaymentMethod to an empty string `''` when this is the case. I've also added tests to cover the complexity in setting the default state here.

Closes # .
Related p1743499856652569-slack-C02FL3X7KR6


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable all payment methods in WC
2. In the Editor, head to Appearance > Editor > Templates > Single Product
3. See that there are no console errors. 
4. Open the checkout block in the editor, and verify there are no console errors. Smoke test.
5. On the front-end, smoke test the payment methods. Select between them, refresh the page, make sure they are persisted and the payment method you would expect is there on first load.

<!-- End testing instructions -->

### Testing that has already taken place:

Included unit tests as part of this PR. Tested the same steps as above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix block registration problems in the editor when no payment methods enabled.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>