### PR TITLE
[dev] CI: PR-level workflows update to reduce the number of runs for draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     # which projects have changed and what kind of change occurred. This lets us build the
     # matrices that we can use to run CI tasks only on the projects that need them.
     name: 'Build Project Jobs'
-    if: ${{ !cancelled() && ( github.event_name != 'pull_request' || needs.identify-jobs-to-run.outputs.needs-code-validation == 'true' ) }}
+    if: ${{ !cancelled() }}
     needs: 'identify-jobs-to-run'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr-assess-bundle-size.yml
+++ b/.github/workflows/pr-assess-bundle-size.yml
@@ -31,7 +31,7 @@ on:
             - '.github/workflows/pr-assess-bundle-size.yml'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 env:

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -23,8 +23,7 @@ on:
             - '!.github/workflows/pr-build-live-branch.yml'
 
 concurrency:
-    # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.
-    group: build-${{ github.event_name == 'push' && github.run_id || 'pr' }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 env:

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'trunk'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: 'Analyze Branch Changes'

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -4,7 +4,7 @@ on:
         types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
-    group: label-pr-${{ github.event.pull_request.number }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -1,24 +1,24 @@
 name: 'Label Pull Request Project'
 on:
     pull_request_target:
-        types:
-            - opened
-            - reopened
-            - synchronize
+        types: [opened, reopened, synchronize, ready_for_review]
+
 concurrency:
-    group: label-pr-${{ github.event_name }}-${{ github.event.action }}-${{ github.event.pull_request.head.ref }}
+    group: label-pr-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 permissions: {}
 
 jobs:
     label_project:
+        # For draft PRs we'll only update labels initially, and keep updating only them after it ready for review.
+        if: ${{ github.event.pull_request.draft == false || join(github.event.pull_request.labels.*.name, '') == '' }}
         runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: write
         steps:
-            - uses: actions/labeler@v3
+            - uses: actions/labeler@v5
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   configuration-path: .github/project-pr-labeler.yml

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -18,7 +18,7 @@ jobs:
             contents: read
             pull-requests: write
         steps:
-            - uses: actions/labeler@v5
+            - uses: actions/labeler@v3
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   configuration-path: .github/project-pr-labeler.yml


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Revisit PR labeler workflow for draft PRs
- Housekeeping
- Bug-fix CI-workflow blocking PRs without code changes

### Testing

- Testing with https://github.com/woocommerce/woocommerce/pull/57007
