### PR TITLE
Fix: Check if get_current_screen() exists before calling it in PageController

### DIFF
--- a/plugins/woocommerce/changelog/57208-fix-check-get-current-screen-exists-
+++ b/plugins/woocommerce/changelog/57208-fix-check-get-current-screen-exists-
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: This is a bug fix for an edge case that prevents a fatal error but doesn't change any functionality. The fix simply adds a defensive check to ensure proper degradation when a WordPress core function is called too early.
+

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -267,7 +267,13 @@ class PageController {
 			return apply_filters( 'woocommerce_navigation_current_screen_id', false, null );
 		}
 
-		$current_screen = get_current_screen();
+		$current_screen = null;
+		// Check if the current screen is set.
+		// @see: https://github.com/woocommerce/woocommerce/issues/57206
+		if ( function_exists( 'get_current_screen' ) ) {
+			$current_screen = get_current_screen();
+		}
+
 		if ( ! $current_screen ) {
 			// Filter documentation below.
 			return apply_filters( 'woocommerce_navigation_current_screen_id', false, $current_screen );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a PHP Fatal error that occurs when `get_current_screen()` is called in the WooCommerce admin's PageController before the function is available in the WordPress loading sequence.

The current implementation in PageController.php directly calls `get_current_screen()` without checking if the function exists, which can lead to fatal errors when the function is accessed too early in the WordPress loading process:

```
PHP Fatal error: Uncaught Error: Call to undefined function get_current_screen() in .../wp-content/plugins/woocommerce/src/Admin/PageController.php:260
```

This PR adds a simple check to verify the function exists before calling it, preventing the fatal error and allowing the code to gracefully handle this edge case.

Closes #57206.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

- [General Screenshot](https://github.com/user-attachments/assets/8dfb8f88-6877-4b41-9439-57db5b8a229d)
- [Screenshot with xDebug](https://github.com/user-attachments/assets/a4229f21-5fe7-47aa-86bd-b4b11683babc)

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a development environment with WordPress and WooCommerce
2. Create a scenario where the admin page loads before WordPress has fully initialized (this can happen in various contexts, such as when developing custom admin pages or plugins)
3. Without the fix, you'll see a PHP Fatal error related to the undefined `get_current_screen()` function
4. Apply this patch
5. Verify the error no longer appears and WooCommerce admin pages load correctly even when accessed early

### Testing that has already taken place:

I've tested this fix in a local development environment where I was experiencing the fatal error. After implementing the check for `function_exists()`, the error was resolved and the admin pages loaded correctly.

The fix has been tested on:
- WordPress 6.5
- WooCommerce 8.6.1
- PHP 8.2
- Local development environment with Dokan Multivendor plugin

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
This is a bug fix for an edge case that prevents a fatal error but doesn't change any functionality. The fix simply adds a defensive check to ensure proper degradation when a WordPress core function is called too early.
</details>