### PR TITLE
Fix console error when loading a post or page with the Product Description block in it

### DIFF
--- a/plugins/woocommerce/changelog/57164-fix-product-description-block-undefined-error
+++ b/plugins/woocommerce/changelog/57164-fix-product-description-block-undefined-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix JS console error in Product Description block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-description/edit.tsx
@@ -143,7 +143,7 @@ function EditableContent( { context = {} } ) {
 	} );
 
 	if ( ! entityRecord ) {
-		return <Placeholder layoutClassNames={ blockProps } />;
+		return <Placeholder layoutClassNames={ blockProps.className } />;
 	}
 
 	return <div { ...props } />;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-description/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-description/edit.tsx
@@ -93,8 +93,26 @@ function ReadOnlyContent( {
 	);
 }
 
+function Placeholder( { layoutClassNames } ) {
+	const blockProps = useBlockProps( { className: layoutClassNames } );
+	return (
+		<div { ...blockProps }>
+			<p>
+				{ __(
+					'This block displays the product description. When viewing a product page, the description content will automatically appear here.',
+					'woocommerce'
+				) }
+			</p>
+		</div>
+	);
+}
+
 function EditableContent( { context = {} } ) {
 	const { postType, postId } = context;
+
+	const blockProps = useBlockProps( {
+		className: 'product-description__editable-content',
+	} );
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
@@ -117,15 +135,17 @@ function EditableContent( { context = {} } ) {
 
 	const initialInnerBlocks = [ [ 'core/paragraph' ] ];
 
-	const props = useInnerBlocksProps(
-		useBlockProps( { className: 'product-description__editable-content' } ),
-		{
-			value: blocks,
-			onInput,
-			onChange,
-			template: ! hasInnerBlocks ? initialInnerBlocks : undefined,
-		}
-	);
+	const props = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		template: ! hasInnerBlocks ? initialInnerBlocks : undefined,
+	} );
+
+	if ( ! entityRecord ) {
+		return <Placeholder layoutClassNames={ blockProps } />;
+	}
+
 	return <div { ...props } />;
 }
 
@@ -147,20 +167,6 @@ function Content( props ) {
 			postType={ postType }
 			postId={ postId }
 		/>
-	);
-}
-
-function Placeholder( { layoutClassNames } ) {
-	const blockProps = useBlockProps( { className: layoutClassNames } );
-	return (
-		<div { ...blockProps }>
-			<p>
-				{ __(
-					'This block displays the product description. When viewing a product page, the description content will automatically appear here.',
-					'woocommerce'
-				) }
-			</p>
-		</div>
 	);
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a JavaScript error in the console that occurs when loading a page or post with the `Product Description` block in it.
- The issue was happening because the component was trying to use `useInnerBlocksProps` before the `entityRecord` was fully loaded, resulting in an _"Uncaught TypeError: can't access property 'selection', u is undefined"_ error.
- The fix adds a guard clause to check if the `entityRecord` exists before rendering the inner blocks, returning a `Placeholder` component during the initial loading state.

Closes #56915 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

#### Testing in Post:

https://github.com/user-attachments/assets/4bacfe1e-3cec-4c55-b03a-d11f358d9696

#### Testing in Page:

https://github.com/user-attachments/assets/5643c51a-f1de-4c99-aa50-c3ca77a64a5c

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the `WooCommerce Beta Tester` plugin.
2. Go to _Tools > Helper > Features_ and enable `experimental-blocks`.
3. Create any Post or Page.
4. Add the `Single Product` block and insert the `Product Description` block inside (in the second column block for better experience).
5. Save the post.
6. Refresh the page.
7. Notice the error appearing earlier is gone.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
