### PR TITLE
Improve Product Filters block performance with optimized caching for product IDs.

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3825-product-filters-cache-repeated-sub-queries
+++ b/plugins/woocommerce/changelog/wooplug-3825-product-filters-cache-repeated-sub-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve Product Filters block performance with optimized caching for product IDs.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -254,6 +254,10 @@ final class ProductFilterAttribute extends AbstractBlock {
 	 * @param string   $query_type Query type, accept 'and' or 'or'.
 	 */
 	private function get_attribute_counts( $block, $slug, $query_type ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
 		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
 
 		if ( 'and' !== strtolower( $query_type ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -216,6 +216,10 @@ final class ProductFilterPrice extends AbstractBlock {
 	 * @param WP_Block $block Block instance.
 	 */
 	private function get_filtered_price( $block ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
 		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
 
 		unset( $query_vars['min_price'], $query_vars['max_price'] );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -222,6 +222,10 @@ final class ProductFilterRating extends AbstractBlock {
 	 * @param WP_Block $block Block instance.
 	 */
 	private function get_rating_counts( $block ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
 		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
 
 		if ( ! empty( $query_vars['tax_query'] ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -187,6 +187,10 @@ final class ProductFilterStatus extends AbstractBlock {
 	 * @param WP_Block $block Block instance.
 	 */
 	private function get_stock_status_counts( $block ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
 		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
 
 		unset(

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * Hooks into WooCommerce actions to register cache invalidation.
  */
 class CacheController implements RegisterHooksInterface {
-	const TRANSIENT_GROUP = 'filter_data';
+	const CACHE_GROUP = 'filter_data';
 
 	/**
 	 * Hook into actions and filters.
@@ -28,6 +28,6 @@ class CacheController implements RegisterHooksInterface {
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function clear_filter_data_cache() {
-		WC_Cache_Helper::get_transient_version( self::TRANSIENT_GROUP, true );
+		WC_Cache_Helper::get_transient_version( self::CACHE_GROUP, true );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -29,5 +29,6 @@ class CacheController implements RegisterHooksInterface {
 	 */
 	public function clear_filter_data_cache() {
 		WC_Cache_Helper::get_transient_version( self::CACHE_GROUP, true );
+		WC_Cache_Helper::invalidate_cache_group( self::CACHE_GROUP );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -338,7 +338,7 @@ class FilterData {
 	private function get_transient_key( $query_vars, $filter_type, $extra = array() ) {
 		return sprintf(
 			'wc_%s_%s',
-			CacheController::TRANSIENT_GROUP,
+			CacheController::CACHE_GROUP,
 			md5(
 				wp_json_encode(
 					array(
@@ -362,7 +362,7 @@ class FilterData {
 		}
 
 		$cache             = get_transient( $key );
-		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::TRANSIENT_GROUP );
+		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::CACHE_GROUP );
 
 		if ( empty( $cache['version'] ) ||
 			! is_array( $cache['value'] ) ||
@@ -388,7 +388,7 @@ class FilterData {
 			return false;
 		}
 
-		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::TRANSIENT_GROUP );
+		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::CACHE_GROUP );
 		$transient_value   = array(
 			'version' => $transient_version,
 			'value'   => $value,
@@ -409,7 +409,7 @@ class FilterData {
 	 * @return string Comma-separated list of product IDs.
 	 */
 	private function get_cached_product_ids( $product_query_sql ) {
-		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::TRANSIENT_GROUP ) . md5( $product_query_sql );
+		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . md5( $product_query_sql );
 		$cache     = wp_cache_get( $cache_key );
 
 		if ( $cache ) {
@@ -431,5 +431,4 @@ class FilterData {
 
 		return $results;
 	}
-
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -64,20 +64,7 @@ class FilterData {
 
 		global $wpdb;
 
-		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10, 2 );
-		add_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$query_vars['no_found_rows']  = true;
-		$query_vars['posts_per_page'] = -1;
-		$query_vars['fields']         = 'ids';
-		$query                        = new \WP_Query();
-
-		$query->query( $query_vars );
-
-		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
-		remove_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$product_ids = $this->get_cached_product_ids( $query->request );
+		$product_ids = $this->get_cached_product_ids( $query_vars );
 
 		$price_filter_sql = "
 		SELECT min( min_price ) as min_price, MAX( max_price ) as max_price
@@ -137,20 +124,7 @@ class FilterData {
 			return $cached_data;
 		}
 
-		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10, 2 );
-		add_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$query_vars['no_found_rows']  = true;
-		$query_vars['posts_per_page'] = -1;
-		$query_vars['fields']         = 'ids';
-		$query                        = new \WP_Query();
-
-		$query->query( $query_vars );
-
-		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
-		remove_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$product_ids = $this->get_cached_product_ids( $query->request );
+		$product_ids = $this->get_cached_product_ids( $query_vars );
 
 		global $wpdb;
 		$stock_status_counts = array();
@@ -211,20 +185,7 @@ class FilterData {
 
 		global $wpdb;
 
-		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10, 2 );
-		add_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$query_vars['no_found_rows']  = true;
-		$query_vars['posts_per_page'] = -1;
-		$query_vars['fields']         = 'ids';
-		$query                        = new \WP_Query();
-
-		$query->query( $query_vars );
-
-		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
-		remove_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$product_ids = $this->get_cached_product_ids( $query->request );
+		$product_ids = $this->get_cached_product_ids( $query_vars );
 
 		$rating_count_sql = "
 			SELECT COUNT( DISTINCT product_id ) as product_count, ROUND( average_rating, 0 ) as rounded_average_rating
@@ -281,20 +242,7 @@ class FilterData {
 
 		global $wpdb;
 
-		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10, 2 );
-		add_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$query_vars['no_found_rows']  = true;
-		$query_vars['posts_per_page'] = -1;
-		$query_vars['fields']         = 'ids';
-		$query                        = new \WP_Query();
-
-		$query->query( $query_vars );
-
-		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
-		remove_filter( 'posts_pre_query', '__return_empty_array' );
-
-		$product_ids = $this->get_cached_product_ids( $query->request );
+		$product_ids = $this->get_cached_product_ids( $query_vars );
 
 		$attributes_to_count_sql = 'AND term_taxonomy.taxonomy IN ("' . esc_sql( wc_sanitize_taxonomy_name( $attribute_to_count ) ) . '")';
 		$attribute_count_sql     = "
@@ -400,26 +348,39 @@ class FilterData {
 	}
 
 	/**
-	 * Get cached product IDs from a SQL query.
+	 * Get cached product IDs from query vars.
 	 *
-	 * Executes the product query and returns a comma-separated string of product IDs.
+	 * Executes a WP_Query with the given query vars and returns a comma-separated string of product IDs.
 	 * Results are cached to avoid repeated database queries.
 	 *
-	 * @param string $product_query_sql SQL query to get product IDs.
+	 * @param array $query_vars The WP_Query arguments.
 	 * @return string Comma-separated list of product IDs.
 	 */
-	private function get_cached_product_ids( $product_query_sql ) {
-		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . md5( $product_query_sql );
+	private function get_cached_product_ids( array $query_vars ) {
+		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . md5( wp_json_encode( $query_vars ) );
 		$cache     = wp_cache_get( $cache_key );
 
 		if ( $cache ) {
 			return $cache;
 		}
 
+		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10, 2 );
+		add_filter( 'posts_pre_query', '__return_empty_array' );
+
+		$query_vars['no_found_rows']  = true;
+		$query_vars['posts_per_page'] = -1;
+		$query_vars['fields']         = 'ids';
+		$query                        = new \WP_Query();
+
+		$query->query( $query_vars );
+
+		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
+		remove_filter( 'posts_pre_query', '__return_empty_array' );
+
 		global $wpdb;
 
 		// The query is already prepared by WP_Query.
-		$results = $wpdb->get_results( $product_query_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $query->request, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( ! $results ) {
 			$results = array();

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -77,10 +77,12 @@ class FilterData {
 		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
 		remove_filter( 'posts_pre_query', '__return_empty_array' );
 
+		$product_ids = $this->get_cached_product_ids( $query->request );
+
 		$price_filter_sql = "
 		SELECT min( min_price ) as min_price, MAX( max_price ) as max_price
 		FROM {$wpdb->wc_product_meta_lookup}
-		WHERE product_id IN ( {$query->request} )
+		WHERE product_id IN ( {$product_ids} )
 		";
 
 		/**
@@ -148,6 +150,8 @@ class FilterData {
 		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
 		remove_filter( 'posts_pre_query', '__return_empty_array' );
 
+		$product_ids = $this->get_cached_product_ids( $query->request );
+
 		global $wpdb;
 		$stock_status_counts = array();
 
@@ -158,7 +162,7 @@ class FilterData {
 				INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
 				AND postmeta.meta_key = '_stock_status'
 				AND postmeta.meta_value = '" . esc_sql( $status ) . "'
-				WHERE posts.ID IN ( {$query->request} )
+				WHERE posts.ID IN ( {$product_ids} )
 			";
 
 			/**
@@ -220,10 +224,12 @@ class FilterData {
 		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
 		remove_filter( 'posts_pre_query', '__return_empty_array' );
 
+		$product_ids = $this->get_cached_product_ids( $query->request );
+
 		$rating_count_sql = "
 			SELECT COUNT( DISTINCT product_id ) as product_count, ROUND( average_rating, 0 ) as rounded_average_rating
 			FROM {$wpdb->wc_product_meta_lookup}
-			WHERE product_id IN ( {$query->request} )
+			WHERE product_id IN ( {$product_ids} )
 			AND average_rating > 0
 			GROUP BY rounded_average_rating
 			ORDER BY rounded_average_rating DESC
@@ -288,6 +294,8 @@ class FilterData {
 		remove_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses' ), 10 );
 		remove_filter( 'posts_pre_query', '__return_empty_array' );
 
+		$product_ids = $this->get_cached_product_ids( $query->request );
+
 		$attributes_to_count_sql = 'AND term_taxonomy.taxonomy IN ("' . esc_sql( wc_sanitize_taxonomy_name( $attribute_to_count ) ) . '")';
 		$attribute_count_sql     = "
 			SELECT COUNT( DISTINCT posts.ID ) as term_count, terms.term_id as term_count_id
@@ -295,7 +303,7 @@ class FilterData {
 			INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
 			INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
 			INNER JOIN {$wpdb->terms} AS terms USING( term_id )
-			WHERE posts.ID IN ( {$query->request} )
+			WHERE posts.ID IN ( {$product_ids} )
 			{$attributes_to_count_sql}
 			GROUP BY terms.term_id
 		";
@@ -390,4 +398,38 @@ class FilterData {
 
 		return $result;
 	}
+
+	/**
+	 * Get cached product IDs from a SQL query.
+	 *
+	 * Executes the product query and returns a comma-separated string of product IDs.
+	 * Results are cached to avoid repeated database queries.
+	 *
+	 * @param string $product_query_sql SQL query to get product IDs.
+	 * @return string Comma-separated list of product IDs.
+	 */
+	private function get_cached_product_ids( $product_query_sql ) {
+		$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::TRANSIENT_GROUP ) . md5( $product_query_sql );
+		$cache     = wp_cache_get( $cache_key );
+
+		if ( $cache ) {
+			return $cache;
+		}
+
+		global $wpdb;
+
+		// The query is already prepared by WP_Query.
+		$results = $wpdb->get_results( $product_query_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $results ) {
+			$results = array();
+		}
+
+		$results = implode( ',', array_column( $results, 'ID' ) );
+
+		wp_cache_set( $cache_key, $results );
+
+		return $results;
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR improves the caching mechanism in the Product Filters block by:

1. Introducing a dedicated caching layer for product IDs to reduce redundant database queries
2. Renaming `TRANSIENT_GROUP` to `CACHE_GROUP` for better semantic clarity

These changes enhance performance by:

-   Preventing duplicate SQL queries for the same product set
-   Using WordPress object cache for frequently accessed product IDs

Closes https://linear.app/a8c/issue/WOOPLUG-3825/product-filters-cache-repeated-sub-queries.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with a significant number of products (100+)
2. Add a Product Filters block to a product catalog page
3. Test the caching behavior:
    - Enable Query Monitor plugin to monitor database queries
    - Load the product catalog page, verify that there is only one query of `get_cached_product_ids()` See [screenshot](https://github.com/user-attachments/assets/23ac5ce5-faae-4e5e-9340-3772e2d27ff1).
    - Select a filter and then manually refresh the page, see that the number of queries of `get_cached_product_ids()` is smaller than the number of filter blocks. In [this example](https://github.com/user-attachments/assets/ee948988-62cd-4b4c-b97e-a322db8abd4c), when select the Red color, we still have for filter blocks visible, but there are only 2 queries from `get_cached_product_ids()` query.
    - Ensure there is no duplicated queries from `FilterData`.
4. Test cache invalidation:
    - Update a product's price/stock/rating
    - Verify that filters reflect the updated data
    - Check that cache is properly cleared

### Testing that has already taken place:

<details><summary>System Status Report</summary>

```
### WordPress Environment ###

WordPress address (URL): [Redacted]
Site address (URL): [Redacted]
WC Version: 9.9.0-dev
Legacy REST API Package Version: The Legacy REST API plugin is not installed on this site.
Action Scheduler Version: ✔ 3.9.2
Log Directory Writable: ✔
WP Version: 6.7.2
WP Multisite: –
WP Memory Limit: 256 MB
WP Debug Mode: ✔
WP Cron: ✔
Language: en_US
External object cache: –

### Server Environment ###

Server Info: nginx/1.25.4
PHP Version: 7.4.33
PHP Post Max Size: 8 MB
PHP Time Limit: 30
PHP Max Input Vars: 1000
cURL Version: 8.5.0
OpenSSL/3.1.4

SUHOSIN Installed: –
MySQL Version: 8.0.33
Max Upload Size: 2 MB
Default Timezone is UTC: ✔
fsockopen/cURL: ✔
SoapClient: ✔
DOMDocument: ✔
GZip: ✔
Multibyte String: ✔
Remote Post: ✔
Remote Get: ✔

### Database ###

[REDACTED]

### Post Type Counts ###

attachment: 24
customize_changeset: 1
page: 11
post: 4
product: 18
product_variation: 7
revision: 52
wp_font_face: 36
wp_font_family: 12
wp_global_styles: 2
wp_navigation: 1
wp_template: 3
wp_template_part: 4

### Security ###

Secure connection (HTTPS): ❌
					Your store is not using HTTPS. Learn more about HTTPS and SSL Certificates.
Hide errors from visitors: ❌Error messages should not be shown to visitors.

### Active Plugins (3) ###

Laravel DD for Wordpress: by Peter Hegman – 1.0.1
WooCommerce Beta Tester: by WooCommerce – 3.0.0
WooCommerce: by Automattic – 9.9.0-dev

### Inactive Plugins (7) ###

Akismet Anti-spam: Spam Protection: by Automattic - Anti-spam Team – 5.3.6
Gutenberg: by Gutenberg Team – 20.5.0
Hello Dolly: by Matt Mullenweg – 1.7.2
Query Monitor: by John Blackbourn – 3.17.2
WooCommerce: by Automattic – 9.7.1
WooCommerce PayPal Payments: by PayPal – 3.0.0 (update to version 3.0.2 is available)
WooPayments: by WooCommerce – 9.1.0

### Must Use Plugins (1) ###

test.php: by  –

### Settings ###

Legacy API Enabled: –
Force SSL: –
Currency: USD ($)
Currency Position: right_space
Thousand Separator: .
Decimal Separator: ,
Number of Decimals: 1
Taxonomies: Product Types: external (external)
grouped (grouped)
simple (simple)
variable (variable)

Taxonomies: Product Visibility: exclude-from-catalog (exclude-from-catalog)
exclude-from-search (exclude-from-search)
featured (featured)
outofstock (outofstock)
rated-1 (rated-1)
rated-2 (rated-2)
rated-3 (rated-3)
rated-4 (rated-4)
rated-5 (rated-5)

Connected to WooCommerce.com: –
Enforce Approved Product Download Directories: ✔
HPOS feature enabled: ✔
Order datastore: Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore
HPOS data sync enabled: –

### Logging ###

Enabled: ✔
Handler: Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2
Retention period: 30 days
Level threshold: –
Log directory size: 173 KB

### WC Pages ###

Shop base: #7 - /
Cart: #8 - /cart/ -  Contains the woocommerce/cart block
Checkout: #9 - /checkout/ -  Contains the woocommerce/checkout block
My account: #10 - /my-account/ -  Contains the [woocommerce_my_account] shortcode
Terms and conditions: ❌ Page not set

### Theme ###

Name: Twenty Twenty-Five
Version: 1.1
Author URL: https://wordpress.org
Child Theme: ❌ – If you are modifying WooCommerce on a parent theme that you did not build personally we recommend using a child theme. See: How to create a child theme
Theme type: Block theme
WooCommerce Support: ❌ Not declared

### Templates ###

Overrides: /Users/tung/workspace/woocommerce/plugins/woocommerce/templates/block-notices/error.php
/Users/tung/workspace/woocommerce/plugins/woocommerce/templates/block-notices/notice.php
/Users/tung/workspace/woocommerce/plugins/woocommerce/templates/block-notices/success.php


### Admin ###

Enabled Features: activity-panels
analytics
product-block-editor
experimental-blocks
coupons
core-profiler
customize-store
customer-effort-score-tracks
import-products-task
experimental-fashion-sample-products
shipping-smart-defaults
shipping-setting-tour
homescreen
marketing
minified-js
mobile-app-banner
onboarding
onboarding-tasks
pattern-toolkit-full-composability
payment-gateway-suggestions
product-custom-fields
printful
remote-inbox-notifications
remote-free-extensions
shipping-label-banner
subscriptions
store-alerts
transient-notices
woo-mobile-welcome
wc-pay-promotion
wc-pay-welcome-page
async-product-editor-category-field
launch-your-store
add-to-cart-with-options-stepper-layout
blockified-add-to-cart
disable-core-profiler-fallback

Disabled Features: product-data-views
coming-soon-newsletter-template
product-pre-publish-modal
settings
product-editor-template-system
use-wp-horizon
beta-tester-slotfill-examples

Daily Cron: ✔ Next scheduled: 2025-04-08 10:10:56 +00:00
Options: ✔
Notes: 68
Onboarding: completed

### Action Scheduler ###

Complete: 140
Oldest: 2025-03-08 02:21:56 +0000
Newest: 2025-04-07 13:20:05 +0000

Failed: 1
Oldest: 2025-03-05 03:00:25 +0000
Newest: 2025-03-05 03:00:25 +0000

Pending: 1
Oldest: 2025-04-08 10:07:38 +0000
Newest: 2025-04-08 10:07:38 +0000


### Status report information ###

Generated at: 2025-04-08 00:56:12 +00:00
```

</details>