### PR TITLE
Always run validation for postcode and email in Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/57128-fix-always-validate-fields-on-client
+++ b/plugins/woocommerce/changelog/57128-fix-always-validate-fields-on-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue in which client side validation in Checkout didn't work.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -91,7 +91,11 @@ const Form = <
 
 	const { errors, previousErrors } = useFormValidation(
 		formFields,
-		addressType
+		addressType,
+		// Temporary override for shipping calculator address form.
+		addressType === 'shipping' || addressType === 'billing'
+			? ( values as AddressFormValues )
+			: undefined
 	);
 
 	useEffect( () => {
@@ -124,7 +128,7 @@ const Form = <
 				}
 			} );
 		}
-	}, [ errors, previousErrors, addressType, values ] );
+	}, [ errors, previousErrors, addressType ] );
 
 	// Changing country may change format for postcodes.
 	useEffect( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/form.tsx
@@ -93,9 +93,7 @@ const Form = <
 		formFields,
 		addressType,
 		// Temporary override for shipping calculator address form.
-		addressType === 'shipping' || addressType === 'billing'
-			? ( values as AddressFormValues )
-			: undefined
+		addressType === 'shipping' ? ( values as AddressFormValues ) : undefined
 	);
 
 	useEffect( () => {
@@ -128,7 +126,7 @@ const Form = <
 				}
 			} );
 		}
-	}, [ errors, previousErrors, addressType ] );
+	}, [ errors, previousErrors, addressType, values ] );
 
 	// Changing country may change format for postcodes.
 	useEffect( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -95,7 +95,9 @@ const EMPTY_OBJECT: FormErrors = {};
 export const useFormValidation = (
 	formFields: KeyedFormFields,
 	// Form type, can be billing, shipping, contact, order, or calculator.
-	formType: FormType
+	formType: FormType,
+	// Allows certain fields to be overridden for forms that don't auto update data store.
+	overrideValues?: AddressFormValues
 ): {
 	errors: FormErrors;
 	previousErrors: FormErrors | undefined;
@@ -117,18 +119,22 @@ export const useFormValidation = (
 		| OrderFormValues
 		| Record< string, never >;
 
-	switch ( formType ) {
-		case 'billing':
-		case 'shipping':
-			values = data.customer.address || {};
-			break;
-		case 'contact':
-		case 'order':
-			values = data.checkout.additional_fields || {};
-			break;
-		default:
-			values = {};
-			break;
+	if ( overrideValues ) {
+		values = overrideValues;
+	} else {
+		switch ( formType ) {
+			case 'billing':
+			case 'shipping':
+				values = data.customer.address || {};
+				break;
+			case 'contact':
+			case 'order':
+				values = data.checkout.additional_fields || {};
+				break;
+			default:
+				values = {};
+				break;
+		}
 	}
 
 	const partialSchema = formFields.reduce<

--- a/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/hooks/use-schema-parser.ts
@@ -142,7 +142,7 @@ export const useSchemaParser = < T extends FormType | 'global' >(
 	}
 	return {
 		parser: null,
-		data: null,
+		data,
 	};
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue in which Checkout validation for postcode and email would not work. This was introduced in https://github.com/woocommerce/woocommerce/pull/55254 and is only visible if you don't have additional fields installed, likely why our E2E tests didn't catch it.

Closes WOOPLUG-3857

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/55254

### How to test the changes in this Pull Request:

1. Go to checkout, type an invalid email, notice an inline error.
2. In shipping address, type an invalid postcode `abc` for country United States
3. Notice an inline error.
4. Fix the postcode, notice the error is gone and a request is sent to the server.
5. In Cart, try changing the address.
6. Make sure the zipcode error is shown for invalid zipcodes, and is gone once you input a valid one.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix issue in which client side validation in Checkout didn't work.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
