### PR TITLE
Prevent shipping rates being hidden when fields are disabled in shipping calculator/checkout fields

### DIFF
--- a/plugins/woocommerce/changelog/refactor-show-shipping-usage-54894
+++ b/plugins/woocommerce/changelog/refactor-show-shipping-usage-54894
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Merge legacy cart and block based cart shipping calculation methods to ensure shipping calculations happen only when a full address has been provided.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -54,6 +54,14 @@ class WC_Cart extends WC_Legacy_Cart {
 	protected $shipping_methods;
 
 	/**
+	 * Whether the shipping totals have been calculated. This will only return true if shipping was calculated, not if
+	 * shipping is disabled or if there are no cart contents.
+	 *
+	 * @var bool
+	 */
+	protected $has_calculated_shipping = false;
+
+	/**
 	 * Total defaults used to reset.
 	 *
 	 * @var array
@@ -1399,7 +1407,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Get cart's owner.
 	 *
 	 * @since  3.2.0
-	 * @return WC_Customer
+	 * @return \WC_Customer
 	 */
 	public function get_customer() {
 		return WC()->customer;
@@ -1448,23 +1456,42 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
+	 * Whether the shipping totals have been calculated.
+	 *
+	 * @return bool
+	 */
+	public function has_calculated_shipping() {
+		return $this->has_calculated_shipping;
+	}
+
+	/**
 	 * Uses the shipping class to calculate shipping then gets the totals when its finished.
 	 */
 	public function calculate_shipping() {
-		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) ) : array();
+		// Reset totals.
+		$this->set_shipping_total( 0 );
+		$this->set_shipping_tax( 0 );
+		$this->set_shipping_taxes( array() );
+		$this->shipping_methods        = array();
+		$this->has_calculated_shipping = false;
 
+		if ( ! $this->needs_shipping() || ! $this->show_shipping() ) {
+			return $this->shipping_methods;
+		}
+
+		$this->has_calculated_shipping = true;
+		$this->shipping_methods        = $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) );
+
+		$shipping_costs = wp_list_pluck( $this->shipping_methods, 'cost' );
 		$shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
 		$merged_taxes   = array();
 		foreach ( $shipping_taxes as $taxes ) {
 			foreach ( $taxes as $tax_id => $tax_amount ) {
-				if ( ! isset( $merged_taxes[ $tax_id ] ) ) {
-					$merged_taxes[ $tax_id ] = 0;
-				}
-				$merged_taxes[ $tax_id ] += $tax_amount;
+				$merged_taxes[ $tax_id ] = ( $merged_taxes[ $tax_id ] ?? 0 ) + $tax_amount;
 			}
 		}
 
-		$this->set_shipping_total( array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) ) );
+		$this->set_shipping_total( array_sum( $shipping_costs ) );
 		$this->set_shipping_tax( array_sum( $merged_taxes ) );
 		$this->set_shipping_taxes( $merged_taxes );
 
@@ -1560,6 +1587,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) ) {
 			return false;
 		}
+
 		$needs_shipping = false;
 
 		foreach ( $this->get_cart_contents() as $values ) {
@@ -1582,49 +1610,31 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Sees if the customer has entered enough data to calc the shipping yet.
+	 * Sees if the customer has entered enough data to calculate shipping.
 	 *
 	 * @return bool
 	 */
 	public function show_shipping() {
-		if ( ! wc_shipping_enabled() || ! $this->get_cart_contents() ) {
+		// If there are no shipping methods or no cart contents, no need to calculate shipping.
+		if ( ! wc_shipping_enabled() || 0 === wc_get_shipping_method_count( true ) || ! $this->get_cart_contents() ) {
 			return false;
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
-			$country = $this->get_customer()->get_shipping_country();
-			if ( ! $country ) {
-				return false;
-			}
-			$country_fields = WC()->countries->get_address_fields( $country, 'shipping_' );
-			/**
-			 * Filter to not require shipping state for shipping calculation, even if it is required at checkout.
-			 * This can be used to allow shipping calculations to be done without a state.
-			 *
-			 * @since 8.4.0
-			 *
-			 * @param bool $show_state Whether to use the state field. Default true.
-			 */
-			$state_enabled  = apply_filters( 'woocommerce_shipping_calculator_enable_state', true );
-			$state_required = isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'];
-			if ( $state_enabled && $state_required && ! $this->get_customer()->get_shipping_state() ) {
-				return false;
-			}
-			/**
-			 * Filter to not require shipping postcode for shipping calculation, even if it is required at checkout.
-			 * This can be used to allow shipping calculations to be done without a postcode.
-			 *
-			 * @since 8.4.0
-			 *
-			 * @param bool $show_postcode Whether to use the postcode field. Default true.
-			 */
-			$postcode_enabled  = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true );
-			$postcode_required = isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'];
-			if ( $postcode_enabled && $postcode_required && '' === $this->get_customer()->get_shipping_postcode() ) {
+			$customer = $this->get_customer();
+
+			if ( ! $customer instanceof \WC_Customer || ! $customer->has_full_shipping_address() ) {
 				return false;
 			}
 		}
 
+		/**
+		 * Filter to allow plugins to prevent shipping calculations.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param bool $ready Whether the cart is ready to calculate shipping.
+		 */
 		return apply_filters( 'woocommerce_cart_ready_to_calc_shipping', true );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -957,7 +957,7 @@ class WC_Checkout {
 			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				if ( WC()->countries->country_exists( $shipping_country ) ) {
 					/* translators: %s: shipping location (prefix e.g. 'to' + ISO 3166-1 alpha-2 country code) */
-					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . $shipping_country ) );
+					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix( $shipping_country ) . ' ' . $shipping_country ) );
 				}
 			} else {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartSchema.php
@@ -338,17 +338,11 @@ class CartSchema extends AbstractSchema {
 		// Get cart errors first so if recalculations are performed, it's reflected in the response.
 		$cart_errors = $this->get_cart_errors( $cart );
 
-		// The core cart class will not include shipping in the cart totals if `show_shipping()` returns false. This can
-		// happen if an address is required, or through the use of hooks. This tracks if shipping has actually been
-		// calculated so we can avoid returning costs and rates prematurely.
-		$has_calculated_shipping = $cart->show_shipping();
-
-		$has_local_pickup_methods = LocalPickupUtils::is_local_pickup_enabled() && count( LocalPickupUtils::get_local_pickup_method_ids() ) > 0;
-
 		// Get shipping packages to return in the response from the cart. Always get the shipping packages if local
 		// pickup is enabled and has methods. If the address is required then regular shipping rates will be filtered
 		// out later.
-		$shipping_packages = $has_calculated_shipping || $has_local_pickup_methods ? $controller->get_shipping_packages() : [];
+		$has_local_pickup_methods = LocalPickupUtils::is_local_pickup_enabled() && count( LocalPickupUtils::get_local_pickup_method_ids() ) > 0;
+		$shipping_packages        = $cart->has_calculated_shipping() || $has_local_pickup_methods ? $controller->get_shipping_packages() : [];
 
 		// Get visible cross sells products.
 		$cross_sells = array_filter( array_map( 'wc_get_product', $cart->get_cross_sells() ), 'wc_products_array_filter_visible' );
@@ -363,7 +357,7 @@ class CartSchema extends AbstractSchema {
 			'needs_payment'           => $cart->needs_payment(),
 			'needs_shipping'          => $cart->needs_shipping(),
 			'payment_requirements'    => $this->extend->get_payment_requirements(),
-			'has_calculated_shipping' => $has_calculated_shipping,
+			'has_calculated_shipping' => $cart->has_calculated_shipping(),
 			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
 			'items_count'             => $cart->get_cart_contents_count(),
 			'items_weight'            => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
@@ -381,8 +375,7 @@ class CartSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_totals( $cart ) {
-		$has_calculated_shipping = $cart->show_shipping();
-		$decimals                = wc_get_price_decimals();
+		$decimals = wc_get_price_decimals();
 
 		return [
 			'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), $decimals ),
@@ -391,8 +384,8 @@ class CartSchema extends AbstractSchema {
 			'total_fees_tax'     => $this->prepare_money_response( $cart->get_fee_tax(), $decimals ),
 			'total_discount'     => $this->prepare_money_response( $cart->get_discount_total(), $decimals ),
 			'total_discount_tax' => $this->prepare_money_response( $cart->get_discount_tax(), $decimals ),
-			'total_shipping'     => $has_calculated_shipping ? $this->prepare_money_response( $cart->get_shipping_total(), $decimals ) : null,
-			'total_shipping_tax' => $has_calculated_shipping ? $this->prepare_money_response( $cart->get_shipping_tax(), $decimals ) : null,
+			'total_shipping'     => $cart->has_calculated_shipping() ? $this->prepare_money_response( $cart->get_shipping_total(), $decimals ) : null,
+			'total_shipping_tax' => $cart->has_calculated_shipping() ? $this->prepare_money_response( $cart->get_shipping_tax(), $decimals ) : null,
 			// Explicitly request context='edit'; default ('view') will render total as markup.
 			'total_price'        => $this->prepare_money_response( $cart->get_total( 'edit' ), $decimals ),
 			'total_tax'          => $this->prepare_money_response( $cart->get_total_tax(), $decimals ),

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -4,11 +4,20 @@
  *
  * @package WooCommerce\Tests\Cart.
  */
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 
 /**
  * Class WC_Cart_Test
  */
 class WC_Cart_Test extends \WC_Unit_Test_Case {
+	/**
+	 * Called before every test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$fixtures = new FixtureData();
+		$fixtures->shipping_add_flat_rate();
+	}
 
 	/**
 	 * tearDown.
@@ -219,6 +228,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		// Set address for shipping calculation required for "woocommerce_shipping_cost_requires_address".
 		WC()->cart->get_customer()->set_shipping_country( 'US' );
 		WC()->cart->get_customer()->set_shipping_state( 'NY' );
+		WC()->cart->get_customer()->set_shipping_city( 'New York' );
 		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
@@ -227,6 +237,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product->delete( true );
 		WC()->cart->get_customer()->set_shipping_country( 'GB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( '' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
 
@@ -246,12 +257,14 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		// Country that does not require state.
 		WC()->cart->get_customer()->set_shipping_country( 'LB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
 		// Country that does not require postcode.
 		WC()->cart->get_customer()->set_shipping_country( 'NG' );
 		WC()->cart->get_customer()->set_shipping_state( 'AB' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 		$this->assertTrue( WC()->cart->show_shipping() );
 
@@ -260,6 +273,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$product->delete( true );
 		WC()->cart->get_customer()->set_shipping_country( 'GB' );
 		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_city( 'Test' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -54,7 +54,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_cart_needs_shipping_address',
-			function() {
+			function () {
 				return true;
 			}
 		);
@@ -76,7 +76,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_order_notes() {
 		$data = array(
 			'ship_to_different_address' => false,
-			'order_comments'             => '<a href="http://attackerpage.com/csrf.html">This text should not save inside an anchor.</a><script>alert("alert")</script>',
+			'order_comments'            => '<a href="http://attackerpage.com/csrf.html">This text should not save inside an anchor.</a><script>alert("alert")</script>',
 			'payment_method'            => WC_Gateway_BACS::ID,
 		);
 
@@ -181,28 +181,28 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_validate_checkout_adds_we_dont_ship_error_only_if_country_exists( $country, $expect_we_dont_ship_error ) {
 		add_filter(
 			'woocommerce_countries_allowed_countries',
-			function() {
+			function () {
 				return array( 'ES' );
 			}
 		);
 
 		add_filter(
 			'woocommerce_cart_needs_shipping',
-			function() {
+			function () {
 				return true;
 			}
 		);
 
 		add_filter(
 			'wc_shipping_enabled',
-			function() {
+			function () {
 				return true;
 			}
 		);
 
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'wc_get_shipping_method_count' => function( $include_legacy = false, $enabled_only = false ) {
+				'wc_get_shipping_method_count' => function ( $include_legacy = false, $enabled_only = false ) {
 					return 1;
 				},
 			)
@@ -219,7 +219,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		$this->sut->validate_checkout( $data, $errors );
 
 		$this->assertEquals(
-			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to the JP</strong>. Please enter an alternative shipping address.' : '',
+			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to JP</strong>. Please enter an alternative shipping address.' : '',
 			$errors->get_error_message( 'shipping' )
 		);
 	}
@@ -239,4 +239,3 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		WC()->customer = $orig_customer;
 	}
 }
-

--- a/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Shipping/ShippingControllerTest.php
@@ -41,23 +41,23 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 	public function test_has_full_shipping_address_returns_correctly() {
 		// With GB, state is not required. Test it returns false with only a country, nothing else.
 		WC()->customer->set_shipping_country( 'GB' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		WC()->customer->set_shipping_city( 'Preston' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Now switch to US, ensure that it returns false because state is not input.
 		WC()->customer->set_shipping_country( 'US' );
 		WC()->customer->set_shipping_postcode( '90210' );
 		WC()->customer->set_shipping_city( 'Beverly Hills' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		// Now add state, ensure that it returns true.
 		WC()->customer->set_shipping_state( 'CA' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Now add a filter to set US state to optional, and UK state to required.
 		add_filter(
@@ -76,15 +76,18 @@ class ShippingControllerTest extends \WP_UnitTestCase {
 
 		// Test that US state is now optional.
 		WC()->customer->set_shipping_state( '' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
 
 		// Test that UK state is now required.
 		WC()->customer->set_shipping_country( 'GB' );
 		WC()->customer->set_shipping_postcode( 'PR1 4SS' );
-		$this->assertFalse( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertFalse( WC()->customer->has_full_shipping_address() );
 
 		// Finally test that it passes when an ordinarily optional prop filtered to be required is provided.
 		WC()->customer->set_shipping_state( 'Lancashire' );
-		$this->assertTrue( $this->shipping_controller->has_full_shipping_address() );
+		$this->assertTrue( WC()->customer->has_full_shipping_address() );
+
+		// Remove filter.
+		remove_all_filters( 'woocommerce_get_country_locale' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Prevent shipping rates being hidden when fields are disabled in shipping calculator/checkout fields
- Cherry pick of https://github.com/woocommerce/woocommerce/pull/55804

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/53466


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following snippet to your site:

```php
add_filter( 'woocommerce_shipping_calculator_enable_postcode', '__return_false' );

add_filter( 'woocommerce_checkout_fields', 'remove_postcode_checkout_field' );
function remove_postcode_checkout_field( $fields ) {
    // Remove postcode field from billing address
    if( isset( $fields['billing']['billing_postcode'] ) ) {
        unset( $fields['billing']['billing_postcode'] );
    }
    
    // Remove postcode field from shipping address
    if( isset( $fields['shipping']['shipping_postcode'] ) ) {
        unset( $fields['shipping']['shipping_postcode'] );
    }
    
    return $fields;
}
```
3. Go to WC -> Settings -> Shipping -> Shipping Settings and enable `Enable the shipping calculator on the cart page` and `Hide shipping costs until an address is entered`
4. Set up rates for a specific country, e.g. UK.
5. Add an item to your cart and go to the Shortcode cart.
6. Using the shipping calculator, enter an address for the country added in step 4.
7. Ensure rates show up, and you can select them.
8. Go to the Shortcode checkout and fill in data. Ensure you can select rates and place the order correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

Followed instructions, tests are included in this (and the original) PR too.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
