### PR TITLE
Fix implicitly nullable parameters deprecation warnings in PluginsHelper and CheckoutSchema

### DIFF
--- a/plugins/woocommerce/changelog/57212-wooplug-3887-deprecated
+++ b/plugins/woocommerce/changelog/57212-wooplug-3887-deprecated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix implicitly nullable parameters deprecation warnings in PluginsHelper and CheckoutSchema

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -228,7 +228,7 @@ class PluginsHelper {
 	 *
 	 * @return array
 	 */
-	public static function install_plugins( $plugins, ?PluginsInstallLogger $logger = null, string $source = null ) {
+	public static function install_plugins( $plugins, ?PluginsInstallLogger $logger = null, ?string $source = null ) {
 		/**
 		 * Filter the list of plugins to install.
 		 *
@@ -409,7 +409,7 @@ class PluginsHelper {
 	 *
 	 * @return bool
 	 */
-	public static function install_and_activate_plugins_async_callback( array $plugins, string $job_id, string $source = null ) {
+	public static function install_and_activate_plugins_async_callback( array $plugins, string $job_id, ?string $source = null ) {
 		$option_name = 'woocommerce_onboarding_plugins_install_and_activate_async_' . $job_id;
 		$logger      = new AsyncPluginsInstallLogger( $option_name );
 		self::install_plugins( $plugins, $logger, $source );

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -149,7 +149,7 @@ class WCAdminHelper {
 		$store_pages = apply_filters( 'woocommerce_store_pages', $store_pages );
 
 		foreach ( $store_pages as $page_slug => $page_id ) {
-			if ( is_page( $page_slug ) || ( $page_id > 0 && is_page( $page_id ) ) ) {
+			if ( $page_id > 0 && is_page( $page_id ) ) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -149,7 +149,7 @@ class WCAdminHelper {
 		$store_pages = apply_filters( 'woocommerce_store_pages', $store_pages );
 
 		foreach ( $store_pages as $page_slug => $page_id ) {
-			if ( $page_id > 0 && is_page( $page_id ) ) {
+			if ( is_page( $page_slug ) || ( $page_id > 0 && is_page( $page_id ) ) ) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -225,7 +225,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @param \WC_Cart|null      $cart           Cart object.
 	 * @return array
 	 */
-	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null, \WC_Cart $cart = null ) {
+	protected function get_checkout_response( \WC_Order $order, ?PaymentResult $payment_result = null, ?\WC_Cart $cart = null ) {
 		$payment_result = $payment_result ? [
 			'payment_status'  => $payment_result->status,
 			'payment_details' => $this->prepare_payment_details_for_response( $payment_result->payment_details ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-3887 WOOPLUG-3776

Related to wooplug-2650-php-84-compatibility

Beginning with PHP 8.4, implicitly nullable parameters in function signatures (such as `function f( int $x = null )`) [will trigger a deprecation notice](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Those parameters now have to be explicitly made nullable (i.e. ` function f( ?int $x = null )`).

This PR makes the relevant code changes related to the PluginsHelper and CheckoutSchema  functionality to reduce the amount of noise when running under this PHP version.

In particular, it fixes deprecation notices such as the following:

```
Deprecated: Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema::get_checkout_response(): Implicitly marking parameter $payment_result as nullable is deprecated, the explicit nullable type must be used instead in /Users/th22/test/woogallery-pro/wp-content/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php on line 228

Deprecated: Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema::get_checkout_response(): Implicitly marking parameter $cart as nullable is deprecated, the explicit nullable type must be used instead in /Users/th22/test/woogallery-pro/wp-content/plugins/woocommerce/src/StoreApi/Schemas/V1/CheckoutSchema.php on line 228

Deprecated: Automattic\WooCommerce\Admin\PluginsHelper::install_plugins(): Implicitly marking parameter $source as nullable is deprecated, the explicit nullable type must be used instead in /Users/th22/test/woogallery-pro/wp-content/plugins/woocommerce/src/Admin/PluginsHelper.php on line 231

Deprecated: Automattic\WooCommerce\Admin\PluginsHelper::install_and_activate_plugins_async_callback(): Implicitly marking parameter $source as nullable is deprecated, the explicit nullable type must be used instead in /Users/th22/test/woogallery-pro/wp-content/plugins/woocommerce/src/Admin/PluginsHelper.php on line 412
```

**Note:** The changes are mostly mechanical in nature, so for reviewing is probably enough to just make sure that things look ok and run some smoke tests comparing the output between trunk and this branch.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your test environment is running PHP 8.4+, has error logging enabled and that the error reporting level includes deprecation warnings. If opcache is in use, temporarily disable it. A PHP snippet such as the following could work:
   ```php
   <?php
   @error_reporting( -1 );
   @ini_set( 'opcache.enable', false );
   ```
2. Run some smoke tests and make sure that deprecation warnings (see description above for examples) related to ` PluginsHelper` and `CheckoutSchema`
   Optionally, compare the logged errors to those when running on the `trunk` branch, which doesn't have the fixes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix implicitly nullable parameters deprecation warnings in PluginsHelper and CheckoutSchema

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
