### PR TITLE
Add vertical margin between charts in WooCommerce Analytics

### DIFF
--- a/packages/js/components/changelog/fix-57109-analytics-charts-margin
+++ b/packages/js/components/changelog/fix-57109-analytics-charts-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Vertically align chart type buttons in <Chart> component

--- a/packages/js/components/src/chart/style.scss
+++ b/packages/js/components/src/chart/style.scss
@@ -101,6 +101,8 @@
 }
 
 .woocommerce-chart__types {
+	align-items: center;
+	display: flex;
 	padding: 0 8px;
 	white-space: nowrap;
 }

--- a/plugins/woocommerce/changelog/fix-57109-analytics-charts-margin
+++ b/plugins/woocommerce/changelog/fix-57109-analytics-charts-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add vertical margin between charts in WooCommerce Analytics

--- a/plugins/woocommerce/client/admin/client/dashboard/style.scss
+++ b/plugins/woocommerce/client/admin/client/dashboard/style.scss
@@ -6,7 +6,7 @@
 .woocommerce-dashboard__columns {
 	display: grid;
 	grid-template-columns: calc(50% - #{math.div($gap-large, 2)}) calc(50% - #{math.div($gap-large, 2)});
-	grid-column-gap: $gap-large;
+	grid-gap: $gap-large;
 
 	// Auto-position fix for IE11.
 	> div {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #57109.
Closes WOOPLUG-3843.

This PR adds some vertical margin between charts in WooCommerce > Analytics. It also makes it so the line chart/bar chart buttons on the top right are vertically aligned.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Analytics.
2. Using the ellipsis menu, enable three or more charts.
3. Verify there is vertical margin between the charts and the line cart/bar chart buttons on the top right are verticall centered:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/b2bc7bd1-2078-4a07-a325-283472038629) | ![imatge](https://github.com/user-attachments/assets/488317ae-6c51-448f-b5ec-3be370a69ae2)