### PR TITLE
registerProductBlockType: Skip dataviews test

### DIFF
--- a/plugins/woocommerce/changelog/test-skip-blocks-data-views-test
+++ b/plugins/woocommerce/changelog/test-skip-blocks-data-views-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Skip E2E test which checkes for registered product blocks in the all templates data view

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -129,7 +129,8 @@ test.describe( 'registerProductBlockType registers', () => {
 		} );
 	} );
 
-	test( 'blocks which are registered via the registerProductBlockType function are visible in the templates data views', async ( {
+	// Skipping test due to flaky nature of the test not being able to detect when the blocks in the iframes are available.
+	test.skip( 'blocks which are registered via the registerProductBlockType function are visible in the templates data views', async ( {
 		admin,
 		page,
 	} ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Skipping this test since its flaky and doesn't cover critical flow functionality. We have coverage for ensuring correct blocks are registered and available when editing a template, this skipped test covers the preview of blocks in the "All templates" data view.

Closes # .

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56923/

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Ensuring CI passes should be sufficient enough.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
