### PR TITLE
Revert "Disable blueprint feature flag and UI"

### DIFF
--- a/plugins/woocommerce/changelog/enable-blueprint-feature-ui
+++ b/plugins/woocommerce/changelog/enable-blueprint-feature-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Dev - Re-enable Blueprint feature UI in features settings page and make it enabled by default. 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -407,8 +407,8 @@ class FeaturesController {
 						'Enable blueprint to import and export settings in bulk',
 						'woocommerce'
 					),
-					'enabled_by_default' => false,
-					'disable_ui'         => true,
+					'enabled_by_default' => true,
+					'disable_ui'         => false,
 
 				/*
 				* This is not truly a legacy feature (it is not a feature that pre-dates the FeaturesController),


### PR DESCRIPTION
Reverts woocommerce/woocommerce#57149 to re-enable blueprint feature. We're targeting 9.9 for the feature launch.

No review is needed for this PR since it's already reviewed in the original PR. https://github.com/woocommerce/woocommerce/pull/56698