### PR TITLE
Switch over community PR review assignment from Proton to Flux

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -81,14 +81,14 @@
   - team: ghidorah
 
 "plugins/woocommerce/**/*":
-  - team: proton
+  - team: flux
 
 "plugins/woocommerce/templates/**/*":
   - team: rubik
   - team: woo-fse
 
 "plugins/woocommerce/templates/emails/**/*":
-  - team: proton
+  - team: flux
 
 "plugins/woocommerce/src/Admin/**/*":
   - team: woo-fse


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Community PRs assigned to Proton (based on code paths) are now assigned to Flux.