### PR TITLE
Fix: DOING_AJAX being set when wc-ajax is empty after sanitized

### DIFF
--- a/plugins/woocommerce/changelog/pr-57093
+++ b/plugins/woocommerce/changelog/pr-57093
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: DOING_AJAX being set when wc-ajax is empty after sanitized

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -198,7 +198,7 @@ class WC_AJAX {
 		foreach ( $ajax_private_events as $ajax_event ) {
 			add_action(
 				'wp_ajax_woocommerce_' . $ajax_event,
-				function() use ( $ajax_event ) {
+				function () use ( $ajax_event ) {
 					call_user_func( array( __CLASS__, $ajax_event ) );
 				}
 			);
@@ -212,7 +212,7 @@ class WC_AJAX {
 		foreach ( $ajax_heartbeat_callbacks as $ajax_callback ) {
 			add_filter(
 				'heartbeat_received',
-				function( $response, $data ) use ( $ajax_callback ) {
+				function ( $response, $data ) use ( $ajax_callback ) {
 					return call_user_func_array( array( __CLASS__, $ajax_callback ), func_get_args() );
 				},
 				11,
@@ -738,7 +738,7 @@ class WC_AJAX {
 					if ( ! $attribute ) {
 						continue;
 					}
-					$i++;
+					++$i;
 					$metabox_class = array();
 
 					if ( $attribute->is_taxonomy() ) {
@@ -949,8 +949,8 @@ class WC_AJAX {
 					$inserted_id = wc_downloadable_file_permission( $download_id, $product->get_id(), $order, $download_data['quantity'], $download_data['order_item'] );
 					if ( $inserted_id ) {
 						$download = new WC_Customer_Download( $inserted_id );
-						$loop ++;
-						$file_counter ++;
+						++$loop;
+						++$file_counter;
 
 						if ( $file->get_name() ) {
 							$file_count = $file->get_name();
@@ -1899,7 +1899,7 @@ class WC_AJAX {
 						$item_exists = count(
 							array_filter(
 								$terms_map[ $ancestor ]->children,
-								function( $term ) use ( $current_child ) {
+								function ( $term ) use ( $current_child ) {
 									return $term->term_id === $current_child->term_id;
 								}
 							)
@@ -1914,7 +1914,7 @@ class WC_AJAX {
 		}
 		$parent_terms = array_filter(
 			array_values( $terms_map ),
-			function( $term ) {
+			function ( $term ) {
 				return 0 === $term->parent;
 			}
 		);
@@ -2111,9 +2111,9 @@ class WC_AJAX {
 				continue;
 			}
 			if ( $nextid === $id ) {
-				$index ++;
+				++$index;
 			}
-			$index ++;
+			++$index;
 			$menu_orders[ $id ] = $index;
 
 			if ( $wpdb->update( $wpdb->posts, array( 'menu_order' => $index ), array( 'ID' => $id ) ) ) {
@@ -3672,7 +3672,7 @@ class WC_AJAX {
 	 *
 	 * @return void
 	 */
-	private static function order_delete_meta() : void {
+	private static function order_delete_meta(): void {
 		wc_get_container()->get( CustomMetaBox::class )->delete_meta_ajax();
 	}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -47,11 +47,27 @@ class WC_AJAX {
 	}
 
 	/**
+	 * Set the 'wc-ajax' argument in $wp_query.
+	 */
+	private static function set_wc_ajax_argument_in_query() {
+		global $wp_query;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET['wc-ajax'] ) && empty( $wp_query->get( 'wc-ajax' ) ) ) {
+			$wp_query->set( 'wc-ajax', sanitize_text_field( wp_unslash( $_GET['wc-ajax'] ) ) );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
 	 * Set WC AJAX constant and headers.
 	 */
 	public static function define_ajax() {
+		global $wp_query;
+
 		// phpcs:disable
-		if ( ! empty( $_GET['wc-ajax'] ) ) {
+		self::set_wc_ajax_argument_in_query();
+		if ( ! empty( $wp_query->get( 'wc-ajax' ) ) ) {
 			wc_maybe_define_constant( 'DOING_AJAX', true );
 			wc_maybe_define_constant( 'WC_DOING_AJAX', true );
 			if ( ! WP_DEBUG || ( WP_DEBUG && ! WP_DEBUG_DISPLAY ) ) {
@@ -88,9 +104,7 @@ class WC_AJAX {
 		global $wp_query;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! empty( $_GET['wc-ajax'] ) ) {
-			$wp_query->set( 'wc-ajax', sanitize_text_field( wp_unslash( $_GET['wc-ajax'] ) ) );
-		}
+		self::set_wc_ajax_argument_in_query();
 
 		$action = $wp_query->get( 'wc-ajax' );
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -226,6 +226,7 @@ class WC_AJAX {
 		foreach ( $ajax_heartbeat_callbacks as $ajax_callback ) {
 			add_filter(
 				'heartbeat_received',
+				// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 				function ( $response, $data ) use ( $ajax_callback ) {
 					return call_user_func_array( array( __CLASS__, $ajax_callback ), func_get_args() );
 				},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request fixes a case where the `DOING_AJAX` and `WC_DOING_AJAX` constants were set even though no actual AJAX request was being processed: when `$_GET['wc-ajax']` wasn't empty but turned empty after serialization. With these changes `$wp-query`'s `wc-ajax` argument is set to the sanitized version of  `$_GET['wc-ajax']` _before_ the constants are set.

See p5TWut-1mH-p2

### How to test the changes in this Pull Request:

1. Add the following snippet to your testing site:

```php

add_action( 'wp_loaded', function() {
	if(isset($_GET['sirt-test'])) {
		wc_get_logger()->info("DOING_AJAX defined? " . (defined('DOING_AJAX') ? "YES" : "NO"), ['source' => 'ajax-sirt-test']);
		wc_get_logger()->info("WC_DOING_AJAX defined? " . (defined('WC_DOING_AJAX') ? "YES" : "NO"), ['source' => 'ajax-sirt-test']);
	}
}, 0);

add_action( 'wc_ajax_foobar', function() {
	if(isset($_GET['sirt-test'])) {
		wc_get_logger()->info("doing ajax action 'foobar'!", ['source' => 'ajax-sirt-test']);
	}
}, 0);
```

2. Without this fix run the following from the command line:

```
curl "http://localhost?sirt-test=true&wc-ajax=foobar" > nul
curl "http://localhost?sirt-test=true&wc-ajax=<foobar>" > nul
```

3. Go to WooCommerce - Status - Logs in the admin area of your site and open the _ajax-sirt-test_ log, you should see the following entries:

```
DOING_AJAX defined? YES
WC_DOING_AJAX defined? YES
doing ajax action 'foobar'!
DOING_AJAX defined? YES
WC_DOING_AJAX defined? YES
```

4. Now delete the log file ("Delete permanently" button in the log entries list), apply this fix and run the commands again.

5. Open again the _ajax-sirt-test_ log, this time you should see this:

```
DOING_AJAX defined? YES
WC_DOING_AJAX defined? YES
doing ajax action 'foobar'!
DOING_AJAX defined? NO
WC_DOING_AJAX defined? NO
```


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
