### PR TITLE
Prevent possible fatal in 9.9 update routine

### DIFF
--- a/plugins/woocommerce/changelog/fix-possible-fatal-in-9.9-update-routine
+++ b/plugins/woocommerce/changelog/fix-possible-fatal-in-9.9-update-routine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible fatal error in 9.9 migration.

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -3019,7 +3019,7 @@ function wc_update_990_add_old_refunded_order_items_to_product_lookup_table() {
 			// If the refund order has no line items, mark it as a full refund in orders_meta table.
 			// In the above query we already excluded orders for refunded shipping and tax, so it's safe to assume that the refund order without items is a full refund.
 			// Note that the "full" refund here means it's created by changing the order status to "Refunded", not partially refund all the items in the order.
-			if ( empty( $order->get_items() ) ) {
+			if ( $order && empty( $order->get_items() ) ) {
 				$order->update_meta_data( '_refund_type', 'full' );
 				$order->save_meta_data();
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

While testing an update to 9.9.0 for an unrelated PR, I noticed a fatal error coming from the `wc_update_990_add_old_refunded_order_items_to_product_lookup_table` migration:

> PHP Fatal error:  Uncaught Error: Call to a member function get_items() on bool in /[...]/woocommerce/includes/wc-update-functions.php:3022

This upgrade routine queries the order stats table and operates on orders based on the results. This table is not authoritative for orders and might not be up to date, so we can't assume that those orders exist (i.e. `wc_get_order()` doesn't return `false`).

This PR adds some defensive check to prevent the fatal error from occurring.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:



1. Insert (using phpMyAdmin) or any other method a row into `wc_order_stats` referencing an order that doesn't exist (`order_id` column).
2. Run the following CLI command to trigger the update routine:
   ```
   wp eval "require_once WC_ABSPATH . 'includes/wc-update-functions.php'; wc_update_990_add_old_refunded_order_items_to_product_lookup_table();"
   ```
3. No fatal error should be logged.
4. (Optional) Repeat the above on `trunk` and confirm that a fatal error is logged and the script terminates abruptly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
