### PR TITLE
Create saveAdminPage E2E utility for waiting for admin settings save completion

### DIFF
--- a/plugins/woocommerce/changelog/fix-shopper-shipping-e2e-test
+++ b/plugins/woocommerce/changelog/fix-shopper-shipping-e2e-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Added saveAdminPage e2e util

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -50,9 +50,7 @@ test.describe( 'Shopper → Shipping', () => {
 		await admin.page
 			.getByLabel( 'Default customer location' )
 			.selectOption( 'No location by default' );
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await admin.visitAdminPage(
 			'admin.php?page=wc-settings&tab=shipping&zone_id=new'
@@ -64,9 +62,7 @@ test.describe( 'Shopper → Shipping', () => {
 		await admin.page
 			.getByRole( 'checkbox', { name: 'United Kingdom (UK)' } )
 			.click(); // .check() won't work here as the input disappears immediately after checking.
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 		await admin.page
 			.getByRole( 'button', { name: 'Add shipping method' } )
 			.click();
@@ -81,9 +77,7 @@ test.describe( 'Shopper → Shipping', () => {
 				.getByRole( 'button', { name: 'Save changes' } )
 				.isDisabled() )
 		) {
-			await admin.page
-				.getByRole( 'button', { name: 'Save changes' } )
-				.click();
+			await admin.saveAdminPage();
 		}
 		await expect(
 			admin.page.getByRole( 'button', { name: 'Save changes' } )
@@ -266,9 +260,7 @@ test.describe( 'Shopper → Shipping', () => {
 		await admin.page
 			.getByLabel( 'Default customer location' )
 			.selectOption( 'No location by default' );
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await admin.visitAdminPage( 'admin.php?page=wc-settings&tab=shipping' );
 
@@ -281,9 +273,7 @@ test.describe( 'Shopper → Shipping', () => {
 		// Then only one "name: yes" remains, making it the first, even though it's the second rate.
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
@@ -424,9 +414,7 @@ test.describe( 'Shopper → Shipping', () => {
 		// Then only one "name: yes" remains, making it the first, even though it's the second rate.
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );
@@ -571,9 +559,7 @@ test.describe( 'Shopper → Shipping', () => {
 		// Then only one "name: yes" remains, making it the first, even though it's the second rate.
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-shipping.block_theme.spec.ts
@@ -364,9 +364,7 @@ test.describe( 'Shopper → Shipping', () => {
 		// Then only one "name: yes" remains, making it the first, even though it's the second rate.
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
 		await admin.page.getByRole( 'link', { name: 'Yes' } ).first().click();
-		await admin.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.click();
+		await admin.saveAdminPage();
 
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( REGULAR_PRICED_PRODUCT_NAME );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
@@ -87,9 +87,10 @@ export class Admin extends CoreAdmin {
 	 * Clicks the 'Save changes' button on an admin page and waits for it to become disabled to ensure the page is saved.
 	 */
 	async saveAdminPage() {
-		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
-		await this.page
-			.getByRole( 'button', { name: 'Save changes' } )
-			.isDisabled();
+		const saveButton = this.page.getByRole( 'button', {
+			name: 'Save changes',
+		} );
+		await saveButton.click();
+		await saveButton.isDisabled();
 	}
 }

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
@@ -82,4 +82,16 @@ export class Admin extends CoreAdmin {
 
 		await Promise.any( [ welcomePopUp(), editorLoaded() ] );
 	}
+
+	/**
+	 * Clicks the 'Save changes' button on an admin page and waits for it to become disabled to ensure the page is saved.
+	 *
+	 * @param this The Admin instance.
+	 */
+	async saveAdminPage() {
+		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();
+		await this.page
+			.getByRole( 'button', { name: 'Save changes' } )
+			.isDisabled();
+	}
 }

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/admin/index.ts
@@ -85,8 +85,6 @@ export class Admin extends CoreAdmin {
 
 	/**
 	 * Clicks the 'Save changes' button on an admin page and waits for it to become disabled to ensure the page is saved.
-	 *
-	 * @param this The Admin instance.
 	 */
 	async saveAdminPage() {
 		await this.page.getByRole( 'button', { name: 'Save changes' } ).click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are occasions where we click the save button and immediately navigate away instead of waiting for the save action to complete. This causes flaky tests like the one updated in this PR.

Instead, I've introduced a utility method which waits for the Save Changes button to become disabled indicating saving is complete.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. CI checks passing should be sufficient enough.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
