### PR TITLE
 Fix loading wc admin scripts on unrelated WP admin pages

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3876-woocommerce-loading-clientadmin-scripts-on-unrelated-wp
+++ b/plugins/woocommerce/changelog/wooplug-3876-woocommerce-loading-clientadmin-scripts-on-unrelated-wp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc admin scripts loading on unrelated WP admin pages

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
+use Automattic\WooCommerce\Admin\PageController;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -72,10 +74,16 @@ class WCAdminSharedSettings {
 				}
 			);
 
-			add_action( 'admin_enqueue_scripts', function() {
-				// Enqueue deprecation scripts (client/wp-admin-scripts/wcsettings-deprecation/index.js).
-				WCAdminAssets::register_script( 'wp-admin-scripts', 'wcsettings-deprecation', true );
-			} );
+			add_action(
+				'admin_enqueue_scripts',
+				function () {
+					if ( ! PageController::is_admin_or_embed_page() ) {
+						return;
+					}
+					// Enqueue deprecation scripts (client/wp-admin-scripts/wcsettings-deprecation/index.js).
+					WCAdminAssets::register_script( 'wp-admin-scripts', 'wcsettings-deprecation', true );
+				}
+			);
 		}
 	}
 }


### PR DESCRIPTION
* Fix admin script loading condition in WCAdminSharedSettings

Updated the admin script enqueue logic to check if the current page is an admin or embed page before loading the deprecation scripts. This improves performance by preventing unnecessary script loading on non-relevant pages.

* Add changelog

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Note:** this is already merged to trunk, but the issue also exists in the 9.8 release, see this issue for example: https://github.com/woocommerce/woocommerce/issues/57183

WC 9.8 (PR: https://github.com/woocommerce/woocommerce/pull/55707) introduced a bug where the `settings-deprecation` script is loaded on all admin pages without any condition, so all its dependencies are also loaded.

This PR adds a condition to check if the current page is an admin or embed page before loading deprecation scripts to ensure we only load the script on relevant pages.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to any non WooCommerce page in WordPress (e.g., Settings > General)
2. Check browser's network tab
3. Verify that `/woocommerce/assets/client/admin` scripts not being loaded
4. Go to WooCommerce admin pages
5. Verify that `wcsettings-deprecation.js` is still being loaded correctly
6. Install and activate the **Speed Optimizer** by Siteground plugin
7. Go to **Speed Optimizer > Dashboard**
8. Open your console and make sure there are no JS errors

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
