### PR TITLE
[dev] Update test paths in project-pr-labeler for performance and API tests

### DIFF
--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -79,6 +79,7 @@
 
 'focus: e2e tests':
   - plugins/woocommerce/tests/e2e-pw/**/*
+  - plugins/woocommerce/client/blocks/tests/e2e/**/*
 
 'focus: documentation':
   - docs/**/*

--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -72,9 +72,10 @@
 
 'focus: performance tests':
   - plugins/woocommerce/tests/performance/**/*
+  - plugins/woocommerce/tests/metrics/**/*
 
 'focus: api tests':
-  - plugins/woocommerce/tests/api-core-tests/**/*
+  - plugins/woocommerce/tests/e2e-pw/tests/api-tests/**/*
 
 'focus: e2e tests':
   - plugins/woocommerce/tests/e2e-pw/**/*


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated paths in project-pr-labeler config. The api-core-tests path was not available anymore. Also included the blocks e2e and metrics project paths.

### How to test the changes in this Pull Request:

Check the updated paths. CI passes.
