### PR TITLE
Move HPOS Datastore Caching feature from an alpha to beta feature.

### DIFF
--- a/plugins/woocommerce/changelog/move-order-data-caching-to-beta
+++ b/plugins/woocommerce/changelog/move-order-data-caching-to-beta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updated HPOS Datastore Caching feature from an alpha to beta feature.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -347,21 +347,7 @@ class FeaturesController {
 				'is_experimental'    => true,
 				'enabled_by_default' => false,
 				'is_legacy'          => true,
-				'disable_ui'         => ! $alpha_feature_testing_is_enabled,
-				'setting'            => array(
-					'disabled' => ! ( $alpha_feature_testing_is_enabled && wp_using_ext_object_cache() ),
-					'desc_tip' => function () {
-						$string = '';
-						if ( ! wp_using_ext_object_cache() ) {
-							$string = __(
-								'⚠ This feature is currently only suggested with the use of external object caching.',
-								'woocommerce'
-							);
-						}
-
-						return $string;
-					},
-				),
+				'disable_ui'         => false,
 				'option_key'         => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
 			'remote_logging'                     => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This updates the feature setting that controls whether HPOS Datastore Caching is enabled so that it is no longer in ALPHA testing.  

Previously, in order to see the option to enable datastore caching, it required adding `define( 'WOOCOMMERCE_ENABLE_ALPHA_FEATURE_TESTING', 'true' );` to the codebase.  This was released in 9.6.  However, we haven't yet had any feedback, positive or negative on the feature, so we are removing the block and making a standard experimental feature that no longer requires the above define to control.

More details: https://developer.woocommerce.com/2025/01/16/order-datastore-caching-a-new-approach-to-optimize-woocommerce-performance/

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

![Screenshot 2025-04-08 at 1 00 04 PM](https://github.com/user-attachments/assets/ff977adb-fcda-484e-9e7c-51ed1d0fa185)

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Verify that your test site doesn't have `WOOCOMMERCE_ENABLE_ALPHA_FEATURE_TESTING` defined anywhere from previous testing.
2.  Visit wp-admin -> WooCommerce -> Setttings -> Advanced -> Features.
3.  Verify that you're able to update the `HPOS Data Caching` setting.

<!-- End testing instructions -->
