### PR TITLE
[Blueprint] Add permission validation for export steps and REST API

### DIFF
--- a/packages/php/blueprint/changelog/update-blueprint-require-permission-exporters-api
+++ b/packages/php/blueprint/changelog/update-blueprint-require-permission-exporters-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add permission validation for export steps and REST API

--- a/packages/php/blueprint/changelog/wooplug-3946-blueprint-centralized-audit-logging
+++ b/packages/php/blueprint/changelog/wooplug-3946-blueprint-centralized-audit-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Implement logging functionality in ExportSchema and ImportStep classes

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -97,7 +97,7 @@ class ExportSchema {
 		// Make sure the user has the required capabilities to export the steps.
 		foreach ( $exporters as $exporter ) {
 			if ( ! $exporter->check_step_capabilities() ) {
-				return new \WP_Error( 'wooblueprint_insufficient_permissions', 'Insufficient permissions to export step: ' . $exporter->get_step_name() );
+				return new \WP_Error( 'wooblueprint_insufficient_permissions', 'Insufficient permissions to export for step: ' . $exporter->get_step_name() );
 			}
 		}
 

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -94,14 +94,17 @@ class ExportSchema {
 			}
 		}
 
-		/**
-		 * StepExporter.
-		 *
-		 * @var StepExporter $exporter
-		 */
+		// Make sure the user has the required capabilities to export the steps.
+		foreach ( $exporters as $exporter ) {
+			if ( ! $exporter->check_step_capabilities() ) {
+				return new \WP_Error( 'wooblueprint_insufficient_permissions', 'Insufficient permissions to export step: ' . $exporter->get_step_name() );
+			}
+		}
+
 		foreach ( $exporters as $exporter ) {
 			$this->publish( 'onBeforeExport', $exporter );
 			$step = $exporter->export();
+
 			if ( is_array( $step ) ) {
 				foreach ( $step as $_step ) {
 					$schema['steps'][] = $_step->get_json_array();

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -4,6 +4,8 @@ namespace Automattic\WooCommerce\Blueprint;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
+use Automattic\WooCommerce\Blueprint\Logger;
+use Automattic\WooCommerce\Blueprint\Steps\Step;
 use WP_Error;
 
 /**
@@ -100,18 +102,23 @@ class ExportSchema {
 			}
 		}
 
-		foreach ( $exporters as $exporter ) {
-			$this->publish( 'onBeforeExport', $exporter );
-			$step = $exporter->export();
+		$logger = new Logger();
+		$logger->start_export( $exporters );
 
-			if ( is_array( $step ) ) {
-				foreach ( $step as $_step ) {
-					$schema['steps'][] = $_step->get_json_array();
-				}
-			} else {
-				$schema['steps'][] = $step->get_json_array();
+		foreach ( $exporters as $exporter ) {
+			try {
+				$this->publish( 'onBeforeExport', $exporter );
+				$step = $exporter->export();
+				$this->add_result_to_schema( $schema, $step );
+
+			} catch ( \Throwable $e ) {
+				$step_name = $exporter instanceof HasAlias ? $exporter->get_alias() : $exporter->get_step_name();
+				$logger->export_step_failed( $step_name, $e );
+				return new WP_Error( 'wooblueprint_export_step_failed', 'Export step failed: ' . $e->getMessage() );
 			}
 		}
+
+		$logger->complete_export( $exporters );
 
 		return $schema;
 	}
@@ -131,5 +138,22 @@ class ExportSchema {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Add export result to the schema array.
+	 *
+	 * @param array      $schema Schema array to add steps to.
+	 * @param array|Step $step   Step or array of steps to add.
+	 */
+	private function add_result_to_schema( array &$schema, $step ): void {
+		if ( is_array( $step ) ) {
+			foreach ( $step as $_step ) {
+				$schema['steps'][] = $_step->get_json_array();
+			}
+			return;
+		}
+
+		$schema['steps'][] = $step->get_json_array();
 	}
 }

--- a/packages/php/blueprint/src/ExportSchema.php
+++ b/packages/php/blueprint/src/ExportSchema.php
@@ -74,7 +74,6 @@ class ExportSchema {
 		 * @since 0.0.1
 		 */
 		$exporters = $this->wp_apply_filters( 'wooblueprint_exporters', array_merge( $this->exporters, $built_in_exporters ) );
-
 		// Validate that the exporters are instances of StepExporter.
 		$exporters = array_filter(
 			$exporters,
@@ -97,7 +96,7 @@ class ExportSchema {
 		// Make sure the user has the required capabilities to export the steps.
 		foreach ( $exporters as $exporter ) {
 			if ( ! $exporter->check_step_capabilities() ) {
-				return new \WP_Error( 'wooblueprint_insufficient_permissions', 'Insufficient permissions to export for step: ' . $exporter->get_step_name() );
+				return new WP_Error( 'wooblueprint_insufficient_permissions', 'Insufficient permissions to export for step: ' . $exporter->get_step_name() );
 			}
 		}
 

--- a/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallPluginSteps.php
@@ -158,4 +158,12 @@ class ExportInstallPluginSteps implements StepExporter {
 	public function get_step_name() {
 		return InstallPlugin::get_step_name();
 	}
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'activate_plugins' );
+	}
 }

--- a/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
+++ b/packages/php/blueprint/src/Exporters/ExportInstallThemeSteps.php
@@ -80,4 +80,13 @@ class ExportInstallThemeSteps implements StepExporter {
 	public function get_step_name() {
 		return InstallTheme::get_step_name();
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'switch_themes' );
+	}
 }

--- a/packages/php/blueprint/src/Exporters/StepExporter.php
+++ b/packages/php/blueprint/src/Exporters/StepExporter.php
@@ -24,4 +24,11 @@ interface StepExporter {
 	 * @return string
 	 */
 	public function get_step_name();
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool;
 }

--- a/packages/php/blueprint/src/ImportStep.php
+++ b/packages/php/blueprint/src/ImportStep.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blueprint;
 
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
+use Automattic\WooCommerce\Blueprint\Logger;
 
 /**
  * Class ImportStep
@@ -80,33 +81,61 @@ class ImportStep {
 	public function import() {
 		$result = StepProcessorResult::success( $this->step_definition->step );
 
-		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
-			$result->add_warn( "Unable to find an importer for {$this->step_definition->step}" );
+		if ( ! $this->can_import( $result ) ) {
 			return $result;
 		}
 
 		$importer = $this->indexed_importers[ $this->step_definition->step ];
-		// validate importer is a step processor before processing.
-		if ( ! $importer instanceof StepProcessor ) {
-			$result->add_warn( "Importer {$this->step_definition->step} is not a valid step processor" );
-			return $result;
-		}
-
-		// validate steps before processing.
-		if ( ! $this->validate_step_schemas( $importer, $result ) ) {
-			return $result;
-		}
-
-		// validate step capabilities before processing.
-		if ( ! $importer->check_step_capabilities( $this->step_definition ) ) {
-			$result->add_error( "User does not have the required capabilities to run {$this->step_definition->step} step" );
-			return $result;
-		}
+		$logger   = new Logger();
+		$logger->start_import( $this->step_definition->step, get_class( $importer ) );
 
 		$importer_result = $importer->process( $this->step_definition );
+
+		if ( $importer_result->is_success() ) {
+			$logger->complete_import( $this->step_definition->step, $importer_result );
+		} else {
+			$logger->import_step_failed( $this->step_definition->step, $importer_result );
+		}
+
 		$result->merge_messages( $importer_result );
 
 		return $result;
+	}
+
+	/**
+	 * Check if the step can be imported.
+	 *
+	 * @param StepProcessorResult $result The result object to add messages to.
+	 *
+	 * @return bool True if the step can be imported, false otherwise.
+	 */
+	protected function can_import( &$result ) {
+		// Check if the importer exists.
+		if ( ! isset( $this->indexed_importers[ $this->step_definition->step ] ) ) {
+			$result->add_error( 'Unable to find an importer' );
+			return false;
+		}
+
+		$importer = $this->indexed_importers[ $this->step_definition->step ];
+		// Validate importer is a step processor before processing.
+		if ( ! $importer instanceof StepProcessor ) {
+			$result->add_error( 'Incorrect importer type' );
+			return false;
+		}
+
+		// Validate steps schemas before processing.
+		if ( ! $this->validate_step_schemas( $importer, $result ) ) {
+			$result->add_error( 'Schema validation failed for step' );
+			return false;
+		}
+
+		// Validate step capabilities before processing.
+		if ( ! $importer->check_step_capabilities( $this->step_definition ) ) {
+			$result->add_error( 'User does not have the required capabilities to run step' );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/packages/php/blueprint/src/Logger.php
+++ b/packages/php/blueprint/src/Logger.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Automattic\WooCommerce\Blueprint;
+
+use Automattic\WooCommerce\Blueprint\UseWPFunctions;
+
+/**
+ * Class Logger
+ */
+class Logger {
+	use UseWPFunctions;
+
+	/**
+	 * WooCommerce logger class instance.
+	 *
+	 * @var \WC_Logger_Interface
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->logger = wc_get_logger();
+	}
+
+	/**
+	 * Log a message as a debug log entry.
+	 *
+	 * @param string $message The message to log.
+	 * @param string $level   The log level.
+	 * @param array  $context The context of the log.
+	 */
+	public function log( string $message, string $level = \WC_Log_Levels::DEBUG, $context = array() ) {
+		$this->logger->log(
+			$level,
+			$message,
+			array_merge(
+				array(
+					'source'  => 'wc-blueprint',
+					'user_id' => $this->wp_get_current_user_id(),
+				),
+				$context
+			)
+		);
+	}
+
+	/**
+	 * Log the start of an export operation.
+	 *
+	 * @param array $exporters Array of exporters.
+	 */
+	public function start_export( array $exporters ) {
+		$export_data = $this->get_export_data( $exporters );
+
+		$this->log(
+			sprintf( 'Starting export of %d steps', count( $export_data['steps'] ) ),
+			\WC_Log_Levels::INFO,
+			array(
+				'steps'     => $export_data['steps'],
+				'exporters' => $export_data['exporters'],
+			)
+		);
+	}
+
+	/**
+	 * Log the completion of an export operation.
+	 *
+	 * @param array $exporters Array of exporters.
+	 */
+	public function complete_export( array $exporters ) {
+		$export_data = $this->get_export_data( $exporters );
+
+		$this->log(
+			sprintf( 'Export of %d steps completed', count( $export_data['steps'] ) ),
+			\WC_Log_Levels::INFO,
+			array(
+				'steps'     => $export_data['steps'],
+				'exporters' => $export_data['exporters'],
+			)
+		);
+	}
+
+	/**
+	 * Extract export step names and exporter classes from exporters.
+	 *
+	 * @param array $exporters Array of exporters.
+	 * @return array Associative array with 'steps' and 'exporters' keys.
+	 */
+	private function get_export_data( array $exporters ) {
+		$export_steps     = array();
+		$exporter_classes = array();
+
+		foreach ( $exporters as $exporter ) {
+			$step_name          = method_exists( $exporter, 'get_alias' ) ? $exporter->get_alias() : $exporter->get_step_name();
+			$export_steps[]     = $step_name;
+			$exporter_classes[] = get_class( $exporter );
+		}
+
+		return array(
+			'steps'     => $export_steps,
+			'exporters' => $exporter_classes,
+		);
+	}
+
+	/**
+	 * Log an export step failure.
+	 *
+	 * @param string     $step_name The name of the step that failed.
+	 * @param \Throwable $exception The exception that was thrown.
+	 */
+	public function export_step_failed( string $step_name, \Throwable $exception ) {
+		$this->log(
+			sprintf( 'Export "%s" step failed', $step_name ),
+			\WC_Log_Levels::ERROR,
+			array(
+				'error' => $exception->getMessage(),
+			)
+		);
+	}
+
+	/**
+	 * Log the start of an import step.
+	 *
+	 * @param string $step_name      The name of the step being imported.
+	 * @param string $importer_class The class name of the importer.
+	 */
+	public function start_import( string $step_name, string $importer_class ) {
+		$this->log(
+			sprintf( 'Starting import "%s" step', $step_name ),
+			\WC_Log_Levels::INFO,
+			array(
+				'importer' => $importer_class,
+			)
+		);
+	}
+
+	/**
+	 * Log the successful completion of an import step.
+	 *
+	 * @param string              $step_name The name of the step that was imported.
+	 * @param StepProcessorResult $result    The result of the import.
+	 */
+	public function complete_import( string $step_name, StepProcessorResult $result ) {
+		$this->log(
+			sprintf( 'Import "%s" step completed', $step_name ),
+			\WC_Log_Levels::INFO,
+			array(
+				'messages' => $result->get_messages( 'info' ),
+			)
+		);
+	}
+
+	/**
+	 * Log an import step failure.
+	 *
+	 * @param string              $step_name The name of the step that failed.
+	 * @param StepProcessorResult $result    The result of the import.
+	 */
+	public function import_step_failed( string $step_name, StepProcessorResult $result ) {
+		$this->log(
+			sprintf( 'Import "%s" step failed', $step_name ),
+			\WC_Log_Levels::ERROR,
+			array(
+				'messages' => $result->get_messages( 'error' ),
+			)
+		);
+	}
+}

--- a/packages/php/blueprint/src/UseWPFunctions.php
+++ b/packages/php/blueprint/src/UseWPFunctions.php
@@ -311,4 +311,13 @@ trait UseWPFunctions {
 
 		return $wp_filesystem->get_contents( $file_path );
 	}
+
+	/**
+	 * Retrieves the current user's ID.
+	 *
+	 * @return int The current user's ID.
+	 */
+	public function wp_get_current_user_id() {
+		return get_current_user_id();
+	}
 }

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -148,4 +148,20 @@ class ExportSchemaTest extends TestCase {
 		$this->assertCount( 1, $result['steps'] );
 		$this->assertEquals( 'setSiteOptions', $result['steps'][0]['step'] );
 	}
+
+	/**
+	 * Test that it returns a WP_Error when the exporter is not capable.
+	 */
+	public function test_it_returns_wp_error_when_exporter_is_not_capable() {
+		$exporter = Mockery::mock( EmptySetSiteOptionsExporter::class );
+		$exporter->makePartial();
+		$exporter->shouldReceive( 'check_step_capabilities' )
+			->andReturn( false );
+
+		$mock = Mock( ExportSchema::class, array( array( $exporter ) ) );
+		$mock->makePartial();
+
+		$result = $mock->export();
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
 }

--- a/packages/php/blueprint/tests/Unit/ImportStepTest.php
+++ b/packages/php/blueprint/tests/Unit/ImportStepTest.php
@@ -4,12 +4,11 @@ use Automattic\WooCommerce\Blueprint\Tests\stubs\Importers\DummyImporter;
 use Automattic\WooCommerce\Blueprint\Tests\stubs\Steps\DummyStep;
 use Automattic\WooCommerce\Blueprint\ImportStep;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use WP_UnitTestCase;
 
 /**
  * Class ImportStepTest
  */
-class ImportStepTest extends WP_UnitTestCase {
+class ImportStepTest extends \WP_UnitTestCase {
 
 	/**
 	 * Tear down Mockery after each test.
@@ -51,21 +50,21 @@ class ImportStepTest extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_it_returns_warn_when_it_cannot_find_valid_importer() {
+	public function test_it_returns_error_when_it_cannot_find_valid_importer() {
 		$rand     = wp_rand( 1, 99999999 );
 		$importer = new ImportStep( (object) array( 'step' => 'dummy' . $rand ) );
 		$result   = $importer->import();
 
-		$this->assertCount( 1, $result->get_messages( 'warn' ) );
-		$this->assertEquals( 'Unable to find an importer for dummy' . $rand, $result->get_messages( 'warn' )[0]['message'] );
+		$this->assertCount( 1, $result->get_messages( 'error' ) );
+		$this->assertEquals( 'Unable to find an importer', $result->get_messages( 'error' )[0]['message'] );
 	}
 
 	/**
-	 * Test it returns warn when importer is not a step processor.
+	 * Test it returns error when importer is not a step processor.
 	 *
 	 * @return void
 	 */
-	public function test_it_returns_warn_when_importer_is_not_a_step_processor() {
+	public function test_it_returns_error_when_importer_is_not_a_step_processor() {
 		// Create a filter that adds an invalid importer (not implementing StepProcessor).
 		add_filter(
 			'wooblueprint_importers',
@@ -87,8 +86,8 @@ class ImportStepTest extends WP_UnitTestCase {
 		$importer = new ImportStep( (object) array( 'step' => DummyStep::get_step_name() ) );
 		$result   = $importer->import();
 
-		$this->assertCount( 1, $result->get_messages( 'warn' ) );
-		$this->assertEquals( sprintf( 'Importer %s is not a valid step processor', DummyStep::get_step_name() ), $result->get_messages( 'warn' )[0]['message'] );
+		$this->assertCount( 1, $result->get_messages( 'error' ) );
+		$this->assertEquals( 'Incorrect importer type', $result->get_messages( 'error' )[0]['message'] );
 	}
 
 	/**
@@ -123,6 +122,6 @@ class ImportStepTest extends WP_UnitTestCase {
 		$importer = new ImportStep( (object) array( 'step' => 'setSiteOptions' ) );
 		$result   = $importer->import();
 		$this->assertNotEmpty( $result->get_messages( 'error' ) );
-		$this->assertEquals( 'User does not have the required capabilities to run setSiteOptions step', $result->get_messages( 'error' )[0]['message'] );
+		$this->assertEquals( 'User does not have the required capabilities to run step', $result->get_messages( 'error' )[0]['message'] );
 	}
 }

--- a/packages/php/blueprint/tests/bootstrap.php
+++ b/packages/php/blueprint/tests/bootstrap.php
@@ -20,16 +20,8 @@ require 'vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
 
+
+define( 'WOO_BLUEPRINT_TESTS', true );
+
 // Stubs.
 require_once __DIR__ . '/stubs/stubs.php';
-
-if ( ! function_exists( 'wc_get_logger' ) ) {
-	/**
-	 * Mock wc_get_logger function.
-	 *
-	 * @return WC_Logger_Interface
-	 */
-	function wc_get_logger() {
-		return Mockery::mock( 'WC_Logger_Interface' )->shouldReceive( 'log' )->getMock();
-	}
-}

--- a/packages/php/blueprint/tests/bootstrap.php
+++ b/packages/php/blueprint/tests/bootstrap.php
@@ -19,3 +19,17 @@ require 'vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
+
+// Stubs.
+require_once __DIR__ . '/stubs/stubs.php';
+
+if ( ! function_exists( 'wc_get_logger' ) ) {
+	/**
+	 * Mock wc_get_logger function.
+	 *
+	 * @return WC_Logger_Interface
+	 */
+	function wc_get_logger() {
+		return Mockery::mock( 'WC_Logger_Interface' )->shouldReceive( 'log' )->getMock();
+	}
+}

--- a/packages/php/blueprint/tests/stubs/Exporters/EmptySetSiteOptionsExporter.php
+++ b/packages/php/blueprint/tests/stubs/Exporters/EmptySetSiteOptionsExporter.php
@@ -28,4 +28,13 @@ class EmptySetSiteOptionsExporter implements StepExporter {
 	public function get_step_name() {
 		return SetSiteOptions::get_step_name();
 	}
+
+	/**
+	 * Check if the step is capable of being exported.
+	 *
+	 * @return bool True if the step is capable of being exported, false otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return true;
+	}
 }

--- a/packages/php/blueprint/tests/stubs/stubs.php
+++ b/packages/php/blueprint/tests/stubs/stubs.php
@@ -5,7 +5,7 @@
 
 // This file should only be loaded during test runs to prevent conflicts in development environments.
 // During local development, files are copied to the WooCommerce vendor directory where the autoloader might attempt to load this file.
-if ( class_exists( 'PHPUnit\Framework\TestCase', false ) ) {
+if ( defined( 'WOO_BLUEPRINT_TESTS' ) ) {
 
 	if ( ! class_exists( 'WC_Log_Levels', false ) ) {
 		/**
@@ -110,6 +110,17 @@ if ( class_exists( 'PHPUnit\Framework\TestCase', false ) ) {
 			 * @param array  $context Log context.
 			 */
 			public function debug( $message, $context = array() );
+		}
+	}
+
+	if ( ! function_exists( 'wc_get_logger' ) ) {
+		/**
+		 * Mock wc_get_logger function.
+		 *
+		 * @return WC_Logger_Interface
+		 */
+		function wc_get_logger() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+			return Mockery::mock( 'WC_Logger_Interface' )->shouldReceive( 'log' )->getMock();
 		}
 	}
 }

--- a/packages/php/blueprint/tests/stubs/stubs.php
+++ b/packages/php/blueprint/tests/stubs/stubs.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Stubs for WooCommerce classes and interfaces.
+ */
+
+// This file should only be loaded during test runs to prevent conflicts in development environments.
+// During local development, files are copied to the WooCommerce vendor directory where the autoloader might attempt to load this file.
+if ( class_exists( 'PHPUnit\Framework\TestCase', false ) ) {
+
+	if ( ! class_exists( 'WC_Log_Levels', false ) ) {
+		/**
+		 * WC Log Levels Class
+		 */
+		class WC_Log_Levels {
+			const EMERGENCY = 'emergency';
+			const ALERT     = 'alert';
+			const CRITICAL  = 'critical';
+			const ERROR     = 'error';
+			const WARNING   = 'warning';
+			const NOTICE    = 'notice';
+			const INFO      = 'info';
+			const DEBUG     = 'debug';
+		}
+	}
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+	if ( ! interface_exists( 'WC_Logger_Interface' ) ) {
+		/**
+		 * WC Logger Interface
+		 */
+		interface WC_Logger_Interface {
+			/**
+			 * Log message with level.
+			 *
+			 * @param string $level Log level.
+			 * @param string $message Log message.
+			 * @param array  $context Optional. Additional information for log handlers.
+			 */
+			public function log( $level, $message, $context = array() );
+
+			/**
+			 * Add a log entry.
+			 *
+			 * @param string $handle Log handle.
+			 * @param string $message Log message.
+			 * @param string $level Log level.
+			 */
+			public function add( $handle, $message, $level = 'notice' );
+
+			/**
+			 * Add an emergency level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function emergency( $message, $context = array() );
+
+			/**
+			 * Add an alert level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function alert( $message, $context = array() );
+
+			/**
+			 * Add a critical level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function critical( $message, $context = array() );
+
+			/**
+			 * Add an error level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function error( $message, $context = array() );
+
+			/**
+			 * Add a warning level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function warning( $message, $context = array() );
+
+			/**
+			 * Add a notice level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function notice( $message, $context = array() );
+
+			/**
+			 * Add an info level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function info( $message, $context = array() );
+
+			/**
+			 * Add a debug level message.
+			 *
+			 * @param string $message Log message.
+			 * @param array  $context Log context.
+			 */
+			public function debug( $message, $context = array() );
+		}
+	}
+}

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -50,6 +50,7 @@ const Blueprint = () => {
 	);
 
 	const exportBlueprint = async ( _steps ) => {
+		setError( null );
 		setExportEnabled( false );
 
 		const linkContainer = document.getElementById(

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -65,6 +65,7 @@ const Blueprint = () => {
 					steps: _steps,
 				},
 			} );
+
 			const link = document.createElement( 'a' );
 			let url = null;
 
@@ -94,14 +95,41 @@ const Blueprint = () => {
 				settings_exported: _steps.settings,
 			} );
 		} catch ( e ) {
-			setExportError( e.message );
-
 			recordEvent( 'blueprint_export_error', {
 				error_message: e.message || 'unknown',
 			} );
-		}
 
-		setExportEnabled( true );
+			setExportError( e.message );
+
+			switch ( true ) {
+				case e instanceof Error:
+					setExportError( e.message );
+					break;
+				case typeof e === 'string':
+					setExportError( e );
+					break;
+				case e.errors &&
+					e.errors.wooblueprint_insufficient_permissions &&
+					e.errors.wooblueprint_insufficient_permissions.length > 0:
+					setExportError(
+						__(
+							'Sorry, you are not allowed to export the selected settings.',
+							'woocommerce'
+						)
+					);
+					break;
+				default:
+					setExportError(
+						__(
+							'An unknown error occurred while exporting the settings.',
+							'woocommerce'
+						)
+					);
+					break;
+			}
+		} finally {
+			setExportEnabled( true );
+		}
 	};
 
 	// Handle checkbox change

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -50,7 +50,7 @@ const Blueprint = () => {
 	);
 
 	const exportBlueprint = async ( _steps ) => {
-		setError( null );
+		setExportError( null );
 		setExportEnabled( false );
 
 		const linkContainer = document.getElementById(

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCCoreProfilerOptions.php
@@ -66,4 +66,13 @@ class ExportWCCoreProfilerOptions implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes onboarding configuration options', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCPaymentGateways.php
@@ -84,4 +84,14 @@ class ExportWCPaymentGateways implements StepExporter {
 	public function get_description() {
 		return __( 'Includes all settings in WooCommerce | Settings | Payments.', 'woocommerce' );
 	}
+
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettings.php
@@ -73,4 +73,13 @@ abstract class ExportWCSettings implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes all settings in WooCommerce | Settings | General.', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsSiteVisibility.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsSiteVisibility.php
@@ -68,4 +68,13 @@ class ExportWCSettingsSiteVisibility implements StepExporter, HasAlias {
 	public function get_step_name() {
 		return 'setSiteOptions';
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCShipping.php
@@ -187,4 +187,13 @@ class ExportWCShipping implements StepExporter, HasAlias {
 			)
 		);
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaskOptions.php
@@ -68,4 +68,13 @@ class ExportWCTaskOptions implements StepExporter, HasAlias {
 	public function get_description() {
 		return __( 'Includes the task configurations for WooCommerce.', 'woocommerce' );
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCTaxRates.php
@@ -81,4 +81,13 @@ class ExportWCTaxRates implements StepExporter, HasAlias {
 	public function get_alias(): string {
 		return 'setWCTaxRates';
 	}
+
+	/**
+	 * Check if the current user has the required capabilities for this step.
+	 *
+	 * @return bool True if the user has the required capabilities. False otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -212,15 +212,15 @@ class RestApi {
 	private function steps_payload_to_blueprint_steps( $steps ) {
 		$blueprint_steps = array();
 
-		if ( isset( $steps['settings'] ) ) {
+		if ( isset( $steps['settings'] ) && count( $steps['settings'] ) > 0 ) {
 			$blueprint_steps = array_merge( $blueprint_steps, $steps['settings'] );
 		}
 
-		if ( isset( $steps['plugins'] ) ) {
+		if ( isset( $steps['plugins'] ) && count( $steps['plugins'] ) > 0 ) {
 			$blueprint_steps[] = 'installPlugin';
 		}
 
-		if ( isset( $steps['themes'] ) ) {
+		if ( isset( $steps['themes'] ) && count( $steps['themes'] ) > 0 ) {
 			$blueprint_steps[] = 'installTheme';
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -179,6 +179,10 @@ class RestApi {
 
 		$data = $exporter->export( $steps );
 
+		if ( is_wp_error( $data ) ) {
+			return new \WP_REST_Response( $data, 400 );
+		}
+
 		return new \WP_HTTP_Response(
 			array(
 				'data' => $data,

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -58,7 +58,7 @@ class RestApi {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'export' ),
-					'permission_callback' => array( $this, 'check_permission' ),
+					'permission_callback' => array( $this, 'check_export_permission' ),
 					'args'                => array(
 						'steps' => array(
 							'description' => __( 'A list of plugins to install', 'woocommerce' ),
@@ -98,7 +98,7 @@ class RestApi {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'import_step' ),
-					'permission_callback' => array( $this, 'check_permission' ),
+					'permission_callback' => array( $this, 'check_import_permission' ),
 					'args'                => array(
 						'step_definition' => array(
 							'description' => __( 'The step definition to import', 'woocommerce' ),
@@ -113,13 +113,28 @@ class RestApi {
 	}
 
 	/**
-	 * Check if the current user has permission to perform the request.
+	 * General permission check for export requests.
 	 *
 	 * @return bool|\WP_Error
 	 */
-	public function check_permission() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+	public function check_export_permission() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot export WooCommerce Blueprints.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * General permission check for import requests.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function check_import_permission() {
+		if (
+			! current_user_can( 'manage_woocommerce' ) ||
+			! current_user_can( 'manage_options' )
+		) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot import WooCommerce Blueprints.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Stubs/DummyExporter.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/Stubs/DummyExporter.php
@@ -1,24 +1,58 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint\Stubs;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 
+/**
+ * Dummy exporter for testing purposes.
+ */
 class DummyExporter implements StepExporter {
 
+	/**
+	 * Export the step.
+	 *
+	 * @return null The result of the export.
+	 */
 	public function export() {
 		return null;
 	}
 
+	/**
+	 * Get the description of the step.
+	 *
+	 * @return string The description of the step.
+	 */
 	public function get_description() {
-	    return 'description';
+		return 'description';
 	}
 
+	/**
+	 * Get the label of the step.
+	 *
+	 * @return string The label of the step.
+	 */
 	public function get_label() {
 		return 'Dummy';
 	}
 
+	/**
+	 * Get the name of the step.
+	 *
+	 * @return string The name of the step.
+	 */
 	public function get_step_name() {
 		return 'dummy';
+	}
+
+	/**
+	 * Check if the step is capable of being exported.
+	 *
+	 * @return bool True if the step is capable of being exported, false otherwise.
+	 */
+	public function check_step_capabilities(): bool {
+		return true;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-2482

This PR enhances the security of WooCommerce Blueprint by adding comprehensive permission validation for both export and REST API operations. It ensures that users have the appropriate capabilities before executing any Blueprint operations.

### Key Changes:

- Added capability checks for Blueprint exporters:
  - Core WooCommerce settings require `manage_woocommerce` capability
  - Plugin installation requires `activate_plugins` capability
  - Theme installation requires `switch_themes` capability
- Enhanced general REST API permission validation:
  - Export operations require `manage_woocommerce` capability
  - Import operations require both `manage_woocommerce` and `manage_options` capabilities
- Improved error handling:
  - Added proper WP_Error returns for permission failures
  - Enhanced error messages for better debugging


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


#### Test CLI:

1. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
2. Create a shop manager user `wp user create test test@example.com --role=shop_manager`
3. Run `wp wc blueprint export blueprint.json --user=test`
4. It should fail with message `Error: Insufficient permissions to export step: ...`
5. Run `wp wc blueprint export blueprint.json --steps=setWCSettingsGeneral --user=test`
6. It should succeed and confirm that the output blueprint.json file only contains general settings.
7. Run `wp wc blueprint export blueprint.json --user=admin` with admin user (change the user to your own admin user)
8. It should show the full blueprint.json file.

<img width="1280" alt="Screenshot 2025-04-16 at 16 00 59" src="https://github.com/user-attachments/assets/46160128-e6ac-49d9-b5ea-821ad3520510" />


#### Test REST API:

1. Log in as the shop manager user
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
3. Click on the `Export` button
4. It should display error `Insufficient permissions to export the selected settings.`
5. Uncheck all selected plugins and themes and try again
6. It should export the blueprint.json file successfully
7. Log in as the admin user and try to import all settings, plugins and themes
8. It should import successfully

<img width="397" alt="Screenshot 2025-04-16 at 15 46 52" src="https://github.com/user-attachments/assets/dc6f13cd-11bb-47c6-a2dd-bbb8f1dd9886" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
