### PR TITLE
Products (Beta): Remove obsolete feedback form

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-feedcback-products
+++ b/plugins/woocommerce/changelog/fix-remove-feedcback-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Products (Beta): Remove obsolete feedback form from inspector controls

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/inspector-controls.tsx
@@ -6,7 +6,6 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { type ElementType } from '@wordpress/element';
-import { ProductQueryFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 import { EditorBlock, isNumber } from '@woocommerce/types';
 import { usePrevious } from '@woocommerce/base-hooks';
 import {
@@ -272,9 +271,6 @@ export const withProductQueryControls =
 			<>
 				<ProductQueryControls { ...props } />
 				<BlockEdit { ...props } />
-				<InspectorControls>
-					<ProductQueryFeedbackPrompt />
-				</InspectorControls>
 			</>
 		) : (
 			<BlockEdit { ...props } />

--- a/plugins/woocommerce/client/blocks/assets/js/editor-components/feedback-prompt/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/editor-components/feedback-prompt/index.tsx
@@ -71,14 +71,3 @@ export const CartCheckoutFeedbackPrompt = () => (
 		url="https://github.com/woocommerce/woocommerce/discussions/new?category=checkout-flow&labels=type%3A+product%20feedback"
 	/>
 );
-
-export const ProductQueryFeedbackPrompt = () => (
-	<FeedbackPrompt
-		text={ __(
-			'Thanks for trying out the Products block! Help us make it better by sharing your feedback.',
-			'woocommerce'
-		) }
-		title={ __( 'Share your feedback!', 'woocommerce' ) }
-		url={ 'https://airtable.com/shrFX5FAqmCY6hVYI' }
-	/>
-);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

There was a feedback form in Products (Beta) block. It's obsolete as:
1. Block is not supported and we don't seek feedback on it
2. We're stopping using Airtable that was used in this case

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|      <img width="280" alt="image" src="https://github.com/user-attachments/assets/8c53a57a-a6dc-4072-a54e-4eb17f1dba9e" />  |    <img width="280" alt="image" src="https://github.com/user-attachments/assets/4fe323ae-fdc4-4a6a-a518-c136e05574c3" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create new post
2. Enter Code Editor and paste the Products (Beta) block markup

<details> 
  <summary>Products (Beta) block markup </summary>
   
  ```
<!-- wp:query {"queryId":0,"query":{"perPage":9,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"]},"displayLayout":{"type":"flex","columns":3},"namespace":"woocommerce/product-query","align":"wide"} -->
	<div class="wp-block-query alignwide">
		<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
		<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true, "imageSizing":"thumbnail"} /-->
		<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","isLink":true,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
		<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
		<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
		<!-- /wp:post-template -->

		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
		<!-- wp:query-pagination-previous /-->
		<!-- wp:query-pagination-numbers /-->
		<!-- wp:query-pagination-next /-->
		<!-- /wp:query-pagination -->

		<!-- wp:query-no-results -->
		<!-- wp:pattern {"slug":"woocommerce/no-products-found"} /-->
		<!-- /wp:query-no-results -->
	</div>
	<!-- /wp:query -->
  ```

</details>

3. Go back to visual editor
4. Focus on block and check inspector controls
5. **Expected:** There's no feedback form (see screenshots above)


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
