### PR TITLE
[dev] Fix plugincheck job for nightly checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           LAST_FAILED_RUN: ${{ vars.LAST_FAILED_RUN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           WC_VERSION: ${{ inputs.wc-version }}
-          PLUGIN_NAME: ${{ inputs.refName == 'nightly' && 'woocommerce-trunk-nightly' || '' }} # required by test:plugincheck
+          PLUGIN_SLUG: ${{ inputs.refName == 'nightly' && 'woocommerce-trunk-nightly' || '' }} # required by test:plugincheck
         run: |
           lastRunFile="${{ steps.download-last-run-info.outputs.download-path }}/last-run__${{ strategy.job-index }}/.last-run.json"
           lastRunFileDest="$ARTIFACTS_PATH/.last-run.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
           LAST_FAILED_RUN: ${{ vars.LAST_FAILED_RUN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           WC_VERSION: ${{ inputs.wc-version }}
+          PLUGIN_NAME: ${{ inputs.refName == 'nightly' && 'woocommerce-trunk-nightly' || '' }} # required by test:plugincheck
         run: |
           lastRunFile="${{ steps.download-last-run-info.outputs.download-path }}/last-run__${{ strategy.job-index }}/.last-run.json"
           lastRunFileDest="$ARTIFACTS_PATH/.last-run.json"

--- a/plugins/woocommerce/changelog/dev-wooplug-3822-fix-plugin-check-failure-in-nightly-checks
+++ b/plugins/woocommerce/changelog/dev-wooplug-3822-fix-plugin-check-failure-in-nightly-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+dev: consider PLUGIN_SLUG in the test:plugincheck script

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -72,7 +72,7 @@
 		"test:metrics:ci": "../../.github/workflows/scripts/run-metrics.sh",
 		"test:php:env": "wp-env run --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit -c phpunit.xml --verbose",
 		"test:php:env:watch": "wp-env run --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit-watcher watch --verbose",
-		"test:plugincheck": "wp-env run tests-cli wp plugin check woocommerce",
+		"test:plugincheck": "wp-env run tests-cli wp plugin check ${PLUGIN_NAME:-woocommerce}",
 		"test:unit": "pnpm test:php",
 		"test:unit:watch": "pnpm test:php:watch",
 		"test:unit:env": "pnpm test:php:env",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -72,7 +72,7 @@
 		"test:metrics:ci": "../../.github/workflows/scripts/run-metrics.sh",
 		"test:php:env": "wp-env run --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit -c phpunit.xml --verbose",
 		"test:php:env:watch": "wp-env run --env-cwd='wp-content/plugins/woocommerce' tests-cli vendor/bin/phpunit-watcher watch --verbose",
-		"test:plugincheck": "wp-env run tests-cli wp plugin check ${PLUGIN_NAME:-woocommerce}",
+		"test:plugincheck": "wp-env run tests-cli wp plugin check ${PLUGIN_SLUG:-woocommerce}",
 		"test:unit": "pnpm test:php",
 		"test:unit:watch": "pnpm test:php:watch",
 		"test:unit:env": "pnpm test:php:env",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/57064

The nightly build is using a different plugin name and this causes the pluginchecks job to fail:

```
Error: Invalid plugin slug: Plugin with slug woocommerce is not installed.
```

### How to test the changes in this Pull Request:

Install [woocommerce-trunk-nightly.zip](https://github.com/woocommerce/woocommerce/releases/tag/nightly)

Run the plugin check - expected to fail with `Invalid plugin slug`

```
pnpm test:plugincheck
```

Run the plugin check with PLUGIN_SLUG env variable 


```
PLUGIN_SLUG=woocommerce-trunk-nightly pnpm test:plugincheck
```
