### PR TITLE
Set "discover" as default tab for marketplace_search_start Tracks event

### DIFF
--- a/plugins/woocommerce/client/admin/client/marketplace/components/search/search.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/search/search.tsx
@@ -73,7 +73,7 @@ function Search(): JSX.Element {
 	const onFocus = () => {
 		recordEvent( 'marketplace_search_start', {
 			current_search_term: searchTerm,
-			current_tab: query.tab,
+			current_tab: query.tab || 'discover',
 		} );
 	};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The `wcadmin_marketplace_search_start` Tracks event in the marketplace sets the `tab` property as `undefined` for the Discover tab. This is because the Discover tab is the default, and doesn't include a `tab` query param in the URL like other tabs do.

This PR adds `discover` as a default value for the `query.tab` property passed to the Tracks event.
<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WCCOM-968](https://linear.app/a8c/issue/WCCOM-968/fix-undefined-tab-property-in-wcadmin-marketplace-search-start-event)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. 1. Check out this branch
2. Go to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Visit the [in-app marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)
4. Run `localStorage.setItem( 'debug', 'wc-admin:*' );` in the console so tracks events get logged in the console.
5. Make sure you're on the Discover tab, and click inside the Search box top-right. Check the `tab` property on the `wcadmin_marketplace_search_start` event that's recorded
<img width="855" alt="Extensions_‹_WooCommerce_‹_woocommerce" src="https://github.com/user-attachments/assets/4c4509a9-3a11-432b-87df-b85a475c82f7" />
6. Click the Search field while on any other tab, and confirm the event shows the correct tab in each case.
7. Test around this issue



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Adding a default value for a Tracks property on one of the marketplace Tracks events.
</details>
