### PR TITLE
Use string instead of number for email logo width default value

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3638-value-of-woocommerce_email_header_image_width-email-setting
+++ b/plugins/woocommerce/changelog/wooplug-3638-value-of-woocommerce_email_header_image_width-email-setting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Only changes the default value type from number to string for email logo width. No visible or functional change
+
+

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -149,7 +149,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'title'    => __( 'Logo width (px)', 'woocommerce' ),
 				'id'       => 'woocommerce_email_header_image_width',
 				'desc_tip' => '',
-				'default'  => 120,
+				'default'  => '120',
 				'type'     => 'number',
 			);
 			$header_alignment           = array(

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/settings/settings-crud.test.js
@@ -1634,7 +1634,7 @@ test.describe( 'Settings API tests: CRUD', () => {
 						id: 'woocommerce_email_header_image_width',
 						label: 'Logo width (px)',
 						type: 'number',
-						default: 120,
+						default: '120',
 						value: expect.anything(), // value could be number or string depending on environment
 					} ),
 				] )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR changes the `woocommerce_email_header_image_width` type from number to string. The reason is that there is no harm in using a string, and it's more difficult to ensure that the value is everywhere a number, when in the database, it's saved in the LONGTEXT column.

Closes #56752, closes WOOPLUG-3638.

(For Bug Fixes) Bug introduced in PR #54897.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **Settings > Permalinks** and ensure that anything other than `Plain` is chosen (otherwise REST API doesn't work). 
2. Go to **User > Profile** and create a new Application password (note the password).
3. Locally, you can test that `curl -u "admin:APPLICATION_PASSWORD" "http://localhost:8888/wp-json/wc/v3/settings/email/woocommerce_email_header_image_width"` return strings for both `value` and `default`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I've tested locally that both values are strings. 
