### PR TITLE
Fix coming soon breaks other page

### DIFF
--- a/plugins/woocommerce/changelog/fix-coming-soon-breaks-other-page
+++ b/plugins/woocommerce/changelog/fix-coming-soon-breaks-other-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coming soon breaks other page

--- a/plugins/woocommerce/src/Admin/WCAdminHelper.php
+++ b/plugins/woocommerce/src/Admin/WCAdminHelper.php
@@ -149,7 +149,7 @@ class WCAdminHelper {
 		$store_pages = apply_filters( 'woocommerce_store_pages', $store_pages );
 
 		foreach ( $store_pages as $page_slug => $page_id ) {
-			if ( is_page( $page_slug ) || ( $page_id > 0 && is_page( $page_id ) ) ) {
+			if ( $page_id > 0 && is_page( $page_id ) ) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -402,6 +402,44 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test is_current_page_store_page when checkout page is set to a non-default page.
+	 */
+	public function test_is_current_page_store_page_when_checkout_page_is_set_to_non_default_page() {
+		$default_checkout_page_id = wc_get_page_id( 'checkout' );
+
+		// create a new checkout page with slug "shop-checkout".
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Shop Checkout',
+				'post_name'   => 'shop-checkout',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			)
+		);
+
+		// update the checkout page to the new page.
+		update_option( 'woocommerce_checkout_page_id', $page_id );
+
+		global $wp_rewrite;
+		$wp_rewrite->init();
+		$wp_rewrite->flush_rules( true );
+
+		// go to the new checkout page.
+		$this->go_to( get_permalink( $page_id ) );
+
+		// Test that the new checkout page is a store page.
+		$is_store_page = WCAdminHelper::is_current_page_store_page();
+		$this->assertTrue( $is_store_page, 'Failed to identify new checkout page as store page ' . get_permalink( $page_id ) );
+
+		// go to the default checkout page.
+		$this->go_to( get_permalink( $default_checkout_page_id ) );
+
+		// Test that the default checkout page is not a store page.
+		$is_store_page = WCAdminHelper::is_current_page_store_page();
+		$this->assertFalse( $is_store_page, 'Failed to identify default checkout page as store page ' . get_permalink( $default_checkout_page_id ) );
+	}
+
+	/**
 	 * Copied and modified from https://github.com/WordPress/wordpress-develop/blob/126e3bcc2b41c06c92f95d1796c2766bfbb19f86/tests/phpunit/includes/abstract-testcase.php#L1212.
 	 *
 	 * Sets the global state to as if a given URL has been requested.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

https://wordpress.org/support/topic/coming-soon-apply-to-store-pages-only-breaks-other-checkout-page/


We improved the coming soon matching logic for store pages in https://github.com/woocommerce/woocommerce/pull/54906 to fix the issue. It has covered most of the cases, but there is still a edge case that are not covered: When the checkout page is set to a non-default page.

The issue is because we're using `page_slug` to match the coming soon page, but when the checkout page is set to a non-default page, the `page_slug` to match the coming soon page is not correct.

This PR fixes the issue by removing the slug check and only use the page ID to match the coming soon page which is more reliable. I also added a test to cover this case. 

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/54906


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable coming soon mode `/wp-admin/admin.php?page=wc-settings&tab=site-visibility` and turn on `Apply to store pages only`
2. Create a new page
3. Set the checkout page to the new page `/wp-admin/admin.php?page=wc-settings&tab=advanced`
4. Open an incognito window and go to the new checkout page in the frontend 
5. You should see the coming soon page
6. Go to the default checkout page in the frontend
7. You should see the checkout page (not the coming soon page)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
