### PR TITLE
Update Blueprint package configuration and fix lint errors

### DIFF
--- a/packages/php/blueprint/changelog/dev-fix-blueprint-package-setup
+++ b/packages/php/blueprint/changelog/dev-fix-blueprint-package-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update Blueprint package configuration and fix lint errors

--- a/packages/php/blueprint/composer.json
+++ b/packages/php/blueprint/composer.json
@@ -23,6 +23,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "^9",
 		"mockery/mockery": "^1.6",
+		"automattic/jetpack-changelogger": "3.3.0",
 		"woocommerce/woocommerce-sniffs": "^1.0.0",
 		"yoast/phpunit-polyfills": "^2.0"
 	},

--- a/packages/php/blueprint/composer.json
+++ b/packages/php/blueprint/composer.json
@@ -1,28 +1,51 @@
 {
-  "name": "woocommerce/blueprint",
-  "version": "0.0.1",
-  "autoload": {
-	"psr-4": {
-	  "Automattic\\WooCommerce\\Blueprint\\": "src/",
-	  "Automattic\\WooCommerce\\Blueprint\\Tests\\": "tests/"
+	"name": "woocommerce/blueprint",
+	"version": "0.0.1",
+	"autoload": {
+		"psr-4": {
+			"Automattic\\WooCommerce\\Blueprint\\": "src/",
+			"Automattic\\WooCommerce\\Blueprint\\Tests\\": "tests/"
+		}
+	},
+	"require": {
+		"opis/json-schema": "^2.3"
+	},
+	"scripts": {
+		"test:setup": "wp-env start",
+		"test:unit": "wp-env run tests-cli --env-cwd=wp-content/plugins/blueprint ./vendor/bin/phpunit",
+		"phpcs": [
+			"phpcs -s -p"
+		],
+		"phpcbf": [
+			"phpcbf -p"
+		]
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9",
+		"mockery/mockery": "^1.6",
+		"woocommerce/woocommerce-sniffs": "^1.0.0",
+		"yoast/phpunit-polyfills": "^2.0"
+	},
+	"extra": {
+		"changelogger": {
+			"formatter": {
+				"filename": "../../../tools/changelogger/class-legacy-core-formatter.php"
+			},
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
+			"changelog": "changelog.md"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
-  },
-  "require": {
-	"opis/json-schema": "^2.3"
-  },
-  "scripts": {
-	"test:setup": "wp-env start",
-	"test:unit": "wp-env run tests-cli --env-cwd=wp-content/plugins/blueprint ./vendor/bin/phpunit",
-	"phpcs": [
-	  "phpcs -s -p"
-	],
-	"phpcbf": [
-	  "phpcbf -p"
-	]
-  },
-  "require-dev": {
-	"phpunit/phpunit": "^9",
-	"mockery/mockery": "^1.6",
-    "yoast/phpunit-polyfills": "^2.0"
-  }
 }

--- a/packages/php/blueprint/composer.lock
+++ b/packages/php/blueprint/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8aec61b8a7054256cc04ad7db7e534b",
+    "content-hash": "e922737c04ac35a74849627f2c7c7449",
     "packages": [
         {
             "name": "opis/json-schema",
@@ -198,6 +198,63 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-changelogger.git",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-changelogger/zipball/8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "symfony/console": "^3.4 || ^5.2 || ^6.0",
+                "symfony/process": "^3.4 || ^5.2 || ^6.0",
+                "wikimedia/at-ease": "^1.2 || ^2.0"
+            },
+            "require-dev": {
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "branch-alias": {
+                    "dev-trunk": "3.3.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelog\\": "lib",
+                    "Automattic\\Jetpack\\Changelogger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-changelogger/tree/v3.3.0"
+            },
+            "time": "2022-12-26T13:49:01+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v1.0.0",
@@ -1509,6 +1566,54 @@
             "time": "2024-12-05T13:48:26+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "1.0.2",
             "source": {
@@ -2556,6 +2661,877 @@
             "time": "2025-04-13T04:10:18+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T11:30:55+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5d1662fb32ebc94f17ddb8d635454a776066733d",
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T11:36:42+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/136ca7d72f72b599f2631aca474a4f8e26719799",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-10T20:33:58+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -2604,6 +3580,61 @@
                 }
             ],
             "time": "2024-03-03T12:36:25+00:00"
+        },
+        {
+            "name": "wikimedia/at-ease",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/at-ease.git",
+                "reference": "e8ebaa7bb7c8a8395481a05f6dc4deaceab11c33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/at-ease/zipball/e8ebaa7bb7c8a8395481a05f6dc4deaceab11c33",
+                "reference": "e8ebaa7bb7c8a8395481a05f6dc4deaceab11c33",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.9"
+            },
+            "require-dev": {
+                "mediawiki/mediawiki-codesniffer": "35.0.0",
+                "mediawiki/minus-x": "1.1.1",
+                "ockcyp/covers-validator": "1.3.3",
+                "php-parallel-lint/php-console-highlighter": "0.5.0",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Wikimedia/Functions.php"
+                ],
+                "psr-4": {
+                    "Wikimedia\\AtEase\\": "src/Wikimedia/AtEase/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Starling",
+                    "email": "tstarling@wikimedia.org"
+                },
+                {
+                    "name": "MediaWiki developers",
+                    "email": "wikitech-l@lists.wikimedia.org"
+                }
+            ],
+            "description": "Safe replacement to @ for suppressing warnings.",
+            "homepage": "https://www.mediawiki.org/wiki/at-ease",
+            "support": {
+                "source": "https://github.com/wikimedia/at-ease/tree/v2.1.0"
+            },
+            "time": "2021-02-27T15:53:37+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",

--- a/packages/php/blueprint/composer.lock
+++ b/packages/php/blueprint/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8313e089fce5e7097787c46af729fe1e",
+    "content-hash": "e8aec61b8a7054256cc04ad7db7e534b",
     "packages": [
         {
             "name": "opis/json-schema",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/json-schema.git",
-                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb"
+                "reference": "712827751c62b465daae6e725bf0cf5ffbf965e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/json-schema/zipball/c48df6d7089a45f01e1c82432348f2d5976f9bfb",
-                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/712827751c62b465daae6e725bf0cf5ffbf965e1",
+                "reference": "712827751c62b465daae6e725bf0cf5ffbf965e1",
                 "shasum": ""
             },
             "require": {
@@ -67,22 +67,22 @@
             ],
             "support": {
                 "issues": "https://github.com/opis/json-schema/issues",
-                "source": "https://github.com/opis/json-schema/tree/2.3.0"
+                "source": "https://github.com/opis/json-schema/tree/2.4.1"
             },
-            "time": "2022-01-08T20:38:03+00:00"
+            "time": "2024-12-30T20:20:21+00:00"
         },
         {
             "name": "opis/string",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/string.git",
-                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7"
+                "reference": "ba0b9607b9809462b0e28a11e4881a8d77431feb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/string/zipball/9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
-                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
+                "url": "https://api.github.com/repos/opis/string/zipball/ba0b9607b9809462b0e28a11e4881a8d77431feb",
+                "reference": "ba0b9607b9809462b0e28a11e4881a8d77431feb",
                 "shasum": ""
             },
             "require": {
@@ -129,9 +129,9 @@
             ],
             "support": {
                 "issues": "https://github.com/opis/string/issues",
-                "source": "https://github.com/opis/string/tree/2.0.1"
+                "source": "https://github.com/opis/string/tree/2.0.2"
             },
-            "time": "2022-01-14T15:42:23+00:00"
+            "time": "2024-12-30T21:43:22+00:00"
         },
         {
             "name": "opis/uri",
@@ -198,6 +198,84 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
@@ -404,16 +482,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -452,7 +530,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -460,20 +538,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.1.0",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -516,9 +594,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-07-01T20:03:41+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -639,36 +717,406 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "80ccb1a7640995edf1b87a4409fa584cd5869469"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/80ccb1a7640995edf1b87a4409fa584cd5869469",
+                "reference": "80ccb1a7640995edf1b87a4409fa584cd5869469",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-01-16T22:34:19+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-20T13:34:27+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -677,7 +1125,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -706,7 +1154,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -714,7 +1162,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -959,45 +1407,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.1",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -1042,7 +1490,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
             },
             "funding": [
                 {
@@ -1058,7 +1506,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-12-05T13:48:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2024,6 +2472,90 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-04-13T04:10:18+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -2074,17 +2606,122 @@
             "time": "2024-03-03T12:36:25+00:00"
         },
         {
-            "name": "yoast/phpunit-polyfills",
-            "version": "2.0.1",
+            "name": "woocommerce/woocommerce-sniffs",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "4a088f125c970d6d6ea52c927f96fe39b330d0f1"
+                "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
+                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/4a088f125c970d6d6ea52c927f96fe39b330d0f1",
-                "reference": "4a088f125c970d6d6ea52c927f96fe39b330d0f1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "php": ">=7.0",
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "wp-coding-standards/wpcs": "^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce sniffs",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/1.0.0"
+            },
+            "time": "2023-09-29T13:52:33+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.10",
+                "squizlabs/php_codesniffer": "^3.9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-03-25T16:39:00+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "a0e3e9adecaa352697786cb29bb0f2fcc25f43f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/a0e3e9adecaa352697786cb29bb0f2fcc25f43f5",
+                "reference": "a0e3e9adecaa352697786cb29bb0f2fcc25f43f5",
                 "shasum": ""
             },
             "require": {
@@ -2099,7 +2736,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -2134,15 +2771,15 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-04-05T16:36:44+00:00"
+            "time": "2025-02-09T18:25:29+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/packages/php/blueprint/package.json
+++ b/packages/php/blueprint/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@woocommerce/blueprint",
+	"description": "WooCommerce Blueprint package",
+	"scripts": {
+		"changelog": "XDEBUG_MODE=off composer install --quiet && composer exec -- changelogger",
+		"lint": "pnpm --if-present '/^lint:lang:.*$/'",
+		"lint:fix": "pnpm --if-present '/^lint:fix:lang:.*$/'",
+		"lint:fix:lang:php": "composer run-script phpcbf",
+		"lint:lang:php": "composer run-script phpcs",
+		"postinstall": "XDEBUG_MODE=off composer install --quiet",
+		"env:test": "pnpm env:dev",
+		"env:dev": "pnpm wp-env start --update",
+		"test:unit": "composer run-script test:unit",
+		"test:php:ci": "pnpm test:unit"
+	},
+	"license": "GPL-3.0-or-later",
+	"dependencies": {},
+	"devDependencies": {
+		"@wordpress/env": "10.17.0"
+	},
+	"config": {
+		"ci": {
+			"lint": {
+				"command": "lint",
+				"changes": [
+					"src/**/*.php"
+				]
+			},
+			"tests": [
+				{
+					"name": "PHP: 8.1 WP: latest",
+					"testType": "unit:php",
+					"command": "test:php:ci",
+					"changes": [
+						"composer.json",
+						"composer.lock",
+						"**/*.php",
+						"phpunit.xml"
+					],
+					"testEnv": {
+						"start": "env:test",
+						"config": {
+							"phpVersion": "8.1",
+							"wpVersion": "latest"
+						}
+					},
+					"events": [
+						"pull_request",
+						"push"
+					]
+				}
+			]
+		}
+	}
+}

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -15,7 +15,8 @@ use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
  * @package Automattic\WooCommerce\Blueprint
  */
 class ExportSchema {
-	use UseWPFunctions, UsePubSub;
+	use UseWPFunctions;
+	use UsePubSub;
 
 	/**
 	 * Step exporters.
@@ -89,7 +90,7 @@ class ExportSchema {
 		 * @var StepExporter $exporter
 		 */
 		foreach ( $exporters as $exporter ) {
-			$this->publish('onBeforeExport', $exporter);
+			$this->publish( 'onBeforeExport', $exporter );
 			$step = $exporter->export();
 			if ( is_array( $step ) ) {
 				foreach ( $step as $_step ) {
@@ -103,11 +104,14 @@ class ExportSchema {
 		return $schema;
 	}
 
-	public function onBeforeExport($step_name, $callback) {
-		$this->subscribe('onBeforeExport', function($exporter) use ($step_name, $callback) {
-			if ($step_name === $exporter->get_step_name()) {
-				$callback( $exporter );
+	public function onBeforeExport( $step_name, $callback ) {
+		$this->subscribe(
+			'onBeforeExport',
+			function ( $exporter ) use ( $step_name, $callback ) {
+				if ( $step_name === $exporter->get_step_name() ) {
+					$callback( $exporter );
+				}
 			}
-		});
+		);
 	}
 }

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -104,7 +104,13 @@ class ExportSchema {
 		return $schema;
 	}
 
-	public function onBeforeExport( $step_name, $callback ) {
+	/**
+	 * Subscribe to the onBeforeExport event.
+	 *
+	 * @param string   $step_name The step name to subscribe to.
+	 * @param callable $callback  The callback to execute.
+	 */
+	public function on_before_export( $step_name, $callback ) {
 		$this->subscribe(
 			'onBeforeExport',
 			function ( $exporter ) use ( $step_name, $callback ) {

--- a/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
@@ -108,7 +108,7 @@ class ExportInstallPluginSteps implements StepExporter {
 	 *
 	 * @return array
 	 */
-	protected function sort_plugins_by_dep( array $plugins ) {
+	public function sort_plugins_by_dep( array $plugins ) {
 		$sorted  = array();
 		$visited = array();
 

--- a/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
@@ -13,7 +13,11 @@ use Automattic\WooCommerce\Blueprint\UseWPFunctions;
 class ExportInstallPluginSteps implements StepExporter {
 	use UseWPFunctions;
 
-
+	/**
+	 * Filter callback.
+	 *
+	 * @var callable
+	 */
 	private $filter_callback;
 
 	/**
@@ -35,7 +39,7 @@ class ExportInstallPluginSteps implements StepExporter {
 	/**
 	 * Register a filter callback to filter the plugins to export.
 	 *
-	 * @param callable $callback
+	 * @param callable $callback Filter callback.
 	 *
 	 * @return void
 	 */
@@ -100,15 +104,16 @@ class ExportInstallPluginSteps implements StepExporter {
 	/**
 	 * Sort plugins by dependencies -- put the dependencies at the top.
 	 *
-	 * @param array $plugins a list of plugins to sort (from wp_get_plugins function)
+	 * @param array $plugins List of plugins to sort (from wp_get_plugins function).
+	 *
 	 * @return array
 	 */
-	function sort_plugins_by_dep( array $plugins ) {
+	protected function sort_plugins_by_dep( array $plugins ) {
 		$sorted  = array();
 		$visited = array();
 
-		// Create a mapping of lowercase titles to plugin keys for quick lookups
-		$titleMap = array_reduce(
+		// Create a mapping of lowercase titles to plugin keys for quick lookups.
+		$title_map = array_reduce(
 			array_keys( $plugins ),
 			function ( $carry, $key ) use ( $plugins ) {
 				$title = strtolower( $plugins[ $key ]['Title'] ?? '' );
@@ -120,26 +125,26 @@ class ExportInstallPluginSteps implements StepExporter {
 			array()
 		);
 
-		// Recursive function for topological sort
-		$visit = function ( $pluginKey ) use ( &$visit, &$sorted, &$visited, $plugins, $titleMap ) {
-			if ( isset( $visited[ $pluginKey ] ) ) {
+		// Recursive function for topological sort.
+		$visit = function ( $plugin_key ) use ( &$visit, &$sorted, &$visited, $plugins, $title_map ) {
+			if ( isset( $visited[ $plugin_key ] ) ) {
 				return;
 			}
-			$visited[ $pluginKey ] = true;
+			$visited[ $plugin_key ] = true;
 
-			$requires = $plugins[ $pluginKey ]['RequiresPlugins'] ?? array();
+			$requires = $plugins[ $plugin_key ]['RequiresPlugins'] ?? array();
 			foreach ( (array) $requires as $dependency ) {
-				$dependencyKey = $titleMap[ strtolower( $dependency ) ] ?? null;
-				if ( $dependencyKey ) {
-					$visit( $dependencyKey );
+				$dependency_key = $title_map[ strtolower( $dependency ) ] ?? null;
+				if ( $dependency_key ) {
+					$visit( $dependency_key );
 				}
 			}
-			$sorted[ $pluginKey ] = $plugins[ $pluginKey ];
+			$sorted[ $plugin_key ] = $plugins[ $plugin_key ];
 		};
 
-		// Perform sort for each plugin
-		foreach ( array_keys( $plugins ) as $pluginKey ) {
-			$visit( $pluginKey );
+		// Perform sort for each plugin.
+		foreach ( array_keys( $plugins ) as $plugin_key ) {
+			$visit( $plugin_key );
 		}
 
 		return $sorted;

--- a/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
@@ -23,7 +23,7 @@ class ExportInstallThemeSteps implements StepExporter {
 	 *
 	 * @return void
 	 */
-	public function filter(callable $callback) {
+	public function filter( callable $callback ) {
 		$this->filter_callback = $callback;
 	}
 	/**
@@ -32,8 +32,8 @@ class ExportInstallThemeSteps implements StepExporter {
 	 * @return array
 	 */
 	public function export() {
-		$steps        = array();
-		$themes       = $this->wp_get_themes();
+		$steps  = array();
+		$themes = $this->wp_get_themes();
 		if ( is_callable( $this->filter_callback ) ) {
 			$themes = call_user_func( $this->filter_callback, $themes );
 		}

--- a/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
@@ -15,11 +15,17 @@ use Automattic\WooCommerce\Blueprint\UseWPFunctions;
 class ExportInstallThemeSteps implements StepExporter {
 	use UseWPFunctions;
 
+	/**
+	 * Filter callback.
+	 *
+	 * @var callable
+	 */
 	private $filter_callback;
+
 	/**
 	 * Register a filter callback to filter the plugins to export.
 	 *
-	 * @param callable $callback
+	 * @param callable $callback Filter callback.
 	 *
 	 * @return void
 	 */

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -110,7 +110,7 @@ class ImportStep {
 	protected function validate_step_schemas( StepProcessor $importer, StepProcessorResult $result ) {
 		$step_schema = call_user_func( array( $importer->get_step_class(), 'get_schema' ) );
 
-		$validate = $this->validator->validate( $this->step_definition, json_encode( $step_schema ) );
+		$validate = $this->validator->validate( $this->step_definition, wp_json_encode( $step_schema ) );
 
 		if ( ! $validate->isValid() ) {
 			$result->add_error( "Schema validation failed for step {$this->step_definition->step}" );

--- a/packages/php/blueprint/src/Importers/ImportActivatePlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportActivatePlugin.php
@@ -26,7 +26,7 @@ class ImportActivatePlugin implements StepProcessor {
 		// phpcs:ignore
 		$plugin_path = $schema->pluginPath;
 
-		$activate = $this->wp_activate_plugin($plugin_path);
+		$activate = $this->wp_activate_plugin( $plugin_path );
 
 		if ( $this->is_wp_error( $activate ) ) {
 			$result->add_error( "Unable to activate {$plugin_path}." );

--- a/packages/php/blueprint/src/Importers/ImportInstallTheme.php
+++ b/packages/php/blueprint/src/Importers/ImportInstallTheme.php
@@ -55,8 +55,8 @@ class ImportInstallTheme implements StepProcessor {
 		// phpcs:ignore
 		$theme = $schema->themeData;
 
-		if (  'wordpress.org/themes' !== $theme->resource ) {
-			$this->result->add_info("Skipped installing a theme. Unsupported resource type. Only 'wordpress.org/themes' is supported at the moment.");
+		if ( 'wordpress.org/themes' !== $theme->resource ) {
+			$this->result->add_info( "Skipped installing a theme. Unsupported resource type. Only 'wordpress.org/themes' is supported at the moment." );
 			return $this->result;
 		}
 

--- a/packages/php/blueprint/src/Importers/ImportRunSql.php
+++ b/packages/php/blueprint/src/Importers/ImportRunSql.php
@@ -30,7 +30,8 @@ class ImportRunSql implements StepProcessor {
 		global $wpdb;
 		$result = StepProcessorResult::success( RunSql::get_step_name() );
 
-		$wpdb->query( $schema->sql->contents );
+		// Security check: Check if we can use prepared statements.
+		$wpdb->query( $schema->sql->contents ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		if ( $wpdb->last_error ) {
 			$result->add_error( "Error executing SQL: {$wpdb->last_error}" );
 		} else {

--- a/packages/php/blueprint/src/Importers/ImportRunSql.php
+++ b/packages/php/blueprint/src/Importers/ImportRunSql.php
@@ -31,7 +31,7 @@ class ImportRunSql implements StepProcessor {
 		$result = StepProcessorResult::success( RunSql::get_step_name() );
 
 		$wpdb->query( $schema->sql->contents );
-		if ($wpdb->last_error) {
+		if ( $wpdb->last_error ) {
 			$result->add_error( "Error executing SQL: {$wpdb->last_error}" );
 		} else {
 			$result->add_debug( "Executed SQL ({$schema->sql->name}): {$schema->sql->contents}" );

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -27,7 +27,7 @@ class ImportSetSiteOptions implements StepProcessor {
 	public function process( $schema ): StepProcessorResult {
 		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
 		foreach ( $schema->options as $key => $value ) {
-			$value = json_decode( json_encode( $value ), true );
+			$value   = json_decode( json_encode( $value ), true );
 			$updated = $this->wp_update_option( $key, $value );
 
 			if ( $updated ) {

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -27,7 +27,7 @@ class ImportSetSiteOptions implements StepProcessor {
 	public function process( $schema ): StepProcessorResult {
 		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
 		foreach ( $schema->options as $key => $value ) {
-			$value   = json_decode( json_encode( $value ), true );
+			$value   = json_decode( wp_json_encode( $value ), true );
 			$updated = $this->wp_update_option( $key, $value );
 
 			if ( $updated ) {

--- a/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
+++ b/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
@@ -31,6 +31,8 @@ class CliResultFormatter {
 	 * @param string $message_type The message type to format.
 	 *
 	 * @return void
+	 *
+	 * @throws \Exception If WP CLI Utils is not found.
 	 */
 	public function format( $message_type = 'debug' ) {
 		$header = array( 'Step Processor', 'Type', 'Message' );

--- a/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
+++ b/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
@@ -47,7 +47,7 @@ class CliResultFormatter {
 			}
 		}
 
-		$format_items_exist = function_exists('format_items');
+		$format_items_exist = function_exists( 'format_items' );
 
 		if ( $format_items_exist ) {
 			format_items( 'table', $items, $header );

--- a/packages/php/blueprint/src/Steps/ActivatePlugin.php
+++ b/packages/php/blueprint/src/Steps/ActivatePlugin.php
@@ -17,6 +17,7 @@ class ActivatePlugin extends Step {
 
 	/**
 	 * The path to the plugin file relative to the plugins directory.
+	 *
 	 * @var string  The path to the plugin file relative to the plugins directory.
 	 */
 	private string $plugin_path;

--- a/packages/php/blueprint/src/Steps/ActivateTheme.php
+++ b/packages/php/blueprint/src/Steps/ActivateTheme.php
@@ -18,7 +18,7 @@ class ActivateTheme extends Step {
 	/**
 	 * ActivateTheme constructor.
 	 *
-	 * @param string $theme_name The name of the theme to be activated.
+	 * @param string $theme_folder_name The name of the theme to be activated.
 	 */
 	public function __construct( $theme_folder_name ) {
 		$this->theme_folder_name = $theme_folder_name;

--- a/packages/php/blueprint/src/Steps/ActivateTheme.php
+++ b/packages/php/blueprint/src/Steps/ActivateTheme.php
@@ -43,7 +43,7 @@ class ActivateTheme extends Step {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'      => array(
+				'step'            => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
@@ -62,7 +62,7 @@ class ActivateTheme extends Step {
 	 */
 	public function prepare_json_array(): array {
 		return array(
-			'step'      => static::get_step_name(),
+			'step'            => static::get_step_name(),
 			'themeFolderName' => $this->theme_folder_name,
 		);
 	}

--- a/packages/php/blueprint/src/Steps/InstallPlugin.php
+++ b/packages/php/blueprint/src/Steps/InstallPlugin.php
@@ -54,12 +54,12 @@ class InstallPlugin extends Step {
 	 */
 	public function prepare_json_array(): array {
 		return array(
-			'step'          => static::get_step_name(),
+			'step'       => static::get_step_name(),
 			'pluginData' => array(
 				'resource' => $this->resource,
 				'slug'     => $this->slug,
 			),
-			'options'       => $this->options,
+			'options'    => $this->options,
 		);
 	}
 
@@ -73,22 +73,22 @@ class InstallPlugin extends Step {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'          => array(
+				'step'       => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
 				'pluginData' => array(
-					"anyOf" => [
-						require __DIR__ . "/schemas/definitions/VFSReference.php",
-						require __DIR__ . "/schemas/definitions/LiteralReference.php",
-						require __DIR__ . "/schemas/definitions/CorePluginReference.php",
-						require __DIR__ . "/schemas/definitions/CoreThemeReference.php",
-						require __DIR__ . "/schemas/definitions/UrlReference.php",
-						require __DIR__ . "/schemas/definitions/GitDirectoryReference.php",
-						require __DIR__ . "/schemas/definitions/DirectoryLiteralReference.php",
-					]
+					'anyOf' => array(
+						require __DIR__ . '/schemas/definitions/VFSReference.php',
+						require __DIR__ . '/schemas/definitions/LiteralReference.php',
+						require __DIR__ . '/schemas/definitions/CorePluginReference.php',
+						require __DIR__ . '/schemas/definitions/CoreThemeReference.php',
+						require __DIR__ . '/schemas/definitions/UrlReference.php',
+						require __DIR__ . '/schemas/definitions/GitDirectoryReference.php',
+						require __DIR__ . '/schemas/definitions/DirectoryLiteralReference.php',
+					),
 				),
-				'options'       => array(
+				'options'    => array(
 					'type'       => 'object',
 					'properties' => array(
 						'activate' => array(

--- a/packages/php/blueprint/src/Steps/InstallTheme.php
+++ b/packages/php/blueprint/src/Steps/InstallTheme.php
@@ -54,12 +54,12 @@ class InstallTheme extends Step {
 	 */
 	public function prepare_json_array(): array {
 		return array(
-			'step'         => static::get_step_name(),
+			'step'      => static::get_step_name(),
 			'themeData' => array(
 				'resource' => $this->resource,
 				'slug'     => $this->slug,
 			),
-			'options'      => $this->options,
+			'options'   => $this->options,
 		);
 	}
 
@@ -73,22 +73,22 @@ class InstallTheme extends Step {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'         => array(
+				'step'      => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
 				'themeData' => array(
-					"anyOf" => [
-						require __DIR__ . "/schemas/definitions/VFSReference.php",
-						require __DIR__ . "/schemas/definitions/LiteralReference.php",
-						require __DIR__ . "/schemas/definitions/CorePluginReference.php",
-						require __DIR__ . "/schemas/definitions/CoreThemeReference.php",
-						require __DIR__ . "/schemas/definitions/UrlReference.php",
-						require __DIR__ . "/schemas/definitions/GitDirectoryReference.php",
-						require __DIR__ . "/schemas/definitions/DirectoryLiteralReference.php",
-					]
+					'anyOf' => array(
+						require __DIR__ . '/schemas/definitions/VFSReference.php',
+						require __DIR__ . '/schemas/definitions/LiteralReference.php',
+						require __DIR__ . '/schemas/definitions/CorePluginReference.php',
+						require __DIR__ . '/schemas/definitions/CoreThemeReference.php',
+						require __DIR__ . '/schemas/definitions/UrlReference.php',
+						require __DIR__ . '/schemas/definitions/GitDirectoryReference.php',
+						require __DIR__ . '/schemas/definitions/DirectoryLiteralReference.php',
+					),
 				),
-				'options'      => array(
+				'options'   => array(
 					'type'       => 'object',
 					'properties' => array(
 						'activate' => array(

--- a/packages/php/blueprint/src/Steps/RunSql.php
+++ b/packages/php/blueprint/src/Steps/RunSql.php
@@ -8,12 +8,25 @@ namespace Automattic\WooCommerce\Blueprint\Steps;
  * @package Automattic\WooCommerce\Blueprint\Steps
  */
 class RunSql extends Step {
-	protected string $sql  = '';
-	protected string $name = 'schema.sql';
 	/**
-	 * Sql to run.
+	 * Sql code to run.
 	 *
-	 * @var string $sql Sql code to run.
+	 * @var string
+	 */
+	protected string $sql = '';
+
+	/**
+	 * Name of the sql file.
+	 *
+	 * @var string
+	 */
+	protected string $name = 'schema.sql';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $sql Sql code to run.
+	 * @param string $name Name of the sql file.
 	 */
 	public function __construct( string $sql, $name = 'schema.sql' ) {
 		$this->sql  = $sql;

--- a/packages/php/blueprint/src/Steps/RunSql.php
+++ b/packages/php/blueprint/src/Steps/RunSql.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Blueprint\Steps;
  * @package Automattic\WooCommerce\Blueprint\Steps
  */
 class RunSql extends Step {
-	protected string $sql = '';
+	protected string $sql  = '';
 	protected string $name = 'schema.sql';
 	/**
 	 * Sql to run.
@@ -16,7 +16,7 @@ class RunSql extends Step {
 	 * @var string $sql Sql code to run.
 	 */
 	public function __construct( string $sql, $name = 'schema.sql' ) {
-		$this->sql = $sql;
+		$this->sql  = $sql;
 		$this->name = $name;
 	}
 
@@ -39,19 +39,19 @@ class RunSql extends Step {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'      => array(
+				'step' => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
-				'sql' => array(
-					'type' => 'object',
-					'required' => array( 'contents', 'resource', 'name' ),
+				'sql'  => array(
+					'type'       => 'object',
+					'required'   => array( 'contents', 'resource', 'name' ),
 					'properties' => array(
 						'resource' => array(
 							'type' => 'string',
 							'enum' => array( 'literal' ),
 						),
-						'name' => array(
+						'name'     => array(
 							'type' => 'string',
 						),
 						'contents' => array(
@@ -71,12 +71,12 @@ class RunSql extends Step {
 	 */
 	public function prepare_json_array(): array {
 		return array(
-			'step'      => static::get_step_name(),
-			'sql' => array(
+			'step' => static::get_step_name(),
+			'sql'  => array(
 				'resource' => 'literal',
-				'name' => $this->name,
+				'name'     => $this->name,
 				'contents' => $this->sql,
-			)
+			),
 		);
 	}
 }

--- a/packages/php/blueprint/src/Steps/SetSiteOptions.php
+++ b/packages/php/blueprint/src/Steps/SetSiteOptions.php
@@ -42,13 +42,13 @@ class SetSiteOptions extends Step {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'    => array(
+				'step' => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
 
 			),
-			'required'   => array( 'step'  ),
+			'required'   => array( 'step' ),
 		);
 	}
 

--- a/packages/php/blueprint/src/Steps/schemas/definitions/CorePluginReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/CorePluginReference.php
@@ -1,21 +1,21 @@
 <?php
 
-return [
-	"type" => "object",
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "wordpress.org/plugins",
-			"description" => "Identifies the file resource as a WordPress Core plugin"
-		],
-		"slug" => [
-			"type" => "string",
-			"description" => "The slug of the WordPress Core plugin"
-		]
-	],
-	"required" => [
-		"resource",
-		"slug"
-	],
-	"additionalProperties" => false
-];
+return array(
+	'type'                 => 'object',
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'wordpress.org/plugins',
+			'description' => 'Identifies the file resource as a WordPress Core plugin',
+		),
+		'slug'     => array(
+			'type'        => 'string',
+			'description' => 'The slug of the WordPress Core plugin',
+		),
+	),
+	'required'             => array(
+		'resource',
+		'slug',
+	),
+	'additionalProperties' => false,
+);

--- a/packages/php/blueprint/src/Steps/schemas/definitions/CoreThemeReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/CoreThemeReference.php
@@ -1,21 +1,21 @@
 <?php
 
-return [
-	"type" => "object",
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "wordpress.org/themes",
-			"description" => "Identifies the file resource as a WordPress Core theme"
-		],
-		"slug" => [
-			"type" => "string",
-			"description" => "The slug of the WordPress Core theme"
-		]
-	],
-	"required" => [
-		"resource",
-		"slug"
-	],
-	"additionalProperties" => false
-];
+return array(
+	'type'                 => 'object',
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'wordpress.org/themes',
+			'description' => 'Identifies the file resource as a WordPress Core theme',
+		),
+		'slug'     => array(
+			'type'        => 'string',
+			'description' => 'The slug of the WordPress Core theme',
+		),
+	),
+	'required'             => array(
+		'resource',
+		'slug',
+	),
+	'additionalProperties' => false,
+);

--- a/packages/php/blueprint/src/Steps/schemas/definitions/DirectoryLiteralReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/DirectoryLiteralReference.php
@@ -1,24 +1,24 @@
 <?php
 
-return [
-	"type" => "object",
-	"additionalProperties" => false,
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "literal:directory",
-			"description" => "Identifies the file resource as a git directory"
-		],
-		"files" => [
-			"\$ref" => "#/definitions/FileTree"
-		],
-		"name" => [
-			"type" => "string"
-		]
-	],
-	"required" => [
-		"files",
-		"name",
-		"resource"
-	]
-];
+return array(
+	'type'                 => 'object',
+	'additionalProperties' => false,
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'literal:directory',
+			'description' => 'Identifies the file resource as a git directory',
+		),
+		'files'    => array(
+			'$ref' => '#/definitions/FileTree',
+		),
+		'name'     => array(
+			'type' => 'string',
+		),
+	),
+	'required'             => array(
+		'files',
+		'name',
+		'resource',
+	),
+);

--- a/packages/php/blueprint/src/Steps/schemas/definitions/GitDirectoryReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/GitDirectoryReference.php
@@ -1,31 +1,31 @@
 <?php
 
-return [
-	"type" => "object",
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "git:directory",
-			"description" => "Identifies the file resource as a git directory"
-		],
-		"url" => [
-			"type" => "string",
-			"description" => "The URL of the git repository"
-		],
-		"ref" => [
-			"type" => "string",
-			"description" => "The branch of the git repository"
-		],
-		"path" => [
-			"type" => "string",
-			"description" => "The path to the directory in the git repository"
-		]
-	],
-	"required" => [
-		"resource",
-		"url",
-		"ref",
-		"path"
-	],
-	"additionalProperties" => false
-];
+return array(
+	'type'                 => 'object',
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'git:directory',
+			'description' => 'Identifies the file resource as a git directory',
+		),
+		'url'      => array(
+			'type'        => 'string',
+			'description' => 'The URL of the git repository',
+		),
+		'ref'      => array(
+			'type'        => 'string',
+			'description' => 'The branch of the git repository',
+		),
+		'path'     => array(
+			'type'        => 'string',
+			'description' => 'The path to the directory in the git repository',
+		),
+	),
+	'required'             => array(
+		'resource',
+		'url',
+		'ref',
+		'path',
+	),
+	'additionalProperties' => false,
+);

--- a/packages/php/blueprint/src/Steps/schemas/definitions/LiteralReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/LiteralReference.php
@@ -1,69 +1,69 @@
 <?php
 
-return [
-	"type" => "object",
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "literal",
-			"description" => "Identifies the file resource as a literal file"
-		],
-		"name" => [
-			"type" => "string",
-			"description" => "The name of the file"
-		],
-		"contents" => [
-			"anyOf" => [
-				[
-					"type" => "string"
-				],
-				[
-					"type" => "object",
-					"properties" => [
-						"BYTES_PER_ELEMENT" => [
-							"type" => "number"
-						],
-						"buffer" => [
-							"type" => "object",
-							"properties" => [
-								"byteLength" => [
-									"type" => "number"
-								]
-							],
-							"required" => [
-								"byteLength"
-							],
-							"additionalProperties" => false
-						],
-						"byteLength" => [
-							"type" => "number"
-						],
-						"byteOffset" => [
-							"type" => "number"
-						],
-						"length" => [
-							"type" => "number"
-						]
-					],
-					"required" => [
-						"BYTES_PER_ELEMENT",
-						"buffer",
-						"byteLength",
-						"byteOffset",
-						"length"
-					],
-					"additionalProperties" => [
-						"type" => "number"
-					]
-				]
-			],
-			"description" => "The contents of the file"
-		]
-	],
-	"required" => [
-		"resource",
-		"name",
-		"contents"
-	],
-	"additionalProperties" => false
-];
+return array(
+	'type'                 => 'object',
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'literal',
+			'description' => 'Identifies the file resource as a literal file',
+		),
+		'name'     => array(
+			'type'        => 'string',
+			'description' => 'The name of the file',
+		),
+		'contents' => array(
+			'anyOf'       => array(
+				array(
+					'type' => 'string',
+				),
+				array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'BYTES_PER_ELEMENT' => array(
+							'type' => 'number',
+						),
+						'buffer'            => array(
+							'type'                 => 'object',
+							'properties'           => array(
+								'byteLength' => array(
+									'type' => 'number',
+								),
+							),
+							'required'             => array(
+								'byteLength',
+							),
+							'additionalProperties' => false,
+						),
+						'byteLength'        => array(
+							'type' => 'number',
+						),
+						'byteOffset'        => array(
+							'type' => 'number',
+						),
+						'length'            => array(
+							'type' => 'number',
+						),
+					),
+					'required'             => array(
+						'BYTES_PER_ELEMENT',
+						'buffer',
+						'byteLength',
+						'byteOffset',
+						'length',
+					),
+					'additionalProperties' => array(
+						'type' => 'number',
+					),
+				),
+			),
+			'description' => 'The contents of the file',
+		),
+	),
+	'required'             => array(
+		'resource',
+		'name',
+		'contents',
+	),
+	'additionalProperties' => false,
+);

--- a/packages/php/blueprint/src/Steps/schemas/definitions/UrlReference.php
+++ b/packages/php/blueprint/src/Steps/schemas/definitions/UrlReference.php
@@ -1,25 +1,25 @@
 <?php
 
-return [
-	"type" => "object",
-	"properties" => [
-		"resource" => [
-			"type" => "string",
-			"const" => "url",
-			"description" => "Identifies the file resource as a URL"
-		],
-		"url" => [
-			"type" => "string",
-			"description" => "The URL of the file"
-		],
-		"caption" => [
-			"type" => "string",
-			"description" => "Optional caption for displaying a progress message"
-		]
-	],
-	"required" => [
-		"resource",
-		"url"
-	],
-	"additionalProperties" => false
-];
+return array(
+	'type'                 => 'object',
+	'properties'           => array(
+		'resource' => array(
+			'type'        => 'string',
+			'const'       => 'url',
+			'description' => 'Identifies the file resource as a URL',
+		),
+		'url'      => array(
+			'type'        => 'string',
+			'description' => 'The URL of the file',
+		),
+		'caption'  => array(
+			'type'        => 'string',
+			'description' => 'Optional caption for displaying a progress message',
+		),
+	),
+	'required'             => array(
+		'resource',
+		'url',
+	),
+	'additionalProperties' => false,
+);

--- a/packages/php/blueprint/src/UsePluginHelpers.php
+++ b/packages/php/blueprint/src/UsePluginHelpers.php
@@ -40,10 +40,10 @@ trait UsePluginHelpers {
 	public function is_plugin_dir( $slug ) {
 		$all_plugins = $this->wp_get_plugins();
 		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
-			// Extract the directory name from the plugin file path
+			// Extract the directory name from the plugin file path.
 			$plugin_dir = explode( '/', $plugin_file )[0];
 
-			// Check for an exact match with the slug
+			// Check for an exact match with the slug.
 			if ( $plugin_dir === $slug ) {
 				return true;
 			}

--- a/packages/php/blueprint/src/UsePubSub.php
+++ b/packages/php/blueprint/src/UsePubSub.php
@@ -4,6 +4,11 @@ namespace Automattic\WooCommerce\Blueprint;
 
 trait UsePubSub {
 
+	/**
+	 * Subscribers.
+	 *
+	 * @var array
+	 */
 	private array $subscribers = array();
 
 	/**

--- a/packages/php/blueprint/src/Util.php
+++ b/packages/php/blueprint/src/Util.php
@@ -27,26 +27,26 @@ class Util {
 	}
 
 	/**
-	 * @param array $row array row with key and value
+	 * @param array  $row array row with key and value
 	 * @param string $table name
 	 * @param string $type one of insert, insert ignore, replace into
 	 *
 	 * @return false|string
 	 */
-	public static function array_to_insert_sql ($row, $table, $type = 'insert ignore') {
-		if (empty($row) || !is_array($row)) {
+	public static function array_to_insert_sql( $row, $table, $type = 'insert ignore' ) {
+		if ( empty( $row ) || ! is_array( $row ) ) {
 			return false; // Return false if input data is empty or not an array
 		}
 
-		$allowed_types = ['insert', 'insert ignore', 'replace into'];
-		if (!in_array($type, $allowed_types)) {
+		$allowed_types = array( 'insert', 'insert ignore', 'replace into' );
+		if ( ! in_array( $type, $allowed_types ) ) {
 			return false; // Return false if input type is not valid
 		}
 
 		// Get column names and values
-		$columns = '`' . implode('`, `', array_keys($row)) . '`';
-		$escapedValues = array_map(fn($value) => "'" . addslashes($value) . "'", $row);
-		$values = implode(', ', $escapedValues);
+		$columns       = '`' . implode( '`, `', array_keys( $row ) ) . '`';
+		$escapedValues = array_map( fn( $value ) => "'" . addslashes( $value ) . "'", $row );
+		$values        = implode( ', ', $escapedValues );
 		// Construct final SQL query
 		return "{$type} `$table` ($columns) VALUES ($values);";
 	}
@@ -69,13 +69,13 @@ class Util {
 		return implode( '', $words );
 	}
 
-	public static function array_flatten($array) {
-		return new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
+	public static function array_flatten( $array ) {
+		return new RecursiveIteratorIterator( new RecursiveArrayIterator( $array ) );
 	}
 
 	/**
 	 * Convert a string from camelCase to snake_case.
-	 * 
+	 *
 	 * @param string $input The string to be converted.
 	 *
 	 * @return string

--- a/packages/php/blueprint/src/Util.php
+++ b/packages/php/blueprint/src/Util.php
@@ -27,50 +27,59 @@ class Util {
 	}
 
 	/**
-	 * @param array  $row array row with key and value
-	 * @param string $table name
-	 * @param string $type one of insert, insert ignore, replace into
+	 * Convert an array to an insert SQL query.
+	 *
+	 * @param array  $row Array row with key and value.
+	 * @param string $table Name of the table.
+	 * @param string $type One of insert, insert ignore, replace into.
 	 *
 	 * @return false|string
 	 */
 	public static function array_to_insert_sql( $row, $table, $type = 'insert ignore' ) {
 		if ( empty( $row ) || ! is_array( $row ) ) {
-			return false; // Return false if input data is empty or not an array
+			return false; // Return false if input data is empty or not an array.
 		}
 
 		$allowed_types = array( 'insert', 'insert ignore', 'replace into' );
-		if ( ! in_array( $type, $allowed_types ) ) {
-			return false; // Return false if input type is not valid
+		if ( ! in_array( $type, $allowed_types, true ) ) {
+			return false; // Return false if input type is not valid.
 		}
 
-		// Get column names and values
-		$columns       = '`' . implode( '`, `', array_keys( $row ) ) . '`';
-		$escapedValues = array_map( fn( $value ) => "'" . addslashes( $value ) . "'", $row );
-		$values        = implode( ', ', $escapedValues );
-		// Construct final SQL query
+		// Get column names and values.
+		$columns        = '`' . implode( '`, `', array_keys( $row ) ) . '`';
+		$escaped_values = array_map( fn( $value ) => "'" . addslashes( $value ) . "'", $row );
+		$values         = implode( ', ', $escaped_values );
+		// Construct final SQL query.
 		return "{$type} `$table` ($columns) VALUES ($values);";
 	}
 
 	/**
 	 * Convert a string from snake_case to camelCase.
 	 *
-	 * @param string $string The string to be converted.
+	 * @param string $string_to_convert The string to be converted.
 	 *
 	 * @return string
 	 */
-	public static function snake_to_camel( $string ) {
-		// Split the string by underscores
-		$words = explode( '_', $string );
+	public static function snake_to_camel( $string_to_convert ) {
+		// Split the string by underscores.
+		$words = explode( '_', $string_to_convert );
 
-		// Capitalize the first letter of each word
+		// Capitalize the first letter of each word.
 		$words = array_map( 'ucfirst', $words );
 
-		// Join the words back together
+		// Join the words back together.
 		return implode( '', $words );
 	}
 
-	public static function array_flatten( $array ) {
-		return new RecursiveIteratorIterator( new RecursiveArrayIterator( $array ) );
+	/**
+	 * Flatten an array.
+	 *
+	 * @param array $array_to_flatten The array to be flattened.
+	 *
+	 * @return \RecursiveIteratorIterator
+	 */
+	public static function array_flatten( $array_to_flatten ) {
+		return new RecursiveIteratorIterator( new RecursiveArrayIterator( $array_to_flatten ) );
 	}
 
 	/**
@@ -81,15 +90,15 @@ class Util {
 	 * @return string
 	 */
 	public static function camel_to_snake( $input ) {
-		// Replace all uppercase letters with an underscore followed by the lowercase version of the letter
+		// Replace all uppercase letters with an underscore followed by the lowercase version of the letter.
 		$pattern     = '/([a-z])([A-Z])/';
 		$replacement = '$1_$2';
 		$snake       = preg_replace( $pattern, $replacement, $input );
 
-		// Replace spaces with underscores
+		// Replace spaces with underscores.
 		$snake = str_replace( ' ', '_', $snake );
 
-		// Convert the entire string to lowercase
+		// Convert the entire string to lowercase.
 		return strtolower( $snake );
 	}
 

--- a/packages/php/blueprint/src/ZipExportedSchema.php
+++ b/packages/php/blueprint/src/ZipExportedSchema.php
@@ -212,7 +212,7 @@ class ZipExportedSchema {
 	 */
 	private function create_json_schema_file() {
 		$schema_file = $this->get_working_dir_path( 'woo-blueprint.json' );
-		$this->wp_filesystem_put_contents( $schema_file, json_encode( $this->schema, JSON_PRETTY_PRINT ) );
+		$this->wp_filesystem_put_contents( $schema_file, wp_json_encode( $this->schema, JSON_PRETTY_PRINT ) );
 		return $schema_file;
 	}
 

--- a/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
+++ b/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
@@ -10,15 +10,15 @@ class ExportInstallPluginStepsTest extends TestCase {
 
 	protected array $plugins = array(
 		'plugina/plugina.php' => array(
-			'Title' => 'plugina',
-			'RequiresPlugins' => array('pluginc'),
+			'Title'           => 'plugina',
+			'RequiresPlugins' => array( 'pluginc' ),
 		),
 		'pluginb/pluginb.php' => array(
-			'Title' => 'pluginb',
+			'Title'           => 'pluginb',
 			'RequiresPlugins' => array( 'plugina' ),
 		),
 		'pluginc/pluginc.php' => array(
-			'Title' => 'pluginc',
+			'Title'           => 'pluginc',
 			'RequiresPlugins' => array(),
 		),
 	);
@@ -35,10 +35,12 @@ class ExportInstallPluginStepsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_export() {
-	    $mock = $this->get_mock();
-		$mock->shouldReceive('wp_plugins_api')->andReturn((object) array(
-			'download_link' => 'download_link_url',
-		));
+		$mock = $this->get_mock();
+		$mock->shouldReceive( 'wp_plugins_api' )->andReturn(
+			(object) array(
+				'download_link' => 'download_link_url',
+			)
+		);
 
 		/**
 		 * @var Step[] $result The result of the export.
@@ -46,33 +48,36 @@ class ExportInstallPluginStepsTest extends TestCase {
 		$result = $mock->export();
 		$this->assertCount( 3, $result );
 
-		$slugs = array_map(fn($step) => $step->prepare_json_array()['pluginData']['slug'], $result);
-		$this->assertContains('plugina', $slugs);
-		$this->assertContains('pluginb', $slugs);
-		$this->assertContains('pluginc', $slugs);
-
+		$slugs = array_map( fn( $step ) => $step->prepare_json_array()['pluginData']['slug'], $result );
+		$this->assertContains( 'plugina', $slugs );
+		$this->assertContains( 'pluginb', $slugs );
+		$this->assertContains( 'pluginc', $slugs );
 	}
 
 	/**
 	 * When a plugin does not have a download link, it should not be included in the export.
+	 *
 	 * @return void
 	 */
 	public function test_export_does_not_include_plugins_with_unknown_download_link() {
 		$mock = Mock( ExportInstallPluginSteps::class )->makePartial();
 
 		// Return an empty object for the plugina.
-		$mock->shouldReceive( 'wp_plugins_api' )->withArgs(function($method, $args) {
-			if ($method === 'plugin_information' && $args['slug'] === 'plugina') {
-				return true;
+		$mock->shouldReceive( 'wp_plugins_api' )->withArgs(
+			function ( $method, $args ) {
+				if ( $method === 'plugin_information' && $args['slug'] === 'plugina' ) {
+					return true;
+				}
+				return false;
 			}
-			return false;
-		})->andReturn( (object) array() );
+		)->andReturn( (object) array() );
 
-		$mock->shouldReceive('wp_plugins_api')
-			->andReturn((object) array(
-				'download_link' => 'download_link_url',
-			));
-
+		$mock->shouldReceive( 'wp_plugins_api' )
+			->andReturn(
+				(object) array(
+					'download_link' => 'download_link_url',
+				)
+			);
 
 		$result = $mock->export();
 		$this->assertCount( 2, $result );
@@ -83,21 +88,24 @@ class ExportInstallPluginStepsTest extends TestCase {
 	 */
 	public function test_it_should_return_dependencies_first() {
 		$instance = new ExportInstallPluginSteps();
-		$plugins = $instance->sort_plugins_by_dep($this->plugins);
+		$plugins  = $instance->sort_plugins_by_dep( $this->plugins );
 
-		$this->assertEquals( array(
-			'pluginc/pluginc.php' => array(
-				'Title' => 'pluginc',
-				'RequiresPlugins' => array(),
+		$this->assertEquals(
+			array(
+				'pluginc/pluginc.php' => array(
+					'Title'           => 'pluginc',
+					'RequiresPlugins' => array(),
+				),
+				'plugina/plugina.php' => array(
+					'Title'           => 'plugina',
+					'RequiresPlugins' => array( 'pluginc' ),
+				),
+				'pluginb/pluginb.php' => array(
+					'Title'           => 'pluginb',
+					'RequiresPlugins' => array( 'plugina' ),
+				),
 			),
-			'plugina/plugina.php' => array(
-				'Title' => 'plugina',
-				'RequiresPlugins' => array('pluginc'),
-			),
-			'pluginb/pluginb.php' => array(
-				'Title' => 'pluginb',
-				'RequiresPlugins' => array( 'plugina' ),
-			),
-		), $plugins );
+			$plugins
+		);
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
+++ b/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
@@ -19,14 +19,17 @@ class ExportInstallPluginStepsTest extends TestCase {
 	protected array $plugins = array(
 		'plugina/plugina.php' => array(
 			'Title'           => 'plugina',
+			'Name'            => 'plugina',
 			'RequiresPlugins' => array( 'pluginc' ),
 		),
 		'pluginb/pluginb.php' => array(
 			'Title'           => 'pluginb',
+			'Name'            => 'pluginb',
 			'RequiresPlugins' => array( 'plugina' ),
 		),
 		'pluginc/pluginc.php' => array(
 			'Title'           => 'pluginc',
+			'Name'            => 'pluginc',
 			'RequiresPlugins' => array(),
 		),
 	);
@@ -104,14 +107,17 @@ class ExportInstallPluginStepsTest extends TestCase {
 			array(
 				'pluginc/pluginc.php' => array(
 					'Title'           => 'pluginc',
+					'Name'            => 'pluginc',
 					'RequiresPlugins' => array(),
 				),
 				'plugina/plugina.php' => array(
 					'Title'           => 'plugina',
+					'Name'            => 'plugina',
 					'RequiresPlugins' => array( 'pluginc' ),
 				),
 				'pluginb/pluginb.php' => array(
 					'Title'           => 'pluginb',
+					'Name'            => 'pluginb',
 					'RequiresPlugins' => array( 'plugina' ),
 				),
 			),

--- a/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
+++ b/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
@@ -73,7 +73,7 @@ class ExportInstallPluginStepsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_export_does_not_include_plugins_with_unknown_download_link() {
-		$mock = Mock( ExportInstallPluginSteps::class )->makePartial();
+		$mock = $this->get_mock();
 
 		// Return an empty object for the plugina.
 		$mock->shouldReceive( 'wp_plugins_api' )->withArgs(

--- a/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
+++ b/packages/php/blueprint/tests/Unit/Exporters/ExportInstallPluginStepsTest.php
@@ -6,8 +6,16 @@ use Automattic\WooCommerce\Blueprint\Exporters\ExportInstallPluginSteps;
 use Automattic\WooCommerce\Blueprint\Steps\Step;
 use Automattic\WooCommerce\Blueprint\Tests\TestCase;
 
+/**
+ * Unit tests for ExportInstallPluginSteps class.
+ */
 class ExportInstallPluginStepsTest extends TestCase {
 
+	/**
+	 * The plugins to test.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
 	protected array $plugins = array(
 		'plugina/plugina.php' => array(
 			'Title'           => 'plugina',
@@ -23,6 +31,11 @@ class ExportInstallPluginStepsTest extends TestCase {
 		),
 	);
 
+	/**
+	 * Get a mock of the ExportInstallPluginSteps class.
+	 *
+	 * @return Mockery\MockInterface
+	 */
 	private function get_mock() {
 		$mock = Mock( ExportInstallPluginSteps::class )->makePartial();
 		$mock->shouldReceive( 'wp_get_plugins' )->andReturn( $this->plugins );
@@ -42,9 +55,6 @@ class ExportInstallPluginStepsTest extends TestCase {
 			)
 		);
 
-		/**
-		 * @var Step[] $result The result of the export.
-		 */
 		$result = $mock->export();
 		$this->assertCount( 3, $result );
 
@@ -65,7 +75,7 @@ class ExportInstallPluginStepsTest extends TestCase {
 		// Return an empty object for the plugina.
 		$mock->shouldReceive( 'wp_plugins_api' )->withArgs(
 			function ( $method, $args ) {
-				if ( $method === 'plugin_information' && $args['slug'] === 'plugina' ) {
+				if ( 'plugin_information' === $method && 'plugina' === $args['slug'] ) {
 					return true;
 				}
 				return false;

--- a/packages/php/blueprint/tests/Unit/ImportStepTest.php
+++ b/packages/php/blueprint/tests/Unit/ImportStepTest.php
@@ -19,6 +19,8 @@ class ImportStepTest extends TestCase {
 	}
 
 	/**
+	 * Set up the test.
+	 *
 	 * @return void
 	 */
 	public function setUp(): void {
@@ -44,6 +46,8 @@ class ImportStepTest extends TestCase {
 	}
 
 	/**
+	 * Test it returns warn when it cannot find valid importer.
+	 *
 	 * @return void
 	 */
 	public function test_it_returns_warn_when_it_cannot_find_valid_importer() {
@@ -56,6 +60,8 @@ class ImportStepTest extends TestCase {
 	}
 
 	/**
+	 * Test it returns validation error.
+	 *
 	 * @return void
 	 */
 	public function test_it_returns_validation_error() {

--- a/packages/php/blueprint/tests/Unit/Importers/ImportActivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportActivatePluginTest.php
@@ -8,75 +8,98 @@ use Automattic\WooCommerce\Blueprint\Steps\ActivatePlugin;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportActivatePlugin class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportActivatePluginTest extends TestCase {
+
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test the process method with a successful activation.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_activation() {
-		$pluginPath = 'sample-plugin';
+		$plugin_path = 'sample-plugin';
 
-		// Create a mock schema object
-		$schema             = Mockery::mock();
-		$schema->pluginPath = $pluginPath;
+		// Create a mock schema object.
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema->pluginPath = $plugin_path;
 
-		// Create a partial mock of ImportActivatePlugin
-		$importActivatePlugin = Mockery::mock( ImportActivatePlugin::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportActivatePlugin.
+		$import_activate_plugin = Mockery::mock( ImportActivatePlugin::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the activate_plugin_by_slug method
-		$importActivatePlugin->shouldReceive( 'wp_activate_plugin' )
-							->with( $pluginPath )
-							->andReturn( true );
+		// Mock the activate_plugin_by_slug method.
+		$import_activate_plugin->shouldReceive( 'wp_activate_plugin' )
+			->with( $plugin_path )
+			->andReturn( true );
 
-		// Execute the process method
-		$result = $importActivatePlugin->process( $schema );
+		// Execute the process method.
+		$result = $import_activate_plugin->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert success
+		// Assert success.
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( ActivatePlugin::get_step_name(), $result->get_step_name() );
 
-		// Assert the success message is added
+		// Assert the success message is added.
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Activated {$pluginPath}.", $messages[0]['message'] );
+		$this->assertEquals( "Activated {$plugin_path}.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test the process method with a failed activation.
+	 *
+	 * @return void
+	 */
 	public function test_process_failed_activation() {
-		$pluginPath = 'invalid-plugin';
+		$plugin_path = 'invalid-plugin';
 
-		// Create a mock schema object
-		$schema             = Mockery::mock();
-		$schema->pluginPath = $pluginPath;
+		// Create a mock schema object.
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema->pluginPath = $plugin_path;
 
-		// Create a partial mock of ImportActivatePlugin
-		$importActivatePlugin = Mockery::mock( ImportActivatePlugin::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportActivatePlugin.
+		$import_activate_plugin = Mockery::mock( ImportActivatePlugin::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the activate_plugin_by_slug method
-		$importActivatePlugin->shouldReceive( 'wp_activate_plugin' )
-							->with( $pluginPath )
-							->andReturn( new \WP_Error( 'error', 'Error message' ) );
+		// Mock the activate_plugin_by_slug method.
+		$import_activate_plugin->shouldReceive( 'wp_activate_plugin' )
+			->with( $plugin_path )
+			->andReturn( new \WP_Error( 'error', 'Error message' ) );
 
-		// Execute the process method
-		$result = $importActivatePlugin->process( $schema );
+		// Execute the process method.
+		$result = $import_activate_plugin->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert failure
+		// Assert failure.
 		$this->assertFalse( $result->is_success() );
 		$this->assertEquals( ActivatePlugin::get_step_name(), $result->get_step_name() );
 
-		// Assert the error message is added
+		// Assert the error message is added.
 		$messages = $result->get_messages( 'error' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Unable to activate {$pluginPath}.", $messages[0]['message'] );
+		$this->assertEquals( "Unable to activate {$plugin_path}.", $messages[0]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportActivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportActivatePluginTest.php
@@ -18,65 +18,65 @@ class ImportActivatePluginTest extends TestCase {
 		$pluginPath = 'sample-plugin';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema             = Mockery::mock();
 		$schema->pluginPath = $pluginPath;
 
 		// Create a partial mock of ImportActivatePlugin
-		$importActivatePlugin = Mockery::mock(ImportActivatePlugin::class)
-		                               ->makePartial()
-		                               ->shouldAllowMockingProtectedMethods();
+		$importActivatePlugin = Mockery::mock( ImportActivatePlugin::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock the activate_plugin_by_slug method
-		$importActivatePlugin->shouldReceive('wp_activate_plugin')
-		                     ->with($pluginPath)
-		                     ->andReturn(true);
+		$importActivatePlugin->shouldReceive( 'wp_activate_plugin' )
+							->with( $pluginPath )
+							->andReturn( true );
 
 		// Execute the process method
-		$result = $importActivatePlugin->process($schema);
+		$result = $importActivatePlugin->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert success
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(ActivatePlugin::get_step_name(), $result->get_step_name());
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( ActivatePlugin::get_step_name(), $result->get_step_name() );
 
 		// Assert the success message is added
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Activated {$pluginPath}.", $messages[0]['message']);
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Activated {$pluginPath}.", $messages[0]['message'] );
 	}
 
 	public function test_process_failed_activation() {
 		$pluginPath = 'invalid-plugin';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema             = Mockery::mock();
 		$schema->pluginPath = $pluginPath;
 
 		// Create a partial mock of ImportActivatePlugin
-		$importActivatePlugin = Mockery::mock(ImportActivatePlugin::class)
-		                               ->makePartial()
-		                               ->shouldAllowMockingProtectedMethods();
+		$importActivatePlugin = Mockery::mock( ImportActivatePlugin::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock the activate_plugin_by_slug method
-		$importActivatePlugin->shouldReceive('wp_activate_plugin')
-		                     ->with($pluginPath)
-		                     ->andReturn(new \WP_Error('error', 'Error message'));
+		$importActivatePlugin->shouldReceive( 'wp_activate_plugin' )
+							->with( $pluginPath )
+							->andReturn( new \WP_Error( 'error', 'Error message' ) );
 
 		// Execute the process method
-		$result = $importActivatePlugin->process($schema);
+		$result = $importActivatePlugin->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert failure
-		$this->assertFalse($result->is_success());
-		$this->assertEquals(ActivatePlugin::get_step_name(), $result->get_step_name());
+		$this->assertFalse( $result->is_success() );
+		$this->assertEquals( ActivatePlugin::get_step_name(), $result->get_step_name() );
 
 		// Assert the error message is added
-		$messages = $result->get_messages('error');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Unable to activate {$pluginPath}.", $messages[0]['message']);
+		$messages = $result->get_messages( 'error' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Unable to activate {$pluginPath}.", $messages[0]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportActivateThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportActivateThemeTest.php
@@ -8,81 +8,106 @@ use Automattic\WooCommerce\Blueprint\Steps\ActivateTheme;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportActivateTheme class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportActivateThemeTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test successful theme activation process.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_theme_activation() {
-		$themeName = 'sample-theme';
+		$theme_name = 'sample-theme';
 
-		// Create a mock schema object
+		// Create a mock schema object.
 		$schema            = Mockery::mock();
-		$schema->themeName = $themeName;
+		$schema->themeName = $theme_name; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		// Create a partial mock of ImportActivateTheme
-		$importActivateTheme = Mockery::mock( ImportActivateTheme::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportActivateTheme.
+		$import_activate_theme = Mockery::mock( ImportActivateTheme::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the wp_switch_theme method
-		$importActivateTheme->shouldReceive( 'wp_switch_theme' )
-							->with( $themeName )
-							->andReturn( true );
+		// Mock the wp_switch_theme method.
+		$import_activate_theme->shouldReceive( 'wp_switch_theme' )
+			->with( $theme_name )
+			->andReturn( true );
 
-		// Execute the process method
-		$result = $importActivateTheme->process( $schema );
+		// Execute the process method.
+		$result = $import_activate_theme->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert success
+		// Assert success.
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( ActivateTheme::get_step_name(), $result->get_step_name() );
 
-		// Assert the debug message is added
+		// Assert the debug message is added.
 		$messages = $result->get_messages( 'debug' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Switched theme to '{$themeName}'.", $messages[0]['message'] );
+		$this->assertEquals( "Switched theme to '{$theme_name}'.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test theme activation process when theme switching fails.
+	 *
+	 * @return void
+	 */
 	public function test_process_theme_activation_without_switching() {
-		$themeName = 'invalid-theme';
+		$theme_name = 'invalid-theme';
 
-		// Create a mock schema object
+		// Create a mock schema object.
 		$schema            = Mockery::mock();
-		$schema->themeName = $themeName;
+		$schema->themeName = $theme_name; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		// Create a partial mock of ImportActivateTheme
-		$importActivateTheme = Mockery::mock( ImportActivateTheme::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportActivateTheme.
+		$import_activate_theme = Mockery::mock( ImportActivateTheme::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the wp_switch_theme method
-		$importActivateTheme->shouldReceive( 'wp_switch_theme' )
-							->with( $themeName )
-							->andReturn( false );
+		// Mock the wp_switch_theme method.
+		$import_activate_theme->shouldReceive( 'wp_switch_theme' )
+			->with( $theme_name )
+			->andReturn( false );
 
-		// Execute the process method
-		$result = $importActivateTheme->process( $schema );
+		// Execute the process method.
+		$result = $import_activate_theme->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert success because the process itself is considered successful
+		// Assert success because the process itself is considered successful.
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( ActivateTheme::get_step_name(), $result->get_step_name() );
 
-		// Assert there are no debug messages
+		// Assert there are no debug messages.
 		$messages = $result->get_messages( 'debug' );
 		$this->assertCount( 0, $messages );
 	}
 
+	/**
+	 * Test getting the step class.
+	 *
+	 * @return void
+	 */
 	public function test_get_step_class() {
-		$importActivateTheme = new ImportActivateTheme();
+		$import_activate_theme = new ImportActivateTheme();
 
-		// Assert the correct step class is returned
-		$this->assertEquals( ActivateTheme::class, $importActivateTheme->get_step_class() );
+		// Assert the correct step class is returned.
+		$this->assertEquals( ActivateTheme::class, $import_activate_theme->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportActivateThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportActivateThemeTest.php
@@ -18,71 +18,71 @@ class ImportActivateThemeTest extends TestCase {
 		$themeName = 'sample-theme';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema            = Mockery::mock();
 		$schema->themeName = $themeName;
 
 		// Create a partial mock of ImportActivateTheme
-		$importActivateTheme = Mockery::mock(ImportActivateTheme::class)
-		                              ->makePartial()
-		                              ->shouldAllowMockingProtectedMethods();
+		$importActivateTheme = Mockery::mock( ImportActivateTheme::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock the wp_switch_theme method
-		$importActivateTheme->shouldReceive('wp_switch_theme')
-		                    ->with($themeName)
-		                    ->andReturn(true);
+		$importActivateTheme->shouldReceive( 'wp_switch_theme' )
+							->with( $themeName )
+							->andReturn( true );
 
 		// Execute the process method
-		$result = $importActivateTheme->process($schema);
+		$result = $importActivateTheme->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert success
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(ActivateTheme::get_step_name(), $result->get_step_name());
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( ActivateTheme::get_step_name(), $result->get_step_name() );
 
 		// Assert the debug message is added
-		$messages = $result->get_messages('debug');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Switched theme to '{$themeName}'.", $messages[0]['message']);
+		$messages = $result->get_messages( 'debug' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Switched theme to '{$themeName}'.", $messages[0]['message'] );
 	}
 
 	public function test_process_theme_activation_without_switching() {
 		$themeName = 'invalid-theme';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema            = Mockery::mock();
 		$schema->themeName = $themeName;
 
 		// Create a partial mock of ImportActivateTheme
-		$importActivateTheme = Mockery::mock(ImportActivateTheme::class)
-		                              ->makePartial()
-		                              ->shouldAllowMockingProtectedMethods();
+		$importActivateTheme = Mockery::mock( ImportActivateTheme::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock the wp_switch_theme method
-		$importActivateTheme->shouldReceive('wp_switch_theme')
-		                    ->with($themeName)
-		                    ->andReturn(false);
+		$importActivateTheme->shouldReceive( 'wp_switch_theme' )
+							->with( $themeName )
+							->andReturn( false );
 
 		// Execute the process method
-		$result = $importActivateTheme->process($schema);
+		$result = $importActivateTheme->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert success because the process itself is considered successful
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(ActivateTheme::get_step_name(), $result->get_step_name());
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( ActivateTheme::get_step_name(), $result->get_step_name() );
 
 		// Assert there are no debug messages
-		$messages = $result->get_messages('debug');
-		$this->assertCount(0, $messages);
+		$messages = $result->get_messages( 'debug' );
+		$this->assertCount( 0, $messages );
 	}
 
 	public function test_get_step_class() {
 		$importActivateTheme = new ImportActivateTheme();
 
 		// Assert the correct step class is returned
-		$this->assertEquals(ActivateTheme::class, $importActivateTheme->get_step_class());
+		$this->assertEquals( ActivateTheme::class, $importActivateTheme->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportDeactivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportDeactivatePluginTest.php
@@ -18,39 +18,39 @@ class ImportDeactivatePluginTest extends TestCase {
 		$pluginName = 'sample-plugin';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema             = Mockery::mock();
 		$schema->pluginName = $pluginName;
 
 		// Create a partial mock of ImportDeactivatePlugin
-		$importDeactivatePlugin = Mockery::mock(ImportDeactivatePlugin::class)
-		                                 ->makePartial()
-		                                 ->shouldAllowMockingProtectedMethods();
+		$importDeactivatePlugin = Mockery::mock( ImportDeactivatePlugin::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock the deactivate_plugin_by_slug method
-		$importDeactivatePlugin->shouldReceive('deactivate_plugin_by_slug')
-		                       ->with($pluginName)
-		                       ->andReturnNull();
+		$importDeactivatePlugin->shouldReceive( 'deactivate_plugin_by_slug' )
+								->with( $pluginName )
+								->andReturnNull();
 
 		// Execute the process method
-		$result = $importDeactivatePlugin->process($schema);
+		$result = $importDeactivatePlugin->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert success
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(DeactivatePlugin::get_step_name(), $result->get_step_name());
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( DeactivatePlugin::get_step_name(), $result->get_step_name() );
 
 		// Assert the info message is added
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Deactivated {$pluginName}.", $messages[0]['message']);
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Deactivated {$pluginName}.", $messages[0]['message'] );
 	}
 
 	public function test_get_step_class() {
 		$importDeactivatePlugin = new ImportDeactivatePlugin();
 
 		// Assert the correct step class is returned
-		$this->assertEquals(DeactivatePlugin::class, $importDeactivatePlugin->get_step_class());
+		$this->assertEquals( DeactivatePlugin::class, $importDeactivatePlugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportDeactivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportDeactivatePluginTest.php
@@ -8,49 +8,70 @@ use Automattic\WooCommerce\Blueprint\Steps\DeactivatePlugin;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportDeactivatePlugin class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportDeactivatePluginTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test successful plugin deactivation process.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_deactivation() {
-		$pluginName = 'sample-plugin';
+		$plugin_name = 'sample-plugin';
 
-		// Create a mock schema object
-		$schema             = Mockery::mock();
-		$schema->pluginName = $pluginName;
+		// Create a mock schema object.
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema->pluginName = $plugin_name;
 
-		// Create a partial mock of ImportDeactivatePlugin
-		$importDeactivatePlugin = Mockery::mock( ImportDeactivatePlugin::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportDeactivatePlugin.
+		$import_deactivate_plugin = Mockery::mock( ImportDeactivatePlugin::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the deactivate_plugin_by_slug method
-		$importDeactivatePlugin->shouldReceive( 'deactivate_plugin_by_slug' )
-								->with( $pluginName )
-								->andReturnNull();
+		// Mock the deactivate_plugin_by_slug method.
+		$import_deactivate_plugin->shouldReceive( 'deactivate_plugin_by_slug' )
+			->with( $plugin_name )
+			->andReturnNull();
 
-		// Execute the process method
-		$result = $importDeactivatePlugin->process( $schema );
+		// Execute the process method.
+		$result = $import_deactivate_plugin->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert success
+		// Assert success.
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( DeactivatePlugin::get_step_name(), $result->get_step_name() );
 
-		// Assert the info message is added
+		// Assert the info message is added.
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Deactivated {$pluginName}.", $messages[0]['message'] );
+		$this->assertEquals( "Deactivated {$plugin_name}.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test getting the step class.
+	 *
+	 * @return void
+	 */
 	public function test_get_step_class() {
-		$importDeactivatePlugin = new ImportDeactivatePlugin();
+		$import_deactivate_plugin = new ImportDeactivatePlugin();
 
-		// Assert the correct step class is returned
-		$this->assertEquals( DeactivatePlugin::class, $importDeactivatePlugin->get_step_class() );
+		// Assert the correct step class is returned.
+		$this->assertEquals( DeactivatePlugin::class, $import_deactivate_plugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportDeletePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportDeletePluginTest.php
@@ -18,72 +18,72 @@ class ImportDeletePluginTest extends TestCase {
 		$pluginName = 'sample-plugin';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema             = Mockery::mock();
 		$schema->pluginName = $pluginName;
 
 		// Create a partial mock of ImportDeletePlugin
-		$importDeletePlugin = Mockery::mock(ImportDeletePlugin::class)
-		                             ->makePartial()
-		                             ->shouldAllowMockingProtectedMethods();
+		$importDeletePlugin = Mockery::mock( ImportDeletePlugin::class )
+									->makePartial()
+									->shouldAllowMockingProtectedMethods();
 
 		// Mock the delete_plugin_by_slug method
-		$importDeletePlugin->shouldReceive('delete_plugin_by_slug')
-		                   ->with($pluginName)
-		                   ->andReturn(true);
+		$importDeletePlugin->shouldReceive( 'delete_plugin_by_slug' )
+							->with( $pluginName )
+							->andReturn( true );
 
 		// Execute the process method
-		$result = $importDeletePlugin->process($schema);
+		$result = $importDeletePlugin->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert success
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(DeletePlugin::get_step_name(), $result->get_step_name());
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( DeletePlugin::get_step_name(), $result->get_step_name() );
 
 		// Assert the info message is added
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Deleted {$pluginName}.", $messages[0]['message']);
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Deleted {$pluginName}.", $messages[0]['message'] );
 	}
 
 	public function test_process_failed_deletion() {
 		$pluginName = 'invalid-plugin';
 
 		// Create a mock schema object
-		$schema = Mockery::mock();
+		$schema             = Mockery::mock();
 		$schema->pluginName = $pluginName;
 
 		// Create a partial mock of ImportDeletePlugin
-		$importDeletePlugin = Mockery::mock(ImportDeletePlugin::class)
-		                             ->makePartial()
-		                             ->shouldAllowMockingProtectedMethods();
+		$importDeletePlugin = Mockery::mock( ImportDeletePlugin::class )
+									->makePartial()
+									->shouldAllowMockingProtectedMethods();
 
 		// Mock the delete_plugin_by_slug method
-		$importDeletePlugin->shouldReceive('delete_plugin_by_slug')
-		                   ->with($pluginName)
-		                   ->andReturn(false);
+		$importDeletePlugin->shouldReceive( 'delete_plugin_by_slug' )
+							->with( $pluginName )
+							->andReturn( false );
 
 		// Execute the process method
-		$result = $importDeletePlugin->process($schema);
+		$result = $importDeletePlugin->process( $schema );
 
 		// Assert the result is an instance of StepProcessorResult
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
 		// Assert failure
-		$this->assertFalse($result->is_success());
-		$this->assertEquals(DeletePlugin::get_step_name(), $result->get_step_name());
+		$this->assertFalse( $result->is_success() );
+		$this->assertEquals( DeletePlugin::get_step_name(), $result->get_step_name() );
 
 		// Assert the error message is added
-		$messages = $result->get_messages('error');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Unable to delete {$pluginName}.", $messages[0]['message']);
+		$messages = $result->get_messages( 'error' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Unable to delete {$pluginName}.", $messages[0]['message'] );
 	}
 
 	public function test_get_step_class() {
 		$importDeletePlugin = new ImportDeletePlugin();
 
 		// Assert the correct step class is returned
-		$this->assertEquals(DeletePlugin::class, $importDeletePlugin->get_step_class());
+		$this->assertEquals( DeletePlugin::class, $importDeletePlugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportDeletePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportDeletePluginTest.php
@@ -8,82 +8,109 @@ use Automattic\WooCommerce\Blueprint\Steps\DeletePlugin;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportDeletePlugin class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportDeletePluginTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test successful plugin deletion process.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_deletion() {
-		$pluginName = 'sample-plugin';
+		$plugin_name = 'sample-plugin';
 
-		// Create a mock schema object
-		$schema             = Mockery::mock();
-		$schema->pluginName = $pluginName;
+		// Create a mock schema object.
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema->pluginName = $plugin_name;
 
-		// Create a partial mock of ImportDeletePlugin
-		$importDeletePlugin = Mockery::mock( ImportDeletePlugin::class )
-									->makePartial()
-									->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportDeletePlugin.
+		$import_delete_plugin = Mockery::mock( ImportDeletePlugin::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the delete_plugin_by_slug method
-		$importDeletePlugin->shouldReceive( 'delete_plugin_by_slug' )
-							->with( $pluginName )
-							->andReturn( true );
+		// Mock the delete_plugin_by_slug method.
+		$import_delete_plugin->shouldReceive( 'delete_plugin_by_slug' )
+			->with( $plugin_name )
+			->andReturn( true );
 
-		// Execute the process method
-		$result = $importDeletePlugin->process( $schema );
+		// Execute the process method.
+		$result = $import_delete_plugin->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert success
+		// Assert success.
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( DeletePlugin::get_step_name(), $result->get_step_name() );
 
-		// Assert the info message is added
+		// Assert the info message is added.
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Deleted {$pluginName}.", $messages[0]['message'] );
+		$this->assertEquals( "Deleted {$plugin_name}.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test plugin deletion process when deletion fails.
+	 *
+	 * @return void
+	 */
 	public function test_process_failed_deletion() {
-		$pluginName = 'invalid-plugin';
+		$plugin_name = 'invalid-plugin';
 
-		// Create a mock schema object
-		$schema             = Mockery::mock();
-		$schema->pluginName = $pluginName;
+		// Create a mock schema object.
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$schema->pluginName = $plugin_name;
 
-		// Create a partial mock of ImportDeletePlugin
-		$importDeletePlugin = Mockery::mock( ImportDeletePlugin::class )
-									->makePartial()
-									->shouldAllowMockingProtectedMethods();
+		// Create a partial mock of ImportDeletePlugin.
+		$import_delete_plugin = Mockery::mock( ImportDeletePlugin::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock the delete_plugin_by_slug method
-		$importDeletePlugin->shouldReceive( 'delete_plugin_by_slug' )
-							->with( $pluginName )
-							->andReturn( false );
+		// Mock the delete_plugin_by_slug method.
+		$import_delete_plugin->shouldReceive( 'delete_plugin_by_slug' )
+			->with( $plugin_name )
+			->andReturn( false );
 
-		// Execute the process method
-		$result = $importDeletePlugin->process( $schema );
+		// Execute the process method.
+		$result = $import_delete_plugin->process( $schema );
 
-		// Assert the result is an instance of StepProcessorResult
+		// Assert the result is an instance of StepProcessorResult.
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 
-		// Assert failure
+		// Assert failure.
 		$this->assertFalse( $result->is_success() );
 		$this->assertEquals( DeletePlugin::get_step_name(), $result->get_step_name() );
 
-		// Assert the error message is added
+		// Assert the error message is added.
 		$messages = $result->get_messages( 'error' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Unable to delete {$pluginName}.", $messages[0]['message'] );
+		$this->assertEquals( "Unable to delete {$plugin_name}.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test getting the step class.
+	 *
+	 * @return void
+	 */
 	public function test_get_step_class() {
-		$importDeletePlugin = new ImportDeletePlugin();
+		$import_delete_plugin = new ImportDeletePlugin();
 
-		// Assert the correct step class is returned
-		$this->assertEquals( DeletePlugin::class, $importDeletePlugin->get_step_class() );
+		// Assert the correct step class is returned.
+		$this->assertEquals( DeletePlugin::class, $import_delete_plugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportInstallPluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportInstallPluginTest.php
@@ -9,58 +9,80 @@ use Automattic\WooCommerce\Blueprint\Steps\InstallPlugin;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportInstallPlugin class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportInstallPluginTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test plugin installation when plugin is already installed.
+	 *
+	 * @return void
+	 */
 	public function test_process_skipped_installation() {
-		$pluginSlug = 'already-installed-plugin';
+		$plugin_slug = 'already-installed-plugin';
 
-		$schema             = Mockery::mock();
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$schema->pluginData = (object) array(
-			'slug'     => $pluginSlug,
+			'slug'     => $plugin_slug,
 			'resource' => 'wordpress.org/plugins',
 		);
 
-		$resourceStorage     = Mockery::mock( ResourceStorages::class );
-		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		$resource_storage      = Mockery::mock( ResourceStorages::class );
+		$import_install_plugin = Mockery::mock( ImportInstallPlugin::class, array( $resource_storage ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$importInstallPlugin->shouldReceive( 'get_installed_plugins_paths' )
-							->andReturn( array( $pluginSlug => '/path/to/plugin' ) );
+		$import_install_plugin->shouldReceive( 'get_installed_plugins_paths' )
+			->andReturn( array( $plugin_slug => '/path/to/plugin' ) );
 
-		$result = $importInstallPlugin->process( $schema );
+		$result = $import_install_plugin->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertTrue( $result->is_success() );
 		$this->assertEquals( InstallPlugin::get_step_name(), $result->get_step_name() );
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 1, $messages );
-		$this->assertEquals( "Skipped installing {$pluginSlug}. It is already installed.", $messages[0]['message'] );
+		$this->assertEquals( "Skipped installing {$plugin_slug}. It is already installed.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test plugin installation with invalid resource type.
+	 *
+	 * @return void
+	 */
 	public function test_process_invalid_resource() {
-		$pluginSlug = 'invalid-resource-plugin';
+		$plugin_slug = 'invalid-resource-plugin';
 
-		$schema             = Mockery::mock();
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$schema->pluginData = (object) array(
-			'slug'     => $pluginSlug,
+			'slug'     => $plugin_slug,
 			'resource' => 'invalid-resource',
 		);
 
-		$resourceStorage = Mockery::mock( ResourceStorages::class );
-		$resourceStorage->shouldReceive( 'is_supported_resource' )
-						->with( 'invalid-resource' )
-						->andReturn( false );
+		$resource_storage = Mockery::mock( ResourceStorages::class );
+		$resource_storage->shouldReceive( 'is_supported_resource' )
+			->with( 'invalid-resource' )
+			->andReturn( false );
 
-		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		$import_install_plugin = Mockery::mock( ImportInstallPlugin::class, array( $resource_storage ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$result = $importInstallPlugin->process( $schema );
+		$result = $import_install_plugin->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$messages = $result->get_messages( 'info' );
@@ -68,12 +90,18 @@ class ImportInstallPluginTest extends TestCase {
 		$this->assertEquals( "Skipped installing a plugin. Unsupported resource type. Only 'wordpress.org/plugins' is supported at the moment.", $messages[0]['message'] );
 	}
 
+	/**
+	 * Test successful plugin installation and activation.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_installation_and_activation() {
-		$pluginSlug = 'sample-plugin';
+		$plugin_slug = 'sample-plugin';
 
-		$schema             = Mockery::mock();
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$schema->pluginData = (object) array(
-			'slug'     => $pluginSlug,
+			'slug'     => $plugin_slug,
 			'resource' => 'wordpress.org/plugins',
 		);
 
@@ -81,41 +109,46 @@ class ImportInstallPluginTest extends TestCase {
 			'activate' => true,
 		);
 
-		$resourceStorage = Mockery::mock( ResourceStorages::class );
-		$resourceStorage->shouldReceive( 'is_supported_resource' )
-						->with( 'wordpress.org/plugins' )
-						->andReturn( true );
-		$resourceStorage->shouldReceive( 'download' )
-						->with( $pluginSlug, 'wordpress.org/plugins' )
-						->andReturn( '/path/to/plugin.zip' );
+		$resource_storage = Mockery::mock( ResourceStorages::class );
+		$resource_storage->shouldReceive( 'is_supported_resource' )
+			->with( 'wordpress.org/plugins' )
+			->andReturn( true );
+		$resource_storage->shouldReceive( 'download' )
+			->with( $plugin_slug, 'wordpress.org/plugins' )
+			->andReturn( '/path/to/plugin.zip' );
 
-		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		$import_install_plugin = Mockery::mock( ImportInstallPlugin::class, array( $resource_storage ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$importInstallPlugin->shouldReceive( 'get_installed_plugins_paths' )
-							->andReturn( array() );
-		$importInstallPlugin->shouldReceive( 'install' )
-							->with( '/path/to/plugin.zip' )
-							->andReturn( true );
-		$importInstallPlugin->shouldReceive( 'activate' )
-							->with( $pluginSlug )
-							->andReturnNull();
+		$import_install_plugin->shouldReceive( 'get_installed_plugins_paths' )
+			->andReturn( array() );
+		$import_install_plugin->shouldReceive( 'install' )
+			->with( '/path/to/plugin.zip' )
+			->andReturn( true );
+		$import_install_plugin->shouldReceive( 'activate' )
+			->with( $plugin_slug )
+			->andReturnNull();
 
-		$result = $importInstallPlugin->process( $schema );
+		$result = $import_install_plugin->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertTrue( $result->is_success() );
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 2, $messages );
-		$this->assertEquals( "Installed {$pluginSlug}.", $messages[0]['message'] );
-		$this->assertEquals( "Activated {$pluginSlug}.", $messages[1]['message'] );
+		$this->assertEquals( "Installed {$plugin_slug}.", $messages[0]['message'] );
+		$this->assertEquals( "Activated {$plugin_slug}.", $messages[1]['message'] );
 	}
 
+	/**
+	 * Test getting the step class.
+	 *
+	 * @return void
+	 */
 	public function test_get_step_class() {
-		$resourceStorage     = Mockery::mock( ResourceStorages::class );
-		$importInstallPlugin = new ImportInstallPlugin( $resourceStorage );
+		$resource_storage      = Mockery::mock( ResourceStorages::class );
+		$import_install_plugin = new ImportInstallPlugin( $resource_storage );
 
-		$this->assertEquals( InstallPlugin::class, $importInstallPlugin->get_step_class() );
+		$this->assertEquals( InstallPlugin::class, $import_install_plugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportInstallPluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportInstallPluginTest.php
@@ -18,104 +18,104 @@ class ImportInstallPluginTest extends TestCase {
 	public function test_process_skipped_installation() {
 		$pluginSlug = 'already-installed-plugin';
 
-		$schema = Mockery::mock();
-		$schema->pluginData = (object)[
-			'slug' => $pluginSlug,
-			'resource' => 'wordpress.org/plugins'
-		];
+		$schema             = Mockery::mock();
+		$schema->pluginData = (object) array(
+			'slug'     => $pluginSlug,
+			'resource' => 'wordpress.org/plugins',
+		);
 
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$importInstallPlugin = Mockery::mock(ImportInstallPlugin::class, [$resourceStorage])
-		                              ->makePartial()
-		                              ->shouldAllowMockingProtectedMethods();
+		$resourceStorage     = Mockery::mock( ResourceStorages::class );
+		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
-		$importInstallPlugin->shouldReceive('get_installed_plugins_paths')
-		                    ->andReturn([$pluginSlug => '/path/to/plugin']);
+		$importInstallPlugin->shouldReceive( 'get_installed_plugins_paths' )
+							->andReturn( array( $pluginSlug => '/path/to/plugin' ) );
 
-		$result = $importInstallPlugin->process($schema);
+		$result = $importInstallPlugin->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertTrue($result->is_success());
-		$this->assertEquals(InstallPlugin::get_step_name(), $result->get_step_name());
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Skipped installing {$pluginSlug}. It is already installed.", $messages[0]['message']);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
+		$this->assertEquals( InstallPlugin::get_step_name(), $result->get_step_name() );
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Skipped installing {$pluginSlug}. It is already installed.", $messages[0]['message'] );
 	}
 
 	public function test_process_invalid_resource() {
 		$pluginSlug = 'invalid-resource-plugin';
 
-		$schema = Mockery::mock();
-		$schema->pluginData = (object)[
-			'slug' => $pluginSlug,
-			'resource' => 'invalid-resource'
-		];
+		$schema             = Mockery::mock();
+		$schema->pluginData = (object) array(
+			'slug'     => $pluginSlug,
+			'resource' => 'invalid-resource',
+		);
 
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$resourceStorage->shouldReceive('is_supported_resource')
-		                ->with('invalid-resource')
-		                ->andReturn(false);
+		$resourceStorage = Mockery::mock( ResourceStorages::class );
+		$resourceStorage->shouldReceive( 'is_supported_resource' )
+						->with( 'invalid-resource' )
+						->andReturn( false );
 
-		$importInstallPlugin = Mockery::mock(ImportInstallPlugin::class, [$resourceStorage])
-		                              ->makePartial()
-		                              ->shouldAllowMockingProtectedMethods();
+		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
-		$result = $importInstallPlugin->process($schema);
+		$result = $importInstallPlugin->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals("Skipped installing a plugin. Unsupported resource type. Only 'wordpress.org/plugins' is supported at the moment.", $messages[0]['message']);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( "Skipped installing a plugin. Unsupported resource type. Only 'wordpress.org/plugins' is supported at the moment.", $messages[0]['message'] );
 	}
 
 	public function test_process_successful_installation_and_activation() {
 		$pluginSlug = 'sample-plugin';
 
-		$schema = Mockery::mock();
-		$schema->pluginData = (object)[
-			'slug' => $pluginSlug,
+		$schema             = Mockery::mock();
+		$schema->pluginData = (object) array(
+			'slug'     => $pluginSlug,
 			'resource' => 'wordpress.org/plugins',
-		];
+		);
 
 		$schema->options = (object) array(
 			'activate' => true,
 		);
 
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$resourceStorage->shouldReceive('is_supported_resource')
-		                ->with('wordpress.org/plugins')
-		                ->andReturn(true);
-		$resourceStorage->shouldReceive('download')
-		                ->with($pluginSlug, 'wordpress.org/plugins')
-		                ->andReturn('/path/to/plugin.zip');
+		$resourceStorage = Mockery::mock( ResourceStorages::class );
+		$resourceStorage->shouldReceive( 'is_supported_resource' )
+						->with( 'wordpress.org/plugins' )
+						->andReturn( true );
+		$resourceStorage->shouldReceive( 'download' )
+						->with( $pluginSlug, 'wordpress.org/plugins' )
+						->andReturn( '/path/to/plugin.zip' );
 
-		$importInstallPlugin = Mockery::mock(ImportInstallPlugin::class, [$resourceStorage])
-		                              ->makePartial()
-		                              ->shouldAllowMockingProtectedMethods();
+		$importInstallPlugin = Mockery::mock( ImportInstallPlugin::class, array( $resourceStorage ) )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
-		$importInstallPlugin->shouldReceive('get_installed_plugins_paths')
-		                    ->andReturn([]);
-		$importInstallPlugin->shouldReceive('install')
-		                    ->with('/path/to/plugin.zip')
-		                    ->andReturn(true);
-		$importInstallPlugin->shouldReceive('activate')
-		                    ->with($pluginSlug)
-		                    ->andReturnNull();
+		$importInstallPlugin->shouldReceive( 'get_installed_plugins_paths' )
+							->andReturn( array() );
+		$importInstallPlugin->shouldReceive( 'install' )
+							->with( '/path/to/plugin.zip' )
+							->andReturn( true );
+		$importInstallPlugin->shouldReceive( 'activate' )
+							->with( $pluginSlug )
+							->andReturnNull();
 
-		$result = $importInstallPlugin->process($schema);
+		$result = $importInstallPlugin->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertTrue($result->is_success());
-		$messages = $result->get_messages('info');
-		$this->assertCount(2, $messages);
-		$this->assertEquals("Installed {$pluginSlug}.", $messages[0]['message']);
-		$this->assertEquals("Activated {$pluginSlug}.", $messages[1]['message']);
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 2, $messages );
+		$this->assertEquals( "Installed {$pluginSlug}.", $messages[0]['message'] );
+		$this->assertEquals( "Activated {$pluginSlug}.", $messages[1]['message'] );
 	}
 
 	public function test_get_step_class() {
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$importInstallPlugin = new ImportInstallPlugin($resourceStorage);
+		$resourceStorage     = Mockery::mock( ResourceStorages::class );
+		$importInstallPlugin = new ImportInstallPlugin( $resourceStorage );
 
-		$this->assertEquals(InstallPlugin::class, $importInstallPlugin->get_step_class());
+		$this->assertEquals( InstallPlugin::class, $importInstallPlugin->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportInstallThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportInstallThemeTest.php
@@ -9,83 +9,105 @@ use Automattic\WooCommerce\Blueprint\Steps\InstallTheme;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportInstallTheme class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportInstallThemeTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test successful theme installation and switching.
+	 *
+	 * @return void
+	 */
 	public function test_process_successful_installation_and_switching() {
-		$themeSlug = 'sample-theme';
+		$theme_slug = 'sample-theme';
 
-		$schema            = Mockery::mock();
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$schema->themeData = (object) array(
-			'slug'     => $themeSlug,
+			'slug'     => $theme_slug,
 			'resource' => 'valid-resource',
 			'activate' => true,
 		);
 
-		$resourceStorage = Mockery::mock( ResourceStorages::class );
-		$resourceStorage->shouldReceive( 'is_supported_resource' )
-						->with( 'valid-resource' )
-						->andReturn( true );
-		$resourceStorage->shouldReceive( 'download' )
-						->with( $themeSlug, 'valid-resource' )
-						->andReturn( '/path/to/theme.zip' );
+		$resource_storage = Mockery::mock( ResourceStorages::class );
+		$resource_storage->shouldReceive( 'is_supported_resource' )
+			->with( 'valid-resource' )
+			->andReturn( true );
+		$resource_storage->shouldReceive( 'download' )
+			->with( $theme_slug, 'valid-resource' )
+			->andReturn( '/path/to/theme.zip' );
 
-		$importInstallTheme = Mockery::mock( ImportInstallTheme::class, array( $resourceStorage ) )
-									->makePartial()
-									->shouldAllowMockingProtectedMethods();
+		$import_install_theme = Mockery::mock( ImportInstallTheme::class, array( $resource_storage ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$importInstallTheme->shouldReceive( 'wp_get_themes' )
-							->andReturn( array() );
-		$importInstallTheme->shouldReceive( 'install' )
-							->with( '/path/to/theme.zip' )
-							->andReturn( true );
-		$importInstallTheme->shouldReceive( 'wp_switch_theme' )
-							->with( $themeSlug )
-							->andReturn( true );
+		$import_install_theme->shouldReceive( 'wp_get_themes' )
+			->andReturn( array() );
+		$import_install_theme->shouldReceive( 'install' )
+			->with( '/path/to/theme.zip' )
+			->andReturn( true );
+		$import_install_theme->shouldReceive( 'wp_switch_theme' )
+			->with( $theme_slug )
+			->andReturn( true );
 
-		$result = $importInstallTheme->process( $schema );
+		$result = $import_install_theme->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertTrue( $result->is_success() );
 	}
 
+	/**
+	 * Test theme installation failure.
+	 *
+	 * @return void
+	 */
 	public function test_process_installation_failure() {
-		$themeSlug = 'failed-theme';
+		$theme_slug = 'failed-theme';
 
-		$schema            = Mockery::mock();
+		$schema = Mockery::mock();
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$schema->themeData = (object) array(
-			'slug'     => $themeSlug,
+			'slug'     => $theme_slug,
 			'resource' => 'wordpress.org/themes',
 			'activate' => false,
 		);
 
-		$resourceStorage = Mockery::mock( ResourceStorages::class );
-		$resourceStorage->shouldReceive( 'is_supported_resource' )
-						->with( 'wordpress.org/themes' )
-						->andReturn( true );
-		$resourceStorage->shouldReceive( 'download' )
-						->with( $themeSlug, 'wordpress.org/themes' )
-						->andReturn( '/path/to/theme.zip' );
+		$resource_storage = Mockery::mock( ResourceStorages::class );
+		$resource_storage->shouldReceive( 'is_supported_resource' )
+			->with( 'wordpress.org/themes' )
+			->andReturn( true );
+		$resource_storage->shouldReceive( 'download' )
+			->with( $theme_slug, 'wordpress.org/themes' )
+			->andReturn( '/path/to/theme.zip' );
 
-		$importInstallTheme = Mockery::mock( ImportInstallTheme::class, array( $resourceStorage ) )
-									->makePartial()
-									->shouldAllowMockingProtectedMethods();
+		$import_install_theme = Mockery::mock( ImportInstallTheme::class, array( $resource_storage ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$importInstallTheme->shouldReceive( 'wp_get_themes' )
-							->andReturn( array() );
-		$importInstallTheme->shouldReceive( 'install' )
-							->with( '/path/to/theme.zip' )
-							->andReturn( false );
+		$import_install_theme->shouldReceive( 'wp_get_themes' )
+			->andReturn( array() );
+		$import_install_theme->shouldReceive( 'install' )
+			->with( '/path/to/theme.zip' )
+			->andReturn( false );
 
-		$result = $importInstallTheme->process( $schema );
+		$result = $import_install_theme->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertFalse( $result->is_success() );
-		$errorMessages = $result->get_messages( 'error' );
-		$this->assertCount( 1, $errorMessages ); // Only error message
-		$this->assertEquals( "Failed to install theme '{$themeSlug}'.", $errorMessages[1]['message'] );
+		$error_messages = $result->get_messages( 'error' );
+		$this->assertCount( 1, $error_messages ); // Only error message.
+		$this->assertEquals( "Failed to install theme '{$theme_slug}'.", $error_messages[1]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportInstallThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportInstallThemeTest.php
@@ -18,75 +18,74 @@ class ImportInstallThemeTest extends TestCase {
 	public function test_process_successful_installation_and_switching() {
 		$themeSlug = 'sample-theme';
 
-		$schema = Mockery::mock();
-		$schema->themeData = (object)[
-			'slug' => $themeSlug,
+		$schema            = Mockery::mock();
+		$schema->themeData = (object) array(
+			'slug'     => $themeSlug,
 			'resource' => 'valid-resource',
 			'activate' => true,
-		];
+		);
 
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$resourceStorage->shouldReceive('is_supported_resource')
-		                ->with('valid-resource')
-		                ->andReturn(true);
-		$resourceStorage->shouldReceive('download')
-		                ->with($themeSlug, 'valid-resource')
-		                ->andReturn('/path/to/theme.zip');
+		$resourceStorage = Mockery::mock( ResourceStorages::class );
+		$resourceStorage->shouldReceive( 'is_supported_resource' )
+						->with( 'valid-resource' )
+						->andReturn( true );
+		$resourceStorage->shouldReceive( 'download' )
+						->with( $themeSlug, 'valid-resource' )
+						->andReturn( '/path/to/theme.zip' );
 
-		$importInstallTheme = Mockery::mock(ImportInstallTheme::class, [$resourceStorage])
-		                             ->makePartial()
-		                             ->shouldAllowMockingProtectedMethods();
+		$importInstallTheme = Mockery::mock( ImportInstallTheme::class, array( $resourceStorage ) )
+									->makePartial()
+									->shouldAllowMockingProtectedMethods();
 
-		$importInstallTheme->shouldReceive('wp_get_themes')
-		                   ->andReturn([]);
-		$importInstallTheme->shouldReceive('install')
-		                   ->with('/path/to/theme.zip')
-		                   ->andReturn(true);
-		$importInstallTheme->shouldReceive('wp_switch_theme')
-		                   ->with($themeSlug)
-		                   ->andReturn(true);
+		$importInstallTheme->shouldReceive( 'wp_get_themes' )
+							->andReturn( array() );
+		$importInstallTheme->shouldReceive( 'install' )
+							->with( '/path/to/theme.zip' )
+							->andReturn( true );
+		$importInstallTheme->shouldReceive( 'wp_switch_theme' )
+							->with( $themeSlug )
+							->andReturn( true );
 
-		$result = $importInstallTheme->process($schema);
+		$result = $importInstallTheme->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertTrue($result->is_success());
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
 	}
 
 	public function test_process_installation_failure() {
 		$themeSlug = 'failed-theme';
 
-		$schema = Mockery::mock();
-		$schema->themeData = (object)[
-			'slug' => $themeSlug,
+		$schema            = Mockery::mock();
+		$schema->themeData = (object) array(
+			'slug'     => $themeSlug,
 			'resource' => 'wordpress.org/themes',
 			'activate' => false,
-		];
+		);
 
-		$resourceStorage = Mockery::mock(ResourceStorages::class);
-		$resourceStorage->shouldReceive('is_supported_resource')
-		                ->with('wordpress.org/themes')
-		                ->andReturn(true);
-		$resourceStorage->shouldReceive('download')
-		                ->with($themeSlug, 'wordpress.org/themes')
-		                ->andReturn('/path/to/theme.zip');
+		$resourceStorage = Mockery::mock( ResourceStorages::class );
+		$resourceStorage->shouldReceive( 'is_supported_resource' )
+						->with( 'wordpress.org/themes' )
+						->andReturn( true );
+		$resourceStorage->shouldReceive( 'download' )
+						->with( $themeSlug, 'wordpress.org/themes' )
+						->andReturn( '/path/to/theme.zip' );
 
-		$importInstallTheme = Mockery::mock(ImportInstallTheme::class, [$resourceStorage])
-		                             ->makePartial()
-		                             ->shouldAllowMockingProtectedMethods();
+		$importInstallTheme = Mockery::mock( ImportInstallTheme::class, array( $resourceStorage ) )
+									->makePartial()
+									->shouldAllowMockingProtectedMethods();
 
-		$importInstallTheme->shouldReceive('wp_get_themes')
-		                   ->andReturn([]);
-		$importInstallTheme->shouldReceive('install')
-		                   ->with('/path/to/theme.zip')
-		                   ->andReturn(false);
+		$importInstallTheme->shouldReceive( 'wp_get_themes' )
+							->andReturn( array() );
+		$importInstallTheme->shouldReceive( 'install' )
+							->with( '/path/to/theme.zip' )
+							->andReturn( false );
 
-		$result = $importInstallTheme->process($schema);
+		$result = $importInstallTheme->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertFalse($result->is_success());
-		$errorMessages = $result->get_messages('error');
-		$this->assertCount(1, $errorMessages); // Only error message
-		$this->assertEquals("Failed to install theme '{$themeSlug}'.", $errorMessages[1]['message']);
-
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertFalse( $result->is_success() );
+		$errorMessages = $result->get_messages( 'error' );
+		$this->assertCount( 1, $errorMessages ); // Only error message
+		$this->assertEquals( "Failed to install theme '{$themeSlug}'.", $errorMessages[1]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -15,68 +15,68 @@ class ImportSetSiteOptionsTest extends TestCase {
 	}
 
 	public function test_process_updates_options_successfully() {
-		$schema = Mockery::mock();
-		$schema->options = [
-			'site_name' => 'My New Site',
+		$schema          = Mockery::mock();
+		$schema->options = array(
+			'site_name'   => 'My New Site',
 			'admin_email' => 'admin@example.com',
-		];
+		);
 
-		$importSetSiteOptions = Mockery::mock(ImportSetSiteOptions::class)
-		                               ->makePartial()
-		                               ->shouldAllowMockingProtectedMethods();
+		$importSetSiteOptions = Mockery::mock( ImportSetSiteOptions::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock `wp_update_option` to return true for successful updates
-		$importSetSiteOptions->shouldReceive('wp_update_option')
-		                     ->with('site_name', 'My New Site')
-		                     ->andReturn(true);
-		$importSetSiteOptions->shouldReceive('wp_update_option')
-		                     ->with('admin_email', 'admin@example.com')
-		                     ->andReturn(true);
+		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
+							->with( 'site_name', 'My New Site' )
+							->andReturn( true );
+		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
+							->with( 'admin_email', 'admin@example.com' )
+							->andReturn( true );
 
-		$result = $importSetSiteOptions->process($schema);
+		$result = $importSetSiteOptions->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertTrue($result->is_success());
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
 
-		$messages = $result->get_messages('info');
-		$this->assertCount(2, $messages);
-		$this->assertEquals('site_name has been updated', $messages[0]['message']);
-		$this->assertEquals('admin_email has been updated', $messages[1]['message']);
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 2, $messages );
+		$this->assertEquals( 'site_name has been updated', $messages[0]['message'] );
+		$this->assertEquals( 'admin_email has been updated', $messages[1]['message'] );
 	}
 
 	public function test_process_option_already_up_to_date() {
-		$schema = Mockery::mock();
-		$schema->options = [
+		$schema          = Mockery::mock();
+		$schema->options = array(
 			'site_name' => 'Existing Site',
-		];
+		);
 
-		$importSetSiteOptions = Mockery::mock(ImportSetSiteOptions::class)
-		                               ->makePartial()
-		                               ->shouldAllowMockingProtectedMethods();
+		$importSetSiteOptions = Mockery::mock( ImportSetSiteOptions::class )
+										->makePartial()
+										->shouldAllowMockingProtectedMethods();
 
 		// Mock `wp_update_option` to return false
-		$importSetSiteOptions->shouldReceive('wp_update_option')
-		                     ->with('site_name', 'Existing Site')
-		                     ->andReturn(false);
+		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
+							->with( 'site_name', 'Existing Site' )
+							->andReturn( false );
 
 		// Mock `wp_get_option` to return the same value
-		$importSetSiteOptions->shouldReceive('wp_get_option')
-		                     ->with('site_name')
-		                     ->andReturn('Existing Site');
+		$importSetSiteOptions->shouldReceive( 'wp_get_option' )
+							->with( 'site_name' )
+							->andReturn( 'Existing Site' );
 
-		$result = $importSetSiteOptions->process($schema);
+		$result = $importSetSiteOptions->process( $schema );
 
-		$this->assertInstanceOf(StepProcessorResult::class, $result);
-		$this->assertTrue($result->is_success());
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
 
-		$messages = $result->get_messages('info');
-		$this->assertCount(1, $messages);
-		$this->assertEquals('site_name has not been updated because the current value is already up to date.', $messages[0]['message']);
+		$messages = $result->get_messages( 'info' );
+		$this->assertCount( 1, $messages );
+		$this->assertEquals( 'site_name has not been updated because the current value is already up to date.', $messages[0]['message'] );
 	}
 
 	public function test_get_step_class() {
 		$importSetSiteOptions = new ImportSetSiteOptions();
 
-		$this->assertEquals(SetSiteOptions::class, $importSetSiteOptions->get_step_class());
+		$this->assertEquals( SetSiteOptions::class, $importSetSiteOptions->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -8,12 +8,27 @@ use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test the ImportSetSiteOptions class.
+ *
+ * @package Automattic\WooCommerce\Blueprint\Tests\Unit\Importers
+ */
 class ImportSetSiteOptionsTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test successful update of site options.
+	 *
+	 * @return void
+	 */
 	public function test_process_updates_options_successfully() {
 		$schema          = Mockery::mock();
 		$schema->options = array(
@@ -21,19 +36,19 @@ class ImportSetSiteOptionsTest extends TestCase {
 			'admin_email' => 'admin@example.com',
 		);
 
-		$importSetSiteOptions = Mockery::mock( ImportSetSiteOptions::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock `wp_update_option` to return true for successful updates
-		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
-							->with( 'site_name', 'My New Site' )
-							->andReturn( true );
-		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
-							->with( 'admin_email', 'admin@example.com' )
-							->andReturn( true );
+		// Mock `wp_update_option` to return true for successful updates.
+		$import_set_site_options->shouldReceive( 'wp_update_option' )
+			->with( 'site_name', 'My New Site' )
+			->andReturn( true );
+		$import_set_site_options->shouldReceive( 'wp_update_option' )
+			->with( 'admin_email', 'admin@example.com' )
+			->andReturn( true );
 
-		$result = $importSetSiteOptions->process( $schema );
+		$result = $import_set_site_options->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertTrue( $result->is_success() );
@@ -44,27 +59,32 @@ class ImportSetSiteOptionsTest extends TestCase {
 		$this->assertEquals( 'admin_email has been updated', $messages[1]['message'] );
 	}
 
+	/**
+	 * Test when option value is already up to date.
+	 *
+	 * @return void
+	 */
 	public function test_process_option_already_up_to_date() {
 		$schema          = Mockery::mock();
 		$schema->options = array(
 			'site_name' => 'Existing Site',
 		);
 
-		$importSetSiteOptions = Mockery::mock( ImportSetSiteOptions::class )
-										->makePartial()
-										->shouldAllowMockingProtectedMethods();
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		// Mock `wp_update_option` to return false
-		$importSetSiteOptions->shouldReceive( 'wp_update_option' )
-							->with( 'site_name', 'Existing Site' )
-							->andReturn( false );
+		// Mock `wp_update_option` to return false.
+		$import_set_site_options->shouldReceive( 'wp_update_option' )
+			->with( 'site_name', 'Existing Site' )
+			->andReturn( false );
 
-		// Mock `wp_get_option` to return the same value
-		$importSetSiteOptions->shouldReceive( 'wp_get_option' )
-							->with( 'site_name' )
-							->andReturn( 'Existing Site' );
+		// Mock `wp_get_option` to return the same value.
+		$import_set_site_options->shouldReceive( 'wp_get_option' )
+			->with( 'site_name' )
+			->andReturn( 'Existing Site' );
 
-		$result = $importSetSiteOptions->process( $schema );
+		$result = $import_set_site_options->process( $schema );
 
 		$this->assertInstanceOf( StepProcessorResult::class, $result );
 		$this->assertTrue( $result->is_success() );
@@ -74,9 +94,14 @@ class ImportSetSiteOptionsTest extends TestCase {
 		$this->assertEquals( 'site_name has not been updated because the current value is already up to date.', $messages[0]['message'] );
 	}
 
+	/**
+	 * Test getting the step class.
+	 *
+	 * @return void
+	 */
 	public function test_get_step_class() {
-		$importSetSiteOptions = new ImportSetSiteOptions();
+		$import_set_site_options = new ImportSetSiteOptions();
 
-		$this->assertEquals( SetSiteOptions::class, $importSetSiteOptions->get_step_class() );
+		$this->assertEquals( SetSiteOptions::class, $import_set_site_options->get_step_class() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ResourceStorages/LocalPluginResourceStorageTest.php
+++ b/packages/php/blueprint/tests/Unit/ResourceStorages/LocalPluginResourceStorageTest.php
@@ -12,41 +12,41 @@ class LocalPluginResourceStorageTest extends TestCase {
 		parent::setUp();
 		// Setup a temporary directory for testing
 		$this->testPath = sys_get_temp_dir() . '/test_plugins';
-		mkdir($this->testPath, 0777, true);
-		mkdir("{$this->testPath}/plugins", 0777, true);
+		mkdir( $this->testPath, 0777, true );
+		mkdir( "{$this->testPath}/plugins", 0777, true );
 
 		// Create a sample plugin file
-		file_put_contents("{$this->testPath}/plugins/sample-plugin.zip", 'dummy content');
+		file_put_contents( "{$this->testPath}/plugins/sample-plugin.zip", 'dummy content' );
 	}
 
 	protected function tearDown(): void {
 		// Cleanup temporary directory after test
-		if (is_dir($this->testPath)) {
-			array_map('unlink', glob("{$this->testPath}/plugins/*"));
-			rmdir("{$this->testPath}/plugins");
-			rmdir($this->testPath);
+		if ( is_dir( $this->testPath ) ) {
+			array_map( 'unlink', glob( "{$this->testPath}/plugins/*" ) );
+			rmdir( "{$this->testPath}/plugins" );
+			rmdir( $this->testPath );
 		}
 
 		parent::tearDown();
 	}
 
 	public function test_download_finds_plugin_file() {
-		$storage = new LocalPluginResourceStorage($this->testPath);
-		$result = $storage->download('sample-plugin');
+		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$result  = $storage->download( 'sample-plugin' );
 
-		$this->assertNotNull($result);
-		$this->assertEquals("{$this->testPath}/plugins/sample-plugin.zip", $result);
+		$this->assertNotNull( $result );
+		$this->assertEquals( "{$this->testPath}/plugins/sample-plugin.zip", $result );
 	}
 
 	public function test_download_returns_null_for_missing_plugin() {
-		$storage = new LocalPluginResourceStorage($this->testPath);
-		$result = $storage->download('nonexistent-plugin');
+		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$result  = $storage->download( 'nonexistent-plugin' );
 
-		$this->assertNull($result);
+		$this->assertNull( $result );
 	}
 
 	public function test_get_supported_resource_returns_correct_value() {
-		$storage = new LocalPluginResourceStorage($this->testPath);
-		$this->assertEquals('self/plugins', $storage->get_supported_resource());
+		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$this->assertEquals( 'self/plugins', $storage->get_supported_resource() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ResourceStorages/LocalPluginResourceStorageTest.php
+++ b/packages/php/blueprint/tests/Unit/ResourceStorages/LocalPluginResourceStorageTest.php
@@ -5,48 +5,81 @@ namespace Automattic\WooCommerce\Blueprint\Tests\Unit\ResourceStorages;
 use Automattic\WooCommerce\Blueprint\ResourceStorages\LocalPluginResourceStorage;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Unit tests for LocalPluginResourceStorage class.
+ */
 class LocalPluginResourceStorageTest extends TestCase {
-	protected string $testPath;
+	/**
+	 * Test path.
+	 *
+	 * @var string
+	 */
+	protected string $test_path;
 
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
-		// Setup a temporary directory for testing
-		$this->testPath = sys_get_temp_dir() . '/test_plugins';
-		mkdir( $this->testPath, 0777, true );
-		mkdir( "{$this->testPath}/plugins", 0777, true );
+		// Setup a temporary directory for testing.
+		$this->test_path = sys_get_temp_dir() . '/test_plugins';
+		mkdir( $this->test_path, 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		mkdir( "{$this->test_path}/plugins", 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
 
-		// Create a sample plugin file
-		file_put_contents( "{$this->testPath}/plugins/sample-plugin.zip", 'dummy content' );
+		// Create a sample plugin file.
+		file_put_contents( "{$this->test_path}/plugins/sample-plugin.zip", 'dummy content' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 	}
 
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
-		// Cleanup temporary directory after test
-		if ( is_dir( $this->testPath ) ) {
-			array_map( 'unlink', glob( "{$this->testPath}/plugins/*" ) );
-			rmdir( "{$this->testPath}/plugins" );
-			rmdir( $this->testPath );
+		// Cleanup temporary directory after test.
+		if ( is_dir( $this->test_path ) ) {
+			array_map( 'unlink', glob( "{$this->test_path}/plugins/*" ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_glob
+			rmdir( "{$this->test_path}/plugins" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			rmdir( $this->test_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 		}
 
 		parent::tearDown();
 	}
 
+	/**
+	 * Test download finds plugin file.
+	 *
+	 * @return void
+	 */
 	public function test_download_finds_plugin_file() {
-		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$storage = new LocalPluginResourceStorage( $this->test_path );
 		$result  = $storage->download( 'sample-plugin' );
 
 		$this->assertNotNull( $result );
-		$this->assertEquals( "{$this->testPath}/plugins/sample-plugin.zip", $result );
+		$this->assertEquals( "{$this->test_path}/plugins/sample-plugin.zip", $result );
 	}
 
+	/**
+	 * Test download returns null for missing plugin.
+	 *
+	 * @return void
+	 */
 	public function test_download_returns_null_for_missing_plugin() {
-		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$storage = new LocalPluginResourceStorage( $this->test_path );
 		$result  = $storage->download( 'nonexistent-plugin' );
 
 		$this->assertNull( $result );
 	}
 
+	/**
+	 * Test get supported resource returns correct value.
+	 *
+	 * @return void
+	 */
 	public function test_get_supported_resource_returns_correct_value() {
-		$storage = new LocalPluginResourceStorage( $this->testPath );
+		$storage = new LocalPluginResourceStorage( $this->test_path );
 		$this->assertEquals( 'self/plugins', $storage->get_supported_resource() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ResourceStorages/OrgPluginResourceStorageTest.php
+++ b/packages/php/blueprint/tests/Unit/ResourceStorages/OrgPluginResourceStorageTest.php
@@ -6,51 +6,74 @@ use Automattic\WooCommerce\Blueprint\ResourceStorages\OrgPluginResourceStorage;
 use PHPUnit\Framework\TestCase;
 use Mockery;
 
+/**
+ * Unit tests for OrgPluginResourceStorage class.
+ */
 class OrgPluginResourceStorageTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test the get_supported_resource method returns the correct value.
+	 *
+	 * @return void
+	 */
 	public function test_get_supported_resource_returns_correct_value() {
 		$storage = new OrgPluginResourceStorage();
 		$this->assertEquals( 'wordpress.org/plugins', $storage->get_supported_resource() );
 	}
 
+	/**
+	 * Test the download method returns the path for a valid plugin.
+	 *
+	 * @return void
+	 */
 	public function test_download_returns_path_for_valid_plugin() {
-		$slug         = 'sample-plugin';
-		$downloadLink = "https://downloads.wordpress.org/plugin/{$slug}.zip";
-		$localPath    = "/tmp/{$slug}.zip";
+		$slug          = 'sample-plugin';
+		$download_link = "https://downloads.wordpress.org/plugin/{$slug}.zip";
+		$local_path    = "/tmp/{$slug}.zip";
 
-		$mockStorage = Mockery::mock( OrgPluginResourceStorage::class )
+		$mock_storage = Mockery::mock( OrgPluginResourceStorage::class )
 								->makePartial()
 								->shouldAllowMockingProtectedMethods();
 
-		$mockStorage->shouldReceive( 'get_download_link' )
+		$mock_storage->shouldReceive( 'get_download_link' )
 					->with( $slug )
-					->andReturn( $downloadLink );
+					->andReturn( $download_link );
 
-		$mockStorage->shouldReceive( 'wp_download_url' )
-					->with( $downloadLink )
-					->andReturn( $localPath );
+		$mock_storage->shouldReceive( 'wp_download_url' )
+					->with( $download_link )
+					->andReturn( $local_path );
 
-		$result = $mockStorage->download( $slug );
+		$result = $mock_storage->download( $slug );
 
-		$this->assertEquals( $localPath, $result );
+		$this->assertEquals( $local_path, $result );
 	}
 
+	/**
+	 * Test the download method returns null for an invalid plugin.
+	 *
+	 * @return void
+	 */
 	public function test_download_returns_null_for_invalid_plugin() {
 		$slug = 'nonexistent-plugin';
 
-		$mockStorage = Mockery::mock( OrgPluginResourceStorage::class )
+		$mock_storage = Mockery::mock( OrgPluginResourceStorage::class )
 								->makePartial()
 								->shouldAllowMockingProtectedMethods();
 
-		$mockStorage->shouldReceive( 'get_download_link' )
+		$mock_storage->shouldReceive( 'get_download_link' )
 					->with( $slug )
 					->andReturn( null );
 
-		$result = $mockStorage->download( $slug );
+		$result = $mock_storage->download( $slug );
 
 		$this->assertEmpty( $result );
 	}

--- a/packages/php/blueprint/tests/Unit/ResourceStorages/OrgPluginResourceStorageTest.php
+++ b/packages/php/blueprint/tests/Unit/ResourceStorages/OrgPluginResourceStorageTest.php
@@ -14,44 +14,44 @@ class OrgPluginResourceStorageTest extends TestCase {
 
 	public function test_get_supported_resource_returns_correct_value() {
 		$storage = new OrgPluginResourceStorage();
-		$this->assertEquals('wordpress.org/plugins', $storage->get_supported_resource());
+		$this->assertEquals( 'wordpress.org/plugins', $storage->get_supported_resource() );
 	}
 
 	public function test_download_returns_path_for_valid_plugin() {
-		$slug = 'sample-plugin';
+		$slug         = 'sample-plugin';
 		$downloadLink = "https://downloads.wordpress.org/plugin/{$slug}.zip";
-		$localPath = "/tmp/{$slug}.zip";
+		$localPath    = "/tmp/{$slug}.zip";
 
-		$mockStorage = Mockery::mock(OrgPluginResourceStorage::class)
-		                      ->makePartial()
-		                      ->shouldAllowMockingProtectedMethods();
+		$mockStorage = Mockery::mock( OrgPluginResourceStorage::class )
+								->makePartial()
+								->shouldAllowMockingProtectedMethods();
 
-		$mockStorage->shouldReceive('get_download_link')
-		            ->with($slug)
-		            ->andReturn($downloadLink);
+		$mockStorage->shouldReceive( 'get_download_link' )
+					->with( $slug )
+					->andReturn( $downloadLink );
 
-		$mockStorage->shouldReceive('wp_download_url')
-		            ->with($downloadLink)
-		            ->andReturn($localPath);
+		$mockStorage->shouldReceive( 'wp_download_url' )
+					->with( $downloadLink )
+					->andReturn( $localPath );
 
-		$result = $mockStorage->download($slug);
+		$result = $mockStorage->download( $slug );
 
-		$this->assertEquals($localPath, $result);
+		$this->assertEquals( $localPath, $result );
 	}
 
 	public function test_download_returns_null_for_invalid_plugin() {
 		$slug = 'nonexistent-plugin';
 
-		$mockStorage = Mockery::mock(OrgPluginResourceStorage::class)
-		                      ->makePartial()
-		                      ->shouldAllowMockingProtectedMethods();
+		$mockStorage = Mockery::mock( OrgPluginResourceStorage::class )
+								->makePartial()
+								->shouldAllowMockingProtectedMethods();
 
-		$mockStorage->shouldReceive('get_download_link')
-		            ->with($slug)
-		            ->andReturn(null);
+		$mockStorage->shouldReceive( 'get_download_link' )
+					->with( $slug )
+					->andReturn( null );
 
-		$result = $mockStorage->download($slug);
+		$result = $mockStorage->download( $slug );
 
-		$this->assertEmpty($result);
+		$this->assertEmpty( $result );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ResultFormatters/JsonResultFormatterTest.php
+++ b/packages/php/blueprint/tests/Unit/ResultFormatters/JsonResultFormatterTest.php
@@ -14,121 +14,155 @@ class JsonResultFormatterTest extends TestCase {
 	}
 
 	public function test_format_all_message_types() {
-		$mockResult1 = Mockery::mock(StepProcessorResult::class);
-		$mockResult1->shouldReceive('get_step_name')
-		            ->andReturn('Step 1');
-		$mockResult1->shouldReceive('get_messages')
-		            ->with('all')
-		            ->andReturn([
-			            ['type' => 'info', 'message' => 'Info message 1'],
-			            ['type' => 'error', 'message' => 'Error message 1'],
-		            ]);
-		$mockResult1->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult1 = Mockery::mock( StepProcessorResult::class );
+		$mockResult1->shouldReceive( 'get_step_name' )
+					->andReturn( 'Step 1' );
+		$mockResult1->shouldReceive( 'get_messages' )
+					->with( 'all' )
+					->andReturn(
+						array(
+							array(
+								'type'    => 'info',
+								'message' => 'Info message 1',
+							),
+							array(
+								'type'    => 'error',
+								'message' => 'Error message 1',
+							),
+						)
+					);
+		$mockResult1->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$mockResult2 = Mockery::mock(StepProcessorResult::class);
-		$mockResult2->shouldReceive('get_step_name')
-		            ->andReturn('Step 2');
-		$mockResult2->shouldReceive('get_messages')
-		            ->with('all')
-		            ->andReturn([
-			            ['type' => 'debug', 'message' => 'Debug message 1'],
-		            ]);
-		$mockResult2->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult2 = Mockery::mock( StepProcessorResult::class );
+		$mockResult2->shouldReceive( 'get_step_name' )
+					->andReturn( 'Step 2' );
+		$mockResult2->shouldReceive( 'get_messages' )
+					->with( 'all' )
+					->andReturn(
+						array(
+							array(
+								'type'    => 'debug',
+								'message' => 'Debug message 1',
+							),
+						)
+					);
+		$mockResult2->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$results = [$mockResult1, $mockResult2];
+		$results = array( $mockResult1, $mockResult2 );
 
-		$formatter = new JsonResultFormatter($results);
+		$formatter = new JsonResultFormatter( $results );
 
-		$formatted = $formatter->format('all');
+		$formatted = $formatter->format( 'all' );
 
-		$expected = [
+		$expected = array(
 			'is_success' => true,
-			'messages'   => [
-				'info' => [
-					['step' => 'Step 1', 'type' => 'info', 'message' => 'Info message 1'],
-				],
-				'error' => [
-					['step' => 'Step 1', 'type' => 'error', 'message' => 'Error message 1'],
-				],
-				'debug' => [
-					['step' => 'Step 2', 'type' => 'debug', 'message' => 'Debug message 1'],
-				],
-			],
-		];
+			'messages'   => array(
+				'info'  => array(
+					array(
+						'step'    => 'Step 1',
+						'type'    => 'info',
+						'message' => 'Info message 1',
+					),
+				),
+				'error' => array(
+					array(
+						'step'    => 'Step 1',
+						'type'    => 'error',
+						'message' => 'Error message 1',
+					),
+				),
+				'debug' => array(
+					array(
+						'step'    => 'Step 2',
+						'type'    => 'debug',
+						'message' => 'Debug message 1',
+					),
+				),
+			),
+		);
 
-		$this->assertEquals($expected, $formatted);
+		$this->assertEquals( $expected, $formatted );
 	}
 
 	public function test_format_specific_message_type() {
-		$mockResult1 = Mockery::mock(StepProcessorResult::class);
-		$mockResult1->shouldReceive('get_step_name')
-		            ->andReturn('Step 1');
-		$mockResult1->shouldReceive('get_messages')
-		            ->with('info')
-		            ->andReturn([
-			            ['type' => 'info', 'message' => 'Info message 1'],
-		            ]);
-		$mockResult1->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult1 = Mockery::mock( StepProcessorResult::class );
+		$mockResult1->shouldReceive( 'get_step_name' )
+					->andReturn( 'Step 1' );
+		$mockResult1->shouldReceive( 'get_messages' )
+					->with( 'info' )
+					->andReturn(
+						array(
+							array(
+								'type'    => 'info',
+								'message' => 'Info message 1',
+							),
+						)
+					);
+		$mockResult1->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$mockResult2 = Mockery::mock(StepProcessorResult::class);
-		$mockResult2->shouldReceive('get_step_name')
-		            ->andReturn('Step 2');
-		$mockResult2->shouldReceive('get_messages')
-		            ->with('info')
-		            ->andReturn([]);
-		$mockResult2->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult2 = Mockery::mock( StepProcessorResult::class );
+		$mockResult2->shouldReceive( 'get_step_name' )
+					->andReturn( 'Step 2' );
+		$mockResult2->shouldReceive( 'get_messages' )
+					->with( 'info' )
+					->andReturn( array() );
+		$mockResult2->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$results = [$mockResult1, $mockResult2];
+		$results = array( $mockResult1, $mockResult2 );
 
-		$formatter = new JsonResultFormatter($results);
+		$formatter = new JsonResultFormatter( $results );
 
-		$formatted = $formatter->format('info');
+		$formatted = $formatter->format( 'info' );
 
-		$expected = [
+		$expected = array(
 			'is_success' => true,
-			'messages'   => [
-				'info' => [
-					['step' => 'Step 1', 'type' => 'info', 'message' => 'Info message 1'],
-				],
-			],
-		];
+			'messages'   => array(
+				'info' => array(
+					array(
+						'step'    => 'Step 1',
+						'type'    => 'info',
+						'message' => 'Info message 1',
+					),
+				),
+			),
+		);
 
-		$this->assertEquals($expected, $formatted);
+		$this->assertEquals( $expected, $formatted );
 	}
 
 	public function test_is_success_returns_true() {
-		$mockResult1 = Mockery::mock(StepProcessorResult::class);
-		$mockResult1->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult1 = Mockery::mock( StepProcessorResult::class );
+		$mockResult1->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$mockResult2 = Mockery::mock(StepProcessorResult::class);
-		$mockResult2->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult2 = Mockery::mock( StepProcessorResult::class );
+		$mockResult2->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$results = [$mockResult1, $mockResult2];
+		$results = array( $mockResult1, $mockResult2 );
 
-		$formatter = new JsonResultFormatter($results);
+		$formatter = new JsonResultFormatter( $results );
 
-		$this->assertTrue($formatter->is_success());
+		$this->assertTrue( $formatter->is_success() );
 	}
 
 	public function test_is_success_returns_false() {
-		$mockResult1 = Mockery::mock(StepProcessorResult::class);
-		$mockResult1->shouldReceive('is_success')
-		            ->andReturn(true);
+		$mockResult1 = Mockery::mock( StepProcessorResult::class );
+		$mockResult1->shouldReceive( 'is_success' )
+					->andReturn( true );
 
-		$mockResult2 = Mockery::mock(StepProcessorResult::class);
-		$mockResult2->shouldReceive('is_success')
-		            ->andReturn(false);
+		$mockResult2 = Mockery::mock( StepProcessorResult::class );
+		$mockResult2->shouldReceive( 'is_success' )
+					->andReturn( false );
 
-		$results = [$mockResult1, $mockResult2];
+		$results = array( $mockResult1, $mockResult2 );
 
-		$formatter = new JsonResultFormatter($results);
+		$formatter = new JsonResultFormatter( $results );
 
-		$this->assertFalse($formatter->is_success());
+		$this->assertFalse( $formatter->is_success() );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ResultFormatters/JsonResultFormatterTest.php
+++ b/packages/php/blueprint/tests/Unit/ResultFormatters/JsonResultFormatterTest.php
@@ -7,17 +7,30 @@ use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use PHPUnit\Framework\TestCase;
 use Mockery;
 
+/**
+ * Unit tests for JsonResultFormatter class.
+ */
 class JsonResultFormatterTest extends TestCase {
+	/**
+	 * Tear down the test.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
 	}
 
+	/**
+	 * Test the format method.
+	 *
+	 * @return void
+	 */
 	public function test_format_all_message_types() {
-		$mockResult1 = Mockery::mock( StepProcessorResult::class );
-		$mockResult1->shouldReceive( 'get_step_name' )
+		$mock_result1 = Mockery::mock( StepProcessorResult::class );
+		$mock_result1->shouldReceive( 'get_step_name' )
 					->andReturn( 'Step 1' );
-		$mockResult1->shouldReceive( 'get_messages' )
+		$mock_result1->shouldReceive( 'get_messages' )
 					->with( 'all' )
 					->andReturn(
 						array(
@@ -31,13 +44,13 @@ class JsonResultFormatterTest extends TestCase {
 							),
 						)
 					);
-		$mockResult1->shouldReceive( 'is_success' )
+		$mock_result1->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$mockResult2 = Mockery::mock( StepProcessorResult::class );
-		$mockResult2->shouldReceive( 'get_step_name' )
+		$mock_result2 = Mockery::mock( StepProcessorResult::class );
+		$mock_result2->shouldReceive( 'get_step_name' )
 					->andReturn( 'Step 2' );
-		$mockResult2->shouldReceive( 'get_messages' )
+		$mock_result2->shouldReceive( 'get_messages' )
 					->with( 'all' )
 					->andReturn(
 						array(
@@ -47,10 +60,10 @@ class JsonResultFormatterTest extends TestCase {
 							),
 						)
 					);
-		$mockResult2->shouldReceive( 'is_success' )
+		$mock_result2->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$results = array( $mockResult1, $mockResult2 );
+		$results = array( $mock_result1, $mock_result2 );
 
 		$formatter = new JsonResultFormatter( $results );
 
@@ -86,11 +99,16 @@ class JsonResultFormatterTest extends TestCase {
 		$this->assertEquals( $expected, $formatted );
 	}
 
+	/**
+	 * Test formatting with a specific message type.
+	 *
+	 * @return void
+	 */
 	public function test_format_specific_message_type() {
-		$mockResult1 = Mockery::mock( StepProcessorResult::class );
-		$mockResult1->shouldReceive( 'get_step_name' )
+		$mock_result1 = Mockery::mock( StepProcessorResult::class );
+		$mock_result1->shouldReceive( 'get_step_name' )
 					->andReturn( 'Step 1' );
-		$mockResult1->shouldReceive( 'get_messages' )
+		$mock_result1->shouldReceive( 'get_messages' )
 					->with( 'info' )
 					->andReturn(
 						array(
@@ -100,19 +118,19 @@ class JsonResultFormatterTest extends TestCase {
 							),
 						)
 					);
-		$mockResult1->shouldReceive( 'is_success' )
+		$mock_result1->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$mockResult2 = Mockery::mock( StepProcessorResult::class );
-		$mockResult2->shouldReceive( 'get_step_name' )
+		$mock_result2 = Mockery::mock( StepProcessorResult::class );
+		$mock_result2->shouldReceive( 'get_step_name' )
 					->andReturn( 'Step 2' );
-		$mockResult2->shouldReceive( 'get_messages' )
+		$mock_result2->shouldReceive( 'get_messages' )
 					->with( 'info' )
 					->andReturn( array() );
-		$mockResult2->shouldReceive( 'is_success' )
+		$mock_result2->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$results = array( $mockResult1, $mockResult2 );
+		$results = array( $mock_result1, $mock_result2 );
 
 		$formatter = new JsonResultFormatter( $results );
 
@@ -134,32 +152,42 @@ class JsonResultFormatterTest extends TestCase {
 		$this->assertEquals( $expected, $formatted );
 	}
 
+	/**
+	 * Test that is_success returns true when all results are successful.
+	 *
+	 * @return void
+	 */
 	public function test_is_success_returns_true() {
-		$mockResult1 = Mockery::mock( StepProcessorResult::class );
-		$mockResult1->shouldReceive( 'is_success' )
+		$mock_result1 = Mockery::mock( StepProcessorResult::class );
+		$mock_result1->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$mockResult2 = Mockery::mock( StepProcessorResult::class );
-		$mockResult2->shouldReceive( 'is_success' )
+		$mock_result2 = Mockery::mock( StepProcessorResult::class );
+		$mock_result2->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$results = array( $mockResult1, $mockResult2 );
+		$results = array( $mock_result1, $mock_result2 );
 
 		$formatter = new JsonResultFormatter( $results );
 
 		$this->assertTrue( $formatter->is_success() );
 	}
 
+	/**
+	 * Test that is_success returns false when any result is not successful.
+	 *
+	 * @return void
+	 */
 	public function test_is_success_returns_false() {
-		$mockResult1 = Mockery::mock( StepProcessorResult::class );
-		$mockResult1->shouldReceive( 'is_success' )
+		$mock_result1 = Mockery::mock( StepProcessorResult::class );
+		$mock_result1->shouldReceive( 'is_success' )
 					->andReturn( true );
 
-		$mockResult2 = Mockery::mock( StepProcessorResult::class );
-		$mockResult2->shouldReceive( 'is_success' )
+		$mock_result2 = Mockery::mock( StepProcessorResult::class );
+		$mock_result2->shouldReceive( 'is_success' )
 					->andReturn( false );
 
-		$results = array( $mockResult1, $mockResult2 );
+		$results = array( $mock_result1, $mock_result2 );
 
 		$formatter = new JsonResultFormatter( $results );
 

--- a/packages/php/blueprint/tests/Unit/Steps/ActivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/ActivatePluginTest.php
@@ -18,15 +18,15 @@ class ActivatePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name    = 'sample-plugin/sample-plugin.php';
-		$activatePlugin = new ActivatePlugin( $plugin_name );
+		$plugin_name     = 'sample-plugin/sample-plugin.php';
+		$activate_plugin = new ActivatePlugin( $plugin_name );
 
 		$expected_array = array(
 			'step'       => 'activatePlugin',
 			'pluginPath' => $plugin_name,
 		);
 
-		$this->assertEquals( $expected_array, $activatePlugin->prepare_json_array() );
+		$this->assertEquals( $expected_array, $activate_plugin->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/ActivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/ActivatePluginTest.php
@@ -18,7 +18,7 @@ class ActivatePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name = 'sample-plugin/sample-plugin.php';
+		$plugin_name    = 'sample-plugin/sample-plugin.php';
 		$activatePlugin = new ActivatePlugin( $plugin_name );
 
 		$expected_array = array(

--- a/packages/php/blueprint/tests/Unit/Steps/ActivateThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/ActivateThemeTest.php
@@ -11,11 +11,11 @@ class ActivateThemeTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$theme_name = 'my-theme';
+		$theme_name    = 'my-theme';
 		$activateTheme = new ActivateTheme( $theme_name );
 
 		$expected_array = array(
-			'step'      => 'activateTheme',
+			'step'            => 'activateTheme',
 			'themeFolderName' => $theme_name,
 		);
 
@@ -36,7 +36,7 @@ class ActivateThemeTest extends TestCase {
 		$expected_schema = array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'      => array(
+				'step'            => array(
 					'type' => 'string',
 					'enum' => array( 'activateTheme' ),
 				),

--- a/packages/php/blueprint/tests/Unit/Steps/ActivateThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/ActivateThemeTest.php
@@ -11,15 +11,15 @@ class ActivateThemeTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$theme_name    = 'my-theme';
-		$activateTheme = new ActivateTheme( $theme_name );
+		$theme_name     = 'my-theme';
+		$activate_theme = new ActivateTheme( $theme_name );
 
 		$expected_array = array(
 			'step'            => 'activateTheme',
 			'themeFolderName' => $theme_name,
 		);
 
-		$this->assertEquals( $expected_array, $activateTheme->prepare_json_array() );
+		$this->assertEquals( $expected_array, $activate_theme->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/DeactivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/DeactivatePluginTest.php
@@ -11,15 +11,15 @@ class DeactivatePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name      = 'sample-plugin/sample-plugin.php';
-		$deactivatePlugin = new DeactivatePlugin( $plugin_name );
+		$plugin_name       = 'sample-plugin/sample-plugin.php';
+		$deactivate_plugin = new DeactivatePlugin( $plugin_name );
 
 		$expected_array = array(
 			'step'       => 'deactivatePlugin',
 			'pluginName' => $plugin_name,
 		);
 
-		$this->assertEquals( $expected_array, $deactivatePlugin->prepare_json_array() );
+		$this->assertEquals( $expected_array, $deactivate_plugin->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/DeactivatePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/DeactivatePluginTest.php
@@ -11,7 +11,7 @@ class DeactivatePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name = 'sample-plugin/sample-plugin.php';
+		$plugin_name      = 'sample-plugin/sample-plugin.php';
 		$deactivatePlugin = new DeactivatePlugin( $plugin_name );
 
 		$expected_array = array(

--- a/packages/php/blueprint/tests/Unit/Steps/DeletePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/DeletePluginTest.php
@@ -11,7 +11,7 @@ class DeletePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name = 'sample-plugin/sample-plugin.php';
+		$plugin_name  = 'sample-plugin/sample-plugin.php';
 		$deletePlugin = new DeletePlugin( $plugin_name );
 
 		$expected_array = array(

--- a/packages/php/blueprint/tests/Unit/Steps/DeletePluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/DeletePluginTest.php
@@ -11,15 +11,15 @@ class DeletePluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$plugin_name  = 'sample-plugin/sample-plugin.php';
-		$deletePlugin = new DeletePlugin( $plugin_name );
+		$plugin_name   = 'sample-plugin/sample-plugin.php';
+		$delete_plugin = new DeletePlugin( $plugin_name );
 
 		$expected_array = array(
 			'step'       => 'deletePlugin',
 			'pluginName' => $plugin_name,
 		);
 
-		$this->assertEquals( $expected_array, $deletePlugin->prepare_json_array() );
+		$this->assertEquals( $expected_array, $delete_plugin->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/InstallPluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/InstallPluginTest.php
@@ -11,19 +11,19 @@ class InstallPluginTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$slug = 'sample-plugin';
+		$slug     = 'sample-plugin';
 		$resource = 'https://example.com/sample-plugin.zip';
-		$options = array( 'activate' => true );
+		$options  = array( 'activate' => true );
 
 		$installPlugin = new InstallPlugin( $slug, $resource, $options );
 
 		$expected_array = array(
-			'step'          => 'installPlugin',
+			'step'       => 'installPlugin',
 			'pluginData' => array(
 				'resource' => $resource,
 				'slug'     => $slug,
 			),
-			'options'       => $options,
+			'options'    => $options,
 		);
 
 		$this->assertEquals( $expected_array, $installPlugin->prepare_json_array() );
@@ -43,22 +43,22 @@ class InstallPluginTest extends TestCase {
 		$expected_schema = array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'          => array(
+				'step'       => array(
 					'type' => 'string',
 					'enum' => array( 'installPlugin' ),
 				),
 				'pluginData' => array(
-					"anyOf" => [
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/VFSReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/LiteralReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/CorePluginReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/CoreThemeReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/UrlReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/GitDirectoryReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/DirectoryLiteralReference.php",
-					]
+					'anyOf' => array(
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/VFSReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/LiteralReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/CorePluginReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/CoreThemeReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/UrlReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/GitDirectoryReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/DirectoryLiteralReference.php',
+					),
 				),
-				'options'       => array(
+				'options'    => array(
 					'type'       => 'object',
 					'properties' => array(
 						'activate' => array(

--- a/packages/php/blueprint/tests/Unit/Steps/InstallPluginTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/InstallPluginTest.php
@@ -15,7 +15,7 @@ class InstallPluginTest extends TestCase {
 		$resource = 'https://example.com/sample-plugin.zip';
 		$options  = array( 'activate' => true );
 
-		$installPlugin = new InstallPlugin( $slug, $resource, $options );
+		$install_plugin = new InstallPlugin( $slug, $resource, $options );
 
 		$expected_array = array(
 			'step'       => 'installPlugin',
@@ -26,7 +26,7 @@ class InstallPluginTest extends TestCase {
 			'options'    => $options,
 		);
 
-		$this->assertEquals( $expected_array, $installPlugin->prepare_json_array() );
+		$this->assertEquals( $expected_array, $install_plugin->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/InstallThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/InstallThemeTest.php
@@ -11,19 +11,19 @@ class InstallThemeTest extends TestCase {
 	 * Test the constructor and JSON preparation.
 	 */
 	public function testConstructorAndPrepareJsonArray() {
-		$slug = 'my-theme';
+		$slug     = 'my-theme';
 		$resource = 'https://example.com/my-theme.zip';
-		$options = array( 'activate' => true );
+		$options  = array( 'activate' => true );
 
 		$installTheme = new InstallTheme( $slug, $resource, $options );
 
 		$expected_array = array(
-			'step'         => 'installTheme',
+			'step'      => 'installTheme',
 			'themeData' => array(
 				'resource' => $resource,
 				'slug'     => $slug,
 			),
-			'options'      => $options,
+			'options'   => $options,
 		);
 
 		$this->assertEquals( $expected_array, $installTheme->prepare_json_array() );
@@ -43,22 +43,22 @@ class InstallThemeTest extends TestCase {
 		$expected_schema = array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'         => array(
+				'step'      => array(
 					'type' => 'string',
 					'enum' => array( 'installTheme' ),
 				),
 				'themeData' => array(
-					"anyOf" => [
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/VFSReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/LiteralReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/CorePluginReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/CoreThemeReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/UrlReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/GitDirectoryReference.php",
-						require __DIR__ . "/../../../src/Steps/schemas/definitions/DirectoryLiteralReference.php",
-					]
+					'anyOf' => array(
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/VFSReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/LiteralReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/CorePluginReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/CoreThemeReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/UrlReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/GitDirectoryReference.php',
+						require __DIR__ . '/../../../src/Steps/schemas/definitions/DirectoryLiteralReference.php',
+					),
 				),
-				'options'      => array(
+				'options'   => array(
 					'type'       => 'object',
 					'properties' => array(
 						'activate' => array(

--- a/packages/php/blueprint/tests/Unit/Steps/InstallThemeTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/InstallThemeTest.php
@@ -15,7 +15,7 @@ class InstallThemeTest extends TestCase {
 		$resource = 'https://example.com/my-theme.zip';
 		$options  = array( 'activate' => true );
 
-		$installTheme = new InstallTheme( $slug, $resource, $options );
+		$install_theme = new InstallTheme( $slug, $resource, $options );
 
 		$expected_array = array(
 			'step'      => 'installTheme',
@@ -26,7 +26,7 @@ class InstallThemeTest extends TestCase {
 			'options'   => $options,
 		);
 
-		$this->assertEquals( $expected_array, $installTheme->prepare_json_array() );
+		$this->assertEquals( $expected_array, $install_theme->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
@@ -16,14 +16,14 @@ class SetSiteOptionsTest extends TestCase {
 			'timezone'  => 'UTC',
 		);
 
-		$setSiteOptions = new SetSiteOptions( $options );
+		$set_site_options = new SetSiteOptions( $options );
 
 		$expected_array = array(
 			'step'    => 'setSiteOptions',
 			'options' => (object) $options,
 		);
 
-		$this->assertEquals( $expected_array, $setSiteOptions->prepare_json_array() );
+		$this->assertEquals( $expected_array, $set_site_options->prepare_json_array() );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Steps/SetSiteOptionsTest.php
@@ -40,12 +40,12 @@ class SetSiteOptionsTest extends TestCase {
 		$expected_schema = array(
 			'type'       => 'object',
 			'properties' => array(
-				'step'    => array(
+				'step' => array(
 					'type' => 'string',
 					'enum' => array( 'setSiteOptions' ),
 				),
 			),
-			'required'   => array( 'step'  ),
+			'required'   => array( 'step' ),
 		);
 
 		$this->assertEquals( $expected_schema, SetSiteOptions::get_schema() );

--- a/packages/php/blueprint/tests/Unit/ZipExportedSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ZipExportedSchemaTest.php
@@ -16,7 +16,7 @@ class ZipExportedSchemaTest extends TestCase {
 	 * @throws \Exception If the plugin slug is invalid.
 	 */
 	public function test_it_throws_invalid_argument_exception_with_invalid_slug() {
-		$this->markTestSkipped("Marking this test as skipped since we no longer use ZipExportedSchema. We'll bring it back once Playground implements it.");
+		$this->markTestSkipped( "Marking this test as skipped since we no longer use ZipExportedSchema. We'll bring it back once Playground implements it." );
 		$this->expectException( \InvalidArgumentException::class );
 		// phpcs:ignore
 		$json = json_decode( file_get_contents( $this->get_fixture_path( 'install-plugin-with-invalid-slug.json' ) ), true );

--- a/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
+++ b/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
@@ -6,7 +6,7 @@ use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Steps\DummyStep;
 
-class DummyImporter implements StepProcessor{
+class DummyImporter implements StepProcessor {
 	public function process( $schema ): StepProcessorResult {
 		return StepProcessorResult::success( DummyStep::get_step_name() );
 	}

--- a/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
+++ b/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
@@ -6,11 +6,25 @@ use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Steps\DummyStep;
 
+/**
+ * Dummy importer class.
+ */
 class DummyImporter implements StepProcessor {
+	/**
+	 * Process the step.
+	 *
+	 * @param object $schema The schema to process.
+	 * @return StepProcessorResult The result of the step.
+	 */
 	public function process( $schema ): StepProcessorResult {
 		return StepProcessorResult::success( DummyStep::get_step_name() );
 	}
 
+	/**
+	 * Get the step class.
+	 *
+	 * @return string The step class.
+	 */
 	public function get_step_class(): string {
 		return DummyStep::class;
 	}

--- a/packages/php/blueprint/tests/stubs/Steps/DummyStep.php
+++ b/packages/php/blueprint/tests/stubs/Steps/DummyStep.php
@@ -11,15 +11,15 @@ class DummyStep extends Step {
 
 	public static function get_schema( int $version = 1 ): array {
 		return array(
-			'type'       => 'object',
+			'type'                 => 'object',
 			'additionalProperties' => false,
-			'properties' => array(
+			'properties'           => array(
 				'step' => array(
 					'type' => 'string',
 					'enum' => array( static::get_step_name() ),
 				),
 			),
-			'required'   => array( 'step' ),
+			'required'             => array( 'step' ),
 		);
 	}
 

--- a/packages/php/blueprint/tests/stubs/Steps/DummyStep.php
+++ b/packages/php/blueprint/tests/stubs/Steps/DummyStep.php
@@ -4,11 +4,25 @@ namespace Automattic\WooCommerce\Blueprint\Tests\stubs\Steps;
 
 use Automattic\WooCommerce\Blueprint\Steps\Step;
 
+/**
+ * Dummy step class.
+ */
 class DummyStep extends Step {
+	/**
+	 * Get the step name.
+	 *
+	 * @return string The step name.
+	 */
 	public static function get_step_name(): string {
 		return 'dummy';
 	}
 
+	/**
+	 * Get the schema.
+	 *
+	 * @param int $version The version of the schema.
+	 * @return array The schema.
+	 */
 	public static function get_schema( int $version = 1 ): array {
 		return array(
 			'type'                 => 'object',
@@ -23,6 +37,11 @@ class DummyStep extends Step {
 		);
 	}
 
+	/**
+	 * Prepare the JSON array.
+	 *
+	 * @return array The JSON array.
+	 */
 	public function prepare_json_array(): array {
 		return array(
 			'step' => static::get_step_name(),

--- a/plugins/woocommerce/changelog/dev-fix-blueprint-package-setup
+++ b/plugins/woocommerce/changelog/dev-fix-blueprint-package-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blueprint lint errors

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -149,7 +149,7 @@ class RestApi {
 		$exporter      = new ExportSchema();
 
 		if ( isset( $payload['plugins'] ) ) {
-			$exporter->onBeforeExport(
+			$exporter->on_before_export(
 				'installPlugin',
 				function ( ExportInstallPluginSteps $exporter ) use ( $payload ) {
 					$exporter->filter(
@@ -162,7 +162,7 @@ class RestApi {
 		}
 
 		if ( isset( $payload['themes'] ) ) {
-			$exporter->onBeforeExport(
+			$exporter->on_before_export(
 				'installTheme',
 				function ( ExportInstallThemeSteps $exporter ) use ( $payload ) {
 					$exporter->filter(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3291,6 +3291,12 @@ importers:
         specifier: 0.14.10
         version: 0.14.10
 
+  packages/php/blueprint:
+    devDependencies:
+      '@wordpress/env':
+        specifier: 10.17.0
+        version: 10.17.0(patch_hash=ovltjfwrjswkqlvmxt7r5kywn4)(@types/node@22.9.1)
+
   packages/php/email-editor:
     devDependencies:
       '@wordpress/env':
@@ -24276,6 +24282,9 @@ packages:
   third-party-web@0.26.5:
     resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
+  third-party-web@0.26.6:
+    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
+
   throat@4.1.0:
     resolution: {integrity: sha512-wCVxLDcFxw7ujDxaeJC6nfl2XfHJNYs8yUYJnvMgtPEFlttP9tHSfRUv2vBe6C4hkVFPWoP1P6ZccbYjmSEkKA==}
 
@@ -28741,7 +28750,9 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@jest/reporters@25.5.1':
     dependencies:
@@ -29841,7 +29852,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.39':
     dependencies:
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -48971,7 +48982,9 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   jest-jasmine2@25.5.4:
     dependencies:
@@ -57428,6 +57441,8 @@ snapshots:
   therror@0.2.0: {}
 
   third-party-web@0.26.5: {}
+
+  third-party-web@0.26.6: {}
 
   throat@4.1.0: {}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The `packages/php/blueprint` project has not been set up correctly, including:

- Missing the `package.json` file.
- No linting configuration.
- No changelogs configuration.
- Many linting errors are reported

I suggested setting up and fixing the linting errors in https://github.com/woocommerce/woocommerce/pull/54442#pullrequestreview-2566118254. Unfortunately, the linting errors are still there and keep growing.

This PR updates the PHP Blueprint package configuration and fix the linting errors.

- Update PHP Blueprint package configuration and dependencies cfbfd1e78c20e0a3f114c0afacb4812a562198c3
- Fix linting errors by running `pnpm run lint:fix` ccc8af0358d19ca934ed31465d394c59e1b6e82d
- Fix remaining linting errors manually 46bb17ac8da173a4ace492b3646cc93a1475609f

Most of lint errors are because of variable naming conventions, documentation, and some other minor issues.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The PR doesn't change any existing functionality and blueprint feature has not been enabled yet so reviewing the changes should be sufficient.

Run `pnpm run --filter='@woocommerce/blueprint' lint` should pass without errors.

If you want to test the changes, you can follow these steps:

1. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
3. Try to export and import a Blueprint. Confirm that it still works without errors

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
