### PR TITLE
[dev] Fix value of RELEASE_TAG in wp-env config override step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,9 +177,9 @@ jobs:
           pull-package-deps: '${{ matrix.projectName }}'
 
       - name: 'Update wp-env config'
-        if: ${{ inputs.refName != '' }}
+        if: ${{ inputs.artifactName != '' }}
         env:
-          RELEASE_TAG: ${{ inputs.refName }}
+          RELEASE_TAG: ${{ inputs.refName != '' && inputs.refName || github.ref_name }}
           ARTIFACT_NAME: ${{ inputs.artifactName }}
           # band-aid to get the path to wp-env.json for blocks e2e tests, until they're migrated to plugins/woocommerce
           WP_ENV_CONFIG_PATH: ${{ github.workspace }}/${{ matrix.testEnv.start == 'env:start:blocks' && 'plugins/woocommerce/client/blocks' || matrix.projectPath  }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With the recent updates of the release checks workflows the value of RELEASE_TAG was not being set in the release event and the script that overrides the wp-env config needs that.

### How to test the changes in this Pull Request:

1. Trigger a release event (create a release) from this branch
2. Check the ci.yml workflow triggered by the release event

Expected:
The `Update wp-env config` step ran. The RELEASE_TAG env variable in the step is the tag name.

Tested with: https://github.com/woocommerce/woocommerce/actions/runs/14355881730/job/40245113853#step:4:21
The start env step failed as expected because the test release did not contain a woocommerce.zip, which was not in scope of this test.
