### PR TITLE
[Experimental] Don't trigger hooks in Add to Cart with Options block when simple product is not purchasable

### DIFF
--- a/plugins/woocommerce/changelog/fix-56682-no-hooks-in-simple-not-purchasable-products
+++ b/plugins/woocommerce/changelog/fix-56682-no-hooks-in-simple-not-purchasable-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Don't trigger hooks in Add to Cart with Options block when simple product is not purchasable
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -150,7 +150,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			* @since 7.6.0
 			* @param boolean.
 			*/
-			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
+			$is_disabled_compatibility_layer   = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 			$is_not_purchasable_single_product = ProductType::SIMPLE === $product_type && ( ! $product->is_in_stock() || ! $product->is_purchasable() );
 
 			if ( ! $is_disabled_compatibility_layer && ! $is_not_purchasable_single_product ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -150,12 +150,11 @@ class AddToCartWithOptions extends AbstractBlock {
 			* @since 7.6.0
 			* @param boolean.
 			*/
-			$is_disabled_compatibility_layer   = apply_filters( 'woocommerce_disable_compatibility_layer', false );
-			$is_not_purchasable_single_product = ProductType::SIMPLE === $product_type && ( ! $product->is_in_stock() || ! $product->is_purchasable() );
+			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
-			if ( ! $is_disabled_compatibility_layer && ! $is_not_purchasable_single_product ) {
+			if ( ! $is_disabled_compatibility_layer ) {
 				ob_start();
-				if ( ProductType::SIMPLE === $product_type ) {
+				if ( ProductType::SIMPLE === $product_type && $product->is_in_stock() && $product->is_purchasable() ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
 					 *
@@ -193,7 +192,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				$hooks_before = ob_get_clean();
 
 				ob_start();
-				if ( ProductType::SIMPLE === $product_type ) {
+				if ( ProductType::SIMPLE === $product_type && $product->is_in_stock() && $product->is_purchasable() ) {
 					/**
 					 * Hook: woocommerce_after_add_to_cart_quantity.
 					 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -151,8 +151,9 @@ class AddToCartWithOptions extends AbstractBlock {
 			* @param boolean.
 			*/
 			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
+			$is_not_purchasable_single_product = ProductType::SIMPLE === $product_type && ( ! $product->is_in_stock() || ! $product->is_purchasable() );
 
-			if ( ! $is_disabled_compatibility_layer ) {
+			if ( ! $is_disabled_compatibility_layer && ! $is_not_purchasable_single_product ) {
 				ob_start();
 				if ( ProductType::SIMPLE === $product_type ) {
 					/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -62,6 +62,16 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hook into the add to cart button action.
+	 *
+	 * Outputs a test message when the `woocommerce_before_add_to_cart_button` action is triggered.
+	 * Used for testing that hooks are properly called during add to cart.
+	 */
+	public function hook_into_add_to_cart_button_action() {
+		echo 'Hook into add to cart button action';
+	}
+
+	/**
 	 * Tests that the correct content is rendered for each product type.
 	 */
 	public function test_product_type_add_to_cart_render() {
@@ -134,23 +144,26 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 	 */
 	public function test_product_type_add_to_cart_hooks_are_rendered() {
 		add_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
+		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
 
 		global $product;
-		$product    = new \WC_Product_Simple();
-		$product_id = $product->save();
-		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-
-		$this->assertStringNotContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the hook if the product is not purchasable.' );
-
-		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
-
+		$product = new \WC_Product_Simple();
 		$product->set_regular_price( 10 );
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the hook.' );
+		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the wrapper hook.' );
+		$this->assertStringContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the inner hooks.' );
+
+		$product->set_stock_status( 'outofstock' );
+		$product_id = $product->save();
+		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the wrapper hook if the product is out of stock.' );
+		$this->assertStringNotContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the inner hooks if the product is out of stock.' );
 
 		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
+		remove_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -136,7 +136,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		add_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
 
 		global $product;
-		$product = new \WC_Product_Simple();
+		$product    = new \WC_Product_Simple();
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -137,6 +137,13 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		global $product;
 		$product = new \WC_Product_Simple();
+		$product_id = $product->save();
+		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringNotContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the hook if the product is not purchasable.' );
+
+		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
+
 		$product->set_regular_price( 10 );
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so the compatibility later PHP hooks are not run in the Add to Cart with Options block when the form is not rendered. That happens in simple products which are out of stock or not purchasable.

Closes #56682.
Closes WOOPLUG-3602.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin.
1. Go to _Tools_ > _WCA Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
2. Install [WooCommerce Product Add-Ons](https://woocommerce.com/products/product-add-ons/).
3. Create an out-of-stock product with a product add-on.
4. Create a post or page, add the _Single Product_ block and choose the product you just edited.
5. In the frontend, verify the add-on form element is not shown.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/62226bed-3dc4-4d03-a68c-3451c9cc6b9d) | ![imatge](https://github.com/user-attachments/assets/5152f75f-71f9-43f7-9f2a-20ba8a8e077f)

6. Edit the product again, set it in stock and remove its price, making it not-purchasable.
7. In the frontend, verify again the add-on form element is not shown.