### PR TITLE
Change pill styles to use button elements on add to cart with options block

### DIFF
--- a/plugins/woocommerce/changelog/try-implement-elements-on-add-to-cart-variable
+++ b/plugins/woocommerce/changelog/try-implement-elements-on-add-to-cart-variable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change pill styles to use button elements on add to cart with options block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -19,7 +19,29 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"supports": {
 		"inserter": false,
-		"interactivity": true
+		"interactivity": true,
+		"__experimentalStyle": {
+			"elements": {
+				"button": {
+					"spacing": {
+						"padding": {
+							"top": "0.25em",
+							"bottom": "0.25em",
+							"left": "0.75em",
+							"right": "0.75em"
+						}
+					},
+					"typography": {
+						"fontSize": "var(--wp--preset--font-size--small)"
+					},
+					"border": {
+						"width": "1px",
+						"style": "solid",
+						"radius": "2px"
+					}
+				}
+			}
+		}
 	},
 	"usesContext": [
 		"woocommerce/attributeId",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -33,6 +33,10 @@
 					},
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--small)"
+					},
+					"border": {
+						"width": "1px",
+						"style": "solid"
 					}
 				}
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -33,11 +33,6 @@
 					},
 					"typography": {
 						"fontSize": "var(--wp--preset--font-size--small)"
-					},
-					"border": {
-						"width": "1px",
-						"style": "solid",
-						"radius": "2px"
 					}
 				}
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -45,6 +45,7 @@ function Pills( {
 						{
 							'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected':
 								index === 0,
+							'is-style-outline': index !== 0,
 							'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--disabled':
 								option.disabled,
 						}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -15,11 +15,6 @@ import { useCustomDataContext } from '@woocommerce/shared-context';
 import type { ProductResponseAttributeItem } from '@woocommerce/types';
 import clsx from 'clsx';
 
-/**
- * Internal dependencies
- */
-import { useThemeColors } from '../../../../shared/hooks/use-theme-colors';
-
 interface Attributes {
 	className?: string;
 	style?: 'pills' | 'dropdown';
@@ -67,18 +62,6 @@ export default function AttributeOptionsEdit(
 	const blockProps = useBlockProps( {
 		className,
 	} );
-
-	// Apply selected variation pill styles based on Site Editor's background and text colors.
-	/*useThemeColors(
-		'add-to-cart-with-options-variation-selector-attribute-options',
-		( { editorBackgroundColor, editorColor } ) => `
-			:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected) {
-				background-color: ${ editorColor };
-				color: ${ editorBackgroundColor };
-				border-color: ${ editorColor };
-			}
-		`
-	);*/
 
 	const { data: attribute } =
 		useCustomDataContext< ProductResponseAttributeItem >( 'attribute' );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/edit.tsx
@@ -41,7 +41,7 @@ function Pills( {
 				<li
 					key={ option.value }
 					className={ clsx(
-						'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill',
+						'wp-element-button wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill',
 						{
 							'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected':
 								index === 0,
@@ -68,7 +68,7 @@ export default function AttributeOptionsEdit(
 	} );
 
 	// Apply selected variation pill styles based on Site Editor's background and text colors.
-	useThemeColors(
+	/*useThemeColors(
 		'add-to-cart-with-options-variation-selector-attribute-options',
 		( { editorBackgroundColor, editorColor } ) => `
 			:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected) {
@@ -77,7 +77,7 @@ export default function AttributeOptionsEdit(
 				border-color: ${ editorColor };
 			}
 		`
-	);
+	);*/
 
 	const { data: attribute } =
 		useCustomDataContext< ProductResponseAttributeItem >( 'attribute' );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -8,16 +8,11 @@
 }
 
 .wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
-	border-width: 1px;
-	border-style: solid;
-	border-radius: 2px;
-	padding: 0.25em 0.75em;
-	font-size: var(--wp--preset--font-size--small);
 	cursor: pointer;
 	user-select: none;
 
 	&:hover {
-		background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 10%, transparent);
+		/*background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 10%, transparent);*/
 	}
 
 	&:focus {
@@ -27,7 +22,7 @@
 
 	&[aria-checked="true"] {
 		&:hover {
-			background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 85%, transparent);
+			/*background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 85%, transparent);*/
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -11,19 +11,9 @@
 	cursor: pointer;
 	user-select: none;
 
-	&:hover {
-		/*background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 10%, transparent);*/
-	}
-
 	&:focus {
 		outline-color: var(--wp--preset--color--accent-4);
 		outline-offset: 2px;
-	}
-
-	&[aria-checked="true"] {
-		&:hover {
-			/*background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 85%, transparent);*/
-		}
 	}
 
 	&[aria-checked="false"] {
@@ -39,6 +29,4 @@
 
 .wc-block-add-to-cart-with-options-variation-selector-attribute-options__dropdown {
 	height: 3em;
-	padding: 0.25em 1em;
-	font-size: var(--wp--preset--font-size--small);
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -7,20 +7,28 @@
 	flex-wrap: wrap;
 }
 
-.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
+.wp-element-button.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill {
 	cursor: pointer;
 	user-select: none;
 
-	&:focus {
-		outline-color: var(--wp--preset--color--accent-4);
-		outline-offset: 2px;
+	// Store the original colors as custom properties
+	--pill-original-text: inherit;
+	--pill-original-background: inherit;
+
+	&.is-style-outline {
+		// Default state (button 2) - inverted colors
+		color: var(--pill-original-background);
+		background: var(--pill-original-text);
+		border-color: var(--pill-original-text);
 	}
 
 	&[aria-checked="false"] {
 		border-color: currentColor;
 	}
 
-	&[aria-disabled="true"] {
+	&[aria-disabled="true"],
+	// Disabled state (button 3)
+	&--disabled.is-style-outline {
 		border-color: var(--wc-subtext);
 		color: var(--wc-subtext);
 		text-decoration: line-through;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -15,6 +15,8 @@
 		color: inherit;
 		background-color: transparent;
 		border-color: inherit;
+		border-width: 1px;
+		border-style: solid;
 		backdrop-filter: none;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -15,8 +15,6 @@
 		color: inherit;
 		background-color: transparent;
 		border-color: inherit;
-		border-width: 1px;
-		border-style: solid;
 		backdrop-filter: none;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -11,15 +11,11 @@
 	cursor: pointer;
 	user-select: none;
 
-	// Store the original colors as custom properties
-	--pill-original-text: inherit;
-	--pill-original-background: inherit;
-
 	&.is-style-outline {
-		// Default state (button 2) - inverted colors
-		color: var(--pill-original-background);
-		background: var(--pill-original-text);
-		border-color: var(--pill-original-text);
+		color: inherit;
+		background-color: transparent;
+		border-color: inherit;
+		backdrop-filter: none;
 	}
 
 	&[aria-checked="false"] {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -144,11 +144,11 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 		$pills = '';
 		foreach ( $attribute_terms as $attribute_term ) {
 			$pills .= sprintf(
-				'<div %s>%s</div>',
+				'<li %s>%s</li>',
 				$this->get_normalized_attributes(
 					array(
 						'role'                        => 'radio',
-						'class'                       => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill',
+						'class'                       => 'wp-element-button wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill is-style-outline',
 						'data-wp-bind--tabindex'      => 'state.pillTabIndex',
 						'data-wp-bind--aria-checked'  => 'state.isPillSelected',
 						'data-wp-bind--aria-disabled' => 'state.isPillDisabled',
@@ -165,7 +165,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 		}
 
 		return sprintf(
-			'<div %s>%s</div>',
+			'<ul %s>%s</ul>',
 			$this->get_normalized_attributes(
 				array(
 					'class'               => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pills',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -152,6 +152,8 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 						'data-wp-bind--tabindex'      => 'state.pillTabIndex',
 						'data-wp-bind--aria-checked'  => 'state.isPillSelected',
 						'data-wp-bind--aria-disabled' => 'state.isPillDisabled',
+						'data-wp-class--wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected' => 'state.isPillSelected',
+						'data-wp-class--is-style-outline' => '!state.isPillSelected',
 						'data-wp-watch'               => 'callbacks.watchSelected',
 						'data-wp-on--click'           => 'actions.toggleSelected',
 						'data-wp-on--keydown'         => 'actions.handleKeyDown',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -147,17 +147,17 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'<li %s>%s</li>',
 				$this->get_normalized_attributes(
 					array(
-						'role'                        => 'radio',
-						'class'                       => 'wp-element-button wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill is-style-outline',
-						'data-wp-bind--tabindex'      => 'state.pillTabIndex',
-						'data-wp-bind--aria-checked'  => 'state.isPillSelected',
-						'data-wp-bind--aria-disabled' => 'state.isPillDisabled',
+						'role'                                               => 'radio',
+						'class'                                              => 'wp-element-button wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill is-style-outline',
+						'data-wp-bind--tabindex'                              => 'state.pillTabIndex',
+						'data-wp-bind--aria-checked'                          => 'state.isPillSelected',
+						'data-wp-bind--aria-disabled'                         => 'state.isPillDisabled',
 						'data-wp-class--wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill--selected' => 'state.isPillSelected',
-						'data-wp-class--is-style-outline' => '!state.isPillSelected',
-						'data-wp-watch'               => 'callbacks.watchSelected',
-						'data-wp-on--click'           => 'actions.toggleSelected',
-						'data-wp-on--keydown'         => 'actions.handleKeyDown',
-						'data-wp-context'             => array(
+						'data-wp-class--is-style-outline'                     => '!state.isPillSelected',
+						'data-wp-watch'                                      => 'callbacks.watchSelected',
+						'data-wp-on--click'                                  => 'actions.toggleSelected',
+						'data-wp-on--keydown'                                => 'actions.handleKeyDown',
+						'data-wp-context'                                    => array(
 							'option' => $attribute_term,
 						),
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR changes the way the pills are styled. Instead of getting the colors from the background and text colors, we use the button elements as defined by the theme.json. Doing it this way allows for better control from the theme perspective (elements can be edited on the Global Styles pattern by the user too) instead of expecting the background color and text colors are the ones we want to use always. We are also moving some of the CSS defaults to block.json, we should allow for these settings to be able to be changed by the user. 

This has a few caveats:

- The theme should define these
- There are more than one style, we should allow for themers to style all 3. I wonder if woo should provide its own set of elements to style that are shared between blocks. 
- I wasn't able to make the disabled styles work on the frontend at all.

To do: 
- a fallback for when the theme doesn't have any button element styles
- allow for the user to change the colors in case the background of the section makes the default styles unsuitable

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

This is how it looks on the editor with the woo starter theme

<img width="660" alt="Screenshot 2025-04-15 at 18 08 37" src="https://github.com/user-attachments/assets/6e1a4c88-bdf1-4577-b903-c1f148c407b1" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check the single product template and click on the Add to cart block
2. Make sure that it's the Add to cart with options (the sidebar will let you upgrade)
3. Click on the toolbar of the block to see the Variable product option
4. The buttons should be inheriting from the theme values

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
