### PR TITLE
Improve default enablement for new Payments Settings page core feature flag

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-3916-default-enablement-for-core-feature-flag
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-3916-default-enablement-for-core-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: We fix the default enablement behavior of the new Payments Settings page to properly target all new stores.
+
+

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -309,6 +309,8 @@ class WC_Install {
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'maybe_enable_hpos' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'add_coming_soon_option' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_email_improvements' ), 20 );
+		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'enable_new_payments_settings_page' ), 20 );
+		add_action( 'woocommerce_updated', array( __CLASS__, 'maybe_enable_new_payments_settings_page' ), 20 );
 		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
@@ -1029,6 +1031,53 @@ class WC_Install {
 		update_option( 'woocommerce_email_improvements_first_enabled_at', gmdate( 'Y-m-d H:i:s' ) );
 		update_option( 'woocommerce_email_improvements_last_enabled_at', gmdate( 'Y-m-d H:i:s' ) );
 		update_option( 'woocommerce_email_improvements_enabled_count', 1 );
+	}
+
+	/**
+	 * Enable the new Payments Settings page by default for new shops.
+	 *
+	 * @since 9.8.2
+	 */
+	public static function enable_new_payments_settings_page() {
+		update_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled', 'yes' );
+	}
+
+	/**
+	 * Enable the new Payments Settings page by default for existing shops, under certain circumstances.
+	 *
+	 * @since 9.8.2
+	 */
+	public static function maybe_enable_new_payments_settings_page() {
+		$option_name = 'woocommerce_feature_reactify-classic-payments-settings_enabled';
+
+		// First, migrate the WCAdmin feature flag to the new feature flag.
+		// If there is a value saved for the old feature flag, we will respect it.
+		$wc_admin_helper_features = get_option( 'wc_admin_helper_feature_values', array() );
+		foreach ( $wc_admin_helper_features as $feature => $value ) {
+			if ( 'reactify-classic-payments-settings' === $feature ) {
+				update_option( $option_name, filter_var( $value, FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no' );
+
+				// Remove the old feature flag value to avoid further migrations.
+				unset( $wc_admin_helper_features[ $feature ] );
+				update_option( 'wc_admin_helper_feature_values', $wc_admin_helper_features );
+				return;
+			}
+		}
+
+		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
+		// If the WooCommerce installed version is 9.7+, we enable it.
+		if ( version_compare( $wc_initial_installed_version, '9.7.0', '>=' ) ) {
+			update_option( $option_name, 'yes' );
+		} else {
+			// For stores created pre-9.7, we check 9.7 experiment group first.
+			$experiment_transient = get_transient( 'abtest_variation_woocommerce_payment_settings_2025_v1' );
+			if ( 'treatment' === $experiment_transient ) {
+				// If the user is in the experiment treatment group and he didn't interact with the WCAdmin feature flag
+				// we will enable it by default.
+				update_option( $option_name, 'yes' );
+				delete_transient( 'abtest_variation_woocommerce_payment_settings_2025_v1' );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -26,103 +26,10 @@ class PaymentsController {
 	 * Register hooks.
 	 */
 	public function register() {
-		// Hook into feature flag WP option DB addition (not update) to one-time adjust the feature's default enablement.
-		add_action(
-			'add_option_woocommerce_feature_reactify-classic-payments-settings_enabled',
-			array( $this, 'adjust_feature_default_enablement' ),
-			10,
-			2
-		);
-
-		// Hook into the WooCommerce updated event to handle feature enablement for v9.8.0 and v9.8.1.
-		// This action is fired after the WC_Install::install() method is run and the option is added to the DB.
-		add_action( 'woocommerce_updated', array( $this, 'handle_feature_enablement_for_v9_8' ) );
-
 		// Because we gate the hooking based on a feature flag,
 		// we need to delay the registration until the 'woocommerce_init' hook.
 		// Otherwise, we end up in an infinite loop.
 		add_action( 'woocommerce_init', array( $this, 'delayed_register' ) );
-	}
-
-	/**
-	 * Adjust the new Payments Settings page feature default enablement.
-	 *
-	 * Currently, we target only new stores so we need to make sure that
-	 * the feature is not enabled by default for existing stores.
-	 * At the same time, we need to migrate the old WCAdmin feature flag value.
-	 *
-	 * Note: We rely on the fact that this logic is only executed ONCE, when the feature flag is first added to the DB.
-	 *       If the feature flag is already present in the DB, this method should not be called.
-	 *
-	 * @param string $option_name  The name of the option.
-	 * @param mixed  $option_value The value of the option.
-	 *
-	 * @return void
-	 */
-	public function adjust_feature_default_enablement( $option_name, $option_value ) {
-		// First, migrate the WCAdmin feature flag to the new feature flag.
-		// If there is a value saved for the old feature flag, we will respect it.
-		$wc_admin_helper_features = get_option( 'wc_admin_helper_feature_values', array() );
-		foreach ( $wc_admin_helper_features as $feature => $value ) {
-			if ( 'reactify-classic-payments-settings' === $feature ) {
-				update_option( $option_name, filter_var( $value, FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no' );
-				return;
-			}
-		}
-
-		// If the feature was added as disabled, don't do anything.
-		// This means that some logic explicitly disabled the feature, by default.
-		if ( ! filter_var( $option_value, FILTER_VALIDATE_BOOLEAN ) ) {
-			return;
-		}
-
-		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
-		// If the WooCommerce installed version is 9.7+, we don't need to do anything. Just let it be enabled.
-		if ( version_compare( $wc_initial_installed_version, '9.7.0.rc', '>=' ) ) {
-			return;
-		}
-
-		// For pre-9.7 stores, we check 9.7 experiment group first.
-		$experiment_transient = get_transient( 'abtest_variation_woocommerce_payment_settings_2025_v1' );
-		if ( 'treatment' === $experiment_transient ) {
-			// If the user is in the experiment treatment group and he didn't interact with the WCAdmin feature flag
-			// we will let the feature be enabled by default.
-			return;
-		}
-
-		// Finally, make sure the feature is disabled by default for existing stores, created with WC pre-9.7.
-		// Only do so for stores that are not blank.
-		if ( ! \WC_Install::is_new_install() ) {
-			update_option( $option_name, 'no' );
-		}
-	}
-
-	/**
-	 * Handle the feature enablement for WooCommerce v9.8.0 and v9.8.1.
-	 *
-	 * @return void
-	 */
-	public function handle_feature_enablement_for_v9_8() {
-		// If the feature is already enabled, we don't need to do anything.
-		if ( FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
-			return;
-		}
-
-		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
-		// Sanity check: if we are at the same version as the one we are checking for, we don't need to do anything.
-		if ( WC()->version === $wc_initial_installed_version ) {
-			return;
-		}
-
-		// If the WooCommerce installed version is not 9.8.0 or 9.8.1, we don't need to do anything.
-		if ( version_compare( $wc_initial_installed_version, '9.8.0', '<' ) &&
-			version_compare( $wc_initial_installed_version, '9.8.1', '>' ) ) {
-			return;
-		}
-
-		// If the feature is not enabled and the store was created with 9.8.0 or 9.8.1,
-		// we will one-time force enable it.
-		wc_get_container()->get( FeaturesController::class )->change_feature_enable( 'reactify-classic-payments-settings', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -82,6 +82,13 @@ class PaymentsController {
 			return;
 		}
 
+		$experiment_transient = get_transient( 'abtest_variation_woocommerce_payment_settings_2025_v1' );
+		if ( 'treatment' === $experiment_transient ) {
+			// If the user is in the experiment treatment group and he didn't interact with the WCAdmin feature flag
+			// we will let the feature be enabled by default.
+			return;
+		}
+
 		// Finally, make sure the feature is disabled by default for existing stores, created with WC pre-9.7.
 		// For our purposes here, on top of NOT being a fresh/blank store,
 		// we believe that an "existing" store needs to have enabled gateways, of any kind.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -78,7 +78,7 @@ class PaymentsController {
 
 		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
 		// If the WooCommerce installed version is 9.7+, we don't need to do anything. Just let it be enabled.
-		if ( version_compare( $wc_initial_installed_version, '9.7.0', '>=' ) ) {
+		if ( version_compare( $wc_initial_installed_version, '9.7.0.rc', '>=' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -3,11 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Settings;
 
-use Automattic\WooCommerce\Internal\Admin\FeaturePlugin;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Exception;
-use WooCommerce\Admin\Experimental_Abtest;
 
 defined( 'ABSPATH' ) || exit;
 /**
@@ -28,6 +25,14 @@ class PaymentsController {
 	 * Register hooks.
 	 */
 	public function register() {
+		// Hook into feature flag WP option DB addition (not update) to one-time adjust the feature's default enablement.
+		add_action(
+			'add_option_woocommerce_feature_reactify-classic-payments-settings_enabled',
+			array( $this, 'adjust_feature_default_enablement' ),
+			999,
+			2
+		);
+
 		// Because we gate the hooking based on a feature flag,
 		// we need to delay the registration until the 'woocommerce_init' hook.
 		// Otherwise, we end up in an infinite loop.
@@ -35,49 +40,43 @@ class PaymentsController {
 	}
 
 	/**
-	 * Adjust the new Payments Settings page feature default enablement based on the experiment.
-	 * This is invoked from within FeaturesController.
+	 * Adjust the new Payments Settings page feature default enablement.
 	 *
-	 * @param FeaturesController $features_controller The features controller instance.
+	 * Currently, we target only new stores so we need to make sure that
+	 * the feature is not enabled by default for existing stores.
+	 * At the same time, we need to migrate the old WCAdmin feature flag value.
+	 *
+	 * Note: We rely on the fact that this logic is only executed ONCE, when the feature flag is first added to the DB.
+	 *       If the feature flag is already present in the DB, this method should not be called.
+	 *
+	 * @param string $option_name  The name of the option.
+	 * @param mixed  $option_value The value of the option.
 	 *
 	 * @return void
 	 */
-	public function adjust_feature_default_enablement_by_experiment( FeaturesController $features_controller ) {
-		// Needed for CLI and unit tests.
-		FeaturePlugin::instance()->init();
+	public function adjust_feature_default_enablement( $option_name, $option_value ) {
+		// First, migrate the WCAdmin feature flag to the new feature flag.
+		// If there is a value saved for the old feature flag, we will respect it.
+		$wc_admin_helper_features = get_option( 'wc_admin_helper_feature_values', array() );
+		foreach ( $wc_admin_helper_features as $feature => $value ) {
+			if ( 'reactify-classic-payments-settings' === $feature ) {
+				update_option( $option_name, filter_var( $value, FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no' );
+				return;
+			}
+		}
 
-		// If the feature is disabled (or doesn't exist), don't do anything.
-		if ( ! $features_controller->feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
+		// If the feature was added as disabled, don't do anything.
+		// This means that some logic explicitly disabled the feature, by default.
+		if ( ! filter_var( $option_value, FILTER_VALIDATE_BOOLEAN ) ) {
 			return;
 		}
 
-		// We only want to adjust the default feature value.
-		// If the feature value is already set in the DB, don't do anything.
-		$option_name = $features_controller->feature_enable_option_name( 'reactify-classic-payments-settings' );
-		if ( get_option( $option_name ) !== false ) {
-			return;
-		}
-
-		// Transient key to handle the experiment group assignment failure.
-		$transient_key = 'wc_experiment_failure_woocommerce_payment_settings_2025_v2';
-
-		// If we failed to determine the experiment group assignment in the previous hour, don't do anything.
-		if ( 'error' === get_transient( $transient_key ) ) {
-			return;
-		}
-
-		try {
-			$in_treatment = Experimental_Abtest::in_treatment( 'woocommerce_payment_settings_2025_v2' );
-		} catch ( \Exception $e ) {
-			// If the experiment group assignment fails, set a transient to avoid repeated fetches and
-			// consider the user not in the treatment group.
-			set_transient( $transient_key, 'error', HOUR_IN_SECONDS );
-			$in_treatment = false;
-		}
-
-		// If the user is NOT in the experiment treatment group disable the feature.
-		if ( ! $in_treatment ) {
-			$features_controller->change_feature_enable( 'reactify-classic-payments-settings', false );
+		// Make sure the feature is disabled by default for existing stores.
+		// For our purposes here, on top of NOT being a fresh/blank store,
+		// we believe that an "existing" store needs to have enabled gateways, of any kind.
+		// Otherwise, we consider it's a new store and will let the feature be enabled by default.
+		if ( ! \WC_Install::is_new_install() && $this->store_has_enabled_gateways() ) {
+			update_option( $option_name, 'no' );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -82,6 +82,7 @@ class PaymentsController {
 			return;
 		}
 
+		// For pre-9.7 stores, we check 9.7 experiment group first.
 		$experiment_transient = get_transient( 'abtest_variation_woocommerce_payment_settings_2025_v1' );
 		if ( 'treatment' === $experiment_transient ) {
 			// If the user is in the experiment treatment group and he didn't interact with the WCAdmin feature flag
@@ -90,10 +91,8 @@ class PaymentsController {
 		}
 
 		// Finally, make sure the feature is disabled by default for existing stores, created with WC pre-9.7.
-		// For our purposes here, on top of NOT being a fresh/blank store,
-		// we believe that an "existing" store needs to have enabled gateways, of any kind.
-		// Otherwise, we consider it's a new store and will let the feature be enabled by default.
-		if ( ! \WC_Install::is_new_install() && $this->store_has_enabled_gateways() ) {
+		// Only do so for stores that are not blank.
+		if ( ! \WC_Install::is_new_install() ) {
 			update_option( $option_name, 'no' );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Settings;
 
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Exception;
 
@@ -32,6 +33,9 @@ class PaymentsController {
 			999,
 			2
 		);
+
+		// Hook into the WooCommerce updated event to handle feature enablement for v9.8.0 and v9.8.1.
+		add_action( 'woocommerce_updated', array( $this, 'handle_feature_enablement_for_v9_8' ), 999 );
 
 		// Because we gate the hooking based on a feature flag,
 		// we need to delay the registration until the 'woocommerce_init' hook.
@@ -77,6 +81,36 @@ class PaymentsController {
 		// Otherwise, we consider it's a new store and will let the feature be enabled by default.
 		if ( ! \WC_Install::is_new_install() && $this->store_has_enabled_gateways() ) {
 			update_option( $option_name, 'no' );
+		}
+	}
+
+	/**
+	 * Handle the feature enablement for WooCommerce v9.8.0 and v9.8.1.
+	 *
+	 * @return void
+	 */
+	public function handle_feature_enablement_for_v9_8() {
+		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
+		// Sanity check: if we are at the same version as the one we are checking for, we don't need to do anything.
+		if ( WC()->version === $wc_initial_installed_version ) {
+			return;
+		}
+
+		// If the WooCommerce installed version is not 9.8.0 or 9.8.1, we don't need to do anything.
+		if ( version_compare( $wc_initial_installed_version, '9.8.0', '<' ) &&
+			version_compare( $wc_initial_installed_version, '9.8.1', '>' ) ) {
+			return;
+		}
+
+		// If the feature is already enabled, we don't need to do anything.
+		if ( FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
+			return;
+		}
+
+		// If the feature is not enabled and the store is "empty" or did not enable any gateway yet,
+		// we will one-time force enable it.
+		if ( \WC_Install::is_new_install() || ! $this->store_has_enabled_gateways() ) {
+			wc_get_container()->get( FeaturesController::class )->change_feature_enable( 'reactify-classic-payments-settings', true );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsController.php
@@ -30,12 +30,13 @@ class PaymentsController {
 		add_action(
 			'add_option_woocommerce_feature_reactify-classic-payments-settings_enabled',
 			array( $this, 'adjust_feature_default_enablement' ),
-			999,
+			10,
 			2
 		);
 
 		// Hook into the WooCommerce updated event to handle feature enablement for v9.8.0 and v9.8.1.
-		add_action( 'woocommerce_updated', array( $this, 'handle_feature_enablement_for_v9_8' ), 999 );
+		// This action is fired after the WC_Install::install() method is run and the option is added to the DB.
+		add_action( 'woocommerce_updated', array( $this, 'handle_feature_enablement_for_v9_8' ) );
 
 		// Because we gate the hooking based on a feature flag,
 		// we need to delay the registration until the 'woocommerce_init' hook.
@@ -75,7 +76,13 @@ class PaymentsController {
 			return;
 		}
 
-		// Make sure the feature is disabled by default for existing stores.
+		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
+		// If the WooCommerce installed version is 9.7+, we don't need to do anything. Just let it be enabled.
+		if ( version_compare( $wc_initial_installed_version, '9.7.0', '>=' ) ) {
+			return;
+		}
+
+		// Finally, make sure the feature is disabled by default for existing stores, created with WC pre-9.7.
 		// For our purposes here, on top of NOT being a fresh/blank store,
 		// we believe that an "existing" store needs to have enabled gateways, of any kind.
 		// Otherwise, we consider it's a new store and will let the feature be enabled by default.
@@ -90,6 +97,11 @@ class PaymentsController {
 	 * @return void
 	 */
 	public function handle_feature_enablement_for_v9_8() {
+		// If the feature is already enabled, we don't need to do anything.
+		if ( FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
+			return;
+		}
+
 		$wc_initial_installed_version = get_option( \WC_Install::INITIAL_INSTALLED_VERSION, '0.0.0' );
 		// Sanity check: if we are at the same version as the one we are checking for, we don't need to do anything.
 		if ( WC()->version === $wc_initial_installed_version ) {
@@ -102,16 +114,9 @@ class PaymentsController {
 			return;
 		}
 
-		// If the feature is already enabled, we don't need to do anything.
-		if ( FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
-			return;
-		}
-
-		// If the feature is not enabled and the store is "empty" or did not enable any gateway yet,
+		// If the feature is not enabled and the store was created with 9.8.0 or 9.8.1,
 		// we will one-time force enable it.
-		if ( \WC_Install::is_new_install() || ! $this->store_has_enabled_gateways() ) {
-			wc_get_container()->get( FeaturesController::class )->change_feature_enable( 'reactify-classic-payments-settings', true );
-		}
+		wc_get_container()->get( FeaturesController::class )->change_feature_enable( 'reactify-classic-payments-settings', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -223,7 +223,6 @@ class FeaturesController {
 			$container = wc_get_container();
 			$container->get( CustomOrdersTableController::class )->add_feature_definition( $this );
 			$container->get( CostOfGoodsSoldController::class )->add_feature_definition( $this );
-			$container->get( PaymentsController::class )->adjust_feature_default_enablement_by_experiment( $this );
 
 			$this->init_compatibility_info_by_feature();
 		}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -441,7 +441,7 @@ class FeaturesController {
 					'Enable the new payments settings experience',
 					'woocommerce'
 				),
-				'enabled_by_default' => true,
+				'enabled_by_default' => false,
 				'disable_ui'         => false,
 
 				/*


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up PR for https://github.com/woocommerce/woocommerce/pull/57230 to expand our addressable stores even further. This is PR is needed because the original PR got merged before we had a chance to include them.

The current, combined logic goes like this:
- Stores created with 9.8.0 or 9.8.1, will get the feature **enabled** regardless of store state.
- Stores created with 9.7 will respect the WCAdmin feature stored value (if any), but otherwise will get the feature **enabled** regardless of store state.
- Stores created pre-9.6 will respect the WCAdmin feature stored value (if any), then respect the experiment treatment group by **enabling** the feature, but otherwise will get the feature **disabled** if they are not blank/empty stores.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to https://github.com/woocommerce/woocommerce/issues/57228 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing brand new stores

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dashboard and install and activate WooCommerce using this PR's branch build (either build the zip locally or use the GitHub generated one from the "Build Live Branch" action logs)
1. Skip the core profiler and select a EU store country ("Austria" for example).
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is enabled:
![Screenshot 2025-04-14 at 13 26 46](https://github.com/user-attachments/assets/a55708f2-812b-468e-bde6-bd98abd64034)
1. Click on the "Payments" main menu item and you should see the new Payments Settings page:
![Screenshot 2025-04-14 at 13 28 26](https://github.com/user-attachments/assets/686ca408-77d1-4437-b8d5-14ca15883f7b)
1. Go to WooCommerce > Settings > Advanced > Features and disable the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item and you should be presented with the WooPayments-flavored Payments task page:
![Screenshot 2025-04-14 at 13 31 26](https://github.com/user-attachments/assets/760d5efb-1776-4e6e-835d-5a699a54eb48)
1. Go to WooCommerce > Settings > Payments and you should see the legacy page:
![Screenshot 2025-04-14 at 13 32 25](https://github.com/user-attachments/assets/7e7dc3e9-e5d8-401d-a067-f8819e373bcd)

#### Testing (new) stores upgrading from WC 9.7.x

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dasboard and install and activate **WooCommerce 9.7.1** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.7.1.zip))
1. Go through the core profiler, skip it and select any EU country ("Austria" for example).
1. Go to Plugins > Add new and install and activate the WooCommerce Beta Tester plugin (either [from WCCOM](https://woocommerce.com/products/woocommerce-beta-tester/) or directly from [here](https://github.com/user-attachments/files/19734140/woocommerce-beta-tester.1.zip))
1. Go to Tools > WCA Test Helper > Features and make sure the `reactify-classic-payments-settings` feature is enabled. If it is already enabled when you visit the page, disabled it and enable it back (to make it interacted with and stored):
![Screenshot 2025-04-14 at 13 46 13](https://github.com/user-attachments/assets/1c1d3dd3-0dc9-4836-abcf-5337e3cc1653)
1. Click on the "Payments" main menu item and confirm you see the new Payments Settings page: 
![Screenshot 2025-04-14 at 13 49 08](https://github.com/user-attachments/assets/56930ce5-efd6-4f20-8e66-5448fc97ff31)
1. Go to Plugins > Add new and upload WooCommerce using this PR's branch build (either build the zip locally or use the GitHub generated one from the "Build Live Branch" action logs). When asked, replace the current version (9.7.1) with the new one (9.8.1):
![Screenshot 2025-04-14 at 13 54 18](https://github.com/user-attachments/assets/fcb3419c-dbfa-4bf7-998d-d26e98a5cb13)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is enabled:
![Screenshot 2025-04-14 at 13 26 46](https://github.com/user-attachments/assets/a55708f2-812b-468e-bde6-bd98abd64034)
1. Click on the "Payments" main menu item and you should see the new Payments Settings page:
![Screenshot 2025-04-14 at 13 28 26](https://github.com/user-attachments/assets/686ca408-77d1-4437-b8d5-14ca15883f7b)
1. Go to WooCommerce > Settings > Advanced > Features and disable the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item and you should be presented with the WooPayments-flavored Payments task page:
![Screenshot 2025-04-14 at 13 31 26](https://github.com/user-attachments/assets/760d5efb-1776-4e6e-835d-5a699a54eb48)
1. Go to WooCommerce > Settings > Payments and you should see the legacy page:
![Screenshot 2025-04-14 at 13 32 25](https://github.com/user-attachments/assets/7e7dc3e9-e5d8-401d-a067-f8819e373bcd)
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin (this will run WC Install again):
![Screenshot 2025-04-14 at 13 57 50](https://github.com/user-attachments/assets/1cbdf12a-236b-4679-b241-2348c1f72ece)
1. Go to WooCommerce > Settings > Payments and you should still see the legacy page.
1. Go to WooCommerce > Settings > Advanced > Features and enable the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item and should see the new page.

#### Test (new) stores upgrading from WC 9.8.x

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dasboard and install and activate **WooCommerce 9.8.0** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.8.0.zip))
1. Go through the core profiler, skip it and select any EU country ("Austria" for example).
1. Go to WooCommerce > Settings > Advanced > Features and make sure you _disable_ the "Payments Settings (beta)" feature.
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to Plugins > Add new and upload WooCommerce using this PR's branch build (either build the zip locally or use the GitHub generated one from the "Build Live Branch" action logs). When asked, replace the current version (9.8.0) with the new one (9.8.1).
1. Go to WooCommerce > Settings > Advanced > Features and the "Payments Settings (beta)" feature should be enabled.
1. Click on the "Payments" main menu item and should see the new Payments Settings page.
1. Go to WooCommerce > Settings > Advanced > Features and _disable_ the "Payments Settings (beta)" feature.
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin.
1. Go to WooCommerce > Settings > Payments and you should see the legacy Payments Settings page.

#### Testing existing stores (pre-9.7)

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dasboard and install and activate **WooCommerce 9.6.2** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.6.2.zip))
1. Go through the core profiler, skip it and select any EU country ("Austria" for example).
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to WooCommerce > Settings > Payments and enable an offline payment method.
1. Go to Plugins > Add new and upload WooCommerce using this PR's branch build (either build the zip locally or use the GitHub generated one from the "Build Live Branch" action logs). When asked, replace the current version (9.6.2) with the new one (9.8.1):
![Screenshot 2025-04-14 at 13 54 18](https://github.com/user-attachments/assets/fcb3419c-dbfa-4bf7-998d-d26e98a5cb13)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is **disabled.**
1. Go to WooCommerce > Settings > Payments and you should see the legacy Payments Settings page.
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin (this will run WC Install again).
1. Go to WooCommerce > Settings > Payments and you should still see the legacy Payments Settings page.

#### Testing existing stores (pre-9.7) that upgraded to 9.7.x

1. Create a blank Jurassic Ninja site _without_ the drop-in cache plugin.
1. Go to the new site's WP dasboard and install and activate **WooCommerce 9.6.2** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.6.2.zip))
1. Go through the core profiler, skip it and select any EU country ("Austria" for example).
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to WooCommerce > Settings > Payments and enable an offline payment method.
1. Go to Plugins > Add new and upload **WooCommerce 9.7.1** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.7.1.zip)). When asked, replace the current version (9.6.2) with the new one (9.7.1).
1. Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page. If you don't, it means you landed in the 50% that get the control experience in the experiment. Do the following:
    - Go to Plugins > Add new and install and activate the [Transients Manger](https://wordpress.org/plugins/transients-manager/) plugin
    - Go to Tools > Transients and search for `abtest_variation_woocommerce_payment_settings_2025_v1`. You should have an entry with the `control` value. Edit it to have the `treatment` value.
    - Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page.
1. Go to Plugins > Add new and upload WooCommerce using this PR's branch build (either build the zip locally or use the GitHub generated one from the "Build Live Branch" action logs). When asked, replace the current version (9.7.1) with the new one (9.8.1):
![Screenshot 2025-04-14 at 13 54 18](https://github.com/user-attachments/assets/fcb3419c-dbfa-4bf7-998d-d26e98a5cb13)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is **enabled.**
1. Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page.
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin (this will run WC Install again).
1. Go to WooCommerce > Settings > Payments and you should still see the new Payments Settings page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
