### PR TITLE
[dev] CI: comparative runs on GitHub for Blacksmith runners comparison 

### DIFF
--- a/plugins/woocommerce/client/blocks/package.json
+++ b/plugins/woocommerce/client/blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/block-library",
-	"title": "WooCommerce Blocks",
+	"title": "WooCommerce Blocks...",
 	"private": true,
 	"version": "11.8.0-dev",
 	"license": "GPL-3.0-or-later",

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader class.
+ * Autoloader clazz.
  *
  * @since 3.7.0
  */


### PR DESCRIPTION
Blacksmith comparative run with blacksmith-4vcpu-ubuntu-2204: https://github.com/BlacksmithOSSTests/woocommerce/actions/runs/14183076426?pr=1