### PR TITLE
Product Gallery: remove unnecessary large image and navigation block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3732-product-gallery-remove-large-image-and-navigation-block
+++ b/plugins/woocommerce/changelog/wooplug-3732-product-gallery-remove-large-image-and-navigation-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Gallery: Remove unnecessary group block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/edit.tsx
@@ -33,54 +33,33 @@ const TEMPLATE: InnerBlockTemplate[] = [
 		[
 			[ 'woocommerce/product-gallery-thumbnails' ],
 			[
-				'core/group',
-				{
-					layout: {
-						type: 'flex',
-						orientation: 'vertical',
-						justifyContent: 'center',
-						verticalAlignment: 'top',
-					},
-					style: {
-						layout: { selfStretch: 'fixed', flexSize: '100%' },
-					},
-					metadata: {
-						name: 'Large Image and Navigation',
-					},
-					className:
-						'wc-block-product-gallery__large-image-and-navigation',
-				},
+				'woocommerce/product-gallery-large-image',
+				{},
 				[
 					[
-						'woocommerce/product-gallery-large-image',
-						{},
-						[
-							[
-								'woocommerce/product-sale-badge',
-								{
-									align: 'right',
-									style: {
-										spacing: {
-											margin: {
-												top: '4px',
-												right: '4px',
-												bottom: '4px',
-												left: '4px',
-											},
-										},
+						'woocommerce/product-sale-badge',
+						{
+							align: 'right',
+							style: {
+								spacing: {
+									margin: {
+										top: '4px',
+										right: '4px',
+										bottom: '4px',
+										left: '4px',
 									},
 								},
-							],
-							[
-								'woocommerce/product-gallery-large-image-next-previous',
-								{
-									layout: {
-										type: 'flex',
-										verticalAlignment: 'bottom',
-									},
-								},
-							],
-						],
+							},
+						},
+					],
+					[
+						'woocommerce/product-gallery-large-image-next-previous',
+						{
+							layout: {
+								type: 'flex',
+								verticalAlignment: 'bottom',
+							},
+						},
 					],
 				],
 			],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -349,8 +349,9 @@ body.wc-block-product-gallery-dialog-open {
 		.wc-block-product-gallery__gallery-area {
 			flex-direction: column;
 		}
-		.wc-block-product-gallery__large-image-and-navigation {
-			order: -1;
+
+		.wc-block-product-gallery-thumbnails {
+			order: 1;
 		}
 
 		.wc-block-product-gallery-thumbnails {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

After strong simplification of Product Gallery structure, some blocks became redundant. In this PR I'm removing Large Image and Navigation (Group block variation) as it brings no value with current shape.

Closes WOOPLUG-3732

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|       ![Screen Shot 2025-04-09 at 17 40 34 PM](https://github.com/user-attachments/assets/3ef0c077-be28-437e-868d-14612767f09c) |     <img width="933" alt="image" src="https://github.com/user-attachments/assets/b2f83642-18f5-4cf5-b032-dd5b6c13929c" />  |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Single Product template
2. Replace Product Image Gallery with Product Gallery (Beta)
3. **Expected:** You can change the Gallery Area from Stack to Row and vice versa and Thumbnails are correctly position related to Large Image (see the video below)
4. Save in some positions and go to frontend
5. **Expected:** Layout is the same

https://github.com/user-attachments/assets/8069a7ca-d829-4114-9f67-84f6f4511753

6. Switch to mobile view in the frontend
7. **Expected:** No matter you layout settings, there's opinionated mobile layout with horizontal thumbnails below the large image

<img width="405" alt="image" src="https://github.com/user-attachments/assets/c0254ad3-a504-4760-8993-2a6a022ee93d" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
