### PR TITLE
Prevent infinite redirect loop when cart shortcode is present on checkout page

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3832-prevent-endless-redirect-on-checkout-page-when-cart-is-empty
+++ b/plugins/woocommerce/changelog/wooplug-3832-prevent-endless-redirect-on-checkout-page-when-cart-is-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent infinite redirect loop when cart shortcode is present on checkout page with empty cart.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -32,8 +32,11 @@ function wc_template_redirect() {
 
 	// When on the checkout with an empty cart, redirect to cart page.
 	if ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) && ! is_customize_preview() && apply_filters( 'woocommerce_checkout_redirect_empty_cart', true ) ) {
-		wp_safe_redirect( wc_get_cart_url() );
-		exit;
+		// Only redirect if we're not already on the cart page to prevent infinite loops.
+		if ( ! is_cart() ) {
+			wp_safe_redirect( wc_get_cart_url() );
+			exit;
+		}
 	}
 
 	// Logout endpoint under My Account page. Logging out requires a valid nonce.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an infinite redirect loop that occurs when the cart shortcode is present on the checkout page and the cart is empty. Currently, if a merchant adds both the cart and checkout shortcodes on the same page, it can cause an endless redirect when customers try to access the checkout with an empty cart.

The fix adds a check to prevent the redirect if we're already on what WooCommerce considers to be the cart page, preventing the infinite loop while maintaining the expected behavior of redirecting empty carts from checkout to cart in normal scenarios.

Closes #57082.

### How to test the changes in this Pull Request:

1. Create a new page or edit your checkout page
2. Add both the cart and checkout shortcodes to the page:
   ```
   [woocommerce_cart]
   [woocommerce_checkout]
   ```
3. Empty your cart if it has items
4. Visit the checkout page
5. **Expected:** The page should redirect once to the cart page and stay there
6. **Previous behavior:** The page would enter an infinite redirect loop between cart and checkout

Additional test cases:
1. Test normal checkout with items in cart
   - Add an item to cart
   - Visit checkout
   - **Expected:** Checkout should work normally with no redirects

2. Test normal empty cart behavior
   - Empty your cart
   - Visit a regular checkout page (without cart shortcode)
   - **Expected:** Should redirect once to cart page

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
