### PR TITLE
registerProductBlockType: Re-enable the test for block visibility after addressing flakiness

### DIFF
--- a/plugins/woocommerce/changelog/57325-fix-improve-register-block-single-product-template
+++ b/plugins/woocommerce/changelog/57325-fix-improve-register-block-single-product-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+registerProductBlockType: Re-enable the test for block visibility after addressing flakiness.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -129,8 +129,7 @@ test.describe( 'registerProductBlockType registers', () => {
 		} );
 	} );
 
-	// Skipping test due to flaky nature of the test not being able to detect when the blocks in the iframes are available.
-	test.skip( 'blocks which are registered via the registerProductBlockType function are visible in the templates data views', async ( {
+	test( 'blocks which are registered via the registerProductBlockType function are visible in the templates data views', async ( {
 		admin,
 		page,
 	} ) => {
@@ -143,15 +142,19 @@ test.describe( 'registerProductBlockType registers', () => {
 			'site-editor.php?postType=wp_template&activeView=WooCommerce'
 		);
 
-		const singleProductTemplate = page.getByRole( 'button', {
-			name: 'Single Product',
-		} );
+		const singleProductTemplate = page.getByLabel( 'Single Product' );
 
 		await expect( singleProductTemplate ).toBeVisible();
 
 		const previewCanvas = singleProductTemplate.frameLocator(
 			'iframe[title="Editor canvas"]'
 		);
+
+		// Wait for the iframe to be fully loaded.
+		await previewCanvas.locator( 'body' ).evaluate( () => {
+			return document?.readyState === 'complete';
+		} );
+
 		for ( const blockType of productBlockTypes ) {
 			const block = previewCanvas.locator(
 				`[data-type="${ blockType }"]`


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses the flakiness of an E2E test related to registerProductBlockType, which was previously skipped in [#57311](https://github.com/woocommerce/woocommerce/pull/57311).

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->



### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that E2E tests jobs are green
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

registerProductBlockType: Re-enable the test for block visibility after addressing flakiness.


</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->


</details>
