### PR TITLE
[Blueprint] Add permission validation for import steps

### DIFF
--- a/packages/php/blueprint/changelog/57294-wooplug-2482-feature-blueprint-require-permission-based-on-the-steps
+++ b/packages/php/blueprint/changelog/57294-wooplug-2482-feature-blueprint-require-permission-based-on-the-steps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add permission validation for import steps

--- a/packages/php/blueprint/changelog/update-blueprint-require-permission-exporters-api
+++ b/packages/php/blueprint/changelog/update-blueprint-require-permission-exporters-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add permission validation for export steps and REST API

--- a/packages/php/blueprint/changelog/wooplug-3946-blueprint-centralized-audit-logging
+++ b/packages/php/blueprint/changelog/wooplug-3946-blueprint-centralized-audit-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Implement logging functionality in ExportSchema and ImportStep classes

--- a/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
@@ -158,4 +158,12 @@ class ExportInstallPluginSteps implements StepExporter {
 	public function get_step_name() {
 		return InstallPlugin::get_step_name();
 	}
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'activate_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
@@ -80,4 +80,13 @@ class ExportInstallThemeSteps implements StepExporter {
 	public function get_step_name() {
 		return InstallTheme::get_step_name();
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'switch_themes' );
+	}
 }

--- a/packages/php/blueprint/src/Exporters/StepExporter.php
+++ b/packages/php/blueprint/src/Exporters/StepExporter.php
@@ -24,4 +24,11 @@ interface StepExporter {
 	 * @return string
 	 */
 	public function get_step_name();
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool;
 }

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blueprint;
 
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
+use Automattic\WooCommerce\Blueprint\Logger;
 
 /**
  * Class ImportStep
@@ -80,33 +81,61 @@ class ImportStep {
 	public function import() {
 		$result = StepProcessorResult::success( $this->step_definition->step );
 
-		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
-			$result->add_warn( "Unable to find an importer for {$this->step_definition->step}" );
+		if ( ! $this->can_import( $result ) ) {
 			return $result;
 		}
 
 		$importer = $this->indexed_importers[ $this->step_definition->step ];
-		// validate importer is a step processor before processing.
-		if ( ! $importer instanceof StepProcessor ) {
-			$result->add_warn( "Importer {$this->step_definition->step} is not a valid step processor" );
-			return $result;
-		}
-
-		// validate steps before processing.
-		if ( ! $this->validate_step_schemas( $importer, $result ) ) {
-			return $result;
-		}
-
-		// validate step capabilities before processing.
-		if ( ! $importer->check_step_capabilities( $this->step_definition ) ) {
-			$result->add_error( "User does not have the required capabilities to run {$this->step_definition->step} step" );
-			return $result;
-		}
+		$logger   = new Logger();
+		$logger->start_import( $this->step_definition->step, get_class( $importer ) );
 
 		$importer_result = $importer->process( $this->step_definition );
+
+		if ( $importer_result->is_success() ) {
+			$logger->complete_import( $this->step_definition->step, $importer_result );
+		} else {
+			$logger->import_step_failed( $this->step_definition->step, $importer_result );
+		}
+
 		$result->merge_messages( $importer_result );
 
 		return $result;
+	}
+
+	/**
+	 * Check if the step can be imported.
+	 *
+	 * @param StepProcessorResult $result The result object to add messages to.
+	 *
+	 * @return bool True if the step can be imported, false otherwise.
+	 */
+	protected function can_import( &$result ) {
+		// Check if the importer exists.
+		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
+			$result->add_error( 'Unable to find an importer' );
+			return false;
+		}
+
+		$importer = $this->indexed_importers[ $this->step_definition->step ];
+		// Validate importer is a step processor before processing.
+		if ( ! $importer instanceof StepProcessor ) {
+			$result->add_error( 'Incorrect importer type' );
+			return false;
+		}
+
+		// Validate steps schemas before processing.
+		if ( ! $this->validate_step_schemas( $importer, $result ) ) {
+			$result->add_error( 'Schema validation failed for step' );
+			return false;
+		}
+
+		// Validate step capabilities before processing.
+		if ( ! $importer->check_step_capabilities( $this->step_definition ) ) {
+			$result->add_error( 'User does not have the required capabilities to run step' );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -78,7 +78,7 @@ class ImportStep {
 	 * @return StepProcessorResult
 	 */
 	public function import() {
-		$result = StepProcessorResult::success( 'ImportStep' );
+		$result = StepProcessorResult::success( $this->step_definition->step );
 
 		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
 			$result->add_warn( "Unable to find an importer for {$this->step_definition->step}" );

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -86,7 +86,6 @@ class ImportStep {
 		}
 
 		$importer = $this->indexed_importers[ $this->step_definition->step ];
-
 		// validate importer is a step processor before processing.
 		if ( ! $importer instanceof StepProcessor ) {
 			$result->add_warn( "Importer {$this->step_definition->step} is not a valid step processor" );
@@ -94,13 +93,18 @@ class ImportStep {
 		}
 
 		// validate steps before processing.
-		$this->validate_step_schemas( $importer, $result );
-
-		if ( count( $result->get_messages( 'error' ) ) !== 0 ) {
+		if ( ! $this->validate_step_schemas( $importer, $result ) ) {
 			return $result;
 		}
 
-		$result->merge_messages( $importer->process( $this->step_definition ) );
+		// validate step capabilities before processing.
+		if ( ! $importer->check_step_capabilities( $this->step_definition ) ) {
+			$result->add_error( "User does not have the required capabilities to run {$this->step_definition->step} step" );
+			return $result;
+		}
+
+		$importer_result = $importer->process( $this->step_definition );
+		$result->merge_messages( $importer_result );
 
 		return $result;
 	}
@@ -111,7 +115,7 @@ class ImportStep {
 	 * @param StepProcessor       $importer The importer.
 	 * @param StepProcessorResult $result The result object to add messages to.
 	 *
-	 * @return void
+	 * @return bool True if the step schemas are valid, false otherwise.
 	 */
 	protected function validate_step_schemas( StepProcessor $importer, StepProcessorResult $result ) {
 		$step_schema = call_user_func( array( $importer->get_step_class(), 'get_schema' ) );
@@ -127,6 +131,9 @@ class ImportStep {
 			}
 
 			$result->add_error( implode( "\n", $formatted_errors ) );
+
+			return false;
 		}
+		return true;
 	}
 }

--- a/packages/php/blueprint/src/Importers/ImportActivatePlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportActivatePlugin.php
@@ -45,4 +45,15 @@ class ImportActivatePlugin implements StepProcessor {
 	public function get_step_class(): string {
 		return ActivatePlugin::class;
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'activate_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Importers/ImportActivateTheme.php
+++ b/packages/php/blueprint/src/Importers/ImportActivateTheme.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Blueprint\Importers;
 
 use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use Automattic\WooCommerce\Blueprint\Steps\ActivatePlugin;
 use Automattic\WooCommerce\Blueprint\Steps\ActivateTheme;
 use Automattic\WooCommerce\Blueprint\UsePluginHelpers;
 use Automattic\WooCommerce\Blueprint\UseWPFunctions;
@@ -48,5 +47,16 @@ class ImportActivateTheme implements StepProcessor {
 	 */
 	public function get_step_class(): string {
 		return ActivateTheme::class;
+	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'switch_themes' );
 	}
 }

--- a/packages/php/blueprint/src/Importers/ImportDeactivatePlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportDeactivatePlugin.php
@@ -44,4 +44,15 @@ class ImportDeactivatePlugin implements StepProcessor {
 	public function get_step_class(): string {
 		return DeactivatePlugin::class;
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'deactivate_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Importers/ImportDeletePlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportDeletePlugin.php
@@ -44,4 +44,16 @@ class ImportDeletePlugin implements StepProcessor {
 	public function get_step_class(): string {
 		return DeletePlugin::class;
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'deactivate_plugins' ) &&
+		current_user_can( 'delete_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Importers/ImportDeletePlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportDeletePlugin.php
@@ -53,7 +53,6 @@ class ImportDeletePlugin implements StepProcessor {
 	 * @return bool True if the user has the required capabilities. False otherwise.
 	 */
 	public function check_step_capabilities( $schema ): bool {
-		return current_user_can( 'deactivate_plugins' ) &&
-		current_user_can( 'delete_plugins' );
+		return current_user_can( 'deactivate_plugins' ) && current_user_can( 'delete_plugins' );
 	}
 }

--- a/packages/php/blueprint/src/Importers/ImportInstallPlugin.php
+++ b/packages/php/blueprint/src/Importers/ImportInstallPlugin.php
@@ -171,4 +171,15 @@ class ImportInstallPlugin implements StepProcessor {
 	public function get_step_class(): string {
 		return InstallPlugin::class;
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'install_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Importers/ImportInstallTheme.php
+++ b/packages/php/blueprint/src/Importers/ImportInstallTheme.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use Automattic\WooCommerce\Blueprint\Steps\InstallTheme;
 use Automattic\WooCommerce\Blueprint\UseWPFunctions;
-use Plugin_Upgrader;
 
 /**
  * Class ImportInstallTheme
@@ -143,5 +142,16 @@ class ImportInstallTheme implements StepProcessor {
 	 */
 	public function get_step_class(): string {
 		return InstallTheme::class;
+	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'install_themes' );
 	}
 }

--- a/packages/php/blueprint/src/Importers/ImportRunSql.php
+++ b/packages/php/blueprint/src/Importers/ImportRunSql.php
@@ -56,25 +56,16 @@ class ImportRunSql implements StepProcessor {
 	 * @return bool True if the user has the required capabilities. False otherwise.
 	 */
 	public function check_step_capabilities( $schema ): bool {
-		// General check.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;
 		}
 
-		$sql           = $schema->sql->contents;
-		$sql_lowercase = strtolower( trim( $sql ) );
-
-		// Check for specific operations.
-		if ( strpos( $sql_lowercase, 'posts' ) !== false ) {
-			if ( ! current_user_can( 'edit_posts' ) ) {
-				return false;
-			}
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return false;
 		}
 
-		if ( strpos( $sql_lowercase, 'users' ) !== false ) {
-			if ( ! current_user_can( 'edit_users' ) ) {
-				return false;
-			}
+		if ( ! current_user_can( 'edit_users' ) ) {
+			return false;
 		}
 
 		return true;

--- a/packages/php/blueprint/src/Importers/ImportRunSql.php
+++ b/packages/php/blueprint/src/Importers/ImportRunSql.php
@@ -4,8 +4,6 @@ namespace Automattic\WooCommerce\Blueprint\Importers;
 
 use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use Automattic\WooCommerce\Blueprint\Steps\ActivatePlugin;
-use Automattic\WooCommerce\Blueprint\Steps\ActivateTheme;
 use Automattic\WooCommerce\Blueprint\Steps\RunSql;
 use Automattic\WooCommerce\Blueprint\UsePluginHelpers;
 use Automattic\WooCommerce\Blueprint\UseWPFunctions;
@@ -48,5 +46,37 @@ class ImportRunSql implements StepProcessor {
 	 */
 	public function get_step_class(): string {
 		return RunSql::class;
+	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		// General check.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		$sql           = $schema->sql->contents;
+		$sql_lowercase = strtolower( trim( $sql ) );
+
+		// Check for specific operations.
+		if ( strpos( $sql_lowercase, 'posts' ) !== false ) {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return false;
+			}
+		}
+
+		if ( strpos( $sql_lowercase, 'users' ) !== false ) {
+			if ( ! current_user_can( 'edit_users' ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -51,4 +51,15 @@ class ImportSetSiteOptions implements StepProcessor {
 	public function get_step_class(): string {
 		return SetSiteOptions::class;
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return current_user_can( 'manage_options' );
+	}
 }

--- a/packages/php/blueprint/src/Logger.php
+++ b/packages/php/blueprint/src/Logger.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Automattic\WooCommerce\Blueprint;
+
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+
+/**
+ * Class Logger
+ */
+class Logger {
+	use UseWPFunctions;
+
+	/**
+	 * WooCommerce logger class instance.
+	 *
+	 * @var \WC_Logger_Interface
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->logger = wc_get_logger();
+	}
+
+	/**
+	 * Log a message as a debug log entry.
+	 *
+	 * @param string $message The message to log.
+	 * @param string $level   The log level.
+	 * @param array  $context The context of the log.
+	 */
+	public function log( string $message, string $level = \WC_Log_Levels::DEBUG, $context = array() ) {
+		$this->logger->log(
+			$level,
+			$message,
+			array_merge(
+				array(
+					'source'  => 'wc-blueprint',
+					'user_id' => $this->wp_get_current_user_id(),
+				),
+				$context
+			)
+		);
+	}
+
+	/**
+	 * Log the start of an export operation.
+	 *
+	 * @param array $exporters Array of exporters.
+	 */
+	public function start_export( array $exporters ) {
+		$export_data = $this->get_export_data( $exporters );
+
+		$this->log(
+			sprintf( 'Starting export of %d steps', count( $export_data['steps'] ) ),
+			\WC_Log_Levels::INFO,
+			array(
+				'steps'     => $export_data['steps'],
+				'exporters' => $export_data['exporters'],
+			)
+		);
+	}
+
+	/**
+	 * Log the completion of an export operation.
+	 *
+	 * @param array $exporters Array of exporters.
+	 */
+	public function complete_export( array $exporters ) {
+		$export_data = $this->get_export_data( $exporters );
+
+		$this->log(
+			sprintf( 'Export of %d steps completed', count( $export_data['steps'] ) ),
+			\WC_Log_Levels::INFO,
+			array(
+				'steps'     => $export_data['steps'],
+				'exporters' => $export_data['exporters'],
+			)
+		);
+	}
+
+	/**
+	 * Extract export step names and exporter classes from exporters.
+	 *
+	 * @param array $exporters Array of exporters.
+	 * @return array Associative array with 'steps' and 'exporters' keys.
+	 */
+	private function get_export_data( array $exporters ) {
+		$export_steps     = array();
+		$exporter_classes = array();
+
+		foreach ( $exporters as $exporter ) {
+			$step_name          = method_exists( $exporter, 'get_alias' ) ? $exporter->get_alias() : $exporter->get_step_name();
+			$export_steps[]     = $step_name;
+			$exporter_classes[] = get_class( $exporter );
+		}
+
+		return array(
+			'steps'     => $export_steps,
+			'exporters' => $exporter_classes,
+		);
+	}
+
+	/**
+	 * Log an export step failure.
+	 *
+	 * @param string     $step_name The name of the step that failed.
+	 * @param \Throwable $exception The exception that was thrown.
+	 */
+	public function export_step_failed( string $step_name, \Throwable $exception ) {
+		$this->log(
+			sprintf( 'Export "%s" step failed', $step_name ),
+			\WC_Log_Levels::ERROR,
+			array(
+				'error' => $exception->getMessage(),
+			)
+		);
+	}
+
+	/**
+	 * Log the start of an import step.
+	 *
+	 * @param string $step_name      The name of the step being imported.
+	 * @param string $importer_class The class name of the importer.
+	 */
+	public function start_import( string $step_name, string $importer_class ) {
+		$this->log(
+			sprintf( 'Starting import "%s" step', $step_name ),
+			\WC_Log_Levels::INFO,
+			array(
+				'importer' => $importer_class,
+			)
+		);
+	}
+
+	/**
+	 * Log the successful completion of an import step.
+	 *
+	 * @param string              $step_name The name of the step that was imported.
+	 * @param StepProcessorResult $result    The result of the import.
+	 */
+	public function complete_import( string $step_name, StepProcessorResult $result ) {
+		$this->log(
+			sprintf( 'Import "%s" step completed', $step_name ),
+			\WC_Log_Levels::INFO,
+			array(
+				'messages' => $result->get_messages( 'info' ),
+			)
+		);
+	}
+
+	/**
+	 * Log an import step failure.
+	 *
+	 * @param string              $step_name The name of the step that failed.
+	 * @param StepProcessorResult $result    The result of the import.
+	 */
+	public function import_step_failed( string $step_name, StepProcessorResult $result ) {
+		$this->log(
+			sprintf( 'Import "%s" step failed', $step_name ),
+			\WC_Log_Levels::ERROR,
+			array(
+				'messages' => $result->get_messages( 'error' ),
+			)
+		);
+	}
+}

--- a/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
+++ b/packages/php/blueprint/src/ResultFormatters/CliResultFormatter.php
@@ -49,13 +49,13 @@ class CliResultFormatter {
 			}
 		}
 
-		$format_items_exist = function_exists( 'format_items' );
+		$format_items_exist = function_exists( '\WP_CLI\Utils\format_items' );
 
-		if ( $format_items_exist ) {
-			format_items( 'table', $items, $header );
-		} else {
+		if ( ! $format_items_exist ) {
 			throw new \Exception( 'WP CLI Utils not found' );
 		}
+
+		format_items( 'table', $items, $header );
 	}
 
 	/**

--- a/packages/php/blueprint/src/StepProcessor.php
+++ b/packages/php/blueprint/src/StepProcessor.php
@@ -21,4 +21,12 @@ interface StepProcessor {
 	 * @return string
 	 */
 	public function get_step_class(): string;
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @param object $schema The schema to process.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities( $schema ): bool;
 }

--- a/packages/php/blueprint/src/UseWPFunctions.php
+++ b/packages/php/blueprint/src/UseWPFunctions.php
@@ -311,4 +311,13 @@ trait UseWPFunctions {
 
 		return $wp_filesystem->get_contents( $file_path );
 	}
+
+	/**
+	 * Retrieves the current user's ID.
+	 *
+	 * @return int The current user's ID.
+	 */
+	public function wp_get_current_user_id() {
+		return get_current_user_id();
+	}
 }

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -148,4 +148,20 @@ class ExportSchemaTest extends TestCase {
 		$this->assertCount( 1, $result['steps'] );
 		$this->assertEquals( 'setSiteOptions', $result['steps'][0]['step'] );
 	}
+
+	/**
+	 * Test that it returns a WP_Error when the exporter is not capable.
+	 */
+	public function test_it_returns_wp_error_when_exporter_is_not_capable() {
+		$exporter = Mockery::mock( EmptySetSiteOptionsExporter::class );
+		$exporter->makePartial();
+		$exporter->shouldReceive( 'check_step_capabilities' )
+			->andReturn( false );
+
+		$mock = Mock( ExportSchema::class, array( array( $exporter ) ) );
+		$mock->makePartial();
+
+		$result = $mock->export();
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
 }

--- a/packages/php/blueprint/tests/Unit/ImportStepTest.php
+++ b/packages/php/blueprint/tests/Unit/ImportStepTest.php
@@ -4,12 +4,11 @@ use Automattic\WooCommerce\Blueprint\Tests\stubs\Importers\DummyImporter;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Steps\DummyStep;
 use Automattic\WooCommerce\Blueprint\ImportStep;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use WP_UnitTestCase;
 
 /**
  * Class ImportStepTest
  */
-class ImportStepTest extends WP_UnitTestCase {
+class ImportStepTest extends \WP_UnitTestCase {
 
 	/**
 	 * Tear down Mockery after each test.
@@ -51,21 +50,21 @@ class ImportStepTest extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_it_returns_warn_when_it_cannot_find_valid_importer() {
+	public function test_it_returns_error_when_it_cannot_find_valid_importer() {
 		$rand     = wp_rand( 1, 99999999 );
 		$importer = new ImportStep( (object) array( 'step' => 'dummy' . $rand ) );
 		$result   = $importer->import();
 
-		$this->assertCount( 1, $result->get_messages( 'warn' ) );
-		$this->assertEquals( 'Unable to find an importer for dummy' . $rand, $result->get_messages( 'warn' )[0]['message'] );
+		$this->assertCount( 1, $result->get_messages( 'error' ) );
+		$this->assertEquals( 'Unable to find an importer', $result->get_messages( 'error' )[0]['message'] );
 	}
 
 	/**
-	 * Test it returns warn when importer is not a step processor.
+	 * Test it returns error when importer is not a step processor.
 	 *
 	 * @return void
 	 */
-	public function test_it_returns_warn_when_importer_is_not_a_step_processor() {
+	public function test_it_returns_error_when_importer_is_not_a_step_processor() {
 		// Create a filter that adds an invalid importer (not implementing StepProcessor).
 		add_filter(
 			'wooblueprint_importers',
@@ -87,8 +86,8 @@ class ImportStepTest extends WP_UnitTestCase {
 		$importer = new ImportStep( (object) array( 'step' => DummyStep::get_step_name() ) );
 		$result   = $importer->import();
 
-		$this->assertCount( 1, $result->get_messages( 'warn' ) );
-		$this->assertEquals( sprintf( 'Importer %s is not a valid step processor', DummyStep::get_step_name() ), $result->get_messages( 'warn' )[0]['message'] );
+		$this->assertCount( 1, $result->get_messages( 'error' ) );
+		$this->assertEquals( 'Incorrect importer type', $result->get_messages( 'error' )[0]['message'] );
 	}
 
 	/**
@@ -123,6 +122,6 @@ class ImportStepTest extends WP_UnitTestCase {
 		$importer = new ImportStep( (object) array( 'step' => 'setSiteOptions' ) );
 		$result   = $importer->import();
 		$this->assertNotEmpty( $result->get_messages( 'error' ) );
-		$this->assertEquals( 'User does not have the required capabilities to run setSiteOptions step', $result->get_messages( 'error' )[0]['message'] );
+		$this->assertEquals( 'User does not have the required capabilities to run step', $result->get_messages( 'error' )[0]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/Unit/ImportStepTest.php
+++ b/packages/php/blueprint/tests/Unit/ImportStepTest.php
@@ -2,14 +2,14 @@
 
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Importers\DummyImporter;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Steps\DummyStep;
-use PHPUnit\Framework\TestCase;
 use Automattic\WooCommerce\Blueprint\ImportStep;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
+use WP_UnitTestCase;
 
 /**
  * Class ImportStepTest
  */
-class ImportStepTest extends TestCase {
+class ImportStepTest extends WP_UnitTestCase {
 
 	/**
 	 * Tear down Mockery after each test.
@@ -107,5 +107,22 @@ class ImportStepTest extends TestCase {
 		$result   = $importer->import();
 		$this->assertNotEmpty( $result->get_messages( 'error' ) );
 		$this->assertEquals( 'Schema validation failed for step dummy', $result->get_messages( 'error' )[0]['message'] );
+	}
+
+	/**
+	 * Test it returns error when step capabilities are not valid.
+	 *
+	 * @return void
+	 */
+	public function test_it_returns_error_when_step_capabilities_are_not_valid() {
+		// create a user with editor role using wp native function.
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $user_id );
+
+		$importer = new ImportStep( (object) array( 'step' => 'setSiteOptions' ) );
+		$result   = $importer->import();
+		$this->assertNotEmpty( $result->get_messages( 'error' ) );
+		$this->assertEquals( 'User does not have the required capabilities to run setSiteOptions step', $result->get_messages( 'error' )[0]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/bootstrap.php
+++ b/packages/php/blueprint/tests/bootstrap.php
@@ -19,3 +19,9 @@ require 'vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
+
+
+define( 'WOO_BLUEPRINT_TESTS', true );
+
+// Stubs.
+require_once __DIR__ . '/stubs/stubs.php';

--- a/packages/php/blueprint/tests/stubs/Exporters/EmptySetSiteOptionsExporter.php
+++ b/packages/php/blueprint/tests/stubs/Exporters/EmptySetSiteOptionsExporter.php
@@ -28,4 +28,13 @@ class EmptySetSiteOptionsExporter implements StepExporter {
 	public function get_step_name() {
 		return SetSiteOptions::get_step_name();
 	}
+
+	/**
+	 * Check if the step is capable of being exported.
+	 *
+	 * @return bool True if the step is capable of being exported, false otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return true;
+	}
 }

--- a/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
+++ b/packages/php/blueprint/tests/stubs/Importers/DummyImporter.php
@@ -28,4 +28,14 @@ class DummyImporter implements StepProcessor {
 	public function get_step_class(): string {
 		return DummyStep::class;
 	}
+
+	/**
+	 * Check the step capabilities.
+	 *
+	 * @param object $schema The schema to check.
+	 * @return bool True if the step capabilities are valid.
+	 */
+	public function check_step_capabilities( $schema ): bool {
+		return true;
+	}
 }

--- a/packages/php/blueprint/tests/stubs/stubs.php
+++ b/packages/php/blueprint/tests/stubs/stubs.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Stubs for WooCommerce classes and interfaces.
+ */
+
+// This file should only be loaded during test runs to prevent conflicts in development environments.
+// During local development, files are copied to the WooCommerce vendor directory where the autoloader might attempt to load this file.
+if ( defined( 'WOO_BLUEPRINT_TESTS' ) ) {
+
+	if ( ! class_exists( 'WC_Log_Levels', false ) ) {
+		/**
+		 * WC Log Levels Class
+		 */
+		class WC_Log_Levels {
+			const EMERGENCY = 'emergency';
+			const ALERT     = 'alert';
+			const CRITICAL  = 'critical';
+			const ERROR     = 'error';
+			const WARNING   = 'warning';
+			const NOTICE    = 'notice';
+			const INFO      = 'info';
+			const DEBUG     = 'debug';
+		}
+	}
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+	if ( ! interface_exists( 'WC_Logger_Interface' ) ) {
+		/**
+		 * WC Logger Interface
+		 */
+		interface WC_Logger_Interface {
+			/**
+			 * Log message with level.
+			 *
+			 * @param string $level Log level.
+			 * @param string $message Log message.
+			 * @param array  $context Optional. Additional information for log handlers.
+			 */
+			public function log( $level, $message, $context = array() );
+
+			/**
+			 * Add a log entry.
+			 *
+			 * @param string $handle Log handle.
+			 * @param string $message Log message.
+			 * @param string $level Log level.
+			 */
+			public function add( $handle, $message, $level = 'notice' );
+
+			/**
+			 * Add an emergency level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function emergency( $message, $context = array() );
+
+			/**
+			 * Add an alert level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function alert( $message, $context = array() );
+
+			/**
+			 * Add a critical level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function critical( $message, $context = array() );
+
+			/**
+			 * Add an error level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function error( $message, $context = array() );
+
+			/**
+			 * Add a warning level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function warning( $message, $context = array() );
+
+			/**
+			 * Add a notice level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function notice( $message, $context = array() );
+
+			/**
+			 * Add an info level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function info( $message, $context = array() );
+
+			/**
+			 * Add a debug level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function debug( $message, $context = array() );
+		}
+	}
+
+	if ( ! function_exists( 'wc_get_logger' ) ) {
+		/**
+		 * Mock wc_get_logger function.
+		 *
+		 * @return WC_Logger_Interface
+		 */
+		function wc_get_logger() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+			return Mockery::mock( 'WC_Logger_Interface' )->shouldReceive( 'log' )->getMock();
+		}
+	}
+}

--- a/plugins/woocommerce/changelog/57294-wooplug-2482-feature-blueprint-require-permission-based-on-the-steps
+++ b/plugins/woocommerce/changelog/57294-wooplug-2482-feature-blueprint-require-permission-based-on-the-steps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add permission validation for import steps

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
@@ -66,4 +66,13 @@ class ExportWCCoreProfilerOptions implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes onboarding configuration options', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
@@ -84,4 +84,14 @@ class ExportWCPaymentGateways implements StepExporter {
 	public function get_description() {
 		return __( 'Includes all settings in WooCommerce | Settings | Payments.', 'woocommerce' );
 	}
+
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -73,4 +73,13 @@ abstract class ExportWCSettings implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes all settings in WooCommerce | Settings | General.', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsSiteVisibility.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsSiteVisibility.php
@@ -68,4 +68,13 @@ class ExportWCSettingsSiteVisibility implements StepExporter, HasAlias {
 	public function get_step_name() {
 		return 'setSiteOptions';
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -187,4 +187,13 @@ class ExportWCShipping implements StepExporter, HasAlias {
 			)
 		);
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
@@ -68,4 +68,13 @@ class ExportWCTaskOptions implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes the task configurations for WooCommerce.', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
@@ -81,4 +81,13 @@ class ExportWCTaxRates implements StepExporter, HasAlias {
 	public function get_alias(): string {
 		return 'setWCTaxRates';
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Stubs/DummyExporter.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Stubs/DummyExporter.php
@@ -1,24 +1,58 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint\Stubs;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 
+/**
+ * Dummy exporter for testing purposes.
+ */
 class DummyExporter implements StepExporter {
 
+	/**
+	 * Export the step.
+	 *
+	 * @return null The result of the export.
+	 */
 	public function export() {
 		return null;
 	}
 
+	/**
+	 * Get the description of the step.
+	 *
+	 * @return string The description of the step.
+	 */
 	public function get_description() {
-	    return 'description';
+		return 'description';
 	}
 
+	/**
+	 * Get the label of the step.
+	 *
+	 * @return string The label of the step.
+	 */
 	public function get_label() {
 		return 'Dummy';
 	}
 
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string The name of the step.
+	 */
 	public function get_step_name() {
 		return 'dummy';
+	}
+
+	/**
+	 * Check if the step is capable of being exported.
+	 *
+	 * @return bool True if the step is capable of being exported, false otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return true;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of WOOPLUG-2482

This PR adds permission validation for Blueprint steps to ensure users have the required capabilities before executing each step. This enhancement improves security by preventing unauthorized users from performing sensitive operations.

### Key Changes:

1. Added permission checks for all Blueprint importers:
   - `ImportActivatePlugin`: Requires `activate_plugins` capability
   - `ImportActivateTheme`: Requires `switch_themes` capability
   - `ImportDeactivatePlugin`: Requires `deactivate_plugins` capability
   - `ImportDeletePlugin`: Requires both `deactivate_plugins` and `delete_plugins` capabilities
   - `ImportInstallPlugin`: Requires `install_plugins` capability
   - `ImportInstallTheme`: Requires `install_themes` capability
   - `ImportSetSiteOptions`: Requires `manage_options` capability
   - `ImportRunSql`: Requires `manage_options` and additional specific capabilities based on SQL content

2. Enhanced `ImportStep` class:
   - Added capability validation before processing steps
   - Improved validation return types for better error handling
   - Added new test case for capability validation

3. Simplified `importSchema` class to reduce duplication

4. Fix [CliResultFormatter.php](https://github.com/woocommerce/woocommerce/pull/57294/files#diff-0ebb6e1099f165f32f003774df65aa9708944e646435543c14b14421d2cbada1) to show the messages

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. pnpm install
2. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
3. Create a test user with limited permissions (e.g., Editor role) `wp user create test test@example.com --role=editor`
5. Download this [blueprint.json](https://github.com/user-attachments/files/19771588/blueprint.json) file
6. Run `wp wc blueprint import blueprint.json --user=test --show-messages=all`
7. Confirm that it fails with a message indicating that the user does not have the required capabilities
8. Test with admin user and confirm that import succeeds `wp wc blueprint import blueprint.json --user=admin --show-messages=all`
9. Try with a user that has different capabilities and confirm that it fails with a message indicating that the user does not have the required capabilities

<img width="1280" alt="Screenshot 2025-04-16 at 14 18 51" src="https://github.com/user-attachments/assets/b3d02f61-c566-45cb-b823-0e9549596e14" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add permission validation for import steps

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
