### PR TITLE
[dev] Release checks workflow: separate nightly and release checks jobs with updated conditions

### DIFF
--- a/.github/workflows/tests-on-release.yml
+++ b/.github/workflows/tests-on-release.yml
@@ -1,25 +1,28 @@
 name: 'Release checks run'
-run-name: ${{ github.event_name == 'schedule' && 'scheduled' || github.event_name == 'workflow_dispatch' && 'on demand'  || github.event_name == 'release' && 'release' || '' }} checks for ${{ inputs.tag != '' && inputs.tag || github.ref_name }}
+run-name: ${{ github.event_name == 'schedule' && 'scheduled' || github.event_name == 'release' && 'release' || '' }} checks ${{ github.ref_name != 'trunk' && github.ref_name || '' }}
 
 on:
   schedule:
     - cron: '0 3 * * *' # Runs at 3 AM UTC.
   release:
     types: [ published, edited ]
-  workflow_dispatch:
-    inputs:
-      tag:
-        type: string
-        description: 'The tag name to run tests on. It needs to have a corresponding release published.'
-        required: true
 
 jobs:
-  run-tests:
-    name: 'Run tests'
-    if: github.repository == 'woocommerce/woocommerce'
+  run-nightly-checks:
+    name: 'Run nightly checks'
+    if: github.repository == 'woocommerce/woocommerce' && github.event_name == 'schedule'
     uses: ./.github/workflows/ci.yml
     with:
-      trigger: ${{ github.event_name == 'schedule' && 'nightly-checks' || 'release-checks' }}
+      trigger: 'nightly-checks'
       refName: 'nightly'
-      artifactName: ${{ github.event_name == 'schedule' && 'woocommerce-trunk-nightly.zip' || 'woocommerce.zip' }}
+      artifactName: 'woocommerce-trunk-nightly.zip'
+    secrets: inherit
+
+  run-release-checks:
+    name: 'Run release checks'
+    if: github.repository == 'woocommerce/woocommerce' && github.event_name == 'release'
+    uses: ./.github/workflows/ci.yml
+    with:
+      trigger: 'release-checks'
+      artifactName: 'woocommerce.zip'
     secrets: inherit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Clean up the release checks workflow:

- removed workflow_dispatch event - not seeing a situation where it is useful at the moment. We can revisit if needed.
- separate nightly and release checks in different jobs for clarity

### How to test the changes in this Pull Request:

Will update the nightly tag after merge and check the workflow runs as expected
