### PR TITLE
[dev] CI: randomize wp-env ports for testing containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
           # Finally, run the tests
           if [[ "${{ matrix.testEnv.shouldCreate && 'yes' }}" == "yes" ]]; then
               # WP_BASE_URL is set only to satisfy blocks global setup (setupRest calls).
-              WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT WP_BASE_URL="http://localhost:$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+              WP_BASE_URL="http://localhost:$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
           else
               pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
           fi
 
           # Finally, run the tests
-          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+          WP_ENV_TESTS_PORT="$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
 
       - name: 'Upload Playwright last run info'
         # always upload the last run info, even if the test run passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           max=99
           randomized=$(( $RANDOM % ( $max - $min + 1 ) + $min ))
           httpport="${randomized}80"
-          mysqlport="${randomized}06"
+          mysqlport="${randomized}36"
 
           # provision the environment to propagate the randomized ports
           echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         env: ${{ matrix.testEnv.envVars }}
         run: |
           # randomized wp-env ports to reduce the number of ports usage conflicts
-          pool=(80 81 82 83 84 85 86 86 88 89 90 91 92 93 94 95 96 97 98 99)
+          pool=(70 71 72 73 74 75 76 77 78 79  80 81 82 83 84 85 86 87 88 89  90 91 92 93 94 95 96 97 98 99)
           index=$[$RANDOM % ${#pool[@]}]
           randomized=${pool[$index]}
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,12 @@ jobs:
           randomized=${pool[$index]}
           
           # provision the environment to propagate the randomized ports
-          WP_ENV_TESTS_PORT="${randomized}86"
-          WP_ENV_TESTS_MYSQL_PORT="5${randomized}86"
-          echo "WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT" >> "$GITHUB_ENV"
-          echo "WP_ENV_TESTS_MYSQL_PORT=$WP_ENV_TESTS_MYSQL_PORT" >> "$GITHUB_ENV"
+          httpport="${randomized}86"
+          mysqlport="5${randomized}86"
+          echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
+          echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
           
-          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+          WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,16 @@ jobs:
         id: 'prepare-test-environment'
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
-        run: 'pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+        run: |
+          if [[ "${{ matrix.testType }}" == "unit:php" ]]; then
+              # randomized part of the wp-env ports
+              pool=(80 81 82 83 84 85 86 86 88 89)
+              index=$[$RANDOM % ${#pool[@]}]
+              randomized=${pool[$index]}
+              WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+          else
+              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+          fi
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,11 @@ jobs:
           fi
 
           # Finally, run the tests
-          WP_ENV_TESTS_PORT="$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+          if [[ "${{ matrix.testEnv.shouldCreate && 'yes' }}" == "yes" ]]; then
+              WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+          else
+              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+          fi
 
       - name: 'Upload Playwright last run info'
         # always upload the last run info, even if the test run passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,15 +190,12 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          if [[ "${{ matrix.testType }}" == "unit:php" ]]; then
-              # randomized part of the wp-env ports
-              pool=(80 81 82 83 84 85 86 86 88 89)
-              index=$[$RANDOM % ${#pool[@]}]
-              randomized=${pool[$index]}
-              WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
-          else
-              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
-          fi
+          # randomized part of the wp-env ports to avoid ports usage conflicts
+          pool=(80 81 82 83 84 85 86 86 88 89)
+          index=$[$RANDOM % ${#pool[@]}]
+          randomized=${pool[$index]}
+          
+          WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && 25 ) || 360 }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && 20 ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,13 +194,13 @@ jobs:
           pool=(80 81 82 83 84 85 86 86 88 89)
           index=$[$RANDOM % ${#pool[@]}]
           randomized=${pool[$index]}
-          httpport="${randomized}86"
-          mysqlport="5${randomized}86"
           
-          echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
-          echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
+          # provision the environment to propagate the randomized ports
+          WP_ENV_TESTS_PORT="${randomized}86"
+          WP_ENV_TESTS_MYSQL_PORT="5${randomized}86"
+          echo "WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT" >> "$GITHUB_ENV"
+          echo "WP_ENV_TESTS_MYSQL_PORT=$WP_ENV_TESTS_MYSQL_PORT" >> "$GITHUB_ENV"
           
-          # WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport 
           pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
 
       - name: 'Determine BuildKite Analytics Message'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
           # provision the environment to propagate the randomized ports
           echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
           echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
+          # WP_BASE_URL is set only to satisfy blocks E2Es setup (setupRest).
+          echo "WP_BASE_URL=http://localhost:$httpport" >> "$GITHUB_ENV"
           
           WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
 
@@ -281,12 +283,7 @@ jobs:
           fi
 
           # Finally, run the tests
-          if [[ "${{ matrix.testEnv.shouldCreate && 'yes' }}" == "yes" ]]; then
-              # WP_BASE_URL is set only to satisfy blocks global setup (setupRest calls).
-              WP_BASE_URL="http://localhost:$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
-          else
-              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
-          fi
+          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
 
       - name: 'Upload Playwright last run info'
         # always upload the last run info, even if the test run passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         env: ${{ matrix.testEnv.envVars }}
         run: |
           # randomized wp-env ports to reduce the number of ports usage conflicts
-          pool=(80 81 82 83 84 85 86 86 88 89)
+          pool=(80 81 82 83 84 85 86 86 88 89 90 91 92 93 94 95 96 97 98 99)
           index=$[$RANDOM % ${#pool[@]}]
           randomized=${pool[$index]}
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,14 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          # randomized wp-env ports to reduce the number of ports usage conflicts
-          pool=(70 71 72 73 74 75 76 77 78 79  80 81 82 83 84 85 86 87 88 89  90 91 92 93 94 95 96 97 98 99)
-          index=$[$RANDOM % ${#pool[@]}]
-          randomized=${pool[$index]}
-          
+          # randomized wp-env ports to reduce the number of ports usage conflicts in the range of 1024 - 49151
+          min=10
+          max=99
+          randomized=$(( $RANDOM % ( $max - $min + 1 ) + $min ))
+          httpport="${randomized}80"
+          mysqlport="${randomized}06"
+
           # provision the environment to propagate the randomized ports
-          httpport="${randomized}86"
-          mysqlport="5${randomized}86"
           echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
           echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          # randomized wp-env ports to avoid ports usage conflicts
+          # randomized wp-env ports to reduce the number of ports usage conflicts
           pool=(80 81 82 83 84 85 86 86 88 89)
           index=$[$RANDOM % ${#pool[@]}]
           randomized=${pool[$index]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,12 @@ jobs:
           httpport="${randomized}86"
           mysqlport="5${randomized}86"
           
-          WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
-          
           echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
           echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
+          
+          # WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport 
+          pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+          
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
           
           # WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport 
           pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
-          
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,17 @@ jobs:
         if: ${{ matrix.testEnv.shouldCreate }}
         env: ${{ matrix.testEnv.envVars }}
         run: |
-          # randomized part of the wp-env ports to avoid ports usage conflicts
+          # randomized wp-env ports to avoid ports usage conflicts
           pool=(80 81 82 83 84 85 86 86 88 89)
           index=$[$RANDOM % ${#pool[@]}]
           randomized=${pool[$index]}
+          httpport="${randomized}86"
+          mysqlport="5${randomized}86"
           
-          WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+          WP_ENV_TESTS_PORT=$httpport WP_ENV_TESTS_MYSQL_PORT=$mysqlport pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
+          
+          echo "WP_ENV_TESTS_PORT=$httpport" >> "$GITHUB_ENV"
+          echo "WP_ENV_TESTS_MYSQL_PORT=$mysqlport" >> "$GITHUB_ENV"
 
       - name: 'Determine BuildKite Analytics Message'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,9 @@ jobs:
               pool=(80 81 82 83 84 85 86 86 88 89)
               index=$[$RANDOM % ${#pool[@]}]
               randomized=${pool[$index]}
-              WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+              WP_ENV_TESTS_PORT="${randomized}86" WP_ENV_TESTS_MYSQL_PORT="5${randomized}86" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
           else
-              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}'
+              pnpm --filter="${{ matrix.projectName }}" ${{ matrix.testEnv.start }}
           fi
 
       - name: 'Determine BuildKite Analytics Message'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,8 @@ jobs:
 
           # Finally, run the tests
           if [[ "${{ matrix.testEnv.shouldCreate && 'yes' }}" == "yes" ]]; then
-              WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
+              # WP_BASE_URL is set only to satisfy blocks global setup (setupRest calls).
+              WP_ENV_TESTS_PORT=$WP_ENV_TESTS_PORT WP_BASE_URL="http://localhost:$WP_ENV_TESTS_PORT" pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
           else
               pnpm --filter="${{ matrix.projectName }}" ${{ matrix.command }} $lastRunFlag
           fi

--- a/plugins/woocommerce/changelog/dev-ci-randomize-wpenv-ports
+++ b/plugins/woocommerce/changelog/dev-ci-randomize-wpenv-ports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: randomize wp-env test containers ports when running tests.

--- a/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
@@ -6,7 +6,6 @@
 import { chromium, request } from '@playwright/test';
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 import {
-	BASE_URL,
 	adminFile,
 	wpCLI,
 	customerFile,
@@ -18,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { customer, admin } from './test-data/data/data';
+import { BASE_URL } from './utils/constants';
 
 const prepareAttributes = async () => {
 	const browser = await chromium.launch();

--- a/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
@@ -62,7 +62,11 @@ const prepareAttributes = async () => {
 
 async function globalSetup() {
 	console.log( 'Running global setup:' );
-	console.time( '└ Total time' );
+	console.time( '└ Base URL: ' + BASE_URL );
+	console.time(
+		'├ Port override: ' + ( process.env.WP_ENV_TESTS_PORT || 'n/a' )
+	);
+	console.time( '├ Total time' );
 
 	let databaseImported = false;
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
@@ -62,8 +62,8 @@ const prepareAttributes = async () => {
 
 async function globalSetup() {
 	console.log( 'Running global setup:' );
-	console.time( '└ Base URL: ' + BASE_URL );
-	console.time(
+	console.log( '└ Base URL: ' + BASE_URL );
+	console.log(
 		'├ Port override: ' + ( process.env.WP_ENV_TESTS_PORT || 'n/a' )
 	);
 	console.time( '├ Total time' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/global-setup.ts
@@ -62,11 +62,7 @@ const prepareAttributes = async () => {
 
 async function globalSetup() {
 	console.log( 'Running global setup:' );
-	console.log( '└ Base URL: ' + BASE_URL );
-	console.log(
-		'├ Port override: ' + ( process.env.WP_ENV_TESTS_PORT || 'n/a' )
-	);
-	console.time( '├ Total time' );
+	console.time( '└ Total time' );
 
 	let databaseImported = false;
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -449,7 +449,9 @@ test.describe( 'Product Collection', () => {
 				.click();
 			await page
 				.getByRole( 'option', {
-					name: `Cap http://localhost:8889/product/cap/`,
+					name: `Cap http://localhost:${
+						process.env.WP_ENV_TESTS_PORT || '8889'
+					}/product/cap/`,
 				} )
 				.click();
 			await page

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/constants.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/constants.ts
@@ -17,7 +17,8 @@ export const CLASSIC_CHILD_THEME_WITH_BLOCK_NOTICES_TEMPLATE_SLUG = `${ CLASSIC_
 export const CLASSIC_CHILD_THEME_WITH_CLASSIC_NOTICES_TEMPLATE_SLUG = `${ CLASSIC_THEME_SLUG }-child__classic-notices-template`;
 export const CLASSIC_CHILD_THEME_WITH_BLOCK_TEMPLATE_PARTS_SLUG = `${ CLASSIC_THEME_SLUG }-child__with-block-template-part`;
 export const CLASSIC_CHILD_THEME_WITH_BLOCK_TEMPLATE_PARTS_SUPPORT_SLUG = `${ CLASSIC_THEME_SLUG }-child__with-block-template-part-support`;
-export const BASE_URL = 'http://localhost:8889';
+export const BASE_URL =
+	'http://localhost:' + ( process.env.WP_ENV_TESTS_PORT || '8889' );
 
 export const WP_ARTIFACTS_PATH =
 	process.env.WP_ARTIFACTS_PATH ||

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader class.
+ * Autoloader clazz.
  *
  * @since 3.7.0
  */

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader clazz.
+ * Autoloader class.
  *
  * @since 3.7.0
  */

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -7,7 +7,8 @@ require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 
 if ( ! process.env.BASE_URL ) {
 	console.log( 'BASE_URL is not set. Using default.' );
-	process.env.BASE_URL = 'http://localhost:8086';
+	process.env.BASE_URL =
+		'http://localhost:8086' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
 }
 
 const { BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } = process.env;

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -8,7 +8,9 @@ require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 if ( ! process.env.BASE_URL ) {
 	process.env.BASE_URL =
 		'http://localhost:' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
-	console.log( 'BASE_URL is not set. Using default: ' + process.env.BASE_URL );
+	console.log(
+		'BASE_URL is not set. Using default: ' + process.env.BASE_URL
+	);
 }
 
 const { BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } = process.env;

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -6,9 +6,9 @@ import { defineConfig, devices } from '@playwright/test';
 require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 
 if ( ! process.env.BASE_URL ) {
-	console.log( 'BASE_URL is not set. Using default.' );
 	process.env.BASE_URL =
 		'http://localhost:' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
+	console.log( 'BASE_URL is not set. Using default: ' + process.env.BASE_URL );
 }
 
 const { BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } = process.env;

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -8,7 +8,7 @@ require( 'dotenv' ).config( { path: __dirname + '/.env' } );
 if ( ! process.env.BASE_URL ) {
 	console.log( 'BASE_URL is not set. Using default.' );
 	process.env.BASE_URL =
-		'http://localhost:8086' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
+		'http://localhost:' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
 }
 
 const { BASE_URL, CI, E2E_MAX_FAILURES, REPEAT_EACH } = process.env;

--- a/plugins/woocommerce/tests/metrics/playwright.config.js
+++ b/plugins/woocommerce/tests/metrics/playwright.config.js
@@ -11,7 +11,8 @@ process.env.STORAGE_STATE_PATH ??= path.join(
 	process.env.WP_ARTIFACTS_PATH,
 	'storage-states/admin.json'
 );
-process.env.WP_BASE_URL ??= 'http://localhost:8086';
+process.env.WP_BASE_URL ??=
+	'http://localhost:' + ( process.env.WP_ENV_TESTS_PORT || '8086' );
 
 const config = defineConfig( {
 	reporter: [ [ 'list' ], [ './config/performance-reporter.ts' ] ],

--- a/plugins/woocommerce/tests/performance/config.js
+++ b/plugins/woocommerce/tests/performance/config.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
-export const base_url = __ENV.URL || 'http://localhost:8086';
-export const base_host = __ENV.HOST || 'localhost:8086';
+export const base_url =
+	__ENV.URL || 'http://localhost:' + ( __ENV.WP_ENV_TESTS_PORT || '8086' );
+export const base_host =
+	__ENV.HOST || 'localhost:' + ( __ENV.WP_ENV_TESTS_PORT || '8086' );
 
 export const STORE_NAME = __ENV.STORE_NAME || 'WooCommerce Core E2E Test Suite';
 export const FOOTER_TEXT = 'Built with WooCommerce';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Attempts to address regular CI failures like the following by randomizing wp-env test containers ports:

```
> @woocommerce/plugin-woocommerce@9.9.0 wp-env /home/runner/work/woocommerce/woocommerce/plugins/woocommerce
> wp-env "start" "--update"

✖ Error while running docker compose command.
 Network 36f129a9d109274d16f01b89c88bf54c_default  Creating
 Network 36f129a9d109274d16f01b89c88bf54c_default  Created
 Volume "36f129a9d109274d16f01b89c88bf54c_mysql-test"  Creating
 Volume "36f129a9d109274d16f01b89c88bf54c_mysql-test"  Created
 Volume "36f129a9d109274d16f01b89c88bf54c_tests-user-home"  Creating
 Volume "36f129a9d109274d16f01b89c88bf54c_tests-user-home"  Created
 Container 36f129a9d109274d16f01b89c88bf54c-tests-mysql-1  Creating
 Container 36f129a9d109274d16f01b89c88bf54c-tests-mysql-1  Created
 Container 36f129a9d109274d16f01b89c88bf54c-tests-mysql-1  Starting
Error response from daemon: driver failed programming external connectivity on endpoint 36f129a9d109274d16f01b89c88bf54c-tests-mysql-1 (c8d89f1b623d2e61c726063a01a3d975c462df30dd1b452ba29a6f5ab5471982): Error starting userland proxy: listen tcp4 0.0.0.0:58086: bind: address already in use
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

### How to test the changes in this Pull Request:

- CI-checks shall pass
