### PR TITLE
[Experimental] Add the correct product quantities in the Add to Cart with Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-button-quantity
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-button-quantity
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Make Add to Cart Button show correct quantity when adding simple products to cart from the Add to Cart with Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -70,20 +70,15 @@ const addToCartWithOptionsStore = store(
 					{ lock: universalLock }
 				);
 
-				const { productId } = getContext< Context >();
+				const { productId, quantity, variation } =
+					getContext< Context >();
 				const product = wooState.cart?.items.find(
 					( item ) => item.id === productId
 				);
 				const currentQuantity = product?.quantity || 0;
 
-				const {
-					productId: id,
-					quantity,
-					variation,
-				} = getContext< Context >();
-
 				yield actions.addCartItem( {
-					id,
+					id: productId,
 					quantity: currentQuantity + quantity,
 					variation,
 				} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -10,11 +10,18 @@ type Context = {
 	productId: number;
 	variation: CartVariationItem[];
 	quantity: number;
+	tempQuantity: number;
 };
 
 // Stores are locked to prevent 3PD usage until the API is stable.
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const { state: wooState } = store< WooCommerce >(
+	'woocommerce',
+	{},
+	{ lock: universalLock }
+);
 
 const addToCartWithOptionsStore = store(
 	'woocommerce/add-to-cart-with-options',
@@ -63,13 +70,23 @@ const addToCartWithOptionsStore = store(
 					{ lock: universalLock }
 				);
 
+				const { productId } = getContext< Context >();
+				const product = wooState.cart?.items.find(
+					( item ) => item.id === productId
+				);
+				const currentQuantity = product?.quantity || 0;
+
 				const {
 					productId: id,
 					quantity,
 					variation,
 				} = getContext< Context >();
 
-				yield actions.addCartItem( { id, quantity, variation } );
+				yield actions.addCartItem( {
+					id,
+					quantity: currentQuantity + quantity,
+					variation,
+				} );
 			},
 		},
 	}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -80,4 +80,50 @@ test.describe( 'Add to Cart with Options Block', () => {
 		const skeleton = block.locator( '.wc-block-components-skeleton' );
 		await expect( skeleton ).toBeVisible();
 	} );
+
+	test( 'allows adding simple products to cart', async ( {
+		page,
+		pageObject,
+		editor,
+		admin,
+	} ) => {
+		await pageObject.setFeatureFlags();
+
+		await admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//single-product',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		const addToCartFormBlock = await editor.getBlockByName(
+			'woocommerce/add-to-cart-form'
+		);
+		await editor.selectBlocks( addToCartFormBlock );
+
+		await page
+			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.click();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/beanie' );
+
+		const increaseQuantityButton = page.getByLabel(
+			'Increase quantity of Beanie'
+		);
+		await increaseQuantityButton.click();
+		await increaseQuantityButton.click();
+
+		const addToCartButton = page.getByLabel( 'Add to cart: “Beanie”' );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( '3 in cart' );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( '6 in cart' );
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so the correct quantities are added to cart when using the _Add to Cart with Options_ block.

Part of #54416.
Part of WOOPLUG-2986.

### How to test the changes in this Pull Request:

0. Install and activate the WooCommerce Beta Tester plugin.
1. Go to _Tools_ > _WCA Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
2. Create a post or page, add the _Single Product_ block and update the _Add to Cart with Options_ block to the blockified version.
3. In the frontend, add several items of this product to the cart. Using the Mini-Cart block, verify the correct amount was added.
4. Also verify the Add to Cart Button shows the correct number of products in the cart.
5. Add more items to the cart. Verify they are added correctly and the totals are correct.
6. Reload the page and verify the Add to Cart Button still shows the correct number of items.


https://github.com/user-attachments/assets/9432daf2-41f4-4f41-901a-bf3c45481b39

