### PR TITLE
is_store_page is deprecated since version 9.8.0

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
+++ b/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php
@@ -185,7 +185,7 @@ class LaunchYourStore {
 		}
 
 		$store_pages_only = get_option( 'woocommerce_store_pages_only' ) === 'yes';
-		if ( $store_pages_only && ! WCAdminHelper::is_store_page() ) {
+		if ( $store_pages_only && ! WCAdminHelper::is_current_page_store_page() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Getting error "Doing it Wrong" on fresh WooCommerce plugin install, while store is still not setup.

WordPress version:  6.7.2
WooCommerce version: 9.8.1
WooCommerce database version: 9.7.1

PHP version: 8.2.13


## Trace

    Automattic\W\A\WCAdminHelper::is_store_page()
    wp-content/plugins/woocommerce/src/Admin/WCAdminHelper.php:195
    Automattic\W\A\F\LaunchYourStore->maybe_add_coming_soon_banner_on_frontend()
    wp-content/plugins/woocommerce/src/Admin/Features/LaunchYourStore.php:188
    do_action('wp_footer')
    wp-includes/plugin.php:517
    wp_footer()
    wp-includes/general-template.php:3080
    load_template('wp-content/themes/st-starter/footer.php')
    wp-includes/template.php:810
    locate_template()
    wp-includes/template.php:745
    get_footer()
    wp-includes/general-template.php:92