### PR TITLE
Fix Product Collection notices

### DIFF
--- a/plugins/woocommerce/changelog/fix-9.8-product-collection-notices
+++ b/plugins/woocommerce/changelog/fix-9.8-product-collection-notices
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix Product Collection notices in WooCommerce 9.8.1

--- a/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
+++ b/plugins/woocommerce/changelog/wooplug-3883-missing-closing-div-in-the-latest-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix missing closing tag for notice inside the Product Collection block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -215,7 +215,6 @@ class Renderer {
 					</div>
 				</template>
 			</div>
-		</div>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR undoes the changes in https://github.com/woocommerce/woocommerce/pull/57191, fixing an issue with Store Notices not showing up in the _Product Collection_ block.

### How to test the changes in this Pull Request:

1. Open a post, page or template with the _Product Collection_ block.
2. In a separate tab, edit one of the products in the grid and set it as out of stock.
3. Try adding the product to your cart.
4. Verify an error notice is displayed.

![imatge](https://github.com/user-attachments/assets/4f51b917-1cd3-4691-b556-6511e44054a8)