### PR TITLE
[dev] CI: disable wireit GitHub integration breaking CI.

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo-blacksmith/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo-blacksmith/action.yml
@@ -134,11 +134,10 @@ runs:
             fi
         # We want to include an option to build projects using this action so that we can make
         # sure that the build cache is always used when building projects.
-        - name: 'Cache Build Output'
-          # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
-          if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
-          uses: 'google/wireit@setup-github-actions-caching/v2'
-          continue-on-error: true
+        #- name: 'Cache Build Output'
+        #  # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
+        #  if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
+        #  uses: 'google/wireit@setup-github-actions-caching/v2'
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/.github/actions/setup-woocommerce-monorepo-blacksmith/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo-blacksmith/action.yml
@@ -138,6 +138,7 @@ runs:
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
           uses: 'google/wireit@setup-github-actions-caching/v2'
+          continue-on-error: true
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -100,11 +100,10 @@ runs:
             fi
         # We want to include an option to build projects using this action so that we can make
         # sure that the build cache is always used when building projects.
-        - name: 'Cache Build Output'
-          # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
-          if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
-          uses: 'google/wireit@setup-github-actions-caching/v2'
-          continue-on-error: true
+        #- name: 'Cache Build Output'
+        #  # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
+        #  if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
+        #  uses: 'google/wireit@setup-github-actions-caching/v2'
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -104,6 +104,7 @@ runs:
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}
           uses: 'google/wireit@setup-github-actions-caching/v2'
+          continue-on-error: true
         - name: 'Build'
           # Boolean inputs aren't parsed into filters so it'll either be "true" or there will be a filter.
           if: ${{ inputs.build == 'true' || steps.project-filters.outputs.build != '' }}

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader class.
+ * Autoloader clazz.
  *
  * @since 3.7.0
  */

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader clazz.
+ * Autoloader class.
  *
  * @since 3.7.0
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It turns out that https://github.com/google/wireit/issues/1297 fixes are not preventing CI failures.
Hence, we allow the wireit cache step to fail without breaking jobs.

### How to test the changes in this Pull Request:

- CI-checks shall pass ([Example run](https://github.com/woocommerce/woocommerce/actions/runs/14484921934/job/40628694023?pr=57293))