### PR TITLE
Fix longer shipping description being misaligned in Firefox

### DIFF
--- a/plugins/woocommerce/changelog/57229-wooplug-3060-shipping-description-in-checkout-block-misaligned-in-firefox
+++ b/plugins/woocommerce/changelog/57229-wooplug-3060-shipping-description-in-checkout-block-misaligned-in-firefox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong alignment of longer shipping option descriptions in Firefox

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -76,6 +76,7 @@ const PackageRates = ( {
 			disabled={ disabled }
 			selected={ selectedOption }
 			options={ rates.map( renderOption ) }
+			descriptionStackingDirection="column"
 		/>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -37,27 +37,6 @@
 		padding-bottom: 0;
 	}
 
-	.wc-block-components-radio-control__description-group {
-		// Display in a column so the delivery time can render first.
-		display: flex;
-		flex-direction: column;
-
-		// Use balance as this is not a good candidate for pretty. Pretty is intended for body copy which this is not.
-		text-wrap: balance;
-		// This targets the rate *description* and prevents the rules applying to the delivery_time.
-		.wc-block-components-radio-control__description {
-			padding-right: $gap-small;
-			order: 2;
-		}
-
-		.wc-block-components-radio-control__secondary-description {
-			order: 1;
-			text-align: left;
-			width: auto;
-			margin: $gap-smaller  0;
-		}
-	}
-
 	&--disabled {
 		opacity: 0.5;
 		transition: opacity 200ms ease;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -55,9 +55,9 @@ const renderShippingRatesControlOption = (
 	return {
 		label: decodeEntities( option.name ),
 		value: option.rate_id,
-		description: decodeEntities( option.description ),
+		description: decodeEntities( option.delivery_time ),
 		secondaryLabel,
-		secondaryDescription: decodeEntities( option.delivery_time ),
+		secondaryDescription: decodeEntities( option.description ),
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/index.tsx
@@ -20,6 +20,7 @@ const RadioControl = ( {
 	options = [],
 	disabled = false,
 	highlightChecked = false,
+	descriptionStackingDirection = 'row',
 }: RadioControlProps ): JSX.Element | null => {
 	const instanceId = useInstanceId( RadioControl );
 	const radioControlId = id || instanceId;
@@ -62,6 +63,9 @@ const RadioControl = ( {
 						}
 					} }
 					disabled={ disabled }
+					descriptionStackingDirection={
+						descriptionStackingDirection
+					}
 				/>
 			) ) }
 		</div>

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
@@ -41,8 +41,8 @@ const OptionLayout = ( {
 					className={ clsx(
 						'wc-block-components-radio-control__description-group',
 						{
-							'wc-block-components-radio-control__description-group--row':
-								descriptionStackingDirection === 'row',
+							'wc-block-components-radio-control__description-group--column':
+								descriptionStackingDirection === 'column',
 						}
 					) }
 				>

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * Internal dependencies
  */
 import type { RadioControlOptionLayout } from './types';
@@ -9,6 +14,7 @@ const OptionLayout = ( {
 	description,
 	secondaryDescription,
 	id,
+	descriptionStackingDirection,
 }: RadioControlOptionLayout ): JSX.Element => {
 	return (
 		<div className="wc-block-components-radio-control__option-layout">
@@ -31,7 +37,12 @@ const OptionLayout = ( {
 				) }
 			</div>
 			{ ( description || secondaryDescription ) && (
-				<div className="wc-block-components-radio-control__description-group">
+				<div
+					className={ clsx(
+						'wc-block-components-radio-control__description-group',
+						`wc-block-components-radio-control__description-group--${ descriptionStackingDirection }`
+					) }
+				>
 					{ description && (
 						<span
 							id={ id && `${ id }__description` }

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/option-layout.tsx
@@ -40,7 +40,10 @@ const OptionLayout = ( {
 				<div
 					className={ clsx(
 						'wc-block-components-radio-control__description-group',
-						`wc-block-components-radio-control__description-group--${ descriptionStackingDirection }`
+						{
+							'wc-block-components-radio-control__description-group--row':
+								descriptionStackingDirection === 'row',
+						}
 					) }
 				>
 					{ description && (

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/option.tsx
@@ -16,6 +16,7 @@ const Option = ( {
 	option,
 	disabled = false,
 	highlightChecked = false,
+	descriptionStackingDirection,
 }: RadioControlOptionProps ): JSX.Element => {
 	const {
 		value,
@@ -75,6 +76,7 @@ const Option = ( {
 				secondaryLabel={ secondaryLabel }
 				description={ description }
 				secondaryDescription={ secondaryDescription }
+				descriptionStackingDirection={ descriptionStackingDirection }
 			/>
 		</label>
 	);

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -32,7 +32,8 @@
 		}
 
 		// This rule removes the fake border-top from the selected element to prevent a double border.
-		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option::after {
+		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted
+			+ div.wc-block-components-radio-control-accordion-option::after {
 			display: none;
 		}
 	}
@@ -84,7 +85,8 @@
 
 	// Remove the fake border-top from the item after the selected element, this is to prevent a double border with the
 	// selected element's box-shadow.
-	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option::after {
+	.wc-block-components-radio-control__option--checked-option-highlighted
+		+ .wc-block-components-radio-control__option::after {
 		display: none;
 	}
 
@@ -137,7 +139,7 @@
 }
 
 .wc-block-components-radio-control__option
-.wc-block-components-radio-control__option-layout {
+	.wc-block-components-radio-control__option-layout {
 	&::after {
 		display: none;
 	}
@@ -159,8 +161,8 @@
 // There is no variant handling row stacking as it is applied by default.
 .wc-block-components-radio-control__description-group--column {
 	flex-direction: column;
-	
-	// Use balance as this is not a good candidate for pretty. Pretty is 
+
+	// Use balance as this is not a good candidate for pretty. Pretty is
 	// intended  for body copy which this is not.
 	text-wrap: balance;
 
@@ -263,7 +265,7 @@
 
 .theme-twentytwentyone {
 	.wc-block-components-radio-control
-	.wc-block-components-radio-control__input {
+		.wc-block-components-radio-control__input {
 		&:checked {
 			border-width: 2px;
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -121,7 +121,11 @@
 	display: block;
 	margin: em($gap) 0;
 	margin-top: 0;
-	padding: 0 0 0 em($gap-larger);
+	// padding-left here is aligned with the size of the radio input element,
+	// we need to reserve at least this amount of space for the label to not
+	// overflow the input. Input has position: absolute set, so it doesn't
+	// take any space on its own.
+	padding: 0 calc($gap + em(24px)) 0 em($gap-huge);
 	position: relative;
 	cursor: pointer;
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -131,7 +131,8 @@
 }
 
 .wc-block-components-radio-control__option-layout {
-	display: table;
+	display: flex;
+	flex-direction: column;
 	width: 100%;
 }
 
@@ -144,16 +145,34 @@
 
 .wc-block-components-radio-control__label-group,
 .wc-block-components-radio-control__description-group {
-	display: table-row;
-
-	> span {
-		display: table-cell;
-	}
+	display: flex;
+	justify-content: space-between;
 
 	.wc-block-components-radio-control__secondary-label,
 	.wc-block-components-radio-control__secondary-description {
 		text-align: right;
-		min-width: 50%;
+		flex-basis: 50%;
+	}
+}
+
+// For column description stacking we need to apply some layout changes.
+// There is no variant handling row stacking as it is applied by default.
+.wc-block-components-radio-control__description-group--column {
+	flex-direction: column;
+	
+	// Use balance as this is not a good candidate for pretty. Pretty is 
+	// intended  for body copy which this is not.
+	text-wrap: balance;
+
+	.wc-block-components-radio-control__description {
+		margin: $gap-smaller 0;
+	}
+
+	.wc-block-components-radio-control__secondary-description {
+		text-align: left;
+		// Leaves a bit less space causing longer description to wrap nicer on
+		// smaller screens.
+		padding-right: $gap-small;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -159,8 +159,8 @@
 // There is no variant handling row stacking as it is applied by default.
 .wc-block-components-radio-control__description-group--column {
 	flex-direction: column;
-	
-	// Use balance as this is not a good candidate for pretty. Pretty is 
+
+	// Use balance as this is not a good candidate for pretty. Pretty is
 	// intended  for body copy which this is not.
 	text-wrap: balance;
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/style.scss
@@ -32,8 +32,7 @@
 		}
 
 		// This rule removes the fake border-top from the selected element to prevent a double border.
-		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted
-			+ div.wc-block-components-radio-control-accordion-option::after {
+		&.wc-block-components-radio-control-accordion-option--checked-option-highlighted + div.wc-block-components-radio-control-accordion-option::after {
 			display: none;
 		}
 	}
@@ -85,8 +84,7 @@
 
 	// Remove the fake border-top from the item after the selected element, this is to prevent a double border with the
 	// selected element's box-shadow.
-	.wc-block-components-radio-control__option--checked-option-highlighted
-		+ .wc-block-components-radio-control__option::after {
+	.wc-block-components-radio-control__option--checked-option-highlighted + .wc-block-components-radio-control__option::after {
 		display: none;
 	}
 
@@ -139,7 +137,7 @@
 }
 
 .wc-block-components-radio-control__option
-	.wc-block-components-radio-control__option-layout {
+.wc-block-components-radio-control__option-layout {
 	&::after {
 		display: none;
 	}
@@ -161,8 +159,8 @@
 // There is no variant handling row stacking as it is applied by default.
 .wc-block-components-radio-control__description-group--column {
 	flex-direction: column;
-
-	// Use balance as this is not a good candidate for pretty. Pretty is
+	
+	// Use balance as this is not a good candidate for pretty. Pretty is 
 	// intended  for body copy which this is not.
 	text-wrap: balance;
 
@@ -265,7 +263,7 @@
 
 .theme-twentytwentyone {
 	.wc-block-components-radio-control
-		.wc-block-components-radio-control__input {
+	.wc-block-components-radio-control__input {
 		&:checked {
 			border-width: 2px;
 

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/types.ts
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/types.ts
@@ -18,6 +18,9 @@ export interface RadioControlProps {
 	disabled?: boolean;
 	// Should the selected option be highlighted with a border?
 	highlightChecked?: boolean;
+	// How the description should stack, follows the same naming as flex layout,
+	// so column means vertical stacking, and row means horizontal stacking.
+	descriptionStackingDirection?: 'column' | 'row';
 }
 
 export interface RadioControlOptionProps {
@@ -28,6 +31,7 @@ export interface RadioControlOptionProps {
 	disabled?: boolean;
 	// Should the selected option be highlighted with a border?
 	highlightChecked?: boolean;
+	descriptionStackingDirection: 'column' | 'row';
 }
 
 interface RadioControlOptionContent {
@@ -45,4 +49,5 @@ export interface RadioControlOption extends RadioControlOptionContent {
 
 export interface RadioControlOptionLayout extends RadioControlOptionContent {
 	id?: string;
+	descriptionStackingDirection: 'column' | 'row';
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes [WOOPLUG-3060](https://linear.app/a8c/issue/WOOPLUG-3060/shipping-description-in-checkout-block-misaligned-in-firefox)

Bug introduced in https://github.com/woocommerce/woocommerce/pull/49643

`RadioControl` component relied on `display: table` for layout of the label, value and description (primary and secondary). When using table display, it is important for the last element in the tree to have `display: table-cell` property (it wasn't causing any issues in Chrome or Safari, but Firefox had troubles). In the PR mentioned above, overwrite for the styles was applied at the call site level, changing `display: table-cell` to `display: flex`, it was done to change the layout from horizontal and vertical and control the order of the items.

What I am doing here:
- remove style overwrites and add native support to the `RadioControl` component to control description layout
- while I was there I figured it's probably a wise move to remove our reliance on `display: table` and use standard `flex` instead as it will prevent similar (difficult to debug) problems in the future
- I also noticed that the default styles for `RadioControl` are a bit broken (not enough space for the input itself, [see storybook story build from trunk to see it](https://woocommerce.github.io/woocommerce/?path=/docs/woocommerce-blocks_external-components-radiocontrol--docs)), so I fixed it too

### Screenshots or screen recordings:

| Before | After |
|--------|-------|
| <img width="571" alt="Screenshot 2025-04-14 at 12 00 37" src="https://github.com/user-attachments/assets/895afe40-7029-467a-8c28-bbb264b54464" /> | <img width="567" alt="Screenshot 2025-04-14 at 11 59 57" src="https://github.com/user-attachments/assets/278506da-812f-4e81-9538-f1636d78a33d" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions.

Acknowledging the fact that I mostly copied the below steps from @opr original PR. Thanks 😊

Please perform steps below on at least two browsers:
- **Firefox is a must** (the issue was only reproducible there)
- Chrome or Safari

1. Add several shipping methods to your store. A mix of free and flat rate shipping options should be used. Local pickup _can_ be added, but isn't relevant to this, as it depends on the extension's use of `delivery_time` and `description` props, rather than anything we control.
2. Add the following code using a plugin like [Code Snippets](https://wordpress.org/plugins/code-snippets/)
```php
function custom_shipping_description( $rates, $package ) {
    foreach ( $rates as $rate_id => $rate ) {
		if ( 'pickup_location' === $rate->method_id ) {
			continue;
		}
		$rate->description = 'This is a custom description for ' . $rate->label . '. It is quite a long, descriptive description that should flow onto multiple lines, for testing purposes.';
		$rate->delivery_time = 'This will be delivered in ' . rand( 1, 5 ) . ' days.';
	}
    return $rates;
}
add_filter( 'woocommerce_package_rates', 'custom_shipping_description', 10, 2 );
```
4. Add an item to your cart and process to the Checkout block. Ensure it looks OK with the text on multiple lines. There should be no widows/runts (single words on their own line at the end of a block of text) in the description or delivery time.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix wrong alignment of longer shipping option descriptions in Firefox

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
