### PR TITLE
Fix spacing issue in Settings navigation on the NOX Select Payment Methods screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-settings-navigation-spacing
+++ b/plugins/woocommerce/changelog/fix-settings-navigation-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix spacing issue in Settings navigation on the NOX Select Payment Methods screen.

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -97,7 +97,7 @@ const SettingsPaymentsMain = () => {
 
 	useEffect( () => {
 		if ( location.pathname === '' ) {
-			hideWooCommerceNavTab( 'block' );
+			hideWooCommerceNavTab( 'flex' );
 		}
 	}, [ location ] );
 	return (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses spacing issues in the WooCommerce Settings navigation that occur when the NOX Select Payment Methods screen is displayed.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1487" alt="Screenshot 2025-04-03 at 22 31 11" src="https://github.com/user-attachments/assets/40749e7d-4437-4879-83d3-f3f0c422065c" /> | <img width="1492" alt="Screenshot 2025-04-03 at 22 35 24" src="https://github.com/user-attachments/assets/9739d0a5-2b74-4761-a144-6eefad0a6745" /> |

### How to test the changes in this Pull Request:
1. Create a new JurassicNinja site with WooCommerce on this PR's live branch and WooCommerce Beta Tester (here is [a direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/settings-navigation-spacing))
2. Navigate to the WP Admin Dashboard of the newly created site.
3. Complete the WooCommerce setup wizard. If it doesn’t start automatically, click on the WooCommerce menu item. Then click Skip guided setup, and select United States as the store location.
4. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature. Click Save changes.
5. Click on the Payments tab and scroll down to the WooPayments provider section. Click the Enable button to activate the plugin.
6. When the Select Payment Methods screen appears, click the back arrow (<) next to the “Choose your payment methods” title at the top of the screen to return back.
7. Verify that the spacing between the Settings navigation tabs is preserved and visually consistent.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
