### PR TITLE
[Experimental] Blockified Add to Cart with Options: Remove unnecessary attribute assignment on upgrade

### DIFF
--- a/plugins/woocommerce/changelog/fix-isDescendentOfSingleProductBlock-upgrade-flow
+++ b/plugins/woocommerce/changelog/fix-isDescendentOfSingleProductBlock-upgrade-flow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Remove unnecessary attribute assignment when upgrading to the Add to Cart with Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -28,10 +28,7 @@ const upgradeToBlockifiedAddToCartWithOptions = async (
 		return false;
 	}
 
-	const newBlock = createBlock( 'woocommerce/add-to-cart-with-options', {
-		isDescendentOfSingleProductBlock:
-			foundBlock.attributes.isDescendentOfSingleProductBlock,
-	} );
+	const newBlock = createBlock( 'woocommerce/add-to-cart-with-options' );
 	dispatch( 'core/block-editor' ).replaceBlock(
 		foundBlock.clientId,
 		newBlock


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After writing https://github.com/woocommerce/woocommerce/discussions/57024 I just realized that even though we got rid of the `isDescendentOfSingleProductBlock` attribute in the _Add to Cart with Options_ blocks (the non-blockified and the blockified ones), we were still trying to set it when upgrading from one to the other. This PR removes that code.

### How to test the changes in this Pull Request:

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.
3. Verify no errors appeared.