### PR TITLE
Fix Related Products variation to handle invalid product instances gracefully

### DIFF
--- a/plugins/woocommerce/changelog/57138-wooplug-3751-fatal-php-fatal-error-uncaught-error-call-to-a-member
+++ b/plugins/woocommerce/changelog/57138-wooplug-3751-fatal-php-fatal-error-uncaught-error-call-to-a-member
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Related Products variation to handle invalid product instances gracefully.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/RelatedProducts.php
@@ -164,11 +164,15 @@ class RelatedProducts extends AbstractBlock {
 
 		$product = wc_get_product( $post->ID );
 
+		if ( ! $product instanceof \WC_Product ) {
+			return array();
+		}
+
 		$related_products = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), $product_per_page, $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
 		$related_products = wc_products_array_orderby( $related_products, 'rand', 'desc' );
 
 		$related_product_ids = array_map(
-			function( $product ) {
+			function ( $product ) {
 				return $product->get_id();
 			},
 			$related_products
@@ -176,5 +180,4 @@ class RelatedProducts extends AbstractBlock {
 
 		return $related_product_ids;
 	}
-
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #56948 (WOOPLUG-3751).

This PR prevents a PHP Fatal error when wc_get_product does not return a product instance, specifically when the Related Product (variation of the Query Block) is used. Although this block is deprecated, it may still be present in older stores.

This check is pretty common in the codebase:

https://github.com/woocommerce/woocommerce/blob/cf6ce81c78ebabb2e3378186475bec4c273a28eb/plugins/woocommerce/src/Blocks/AIContent/UpdateProducts.php#L284-L288

https://github.com/woocommerce/woocommerce/blob/cf6ce81c78ebabb2e3378186475bec4c273a28eb/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php#L132-L136



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit the Single Product Template
2. Remove the Related Products block
3. Open the code editor
4. Copy paste this code:

```
	<!-- wp:woocommerce/related-products {"align":"wide"} -->
	<div class="wp-block-woocommerce-related-products alignwide">
		<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":5},"namespace":"woocommerce/related-products","lock":{"remove":true,"move":true}} -->
		<div class="wp-block-query">
			<!-- wp:heading -->
			<h2 class="wp-block-heading">Related products</h2>
			<!-- /wp:heading -->

			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
			<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true} /-->

			<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->

			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->

			<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
			<!-- /wp:post-template -->
		</div>
		<!-- /wp:query -->
	</div>
	<!-- /wp:woocommerce/related-products -->
```
5. Save.
6. Visit a single Product Page.
7. Ensure that the related products are visible.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Related Products variation to handle invalid product instances gracefully.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
