### PR TITLE
[Blueprint] Improve schema/filter validation 

### DIFF
--- a/packages/php/blueprint/changelog/improve-blueprint-validation
+++ b/packages/php/blueprint/changelog/improve-blueprint-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve schema/filter validation

--- a/packages/php/blueprint/src/Cli/ExportCli.php
+++ b/packages/php/blueprint/src/Cli/ExportCli.php
@@ -43,8 +43,13 @@ class ExportCli {
 
 		$exporter = new ExportSchema();
 
-		$schema   = $exporter->export( $args['steps'] );
-		$is_saved = $this->wp_filesystem_put_contents( $this->save_to, wp_json_encode( $schema, JSON_PRETTY_PRINT ) );
+		$result = $exporter->export( $args['steps'] );
+		if ( is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		$is_saved = $this->wp_filesystem_put_contents( $this->save_to, wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 
 		if ( false === $is_saved ) {
 			\WP_CLI::error( "Failed to save to {$this->save_to}" );

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -3,8 +3,6 @@
 namespace Automattic\WooCommerce\Blueprint;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
-use Automattic\WooCommerce\Blueprint\Exporters\ExportInstallPluginSteps;
-use Automattic\WooCommerce\Blueprint\Exporters\ExportInstallThemeSteps;
 use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
 
 /**
@@ -40,10 +38,19 @@ class ExportSchema {
 	 * @param string[] $steps Array of step names to export, optional.
 	 *
 	 * @return array The exported schema array.
+	 *
+	 * @throws \InvalidArgumentException If the landing page path is invalid.
 	 */
 	public function export( $steps = array() ) {
+		$loading_page_path = $this->wp_apply_filters( 'wooblueprint_export_landingpage', '/' );
+
+		// Validate that the landing page path is a valid relative local URL path.
+		if ( ! preg_match( '#^/[^/].*#', $loading_page_path ) ) {
+			throw new \InvalidArgumentException( 'Invalid loading page path.' );
+		}
+
 		$schema = array(
-			'landingPage' => $this->wp_apply_filters( 'wooblueprint_export_landingpage', '/' ),
+			'landingPage' => $loading_page_path,
 			'steps'       => array(),
 		);
 
@@ -59,6 +66,14 @@ class ExportSchema {
 		 * @since 0.0.1
 		 */
 		$exporters = $this->wp_apply_filters( 'wooblueprint_exporters', array_merge( $this->exporters, $built_in_exporters ) );
+
+		// Validate that the exporters are instances of StepExporter.
+		$exporters = array_filter(
+			$exporters,
+			function ( $exporter ) {
+				return $exporter instanceof StepExporter;
+			}
+		);
 
 		// Filter out any exporters that are not in the list of steps to export.
 		if ( count( $steps ) ) {

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -43,9 +43,18 @@ class ExportSchema {
 	 */
 	public function export( $steps = array() ) {
 		$loading_page_path = $this->wp_apply_filters( 'wooblueprint_export_landingpage', '/' );
-
-		// Validate that the landing page path is a valid relative local URL path.
-		if ( ! preg_match( '#^/[^/].*#', $loading_page_path ) ) {
+		/**
+		 * Validate that the landing page path is a valid relative local URL path.
+		 *
+		 * Accepts:
+		 * - /
+		 * - /path/to/page
+		 *
+		 * Rejects:
+		 * - http://example.com/path/to/page
+		 * - invalid-path
+		 */
+		if ( ! preg_match( '#^/$|^/[^/].*#', $loading_page_path ) ) {
 			throw new \InvalidArgumentException( 'Invalid loading page path.' );
 		}
 

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blueprint;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
+use WP_Error;
 
 /**
  * Class ExportSchema
@@ -37,9 +38,7 @@ class ExportSchema {
 	 *
 	 * @param string[] $steps Array of step names to export, optional.
 	 *
-	 * @return array The exported schema array.
-	 *
-	 * @throws \InvalidArgumentException If the landing page path is invalid.
+	 * @return array|WP_Error The exported schema array or a WP_Error if the export fails.
 	 */
 	public function export( $steps = array() ) {
 		$loading_page_path = $this->wp_apply_filters( 'wooblueprint_export_landingpage', '/' );
@@ -55,7 +54,7 @@ class ExportSchema {
 		 * - invalid-path
 		 */
 		if ( ! preg_match( '#^/$|^/[^/].*#', $loading_page_path ) ) {
-			throw new \InvalidArgumentException( 'Invalid loading page path.' );
+			return new WP_Error( 'wooblueprint_invalid_landing_page_path', 'Invalid loading page path.' );
 		}
 
 		$schema = array(

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -89,7 +89,7 @@ class ImportStep {
 
 		// validate importer is a step processor before processing.
 		if ( ! $importer instanceof StepProcessor ) {
-			$result->add_error( "Importer {$this->step_definition->step} is not a valid step processor" );
+			$result->add_warn( "Importer {$this->step_definition->step} is not a valid step processor" );
 			return $result;
 		}
 

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -87,6 +87,12 @@ class ImportStep {
 
 		$importer = $this->indexed_importers[ $this->step_definition->step ];
 
+		// validate importer is a step processor before processing.
+		if ( ! $importer instanceof StepProcessor ) {
+			$result->add_error( "Importer {$this->step_definition->step} is not a valid step processor" );
+			return $result;
+		}
+
 		// validate steps before processing.
 		$this->validate_step_schemas( $importer, $result );
 

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\Blueprint\ExportSchema;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Exporters\EmptySetSiteOptionsExporter;
 use Automattic\WooCommerce\Blueprint\Tests\TestCase;
 use Mockery;
-use Mockery\Mock;
+use WP_Error;
 
 /**
  * Class ExportSchemaTest
@@ -70,18 +70,16 @@ class ExportSchemaTest extends TestCase {
 	}
 
 	/**
-	 * Test that it throws an exception when the landing page path is invalid.
+	 * Test that it returns a WP_Error when the landing page path is invalid.
 	 */
-	public function test_throw_exception_when_landing_page_path_is_invalid() {
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'Invalid loading page path.' );
-
+	public function test_returns_wp_error_when_landing_page_path_is_invalid() {
 		$exporter = $this->get_mock( true );
 		$exporter->shouldReceive( 'wp_apply_filters' )
 			->with( 'wooblueprint_export_landingpage', Mockery::any() )
 			->andReturn( 'invalid-path' );
 
-		$exporter->export();
+		$result = $exporter->export();
+		$this->assertInstanceOf( WP_Error::class, $result );
 	}
 
 	/**

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -107,4 +107,45 @@ class ExportSchemaTest extends TestCase {
 		$this->assertCount( 1, $result['steps'] );
 		$this->assertEquals( 'setSiteOptions', $result['steps'][0]['step'] );
 	}
+
+	/**
+	 * Test that it filters out exporters that are not instances of StepExporter.
+	 *
+	 * @return void
+	 */
+	public function test_it_filters_out_invalid_exporters() {
+		$empty_exporter   = new EmptySetSiteOptionsExporter();
+		$invalid_exporter = new class() {
+			/**
+			 * Export method that should never be called.
+			 *
+			 * @throws \Exception If called.
+			 */
+			public function export() {
+				throw new \Exception( 'This method should not be called.' );
+			}
+		};
+
+		$mock = Mock(
+			ExportSchema::class,
+			array(
+				array(
+					$empty_exporter,
+					$invalid_exporter,
+				),
+			)
+		);
+		$mock->makePartial();
+
+		// Mock the filter to return our test exporters.
+		$mock->shouldReceive( 'wp_apply_filters' )
+			->with( 'wooblueprint_exporters', Mockery::any() )
+			->andReturn( array( $empty_exporter, $invalid_exporter ) );
+
+		$result = $mock->export();
+
+		// Should only have one step from the valid exporter.
+		$this->assertCount( 1, $result['steps'] );
+		$this->assertEquals( 'setSiteOptions', $result['steps'][0]['step'] );
+	}
 }

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -63,10 +63,25 @@ class ExportSchemaTest extends TestCase {
 
 		$exporter->shouldReceive( 'wp_apply_filters' )
 			->with( 'wooblueprint_export_landingpage', Mockery::any() )
-			->andReturn( 'test' );
+			->andReturn( '/test' );
 
 		$result = $exporter->export();
-		$this->assertEquals( 'test', $result['landingPage'] );
+		$this->assertEquals( '/test', $result['landingPage'] );
+	}
+
+	/**
+	 * Test that it throws an exception when the landing page path is invalid.
+	 */
+	public function test_throw_exception_when_landing_page_path_is_invalid() {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Invalid loading page path.' );
+
+		$exporter = $this->get_mock( true );
+		$exporter->shouldReceive( 'wp_apply_filters' )
+			->with( 'wooblueprint_export_landingpage', Mockery::any() )
+			->andReturn( 'invalid-path' );
+
+		$exporter->export();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-3933

This PR enhances the Blueprint package by validating the variable types before using them.

- Added validation to ensure exporters are instances of `StepExporter`
- Added validation to ensure step processors are instances of `StepProcessor`
- Added validation for landing page path format
- Added type validation before processing importers
- Replaced `json_encode` with WordPress-specific `wp_json_encode`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


Review the code changes and ensure the changes make sense.

1. pnpm install
2. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
4. Try to export and import a Blueprint. Confirm that everything works without errors.
5. Test Exporter Filters:
   - Add the following code to your theme's functions.php or a test plugin to test invalid exporter filtering:
   ```php
   add_filter('wooblueprint_exporters', function($exporters) {
       // Add an invalid exporter (not implementing StepExporter)
       $exporters[] = new class() {
           public function export() {
               return throw new \Exception('This method should not be called.');
           }
       };
       return $exporters;
   });
   ```
   - Try to export a Blueprint
   - Verify the export completes successfully without errors

6. Test Landing Page Path Validation:

   - Add this code to test invalid landing page paths:
   ```php
   add_filter('wooblueprint_export_landingpage', function($path) {
       return 'invalid-path'; // Should trigger validation error
   }, 100 );
   ```
   - Try to export a Blueprint `wp wc blueprint export blueprint.json --steps=setWCTaxRates`
   - Verify you receive `Error: Invalid loading page path.`



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
