### PR TITLE
Move deprecated functions to `wc-deprecated-functions.php`

### DIFF
--- a/plugins/woocommerce/changelog/fix-27357
+++ b/plugins/woocommerce/changelog/fix-27357
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Move deprecated functions to wc-deprecated-functions.php

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -42,31 +42,6 @@ function wc_empty_cart() {
 }
 
 /**
- * Load the persistent cart.
- *
- * @param string  $user_login User login.
- * @param WP_User $user       User data.
- * @deprecated 2.3
- */
-function wc_load_persistent_cart( $user_login, $user ) {
-	if ( ! $user || ! apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
-		return;
-	}
-
-	$saved_cart = get_user_meta( $user->ID, '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
-
-	if ( ! $saved_cart ) {
-		return;
-	}
-
-	$cart = WC()->session->cart;
-
-	if ( empty( $cart ) || ! is_array( $cart ) || 0 === count( $cart ) ) {
-		WC()->session->cart = $saved_cart['cart'];
-	}
-}
-
-/**
  * Retrieves unvalidated referer from '_wp_http_referer' or HTTP referer.
  *
  * Do not use for redirects, use {@see wp_get_referer()} instead.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1123,30 +1123,6 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 }
 
 /**
- * Get the URL to the WooCommerce Legacy REST API.
- *
- * Note that as of WooCommerce 9.0 the WooCommerce Legacy REST API has been moved to a dedicated extension,
- * and the implementation of its root endpoint in WooCommerce core is now just a stub that will always return an error.
- * See the setup_legacy_api_stub method in includes/class-woocommerce.php and:
- * https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/
- *
- * @deprecated 9.0.0 The Legacy REST API has been removed from WooCommerce core.
- *
- * @since 2.1
- * @param string $path an endpoint to include in the URL.
- * @return string the URL.
- */
-function get_woocommerce_api_url( $path ) {
-	$url = get_home_url( null, 'wc-api/v3/', is_ssl() ? 'https' : 'http' );
-
-	if ( ! empty( $path ) && is_string( $path ) ) {
-		$url .= ltrim( $path, '/' );
-	}
-
-	return $url;
-}
-
-/**
  * Recursively get page children.
  *
  * @param  int $page_id Page ID.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2763,60 +2763,6 @@ if ( ! function_exists( 'woocommerce_maybe_show_product_subcategories' ) ) {
 	}
 }
 
-if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
-	/**
-	 * This is a legacy function which used to check if we needed to display subcats and then output them. It was called by templates.
-	 *
-	 * From 3.3 onwards this is all handled via hooks and the woocommerce_maybe_show_product_subcategories function.
-	 *
-	 * Since some templates have not updated compatibility, to avoid showing incorrect categories this function has been deprecated and will
-	 * return nothing. Replace usage with woocommerce_output_product_categories to render the category list manually.
-	 *
-	 * This is a legacy function which also checks if things should display.
-	 * Themes no longer need to call these functions. It's all done via hooks.
-	 *
-	 * @deprecated 3.3.1 @todo Add a notice in a future version.
-	 * @param array $args Arguments.
-	 * @return null|boolean
-	 */
-	function woocommerce_product_subcategories( $args = array() ) {
-		$defaults = array(
-			'before'        => '',
-			'after'         => '',
-			'force_display' => false,
-		);
-
-		$args = wp_parse_args( $args, $defaults );
-
-		if ( $args['force_display'] ) {
-			// We can still render if display is forced.
-			woocommerce_output_product_categories(
-				array(
-					'before'    => $args['before'],
-					'after'     => $args['after'],
-					'parent_id' => is_product_category() ? get_queried_object_id() : 0,
-				)
-			);
-			return true;
-		} else {
-			// Output nothing. woocommerce_maybe_show_product_subcategories will handle the output of cats.
-			$display_type = woocommerce_get_loop_display_mode();
-
-			if ( 'subcategories' === $display_type ) {
-				// This removes pagination and products from display for themes not using wc_get_loop_prop in their product loops. @todo Remove in future major version.
-				global $wp_query;
-
-				if ( $wp_query->is_main_query() ) {
-					$wp_query->post_count    = 0;
-					$wp_query->max_num_pages = 0;
-				}
-			}
-
-			return 'subcategories' === $display_type || 'both' === $display_type;
-		}
-	}
-}
-
 if ( ! function_exists( 'woocommerce_output_product_categories' ) ) {
 	/**
 	 * Display product sub categories as thumbnails.
@@ -4199,38 +4145,6 @@ function woocommerce_output_all_notices() {
 	echo '<div class="woocommerce-notices-wrapper">';
 	wc_print_notices();
 	echo '</div>';
-}
-
-/**
- * Products RSS Feed.
- *
- * @deprecated 2.6
- */
-function wc_products_rss_feed() {
-	wc_deprecated_function( 'wc_products_rss_feed', '2.6' );
-}
-
-if ( ! function_exists( 'woocommerce_reset_loop' ) ) {
-
-	/**
-	 * Reset the loop's index and columns when we're done outputting a product loop.
-	 *
-	 * @deprecated 3.3
-	 */
-	function woocommerce_reset_loop() {
-		wc_reset_loop();
-	}
-}
-
-if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
-	/**
-	 * Output the reviews tab content.
-	 *
-	 * @deprecated 2.4.0 Unused.
-	 */
-	function woocommerce_product_reviews_tab() {
-		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );
-	}
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR moves deprecated (global) functions to `wc-deprecated-functions.php`. Specifically, it takes care of the following functions:

- `wc_load_persistent_cart()`
- `get_woocommerce_api_url()`
- `woocommerce_product_reviews_tab()`
- `woocommerce_reset_loop()`
- `wc_products_rss_feed()`
- `woocommerce_product_subcategories()`

I made sure none of the above functions is being used in the codebase.

Closes #27357.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

No visual or functional changes introduced here. Ensure tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
