### PR TITLE
Breadcrumbs block: fix custom font size applied on the frontend

### DIFF
--- a/plugins/woocommerce/changelog/57071-wooplug-3506-store-breadcrumbs-custom-font-size-isnt-applied-on-the
+++ b/plugins/woocommerce/changelog/57071-wooplug-3506-store-breadcrumbs-custom-font-size-isnt-applied-on-the
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Breadcrumbs block: fix custom font size applied on the frontend

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Breadcrumbs.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Breadcrumbs.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
- * CatalogSorting class.
+ * Breadcrumbs class.
  */
 class Breadcrumbs extends AbstractBlock {
 
@@ -34,16 +34,16 @@ class Breadcrumbs extends AbstractBlock {
 			return;
 		}
 
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'font_size' ) );
+
+		$font_size_classes_and_styles  = $this->get_font_size_classes_and_styles( $attributes );
+		$classes_and_styles['classes'] = $classes_and_styles['classes'] . ' ' . $font_size_classes_and_styles['class'] . ' ';
+		$classes_and_styles['styles']  = $classes_and_styles['styles'] . ' ' . $font_size_classes_and_styles['style'] . ' ';
 
 		return sprintf(
-			'<div %1$s>%2$s</div>',
-			get_block_wrapper_attributes(
-				array(
-					'class' => 'wc-block-breadcrumbs woocommerce ' . esc_attr( $classes_and_styles['classes'] ),
-					'style' => $classes_and_styles['styles'],
-				)
-			),
+			'<div class="woocommerce wp-block-breadcrumbs wc-block-breadcrumbs %1$s" style="%2$s">%3$s</div>',
+			esc_attr( $classes_and_styles['classes'] ),
+			esc_attr( $classes_and_styles['styles'] ),
 			$breadcrumb
 		);
 	}
@@ -55,5 +55,41 @@ class Breadcrumbs extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		return null;
+	}
+
+	/**
+	 * Gets font size classes and styles for the breadcrumbs block.
+	 *
+	 * Note: This implementation intentionally avoids using StyleAttributesUtils::get_font_size_class_and_style()
+	 * and get_block_wrapper_attributes() to ensure style attributes take precedence over the class attribute fontSize.
+	 * This is needed because the block.json defines a default fontSize, which is considered an anti-pattern
+	 * since styles should be defined by themes and plugins instead.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @return array The font size classes and styles.
+	 */
+	private function get_font_size_classes_and_styles( $attributes ) {
+		$font_size = $attributes['fontSize'] ?? '';
+
+		$custom_font_size = $attributes['style']['typography']['fontSize'] ?? '';
+
+		if ( ! $font_size && '' === $custom_font_size ) {
+			return array(
+				'class' => null,
+				'style' => null,
+			);
+		}
+
+		if ( '' !== $custom_font_size ) {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'font-size: %s;', $custom_font_size ),
+			);
+		}
+
+		return array(
+			'class' => sprintf( 'has-font-size has-%s-font-size', $font_size ),
+			'style' => null,
+		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Breadcrumbs block had default attributes set for “font Size” and “alignment”. This is an antipattern because blocks should be style-agnostic and only themes should style them. For this reason, the custom font size setting didn't work.

⚠️  This PR could bring unexpected layout changes for stores that have themes that override Woo default templates and don't have templates stored in the database: should we publish a dev advisory? 



<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-3506 (https://github.com/woocommerce/woocommerce/issues/56518).


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Product Catalog Template.
2. Click on the Store Breadcrumbs block.
3. Edit the Typography → Custom size setting.
4. See that the font size changes on the editor side.
5. Save the template.
6. Visit the `/shop` page.
7. Ensure that the custom font size is applied

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Breadcrumbs block: fix custom font size applied on the frontend

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
