### PR TITLE
Add $email_object parameter to woocommerce_email_preview_placeholders filter

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3878-enhancement-pass-the-email_object-to-the-woocommerce_email_preview_placeholders-filter
+++ b/plugins/woocommerce/changelog/wooplug-3878-enhancement-pass-the-email_object-to-the-woocommerce_email_preview_placeholders-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add $email_object to the woocommerce_email_preview_placeholders filter

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -439,9 +439,9 @@ class EmailPreview {
 		/**
 		 * Placeholders for email preview.
 		 *
-		 * @param array    $placeholders Placeholders for email subject.
-		 * @param string   $email_type The email type to preview.
-		 * @param mixed $email_object The object to render email with.
+		 * @param array  $placeholders Placeholders for email subject.
+		 * @param string $email_type   The email type to preview.
+		 * @param mixed  $email_object The object to render email with. @since 9.9.0
 		 *
 		 * @since 9.6.0
 		 */

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -439,12 +439,13 @@ class EmailPreview {
 		/**
 		 * Placeholders for email preview.
 		 *
-		 * @param WC_Order $placeholders Placeholders for email subject.
+		 * @param array    $placeholders Placeholders for email subject.
 		 * @param string   $email_type The email type to preview.
+		 * @param WC_Order|WP_User $email_object The object to render email with.
 		 *
 		 * @since 9.6.0
 		 */
-		return apply_filters( 'woocommerce_email_preview_placeholders', $placeholders, $this->email_type );
+		return apply_filters( 'woocommerce_email_preview_placeholders', $placeholders, $this->email_type, $email_object );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -424,7 +424,7 @@ class EmailPreview {
 	/**
 	 * Get the placeholders for the email preview.
 	 *
-	 * @param WC_Order|WP_User $email_object The object to render email with.
+	 * @param mixed $email_object The object to render email with. Can be WC_Order, WP_User, etc.
 	 * @return array
 	 */
 	private function get_placeholders( $email_object ) {
@@ -441,7 +441,7 @@ class EmailPreview {
 		 *
 		 * @param array    $placeholders Placeholders for email subject.
 		 * @param string   $email_type The email type to preview.
-		 * @param WC_Order|WP_User $email_object The object to render email with.
+		 * @param mixed $email_object The object to render email with.
 		 *
 		 * @since 9.6.0
 		 */


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


#### Enhance `woocommerce_email_preview_placeholders` filter with `$email_object`

**Description:**

This PR enhances the `woocommerce_email_preview_placeholders` filter by adding the `$email_object` (either `WC_Order` or `WP_User`) as the third parameter.

Previously, the filter only received the `$placeholders` array and the `$email_type` string. This made it difficult for developers to customize email preview placeholders based on the specific context (e.g., order details or user information) being previewed.

By adding the `$email_object`, developers hooking into this filter now have direct access to the relevant data object, enabling more powerful and context-aware customizations of the email preview functionality.

Closes #57153
Closes WOOPLUG-3878

**Changes:**

*   Modified the `apply_filters` call for `woocommerce_email_preview_placeholders` in `plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php` to include `$email_object`.
*   Updated the DocBlock for the filter to reflect the new parameter and adjust the type hint for `$placeholders`.
*   Added a changelog entry: `plugins/woocommerce/changelog/wooplug-3878-enhancement-pass-the-email_object-to-the-woocommerce_email_preview_placeholders-filter`.



### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Implement a custom function hooked to the `woocommerce_email_preview_placeholders` filter.
2.  Inside the function, check the type and content of the third argument (`$email_object`).
3.  You can use this code snippet https://github.com/woocommerce/woocommerce/blob/a608d9c53c81320b366daa713b9543f146795d58/docs/emails/email-preview.md?plain=1#L95-L105

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
