### PR TITLE
Fix: Remove Product Collection's Store Notices wrapper

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/stores/store-notices.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/store-notices.ts
@@ -17,10 +17,14 @@ type NoticeWithId = Notice & {
 	id: string;
 };
 
-const getContext = getContextFn< {
-	notices: NoticeWithId[];
+const getStoreNoticeContext = getContextFn< {
 	notice: NoticeWithId;
 } >;
+
+const getProductCollectionContext = () =>
+	getContextFn< {
+		notices: NoticeWithId[];
+	} >( 'woocommerce/product-collection' );
 
 type StoreNoticesState = {
 	get role(): string;
@@ -28,6 +32,7 @@ type StoreNoticesState = {
 	get isError(): boolean;
 	get isSuccess(): boolean;
 	get isInfo(): boolean;
+	get notices(): NoticeWithId[];
 };
 
 export type Store = {
@@ -64,7 +69,7 @@ store< Store >(
 	{
 		state: {
 			get role() {
-				const context = getContext();
+				const context = getStoreNoticeContext();
 				if (
 					context.notice.type === 'error' ||
 					context.notice.type === 'success'
@@ -75,26 +80,30 @@ store< Store >(
 				return 'status';
 			},
 			get iconPath() {
-				const context = getContext();
+				const context = getStoreNoticeContext();
 				const noticeType = context.notice.type;
 				return ICON_PATHS[ noticeType ];
 			},
 			get isError() {
-				const { notice } = getContext();
+				const { notice } = getStoreNoticeContext();
 				return notice.type === 'error';
 			},
 			get isSuccess() {
-				const { notice } = getContext();
+				const { notice } = getStoreNoticeContext();
 				return notice.type === 'success';
 			},
 			get isInfo() {
-				const { notice } = getContext();
+				const { notice } = getStoreNoticeContext();
 				return notice.type === 'notice';
+			},
+			get notices() {
+				const { notices } = getProductCollectionContext();
+				return notices;
 			},
 		},
 		actions: {
 			addNotice: ( notice: Notice ) => {
-				const { notices } = getContext();
+				const { notices } = getProductCollectionContext();
 				const noticeId = generateNoticeId();
 				const noticeWithId = {
 					...notice,
@@ -106,11 +115,11 @@ store< Store >(
 			},
 
 			removeNotice: ( noticeId: string | PointerEvent ) => {
-				const { notices } = getContext();
+				const { notices } = getProductCollectionContext();
 				noticeId =
 					typeof noticeId === 'string'
 						? noticeId
-						: getContext().notice.id;
+						: getStoreNoticeContext().notice.id;
 				const index = notices.findIndex(
 					( { id } ) => id === noticeId
 				);
@@ -121,7 +130,7 @@ store< Store >(
 		},
 		callbacks: {
 			renderNoticeContent: () => {
-				const context = getContext();
+				const context = getStoreNoticeContext();
 				const { ref } = getElement();
 
 				if ( ref ) {

--- a/plugins/woocommerce-blocks/assets/js/base/stores/store-notices.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/stores/store-notices.ts
@@ -21,6 +21,8 @@ const getStoreNoticeContext = getContextFn< {
 	notice: NoticeWithId;
 } >;
 
+// Todo: Go back to the Store Notices block context once more than one context
+// can be added to an element (https://github.com/WordPress/gutenberg/discussions/62720).
 const getProductCollectionContext = () =>
 	getContextFn< {
 		notices: NoticeWithId[];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -176,9 +176,6 @@ class Renderer {
 	 * @return string The rendered store notices HTML.
 	 */
 	protected function render_interactivity_notices_region() {
-		// Remove this extra div wrapper once we can use two context
-		// directives in the top level div (https://github.com/WordPress/gutenberg/discussions/62720).
-
 		wp_interactivity_state(
 			'woocommerce/store-notices',
 			array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -178,6 +178,14 @@ class Renderer {
 	protected function render_interactivity_notices_region() {
 		// Remove this extra div wrapper once we can use two context
 		// directives in the top level div (https://github.com/WordPress/gutenberg/discussions/62720).
+
+		wp_interactivity_state(
+			'woocommerce/store-notices',
+			array(
+				'notices' => array(),
+			)
+		);
+
 		ob_start();
 		?>
 		<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -129,18 +129,17 @@ class Renderer {
 
 			$collection                     = $block['attrs']['collection'] ?? '';
 			$is_enhanced_pagination_enabled = ! ( $block['attrs']['forcePageReload'] ?? false );
+			$context                        = array( 'notices' => array() );
+
+			if ( $collection ) {
+				$context['collection'] = $collection;
+			}
 
 			$p = new \WP_HTML_Tag_Processor( $block_content );
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-product-collection' ) ) ) {
 				$p->set_attribute( 'data-wp-interactive', 'woocommerce/product-collection' );
 				$p->set_attribute( 'data-wp-init', 'callbacks.onRender' );
-				$p->set_attribute(
-					'data-wp-context',
-					$collection ? wp_json_encode(
-						array( 'collection' => $collection ),
-						JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-					) : '{}'
-				);
+				$p->set_attribute( 'data-wp-context', wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) );
 
 				if ( $is_enhanced_pagination_enabled && isset( $this->parsed_block ) ) {
 					$p->set_attribute(
@@ -167,7 +166,7 @@ class Renderer {
 	 * @return string The updated block content.
 	 */
 	private function add_store_notices_fallback( $block_content ) {
-		return preg_replace( '/(<div[^>]+>)/', '$1' . $this->render_interactivity_notices_region(), $block_content, 1 ) . '</div>';
+		return preg_replace( '/(<div[^>]+>)/', '$1' . $this->render_interactivity_notices_region(), $block_content, 1 );
 	}
 
 	/**
@@ -181,40 +180,36 @@ class Renderer {
 		// directives in the top level div (https://github.com/WordPress/gutenberg/discussions/62720).
 		ob_start();
 		?>
-		<div data-wp-context='woocommerce/store-notices::{"notices":[]}' style="display: contents;">
-			<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide">
-				<template
-					data-wp-each--notice="context.notices"
-					data-wp-each-key="context.notice.id"
+		<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide">
+			<template data-wp-each--notice="state.notices" data-wp-each-key="context.notice.id">
+				<div
+					class="wc-block-components-notice-banner"
+					data-wp-init="callbacks.scrollIntoView"
+					data-wp-class--is-error="state.isError"
+					data-wp-class--is-success ="state.isSuccess"
+					data-wp-class--is-info="state.isInfo"
+					data-wp-class--is-dismissible="context.notice.dismissible"
+					data-wp-bind--role="state.role"
 				>
-					<div
-						class="wc-block-components-notice-banner"
-						data-wp-init="callbacks.scrollIntoView"
-						data-wp-class--is-error="state.isError"
-						data-wp-class--is-success ="state.isSuccess"
-						data-wp-class--is-info="state.isInfo"
-						data-wp-class--is-dismissible="context.notice.dismissible"
-						data-wp-bind--role="state.role"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
-							<path data-wp-bind--d="state.iconPath"></path>
-						</svg>
-						<div class="wc-block-components-notice-banner__content">
-							<span data-wp-init="callbacks.renderNoticeContent"></span>
-						</div>
-						<button
-							data-wp-bind--hidden="!context.notice.dismissible"
-							class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
-							aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
-							data-wp-on--click="actions.removeNotice"
-						>
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-								<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
-							</svg>
-						</button>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+						<path data-wp-bind--d="state.iconPath"></path>
+					</svg>
+					<div class="wc-block-components-notice-banner__content">
+						<span data-wp-init="callbacks.renderNoticeContent"></span>
 					</div>
-				</template>
-			</div>
+					<button
+						data-wp-bind--hidden="!context.notice.dismissible"
+						class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
+						aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
+						data-wp-on--click="actions.removeNotice"
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+							<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
+						</svg>
+					</button>
+				</div>
+			</template>
+		</div>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #57162.
Closes WOOPLUG-3883.

#### What 

This PR removes a wrapper introduced in https://github.com/woocommerce/woocommerce/pull/56117.

#### Why

The wrapper is causing problems with the CSS.

- https://github.com/woocommerce/woocommerce/issues/57162#issuecomment-2802084312

#### How

For now, I have moved the context of the notices to the namespace of the Product Collection block.

In the future, once [more than one context directive can be added to the same element](https://github.com/WordPress/gutenberg/discussions/62720), we can reintroduce the store-notices namespace.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

---

Bug introduced in PR #56117.

### How to test the changes in this Pull Request:

1. Open a post, page or template with the _Product Collection_ block.
2. In a separate tab, edit one of the products in the grid and set it as out of stock.
3. Try adding the product to your cart.
4. Verify an error notice is displayed.

![imatge](https://github.com/user-attachments/assets/4f51b917-1cd3-4691-b556-6511e44054a8)

5. With your browser devtools, focus on the Navigation links at the bottom of the product grid. Verify they match the `:root :where(.is-layout-flow) > *` selector and (if using TT5, they have `margin-block-start: 1.2rem;`):

![Captura de pantalla de 2025-04-15 10-01-33](https://github.com/user-attachments/assets/91c9e539-b836-401a-ae0e-029d77cc05f6)

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
