### PR TITLE
[Store API] Revert #55299 to handle sessions and cart tokens when the request is available

### DIFF
--- a/plugins/woocommerce/changelog/fix-revert-moving-session-handling-55299
+++ b/plugins/woocommerce/changelog/fix-revert-moving-session-handling-55299
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store API - Move cart init and validation back within checkout route to avoid loading early.

--- a/plugins/woocommerce/src/StoreApi/Authentication.php
+++ b/plugins/woocommerce/src/StoreApi/Authentication.php
@@ -21,20 +21,9 @@ class Authentication {
 		add_filter( 'rest_authentication_errors', array( $this, 'check_authentication' ) );
 		add_filter( 'rest_authentication_errors', array( $this, 'opt_in_checkout_endpoint' ), 9, 1 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_logged_in_cookie' ) );
-		add_filter( 'rest_pre_serve_request', array( $this, 'send_cors_headers' ), 10, 1 );
+		add_filter( 'rest_pre_serve_request', array( $this, 'send_cors_headers' ), 10, 3 );
 		add_filter( 'rest_allowed_cors_headers', array( $this, 'allowed_cors_headers' ) );
 		add_filter( 'rest_exposed_cors_headers', array( $this, 'exposed_cors_headers' ) );
-
-		// If cart has a valid token, override the core session class.
-		// Validate returns early if no token, so no performance penalty.
-		if ( JsonWebToken::validate( $this->get_cart_token(), $this->get_cart_token_secret() ) ) {
-			add_filter(
-				'woocommerce_session_handler',
-				function () {
-					return SessionHandler::class;
-				}
-			);
-		}
 
 		// Remove the default CORS headers--we will add our own.
 		remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
@@ -75,10 +64,12 @@ class Authentication {
 	 *
 	 * Users of valid Cart Tokens are also allowed access from any origin.
 	 *
-	 * @param bool $value  Whether the request has already been served.
+	 * @param bool             $value  Whether the request has already been served.
+	 * @param \WP_REST_Server  $server The REST server instance.
+	 * @param \WP_REST_Request $request The REST request instance.
 	 * @return bool
 	 */
-	public function send_cors_headers( $value ) {
+	public function send_cors_headers( $value, $server, $request ) {
 		$origin = get_http_origin();
 
 		if ( 'null' !== $origin ) {
@@ -93,7 +84,7 @@ class Authentication {
 
 		// Allow preflight requests, certain http origins, and any origin if a cart token is present. Preflight requests
 		// are allowed because we'll be unable to validate cart token headers at that point.
-		if ( $this->is_preflight() || JsonWebToken::validate( $this->get_cart_token(), $this->get_cart_token_secret() ) || is_allowed_http_origin( $origin ) ) {
+		if ( $this->is_preflight() || JsonWebToken::validate( $this->get_cart_token( $request ), $this->get_cart_token_secret() ) || is_allowed_http_origin( $origin ) ) {
 			$server->send_header( 'Access-Control-Allow-Origin', $origin );
 		}
 
@@ -118,10 +109,11 @@ class Authentication {
 	/**
 	 * Gets the cart token from the request header.
 	 *
+	 * @param \WP_REST_Request $request The REST request instance.
 	 * @return string
 	 */
-	protected function get_cart_token() {
-		return wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
+	protected function get_cart_token( \WP_REST_Request $request ) {
+		return wc_clean( wp_unslash( $request->get_header( 'Cart-Token' ) ?? '' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -111,6 +111,8 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
+		$this->load_cart_session( $request );
+
 		$response    = null;
 		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
 
@@ -158,6 +160,25 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		$response->header( 'Cart-Hash', WC()->cart->get_cart_hash() );
 
 		return $response;
+	}
+
+	/**
+	 * Load the cart session before handling responses.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	protected function load_cart_session( \WP_REST_Request $request ) {
+		if ( $this->has_cart_token( $request ) ) {
+			// Overrides the core session class.
+			add_filter(
+				'woocommerce_session_handler',
+				function () {
+					return SessionHandler::class;
+				}
+			);
+		}
+		$this->cart_controller->load_cart();
+		$this->cart_controller->normalize_cart();
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -86,7 +86,6 @@ class Checkout extends AbstractCartRoute {
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
-				'validate_callback'   => [ $this, 'validate_callback' ],
 				'args'                => array_merge(
 					[
 						'payment_data'      => [
@@ -115,7 +114,6 @@ class Checkout extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'validate_callback'   => [ $this, 'validate_callback' ],
 				'permission_callback' => '__return_true',
 				'args'                => array_merge(
 					[
@@ -148,11 +146,13 @@ class Checkout extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$response    = null;
-		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
+		$this->load_cart_session( $request );
 
-		if ( is_wp_error( $nonce_check ) ) {
-			$response = $nonce_check;
+		$response            = null;
+		$validation_callback = $this->validate_callback( $request );
+
+		if ( is_wp_error( $validation_callback ) ) {
+			$response = $validation_callback;
 		}
 
 		if ( ! $response ) {
@@ -219,6 +219,12 @@ class Checkout extends AbstractCartRoute {
 	 * @return true|\WP_Error
 	 */
 	public function validate_callback( $request ) {
+		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
+
+		if ( is_wp_error( $nonce_check ) ) {
+			return $nonce_check;
+		}
+
 		/**
 		 * The request is cloned to avoid modifying the original request object when sanitizing params.
 		 * Un-sanitized params are used to see if required fields had values. Sanitized params are used to

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -219,14 +219,6 @@ class Checkout extends AbstractCartRoute {
 	 * @return true|\WP_Error
 	 */
 	public function validate_callback( $request ) {
-		/**
-		 * The request is cloned to avoid modifying the original request object when sanitizing params.
-		 * Un-sanitized params are used to see if required fields had values. Sanitized params are used to
-		 * validate field values.
-		 */
-		$sanitized_request = clone $request;
-		$sanitized_request->sanitize_params();
-
 		$validate_contexts = [
 			'shipping_address' => [
 				'group'    => 'shipping',
@@ -262,7 +254,7 @@ class Checkout extends AbstractCartRoute {
 			$errors = new \WP_Error();
 
 			if ( Features::is_enabled( 'experimental-blocks' ) ) {
-				$document_object = $this->get_document_object_from_rest_request( $sanitized_request );
+				$document_object = $this->get_document_object_from_rest_request( $request );
 				$document_object->set_context( $context );
 				$additional_fields = $this->additional_fields_controller->get_contextual_fields_for_location( $context_data['location'], $document_object );
 			} else {
@@ -272,9 +264,6 @@ class Checkout extends AbstractCartRoute {
 			// These values are used to see if required fields have values.
 			$field_values = (array) $request->get_param( $context_data['param'] ) ?? [];
 
-			// These values are used to validate custom rules and generate the document object.
-			$sanitized_field_values = (array) $sanitized_request->get_param( $context_data['param'] ) ?? [];
-
 			foreach ( $additional_fields as $field_key => $field ) {
 				// Skip values that were not posted if the request is partial or the field is not required.
 				if ( ! isset( $field_values[ $field_key ] ) && ( $is_partial || true !== $field['required'] ) ) {
@@ -282,8 +271,7 @@ class Checkout extends AbstractCartRoute {
 				}
 
 				// Clean the field value to trim whitespace.
-				$field_value           = wc_clean( wp_unslash( $field_values[ $field_key ] ?? '' ) );
-				$sanitized_field_value = $sanitized_field_values[ $field_key ] ?? '';
+				$field_value = wc_clean( wp_unslash( $field_values[ $field_key ] ?? '' ) );
 
 				if ( empty( $field_value ) ) {
 					if ( true === $field['required'] ) {
@@ -301,7 +289,7 @@ class Checkout extends AbstractCartRoute {
 					continue;
 				}
 
-				$valid_check = $this->additional_fields_controller->validate_field( $field, $sanitized_field_value );
+				$valid_check = $this->additional_fields_controller->validate_field( $field, $field_value );
 
 				if ( is_wp_error( $valid_check ) && $valid_check->has_errors() ) {
 					foreach ( $valid_check->get_error_codes() as $code ) {
@@ -319,7 +307,7 @@ class Checkout extends AbstractCartRoute {
 			}
 
 			// Validate all fields for this location (this runs custom validation callbacks).
-			$valid_location_check = $this->additional_fields_controller->validate_fields_for_location( $sanitized_field_values, $context_data['location'], $context_data['group'] );
+			$valid_location_check = $this->additional_fields_controller->validate_fields_for_location( $field_values, $context_data['location'], $context_data['group'] );
 
 			if ( is_wp_error( $valid_location_check ) && $valid_location_check->has_errors() ) {
 				foreach ( $valid_location_check->get_error_codes() as $code ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -261,7 +261,7 @@ class Checkout extends AbstractCartRoute {
 				$additional_fields = $this->additional_fields_controller->get_fields_for_location( $context_data['location'] );
 			}
 
-			// These values are used to see if required fields have values.
+			// These values are used to validate custom rules and generate the document object.
 			$field_values = (array) $request->get_param( $context_data['param'] ) ?? [];
 
 			foreach ( $additional_fields as $field_key => $field ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -148,11 +148,17 @@ class Checkout extends AbstractCartRoute {
 	public function get_response( \WP_REST_Request $request ) {
 		$this->load_cart_session( $request );
 
-		$response            = null;
-		$validation_callback = $this->validate_callback( $request );
+		$response    = null;
+		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
 
-		if ( is_wp_error( $validation_callback ) ) {
-			$response = $validation_callback;
+		if ( is_wp_error( $nonce_check ) ) {
+			$response = $nonce_check;
+		} else {
+			$validation_callback = $this->validate_callback( $request );
+
+			if ( is_wp_error( $validation_callback ) ) {
+				$response = $validation_callback;
+			}
 		}
 
 		if ( ! $response ) {
@@ -219,12 +225,6 @@ class Checkout extends AbstractCartRoute {
 	 * @return true|\WP_Error
 	 */
 	public function validate_callback( $request ) {
-		$nonce_check = $this->requires_nonce( $request ) ? $this->check_nonce( $request ) : null;
-
-		if ( is_wp_error( $nonce_check ) ) {
-			return $nonce_check;
-		}
-
 		/**
 		 * The request is cloned to avoid modifying the original request object when sanitizing params.
 		 * Un-sanitized params are used to see if required fields had values. Sanitized params are used to

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php
@@ -153,12 +153,6 @@ class Checkout extends AbstractCartRoute {
 
 		if ( is_wp_error( $nonce_check ) ) {
 			$response = $nonce_check;
-		} else {
-			$validation_callback = $this->validate_callback( $request );
-
-			if ( is_wp_error( $validation_callback ) ) {
-				$response = $validation_callback;
-			}
 		}
 
 		if ( ! $response ) {
@@ -366,9 +360,15 @@ class Checkout extends AbstractCartRoute {
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @throws RouteException On error.
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	protected function get_route_update_response( \WP_REST_Request $request ) {
+		$validation_callback = $this->validate_callback( $request );
+
+		if ( is_wp_error( $validation_callback ) ) {
+			return $validation_callback;
+		}
+
 		/**
 		 * Create (or update) Draft Order and process request data.
 		 */
@@ -420,10 +420,16 @@ class Checkout extends AbstractCartRoute {
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 *
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		wc_log_order_step( '[Store API #1] Place Order flow initiated', null, false, true );
+
+		$validation_callback = $this->validate_callback( $request );
+
+		if ( is_wp_error( $validation_callback ) ) {
+			return $validation_callback;
+		}
 
 		/**
 		 * Ensure required permissions based on store settings are valid to place the order.

--- a/plugins/woocommerce/src/StoreApi/StoreApi.php
+++ b/plugins/woocommerce/src/StoreApi/StoreApi.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\StoreApi\Formatters\MoneyFormatter;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
-use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 
 /**
  * StoreApi Main Class.
@@ -39,24 +38,6 @@ final class StoreApi {
 					return;
 				}
 				self::container()->get( Authentication::class )->init();
-
-				try {
-					$cart_controller = new CartController();
-					$cart_controller->load_cart();
-					$cart_controller->normalize_cart();
-				} catch ( \Exception $e ) {
-					return new \WP_Error(
-						'woocommerce_rest_cart_error',
-						$e->getMessage(),
-						array( 'status' => 500 )
-					);
-				} catch ( \Error $e ) {
-					return new \WP_Error(
-						'woocommerce_rest_cart_error',
-						$e->getMessage(),
-						array( 'status' => 500 )
-					);
-				}
 			},
 			11
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reverts the changes in https://github.com/woocommerce/woocommerce/pull/55299/files so that session is loaded when a `WP_Rest_Request` object is available, rather than early during `rest_api_init`.

Because of this change, `validate_callback` under the checkout route needed some modifications so that it runs later still, has access to cart, and handles sanitized data since it no longer has access to the unsanitized values. 

This is to fix an inconsistent bug in WooPay where sometimes the session would not be loaded and cause an email validation error blocking checkout. Its still not 100% certain why this occurred, but this PR is being prepped ready in case we want to fix it this way.

(For Bug Fixes) Bug introduced in PR #55299

### How to test the changes in this Pull Request:

WooPay team confirmed this seems to mitigate their issue, but on the core side:

1. [Install checkout fields tester](https://github.com/woocommerce/additional-checkout-fields-tester)
2. Confirm you can checkout with additional fields present and filled
3. Via Store API, add an item to the cart, then POST to checkout. Check that you get error messages about missing fields in the request for additional fields and gradually populate them to check that errors are accurate. You should end up with a request something like this to cover additional fields:

```
{
	"billing_address": {
		"first_name": "Steve",
		"last_name": "Stevenson",
		"email": "test@test.com",
		"address_1": "41 Some Street",
		"city": "Townford",
		"postcode": "CB25 6FG",
		"country": "GB",
		"plugin-namespace/gov-id": "12345",
		"plugin-namespace/confirm-gov-id": "12345"
	},
	"shipping_address": {
		"first_name": "Steve",
		"last_name": "Stevenson",
		"email": "test@test.com",
		"address_1": "41 Some Street",
		"city": "Townford",
		"postcode": "CB25 6FG",
		"country": "GB",
		"plugin-namespace/gov-id": "12345",
		"plugin-namespace/confirm-gov-id": "12345"
	},
	"payment_method": "bacs",
	"additional_fields": {
		"plugin-namespace/alt-email": "test@test.com",
		"plugin-namespace/job-function": "director"
	}
}
```

The above needs to be checked against a dev build and a production build, since this has some experimental features.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
