### PR TITLE
Allow edit only the main email template

### DIFF
--- a/packages/js/email-editor/changelog/support-editing-template
+++ b/packages/js/email-editor/changelog/support-editing-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update editor to support editing only email template without a content post

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -86,7 +86,10 @@ export function InnerEditor( {
 			...settings,
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
-			defaultRenderingMode: 'template-locked',
+			defaultRenderingMode:
+				currentPost.postType === 'wp_template'
+					? 'post-only'
+					: 'template-locked',
 			supportsTemplateMode: true,
 			__experimentalBlockPatterns: blockPatterns, // eslint-disable-line
 		} ),
@@ -95,6 +98,7 @@ export function InnerEditor( {
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			blockPatterns,
+			currentPost.postType,
 		]
 	);
 

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -238,7 +238,8 @@ export function Header() {
 			<div className="editor-header__settings edit-post-header__settings">
 				{ editorMode === 'email' && <SaveEmailButton /> }
 				<PreviewDropdown />
-				{ hasNonEmailEdits || editorMode === 'template' ? (
+				{ hasNonEmailEdits ||
+				( editorMode === 'template' && dirtyEntityRecords.length ) ? (
 					<SaveAllButton
 						validateContent={ validateContent }
 						isDisabled={ dirtyEntityRecords.length === 0 }

--- a/packages/js/email-editor/src/components/header/header.tsx
+++ b/packages/js/email-editor/src/components/header/header.tsx
@@ -236,10 +236,13 @@ export function Header() {
 				</div>
 			) }
 			<div className="editor-header__settings edit-post-header__settings">
-				<SaveEmailButton />
+				{ editorMode === 'email' && <SaveEmailButton /> }
 				<PreviewDropdown />
-				{ hasNonEmailEdits ? (
-					<SaveAllButton validateContent={ validateContent } />
+				{ hasNonEmailEdits || editorMode === 'template' ? (
+					<SaveAllButton
+						validateContent={ validateContent }
+						isDisabled={ dirtyEntityRecords.length === 0 }
+					/>
 				) : (
 					<SendButton
 						validateContent={ validateContent }

--- a/packages/js/email-editor/src/components/header/save-all-button.tsx
+++ b/packages/js/email-editor/src/components/header/save-all-button.tsx
@@ -44,7 +44,7 @@ const SaveAllContent = ( { onToggle } ) => {
 	return <EntitiesSavedStates close={ onToggle } />;
 };
 
-export function SaveAllButton( { validateContent } ) {
+export function SaveAllButton( { validateContent, isDisabled } ) {
 	const { isSaving } = useSelect(
 		( select ) => ( {
 			isSaving: select( storeName ).isSaving(),
@@ -78,7 +78,7 @@ export function SaveAllButton( { validateContent } ) {
 							}
 						} }
 						variant="primary"
-						disabled={ isSaving }
+						disabled={ isSaving || isDisabled }
 					>
 						{ label }
 					</Button>

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -14,7 +14,6 @@ import {
  * Internal dependencies
  */
 import { storeName } from '../../store';
-import { useEditorMode } from '../../hooks';
 import { recordEvent } from '../../events';
 
 export function SendButton( { validateContent, isContentInvalid } ) {
@@ -35,14 +34,8 @@ export function SendButton( { validateContent, isContentInvalid } ) {
 		}
 	}
 
-	const [ editorMode ] = useEditorMode();
-
 	const isDisabled =
-		editorMode === 'template' ||
-		hasEmptyContent ||
-		isEmailSent ||
-		isContentInvalid ||
-		isDirty;
+		hasEmptyContent || isEmailSent || isContentInvalid || isDirty;
 
 	const label = applyFilters(
 		'woocommerce_email_editor_send_button_label',

--- a/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
+++ b/packages/js/email-editor/src/components/preview/preview-dropdown.tsx
@@ -13,6 +13,7 @@ import { PostPreviewButton } from '@wordpress/editor';
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
 import { SendPreviewEmail } from './send-preview-email';
+import { useEditorMode } from '../../hooks';
 
 export function PreviewDropdown() {
 	const previewDeviceType = useSelect(
@@ -26,6 +27,8 @@ export function PreviewDropdown() {
 	const changeDeviceType = ( newDeviceType: string ) => {
 		void changePreviewDeviceType( newDeviceType );
 	};
+
+	const [ editorMode ] = useEditorMode();
 
 	const deviceIcons = {
 		mobile,
@@ -74,47 +77,54 @@ export function PreviewDropdown() {
 								{ __( 'Mobile', 'woocommerce' ) }
 							</MenuItem>
 						</MenuGroup>
-						<MenuGroup>
-							<MenuItem
-								className="block-editor-post-preview__button-resize"
-								onClick={ () => {
-									void togglePreviewModal( true );
-									recordEvent(
-										'header_preview_dropdown_send_test_email_selected'
-									);
-									onClose();
-								} }
-							>
-								{ __( 'Send a test email', 'woocommerce' ) }
-							</MenuItem>
-						</MenuGroup>
-						<MenuGroup>
-							<div className="edit-post-header-preview__grouping-external">
-								<PostPreviewButton
-									role="menuitem"
-									forceIsAutosaveable={ true }
-									aria-label={ __(
-										'Preview in new tab',
-										'woocommerce'
-									) }
-									textContent={
-										<>
-											{ __(
+						{ editorMode === 'email' && (
+							<>
+								<MenuGroup>
+									<MenuItem
+										className="block-editor-post-preview__button-resize"
+										onClick={ () => {
+											void togglePreviewModal( true );
+											recordEvent(
+												'header_preview_dropdown_send_test_email_selected'
+											);
+											onClose();
+										} }
+									>
+										{ __(
+											'Send a test email',
+											'woocommerce'
+										) }
+									</MenuItem>
+								</MenuGroup>
+								<MenuGroup>
+									<div className="edit-post-header-preview__grouping-external">
+										<PostPreviewButton
+											role="menuitem"
+											forceIsAutosaveable={ true }
+											aria-label={ __(
 												'Preview in new tab',
 												'woocommerce'
 											) }
-											<Icon icon={ external } />
-										</>
-									}
-									onPreview={ () => {
-										recordEvent(
-											'header_preview_dropdown_preview_in_new_tab_selected'
-										);
-										onClose();
-									} }
-								/>
-							</div>
-						</MenuGroup>
+											textContent={
+												<>
+													{ __(
+														'Preview in new tab',
+														'woocommerce'
+													) }
+													<Icon icon={ external } />
+												</>
+											}
+											onPreview={ () => {
+												recordEvent(
+													'header_preview_dropdown_preview_in_new_tab_selected'
+												);
+												onClose();
+											} }
+										/>
+									</div>
+								</MenuGroup>{ ' ' }
+							</>
+						) }
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/js/email-editor/src/store/constants.ts
+++ b/packages/js/email-editor/src/store/constants.ts
@@ -8,7 +8,5 @@ export const stylesSidebarId = 'email-editor/editor/styles';
 // these values are set once on a page load, so it's fine to keep them here.
 export const editorCurrentPostType =
 	window.WooCommerceEmailEditor.current_post_type;
-export const editorCurrentPostId = parseInt(
-	window.WooCommerceEmailEditor.current_post_id,
-	10
-);
+export const editorCurrentPostId =
+	window.WooCommerceEmailEditor.current_post_id;

--- a/plugins/woocommerce/changelog/allow-edit-email-template-directly
+++ b/plugins/woocommerce/changelog/allow-edit-email-template-directly
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the Edit Template button to the email settings page to allow direct access to edit block email template

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createSlotFill } from '@wordpress/components';
+import { createSlotFill, Button } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 
@@ -34,18 +34,31 @@ export type EmailType = {
 
 const { Fill } = createSlotFill( SETTINGS_SLOT_FILL_CONSTANT );
 
-const EmailListingFill: React.FC< { emailTypes: EmailType[] } > = ( {
-	emailTypes,
-} ) => {
+const EmailListingFill: React.FC< {
+	emailTypes: EmailType[];
+	editTemplateUrl: string | null;
+} > = ( { emailTypes, editTemplateUrl } ) => {
 	return (
 		<Fill>
-			<div id="email_notification_settings-description">
+			<div
+				id="email_notification_settings-description"
+				className="woocommerce-email-listing-description"
+			>
 				<p>
 					{ __(
 						"Manage email notifications sent from WooCommerce below or click on 'Edit template' to customize your email template design.",
 						'woocommerce'
 					) }
 				</p>
+				{ editTemplateUrl && (
+					<Button
+						variant="primary"
+						href={ editTemplateUrl }
+						className="woocommerce-email-listing-edit-template-button"
+					>
+						{ __( 'Edit template', 'woocommerce' ) }
+					</Button>
+				) }
 			</div>
 			<ListView emailTypes={ emailTypes } />
 		</Fill>
@@ -59,6 +72,9 @@ export const registerSettingsEmailListingFill = () => {
 		return null;
 	}
 	const emailTypesData = slotElement.getAttribute( 'data-email-types' );
+	const editTemplateUrl = slotElement.getAttribute(
+		'data-edit-template-url'
+	);
 	let emailTypes: EmailType[] = [];
 	try {
 		emailTypes = JSON.parse( emailTypesData || '' );
@@ -66,6 +82,11 @@ export const registerSettingsEmailListingFill = () => {
 
 	registerPlugin( 'woocommerce-admin-settings-email-listing', {
 		scope: 'woocommerce-email-listing',
-		render: () => <EmailListingFill emailTypes={ emailTypes } />,
+		render: () => (
+			<EmailListingFill
+				emailTypes={ emailTypes }
+				editTemplateUrl={ editTemplateUrl }
+			/>
+		),
 	} );
 };

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-slotfill.tsx
@@ -3,6 +3,7 @@
  */
 import { createSlotFill } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -38,6 +39,14 @@ const EmailListingFill: React.FC< { emailTypes: EmailType[] } > = ( {
 } ) => {
 	return (
 		<Fill>
+			<div id="email_notification_settings-description">
+				<p>
+					{ __(
+						"Manage email notifications sent from WooCommerce below or click on 'Edit template' to customize your email template design.",
+						'woocommerce'
+					) }
+				</p>
+			</div>
 			<ListView emailTypes={ emailTypes } />
 		</Fill>
 	);

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -21,6 +21,27 @@
 	.woocommerce-email-listing-recipients {
 		white-space: wrap;
 	}
+	.woocommerce-email-listing-description {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+
+		.woocommerce-email-listing-edit-template-button {
+			margin-top: -$grid-unit-10;
+			margin-left: $grid-unit-10;
+		}
+
+		@include breakpoint( "<600px" ) {
+			flex-direction: column;
+			justify-content: flex-start;
+
+			.woocommerce-email-listing-edit-template-button {
+				margin-top: 0;
+				margin-bottom: $grid-unit-10;
+				width: fit-content;
+			}
+		}
+	}
 }
 
 .woocommerce-email-listing-recipients-tooltip {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -210,7 +210,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 		if ( FeaturesUtil::feature_is_enabled( 'block_email_editor' ) ) {
 			$email_notifications_field = 'email_notification_block_emails';
-			$email_notifications_desc  = __( 'Manage email notifications sent from WooCommerce below or click on \'Edit template\' to customize your email template design.', 'woocommerce' );
+			$email_notifications_desc  = null;
 		} else {
 			$email_notifications_field = 'email_notification';
 			/* translators: %s: help description with link to WP Mail logging and support page. */

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 use Automattic\WooCommerce\Internal\Email\EmailColors;
 use Automattic\WooCommerce\Internal\Email\EmailFont;
 use Automattic\WooCommerce\Internal\Email\EmailStyleSync;
+use Automattic\WooCommerce\Internal\EmailEditor\EmailTemplates\WooEmailTemplate;
 use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -646,10 +647,19 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				),
 			);
 		}
+		// Create URL for email editor template mode.
+		$edit_template_url = null;
+		if ( $email ) {
+			$email_post        = $email_post_manager->get_email_post( $email->id );
+			$email_template_id = get_stylesheet() . '//' . WooEmailTemplate::TEMPLATE_SLUG;
+			$edit_template_url = admin_url( 'post.php?post=' . $email_post->ID . '&action=edit&template=' . $email_template_id );
+		}
+
 		?>
 		<div
 			id="wc_settings_email_listing_slotfill" class="wc-settings-prevent-change-event woocommerce-email-listing-listview"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
+			data-edit-template-url="<?php echo esc_attr( $edit_template_url ); ?>"
 		></div>
 		<div>
 			<p><?php echo wp_kses_post( wpautop( wptexturize( $desc_help_text ) ) ); ?></p>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces "Edit template" button that allows users to open the main block email template used by all transactional emails in the email editor directly from the settings. Previously they needed to open an individual email and then access the editor. 
![Screenshot 2025-04-14 at 16 49 51](https://github.com/user-attachments/assets/769da147-8f60-432b-b5ab-6018c64b0496)



<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

#### Changes
- Email editor page loader newly checks the template query parameter, and in case it is present, it attempts to open the editor with the template as the main and only document.
- A couple of changes in the editor applications were needed to support the template mode. Visible changes are related to saving buttons. When template mode is active, we don't display "save draft" and we display the main save button covering all documents.
- "Edit template" button was added to the email settings page

Note: We currently still need to pass the post_id of an email post to fulfill conditions for checks in post.php. We may consider fixing this by moving the editor to a different URL.

Closes WOOPLUG-3312 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate the block email editor feature (Settings > Advanced > Features > Experimental)
2. Go to Settings > Emails and click the "Edit template" button and test template editing, saving changes, etc.
3. Go to Settings > Emails and open a couple of individual emails. Verify that changes done in the template mode are present and that the editor for individual emails works as expected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
