### PR TITLE
Fix additional fields crashing and formatting issues

### DIFF
--- a/plugins/woocommerce/changelog/57037-fix-additional-fields-crash-and-others
+++ b/plugins/woocommerce/changelog/57037-fix-additional-fields-crash-and-others
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix logic bugs in additional fields validation and persisting logic.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -121,17 +121,17 @@ const Form = <
 
 		// Previous errors are cleared when they're no longer present.
 		if ( previousErrors ) {
+			const errorsToClear: string[] = [];
 			Object.entries( previousErrors ).forEach( ( [ key ] ) => {
 				const inputRef = inputsRef.current[ key ];
 
 				// If error was previously set but no longer exists, clear it.
 				if ( ! ( key in errors ) ) {
-					dispatch( validationStore ).clearValidationError(
-						`${ addressType }_${ key }`
-					);
+					errorsToClear.push( `${ addressType }_${ key }` );
 					inputRef?.setErrorMessage( '' );
 				}
 			} );
+			dispatch( validationStore ).clearValidationErrors( errorsToClear );
 		}
 	}, [ errors, previousErrors, addressType, values ] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -25,7 +25,7 @@ import {
 } from '@woocommerce/settings';
 import { isNull } from '@woocommerce/types';
 import { useInstanceId } from '@wordpress/compose';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -103,21 +103,28 @@ const Form = <
 				return;
 			}
 			inputRef?.setErrorMessage( error );
+			const hasValidationError = select(
+				validationStore
+			).getValidationError( `${ addressType }_${ key }` );
+
+			// Check if this field already has a validation error, prevents up from surfacing already hidden errors.
+			if ( hasValidationError ) {
+				return;
+			}
 			dispatch( validationStore ).setValidationErrors( {
 				[ `${ addressType }_${ key }` ]: {
 					message: error,
 					hidden: !! inputRef?.isFocused(),
 				},
 			} );
-			if ( ! inputRef?.isFocused() ) {
-				inputRef?.revalidate();
-			}
 		} );
 
+		// Previous errors are cleared when they're no longer present.
 		if ( previousErrors ) {
 			Object.entries( previousErrors ).forEach( ( [ key ] ) => {
 				const inputRef = inputsRef.current[ key ];
-				// If error was previously set but is now cleared
+
+				// If error was previously set but no longer exists, clear it.
 				if ( ! ( key in errors ) ) {
 					dispatch( validationStore ).clearValidationError(
 						`${ addressType }_${ key }`

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -131,7 +131,11 @@ const Form = <
 					inputRef?.setErrorMessage( '' );
 				}
 			} );
-			dispatch( validationStore ).clearValidationErrors( errorsToClear );
+			if ( errorsToClear.length ) {
+				dispatch( validationStore ).clearValidationErrors(
+					errorsToClear
+				);
+			}
 		}
 	}, [ errors, previousErrors, addressType, values ] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -109,7 +109,7 @@ export const useFormValidation = (
 	if ( ! data ) {
 		return {
 			errors: currentResults.current,
-			previousErrors,
+			previousErrors: undefined,
 		};
 	}
 
@@ -205,6 +205,7 @@ export const useFormValidation = (
 				break;
 		}
 		const validate = parser.compile( schema );
+		// AJV mutates validate function and errors to it, so we reach from it. Result only has a boolean value if errors are present.
 		const result = validate( data );
 
 		if ( ! result && validate.errors ) {

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
@@ -249,25 +249,30 @@ export const validateAdditionalFields = (
 	// Check each additional field for validation errors
 	// The validation store prefixes ads a prefix depending on the field location
 	for ( const fieldKey of Object.keys( additionalFields ) ) {
-		let prefix = '';
-		if ( CONTACT_FORM_KEYS.includes( fieldKey as keyof ContactForm ) ) {
-			prefix = 'contact_';
-		} else if (
-			ORDER_FORM_KEYS.includes( fieldKey as keyof AdditionalValues )
-		) {
-			prefix = 'order_';
-		} else {
-			return false;
-		}
-
-		const error = select( validationStore ).getValidationError(
-			`${ prefix }${ fieldKey }`
-		);
-
-		if ( error && ! error.hidden ) {
+		if ( hasValidationError( fieldKey ) ) {
 			return false;
 		}
 	}
 
 	return true;
+};
+
+export const hasValidationError = ( fieldKey: string ) => {
+	let prefix = '';
+	if ( CONTACT_FORM_KEYS.includes( fieldKey as keyof ContactForm ) ) {
+		prefix = 'contact_';
+	} else if (
+		ORDER_FORM_KEYS.includes( fieldKey as keyof AdditionalValues )
+	) {
+		prefix = 'order_';
+	} else {
+		return false;
+	}
+	const error = select( validationStore ).getValidationError(
+		`${ prefix }${ fieldKey }`
+	);
+	if ( error ) {
+		return true;
+	}
+	return false;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
@@ -22,7 +22,13 @@ import {
 } from '@wordpress/data/build-types/types';
 import { checkoutStore } from '@woocommerce/block-data';
 import { select } from '@wordpress/data';
-import type { AdditionalValues, ContactForm } from '@woocommerce/settings';
+import type {
+	ContactForm,
+	ContactFormValues,
+	FormFields,
+	OrderForm,
+	OrderFormValues,
+} from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -242,9 +248,7 @@ export const hasValidationError = ( fieldKey: string ) => {
 	let prefix = '';
 	if ( CONTACT_FORM_KEYS.includes( fieldKey as keyof ContactForm ) ) {
 		prefix = 'contact_';
-	} else if (
-		ORDER_FORM_KEYS.includes( fieldKey as keyof AdditionalValues )
-	) {
+	} else if ( ORDER_FORM_KEYS.includes( fieldKey as keyof OrderForm ) ) {
 		prefix = 'order_';
 	} else {
 		return false;

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
@@ -244,7 +244,9 @@ export const getPaymentResultFromCheckoutResponse = (
 	return paymentResult;
 };
 
-export const hasValidationError = ( fieldKey: string ) => {
+export const hasValidationError = (
+	fieldKey: keyof ContactForm | keyof OrderForm
+) => {
 	let prefix = '';
 	if ( CONTACT_FORM_KEYS.includes( fieldKey as keyof ContactForm ) ) {
 		prefix = 'contact_';
@@ -263,7 +265,7 @@ export const hasValidationError = ( fieldKey: string ) => {
 };
 
 export const validateAdditionalFields = (
-	additionalFields: AdditionalValues
+	additionalFields: OrderFormValues | ContactFormValues
 ): boolean => {
 	// Early return if no additional fields to validate
 	if ( Object.keys( additionalFields ).length === 0 ) {
@@ -271,8 +273,10 @@ export const validateAdditionalFields = (
 	}
 
 	// Check each additional field for validation errors
-	// The validation store prefixes ads a prefix depending on the field location
-	for ( const fieldKey of Object.keys( additionalFields ) ) {
+	// The validation store adds a prefix depending on the field location
+	for ( const fieldKey of Object.keys( additionalFields ) as Array<
+		keyof ContactForm | keyof OrderForm
+	> ) {
 		if ( hasValidationError( fieldKey ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
@@ -238,25 +238,6 @@ export const getPaymentResultFromCheckoutResponse = (
 	return paymentResult;
 };
 
-export const validateAdditionalFields = (
-	additionalFields: AdditionalValues
-): boolean => {
-	// Early return if no additional fields to validate
-	if ( Object.keys( additionalFields ).length === 0 ) {
-		return true;
-	}
-
-	// Check each additional field for validation errors
-	// The validation store prefixes ads a prefix depending on the field location
-	for ( const fieldKey of Object.keys( additionalFields ) ) {
-		if ( hasValidationError( fieldKey ) ) {
-			return false;
-		}
-	}
-
-	return true;
-};
-
 export const hasValidationError = ( fieldKey: string ) => {
 	let prefix = '';
 	if ( CONTACT_FORM_KEYS.includes( fieldKey as keyof ContactForm ) ) {
@@ -275,4 +256,23 @@ export const hasValidationError = ( fieldKey: string ) => {
 		return true;
 	}
 	return false;
+};
+
+export const validateAdditionalFields = (
+	additionalFields: AdditionalValues
+): boolean => {
+	// Early return if no additional fields to validate
+	if ( Object.keys( additionalFields ).length === 0 ) {
+		return true;
+	}
+
+	// Check each additional field for validation errors
+	// The validation store prefixes ads a prefix depending on the field location
+	for ( const fieldKey of Object.keys( additionalFields ) ) {
+		if ( hasValidationError( fieldKey ) ) {
+			return false;
+		}
+	}
+
+	return true;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/utils.ts
@@ -25,7 +25,6 @@ import { select } from '@wordpress/data';
 import type {
 	ContactForm,
 	ContactFormValues,
-	FormFields,
 	OrderForm,
 	OrderFormValues,
 } from '@woocommerce/settings';

--- a/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/blocks/constants.ts
@@ -62,9 +62,9 @@ export const SHIPPING_ENABLED = getSetting< boolean >(
 );
 
 type FieldsLocations = {
-	address: ( keyof AddressForm )[];
-	contact: ( keyof ContactForm )[];
-	order: ( keyof OrderForm )[];
+	address: Array< keyof AddressForm >;
+	contact: Array< keyof ContactForm >;
+	order: Array< keyof OrderForm >;
 };
 
 // Contains country names.

--- a/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/index.ts
@@ -9,13 +9,17 @@ const ajv = new Ajv( {
 	allErrors: true,
 	$data: true,
 	validateSchema: true,
-	validateFormats: false,
+	validateFormats: true,
 	strictSchema: false,
 	strict: false,
 	messages: true,
 } );
 
-addFormats( ajv );
+addFormats( ajv, {
+	mode: 'fast',
+	formats: [ 'date', 'time', 'email', 'uri' ],
+	keywords: true,
+} );
 addErrors( ajv );
 
 // Add type declaration for window.schemaParser

--- a/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/index.ts
@@ -15,9 +15,15 @@ const ajv = new Ajv( {
 	messages: true,
 } );
 
+// Override email format to match PHP's FILTER_VALIDATE_EMAIL.
+ajv.addFormat(
+	'email',
+	/^(?!.*[.]{2})[a-zA-Z0-9](?:[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*[a-zA-Z0-9])?@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/i
+);
+
 addFormats( ajv, {
 	mode: 'fast',
-	formats: [ 'date', 'time', 'email', 'uri' ],
+	formats: [ 'date', 'time', 'uri' ],
 	keywords: true,
 } );
 addErrors( ajv );
@@ -30,3 +36,5 @@ declare global {
 }
 
 window.schemaParser = ajv;
+
+export { ajv as schemaParser };

--- a/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/test/email-format.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/schema-parser/test/email-format.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { schemaParser } from '../index';
+
+describe( 'Schema Parser', () => {
+	describe( 'email format validation', () => {
+		const validateEmail = ( email: string ) => {
+			const schema = {
+				type: 'object',
+				properties: {
+					email: { type: 'string', format: 'email' },
+				},
+			};
+			const validate = schemaParser.compile( schema );
+			return validate( { email } );
+		};
+
+		it.each( [
+			[ 'test@example.com', true ],
+			[ 'test.name@example.com', true ],
+			[ 'test+label@example.com', true ],
+			[ 'test@sub.example.com', true ],
+			[ 'TEST@EXAMPLE.COM', true ],
+			[ 'user123@example.co.uk', true ],
+		] )( 'should validate valid email %s', ( email, expected ) => {
+			expect( validateEmail( email ) ).toBe( expected );
+		} );
+
+		it.each( [
+			[ 'test@localhost', false ],
+			[ 'test@example', false ],
+			[ 'test@.com', false ],
+			[ 'test@com', false ],
+			[ 'test.@example.com', false ],
+			[ '.test@example.com', false ],
+			[ 'test@example..com', false ],
+			[ 'test..name@example.com', false ],
+			[ '@example.com', false ],
+			[ 'test@', false ],
+			[ 'test', false ],
+		] )( 'should invalidate invalid email %s', ( email, expected ) => {
+			expect( validateEmail( email ) ).toBe( expected );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -243,7 +243,7 @@ class CheckoutSchema extends AbstractSchema {
 			'shipping_address'   => (object) $this->shipping_address_schema->get_item_response( $order ),
 			'payment_method'     => $order->get_payment_method(),
 			'payment_result'     => $payment_result,
-			'additional_fields'  => $this->get_additional_fields_response( $order ),
+			'additional_fields'  => (object) $this->get_additional_fields_response( $order ),
 			'__experimentalCart' => $cart ? $this->cart_schema->get_item_response( $cart ) : null,
 			self::EXTENDING_KEY  => $this->get_extended_data( self::IDENTIFIER ),
 		];
@@ -336,7 +336,7 @@ class CheckoutSchema extends AbstractSchema {
 					},
 					$field['options']
 				);
-				if ( true !== $field['required'] ) {
+				if ( true !== $field['required'] || $this->additional_fields_controller->is_conditional_field( $field ) ) {
 					$field_schema['enum'][] = '';
 				}
 			}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -297,7 +297,7 @@ class CheckoutSchema extends AbstractSchema {
 			}
 		}
 
-		return $fields;
+		return (object) $fields;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -244,7 +244,7 @@ class CheckoutSchema extends AbstractSchema {
 			'payment_method'     => $order->get_payment_method(),
 			'payment_result'     => $payment_result,
 			'additional_fields'  => (object) $this->get_additional_fields_response( $order ),
-			'__experimentalCart' => $cart ? $this->cart_schema->get_item_response( $cart ) : null,
+			'__experimentalCart' => $cart ? (object) $this->cart_schema->get_item_response( $cart ) : null,
 			self::EXTENDING_KEY  => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -241,7 +241,7 @@ trait CheckoutTrait {
 		}
 
 		// We need to sync the customer additional fields with the order otherwise they will be overwritten on next page load.
-		if ( get_current_user_id() === $this->order->get_customer_id() ) {
+		if ( 0 !== $this->order->get_customer_id() && get_current_user_id() === $this->order->get_customer_id() ) {
 			$this->additional_fields_controller->sync_customer_additional_fields_with_order( $this->order, wc()->customer );
 		}
 	}

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -240,6 +240,15 @@ trait CheckoutTrait {
 			}
 		}
 
+		// The above logic sets visible fields, but not hidden fields. Unset the hidden fields here.
+		$other_posted_field_values = array_diff_key( $field_values, $additional_fields );
+
+		foreach ( $other_posted_field_values as $key => $value ) {
+			if ( $this->additional_fields_controller->is_field( $key ) ) {
+				$this->additional_fields_controller->persist_field_for_order( $key, '', $this->order, 'other', false );
+			}
+		}
+
 		// We need to sync the customer additional fields with the order otherwise they will be overwritten on next page load.
 		if ( 0 !== $this->order->get_customer_id() && get_current_user_id() === $this->order->get_customer_id() ) {
 			$this->additional_fields_controller->sync_customer_additional_fields_with_order( $this->order, wc()->customer );

--- a/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php
@@ -241,13 +241,8 @@ trait CheckoutTrait {
 		}
 
 		// We need to sync the customer additional fields with the order otherwise they will be overwritten on next page load.
-		if ( 0 !== $this->order->get_customer_id() && get_current_user_id() === $this->order->get_customer_id() ) {
-			$customer = new WC_Customer( $this->order->get_customer_id() );
-			$this->additional_fields_controller->sync_customer_additional_fields_with_order(
-				$this->order,
-				$customer
-			);
-			$customer->save();
+		if ( get_current_user_id() === $this->order->get_customer_id() ) {
+			$this->additional_fields_controller->sync_customer_additional_fields_with_order( $this->order, wc()->customer );
 		}
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -117,9 +117,9 @@ class OrderController {
 		$order->set_customer_id( get_current_user_id() );
 		$order->set_customer_ip_address( \WC_Geolocation::get_ip_address() );
 		$order->set_customer_user_agent( wc_get_user_agent() );
-		$order->update_meta_data( 'is_vat_exempt', wc()->cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no' );
-		$order->calculate_totals();
 		$order->set_payment_method( PaymentUtils::get_default_payment_method() );
+		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( wc()->cart->get_customer()->get_is_vat_exempt() ) );
+		$order->calculate_totals();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -1554,10 +1554,12 @@ class AdditionalFields extends MockeryTestCase {
 			)
 		);
 
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$response          = rest_get_server()->dispatch( $request );
+		$data              = $response->get_data();
+		$additional_fields = (array) $data['additional_fields'];
+
 		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
-		$this->assertEquals( 'sanitized-value', $data['additional_fields'][ $id ], print_r( $data, true ) );
+		$this->assertEquals( 'sanitized-value', $additional_fields[ $id ], print_r( $data, true ) );
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
 
@@ -1699,11 +1701,12 @@ class AdditionalFields extends MockeryTestCase {
 			)
 		);
 
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$response          = rest_get_server()->dispatch( $request );
+		$data              = $response->get_data();
+		$additional_fields = (array) $data['additional_fields'];
 
 		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
-		$this->assertEquals( 'sanitized-value', $data['additional_fields'][ $id ], print_r( $data, true ) );
+		$this->assertEquals( 'sanitized-value', $additional_fields[ $id ], print_r( $data, true ) );
 
 		\__internal_woocommerce_blocks_deregister_checkout_field( $id );
 
@@ -2254,14 +2257,15 @@ class AdditionalFields extends MockeryTestCase {
 		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/checkout' );
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$response          = rest_get_server()->dispatch( $request );
+		$data              = $response->get_data();
+		$additional_fields = (array) $data['additional_fields'];
 
 		$this->assertEquals( 200, $response->get_status(), print_r( $data, true ) );
 		$this->assertEquals( 'billing-saved-gov-id', ( (array) $data['billing_address'] )['plugin-namespace/gov-id'], print_r( $data, true ) );
 		$this->assertEquals( 'shipping-saved-gov-id', ( (array) $data['shipping_address'] )['plugin-namespace/gov-id'], print_r( $data, true ) );
-		$this->assertEquals( 'engineering', ( (array) $data['additional_fields'] )['plugin-namespace/job-function'], print_r( $data, true ) );
-		$this->assertArrayNotHasKey( 'plugin-namespace/leave-on-porch', $data['additional_fields'], print_r( $data, true ) );
+		$this->assertEquals( 'engineering', $additional_fields['plugin-namespace/job-function'], print_r( $data, true ) );
+		$this->assertArrayNotHasKey( 'plugin-namespace/leave-on-porch', $additional_fields, print_r( $data, true ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR fixes a bunch of issues that happened in additional fields, some related to schema validations, other to persist additional fields.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/56997
Closes https://github.com/woocommerce/woocommerce/issues/56996
Closes https://github.com/woocommerce/woocommerce/issues/56987
Closes https://github.com/woocommerce/woocommerce/issues/56960
Closes https://github.com/woocommerce/woocommerce/issues/56958
Closes https://github.com/woocommerce/woocommerce/issues/56993
Closes #56995

### How to test the changes in this Pull Request:

Given this PR fixes 5 things, I will try to cover all 5 of them as unified as possible:

Be on a dev build (pnpm --filter=@woocommerce/plugin-woocommerce watch:build)
Add the following field somewhere in your code:
```php
add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'         => 'plugin-namespace/alt-email',
				'label'      => 'Alternative Email',
				'location'   => 'contact',
				'type'       => 'text',
				'required'   => true,
				'validation' => array(
					'type'         => 'string',
					'format'       => 'email',
					'not'          => array(
						'const' => array( '$data' => '3/customer/billing_address/email' ),
					),
					'errorMessage' => array(
						'format' => 'Please enter a valid email address.',
						'not'    => 'Please enter a different email address to your contact email.',
					),
				),
			)
		);

		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'plugin-namespace/job-function',
				'label'    => 'What is your main role at your company?',
				'location' => 'contact',
				'required' => true,
				'type'     => 'select',
				'hidden'   => array(
					'customer' => array(
						'properties' => array(
							'billing_address' => array(
								'properties' => array(
									'email' => array(
										'pattern' => '^[a-zA-Z0-9._%+-]+@(gmail|hotmail|icloud)\.com$',
									),
								),
							),
						),
					),
				),
				'options'  => array(
					array(
						'label' => 'Director',
						'value' => 'director',
					),
					array(
						'label' => 'Engineering',
						'value' => 'engineering',
					),
					array(
						'label' => 'Customer Support',
						'value' => 'customer-support',
					),
					array(
						'label' => 'Other',
						'value' => 'other',
					),
				),
			)
		);
	}
);
```
1. On an incognito window, go to checkout with a product.
2. You should see email, alternative email, and "role" select, and no error from server (https://github.com/woocommerce/woocommerce/issues/56960)
3. Input an invalid email `test.com` in the alternative email, and blur the field, notice that it shows an error (https://github.com/woocommerce/woocommerce/issues/56997)
4. Notice that it doesn't send a request to the server if the field is invalid (https://github.com/woocommerce/woocommerce/issues/56987)
5. In the email field, enter a gmail email. Add the same email in the alternative email field, make sure it doesn't crash (https://github.com/woocommerce/woocommerce/issues/56958).
6. Change your email domain to something else (a8c.com), notice the error is gone from the alternative email field, and a new select field is visible.
7. Select a value for the new select field, refresh the page, make sure it persisted. Also make sure the email did not revert from its previous value.
8. Change the alternative email to the same one as the primary email, an error would be shown.
9. Change the select to some other value, make sure it persists, refresh the page, it should still have persisted. (no issue marked for this, treating it as enhancement).
10. Change your primary email back to hotmail or gmail but different from alternative, notice that the select will now be hidden, and no validation errors are present.
11. Place the order. In the order confirmation screen, make sure `What is your main role at your company?` is not present because it was hidden. (https://github.com/woocommerce/woocommerce/issues/56996)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix logic bugs in additional fields validation and persisting logic.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
