### PR TITLE
Fix: add the missing closing tag of store notice inside Product Collection block (targeting 9.8)

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
+++ b/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing closing tag for notice inside the Product Collection block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -215,6 +215,7 @@ class Renderer {
 					</div>
 				</template>
 			</div>
+		</div>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/57182.

### How to test the changes in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/57182.