### PR TITLE
Fix: add the missing closing tag of store notice inside Product Collection

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
+++ b/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing closing tag for notice inside the Product Collection block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -210,11 +210,12 @@ class Renderer {
 						>
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 								<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
-							</svg>	
+							</svg>
 						</button>
 					</div>
 				</template>
 			</div>
+		</div>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds the missing closing tag of store notice region which was accidentally removed in #56117.
 
Closes #57162 .

(For Bug Fixes) Bug introduced in PR #56117 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1381" alt="image" src="https://github.com/user-attachments/assets/14a20221-181a-4446-a0a1-2f8753401297" />      |    <img width="1382" alt="image" src="https://github.com/user-attachments/assets/234b21f3-bd54-4e60-b46c-aa786ad7a994" />   |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Shop page on the frontend.
2. Manually inspect the DOM, see the element of `woocommerce/product-template` doesn't nested inside the store notice wrapper.

<!-- End testing instructions -->
