### PR TITLE
Implement a way for autocomplete providers to register in JavaScript

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/index.ts
@@ -1,0 +1,1 @@
+export * from './registry';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/registry.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/registry.ts
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+import type { BaseAddress } from '@woocommerce/type-defs/cart';
+import {
+	isObject,
+	objectHasProp,
+	isFunction,
+	isString,
+} from '@woocommerce/types';
+
+export interface SearchResult {
+	highlightPositions?: { offset: number; length: number }[];
+	text: string;
+	id: string;
+}
+
+interface AddressAutocompleteProvider {
+	id: string;
+	canSearch: ( currentAddress: Partial< BaseAddress > ) => boolean;
+	search: (
+		value: string,
+		currentAddress: Partial< BaseAddress >
+	) => Record< string, SearchResult >;
+	select: ( id: string ) => BaseAddress;
+}
+
+const addressAutocompleteProviders: Record<
+	string,
+	AddressAutocompleteProvider
+> = {};
+
+/**
+ * Type guard to validate AddressAutocompleteProvider.
+ *
+ * @param provider The provider to validate.
+ * @return Whether the provider is valid.
+ */
+const isValidAddressAutocompleteProvider = (
+	provider: unknown
+): provider is AddressAutocompleteProvider => {
+	if ( ! isObject( provider ) ) {
+		// eslint-disable-next-line no-console -- developers should be able to see this error to debug their providers.
+		console.error( 'The provider must be an object.' );
+		return false;
+	}
+
+	if (
+		! objectHasProp( provider, 'id' ) ||
+		! isString( provider.id ) ||
+		provider.id.trim() === ''
+	) {
+		// eslint-disable-next-line no-console -- developers should be able to see this error to debug their providers.
+		console.error( 'The provider ID must be a non-empty string.' );
+		return false;
+	}
+
+	const requiredMethods = [ 'canSearch', 'search', 'select' ] as const;
+	for ( const method of requiredMethods ) {
+		if (
+			! objectHasProp( provider, method ) ||
+			! isFunction( provider[ method ] )
+		) {
+			// eslint-disable-next-line no-console -- developers should be able to see this error to debug their providers.
+			console.error(
+				`The "${ method }" method for provider "${ provider.id }" must be a function.`
+			);
+			return false;
+		}
+	}
+
+	return true;
+};
+
+/**
+ * Register an address autocomplete provider.
+ *
+ * @param provider The provider configuration.
+ */
+export const registerAddressAutocompleteProvider = (
+	provider: unknown
+): void => {
+	if ( ! isValidAddressAutocompleteProvider( provider ) ) {
+		return;
+	}
+
+	// Use getSetting to check if the server-side provider exists.
+	const registeredProviders = getSetting< string[] >(
+		'addressAutocompleteProviders',
+		[]
+	);
+
+	if ( ! registeredProviders.includes( provider.id ) ) {
+		// eslint-disable-next-line no-console -- developers should be able to see this error to debug their providers.
+		console.error(
+			`No server-side provider is registered with the ID "${ provider.id }".`
+		);
+		return;
+	}
+
+	if ( addressAutocompleteProviders[ provider.id ] ) {
+		// eslint-disable-next-line no-console -- developers should be able to see this error to debug their providers.
+		console.error(
+			`A provider with the ID "${ provider.id }" is already registered.`
+		);
+		return;
+	}
+
+	addressAutocompleteProviders[ provider.id ] = provider;
+};
+
+/**
+ * Remove an address autocomplete provider by ID.
+ *
+ * @param id The ID of the provider to remove.
+ */
+export const removeAddressAutocompleteProvider = ( id: string ): void => {
+	if ( addressAutocompleteProviders[ id ] ) {
+		delete addressAutocompleteProviders[ id ];
+	}
+};
+
+/**
+ * Get all registered address autocomplete providers.
+ *
+ * @return A record of registered providers.
+ */
+export const getAddressAutocompleteProviders = (): Record<
+	string,
+	AddressAutocompleteProvider
+> => {
+	return addressAutocompleteProviders;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/registry.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/registry.ts
@@ -16,7 +16,7 @@ export interface SearchResult {
 	id: string;
 }
 
-interface AddressAutocompleteProvider {
+export interface AddressAutocompleteProvider {
 	id: string;
 	canSearch: ( currentAddress: Partial< BaseAddress > ) => boolean;
 	search: (
@@ -78,7 +78,7 @@ const isValidAddressAutocompleteProvider = (
  *
  * @param provider The provider configuration.
  */
-export const registerAddressAutocompleteProvider = (
+export const __experimentalRegisterAddressAutocompleteProvider = (
 	provider: unknown
 ): void => {
 	if ( ! isValidAddressAutocompleteProvider( provider ) ) {
@@ -115,7 +115,9 @@ export const registerAddressAutocompleteProvider = (
  *
  * @param id The ID of the provider to remove.
  */
-export const removeAddressAutocompleteProvider = ( id: string ): void => {
+export const __experimentalRemoveAddressAutocompleteProvider = (
+	id: string
+): void => {
 	if ( addressAutocompleteProviders[ id ] ) {
 		delete addressAutocompleteProviders[ id ];
 	}
@@ -126,7 +128,7 @@ export const removeAddressAutocompleteProvider = ( id: string ): void => {
  *
  * @return A record of registered providers.
  */
-export const getAddressAutocompleteProviders = (): Record<
+export const __experimentalGetAddressAutocompleteProviders = (): Record<
 	string,
 	AddressAutocompleteProvider
 > => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import {
-	registerAddressAutocompleteProvider,
-	getAddressAutocompleteProviders,
-	removeAddressAutocompleteProvider,
+	__experimentalRegisterAddressAutocompleteProvider,
+	__experimentalGetAddressAutocompleteProviders,
+	__experimentalRemoveAddressAutocompleteProvider,
 } from '../registry';
 
 jest.mock( '@woocommerce/settings', () => {
@@ -23,9 +23,9 @@ jest.mock( '@woocommerce/settings', () => {
 
 describe( 'Address Autocomplete Registry', () => {
 	afterEach( () => {
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		Object.keys( providers ).forEach( ( id ) => {
-			removeAddressAutocompleteProvider( id );
+			__experimentalRemoveAddressAutocompleteProvider( id );
 		} );
 	} );
 
@@ -37,9 +37,9 @@ describe( 'Address Autocomplete Registry', () => {
 			select: () => ( { address1: '123 Test St' } ),
 		};
 
-		registerAddressAutocompleteProvider( provider );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
 
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		expect( providers[ provider.id ] ).toBe( provider );
 	} );
 
@@ -51,9 +51,9 @@ describe( 'Address Autocomplete Registry', () => {
 			select: () => ( { address1: '123 Test St' } ),
 		};
 
-		registerAddressAutocompleteProvider( provider );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
 
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		expect( providers[ provider.id ] ).toBeUndefined();
 		expect( console ).toHaveErroredWith(
 			'The provider ID must be a non-empty string.'
@@ -67,9 +67,9 @@ describe( 'Address Autocomplete Registry', () => {
 			select: () => ( { address1: '123 Test St' } ),
 		};
 
-		registerAddressAutocompleteProvider( provider as any );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
 
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		expect( providers[ provider.id ] ).toBeUndefined();
 		expect( console ).toHaveErroredWith(
 			`The "canSearch" method for provider "${ provider.id }" must be a function.`
@@ -84,9 +84,9 @@ describe( 'Address Autocomplete Registry', () => {
 			select: () => ( { address1: '123 Test St' } ),
 		};
 
-		registerAddressAutocompleteProvider( provider );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
 
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		expect( providers[ provider.id ] ).toBeUndefined();
 		expect( console ).toHaveErroredWith(
 			`No server-side provider is registered with the ID "${ provider.id }".`
@@ -101,10 +101,10 @@ describe( 'Address Autocomplete Registry', () => {
 			select: () => ( { address1: '123 Test St' } ),
 		};
 
-		registerAddressAutocompleteProvider( provider );
-		registerAddressAutocompleteProvider( provider );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
+		__experimentalRegisterAddressAutocompleteProvider( provider );
 
-		const providers = getAddressAutocompleteProviders();
+		const providers = __experimentalGetAddressAutocompleteProviders();
 		expect( Object.keys( providers ).length ).toBe( 1 );
 		expect( console ).toHaveErroredWith(
 			`A provider with the ID "${ provider.id }" is already registered.`

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import * as settings from '@woocommerce/settings';
+
+/**
  * Internal dependencies
  */
 import {
@@ -12,12 +17,14 @@ jest.mock( '@woocommerce/settings', () => {
 
 	return {
 		...originalModule,
-		getSetting: ( setting: string, ...rest: unknown[] ) => {
-			if ( setting === 'addressAutocompleteProviders' ) {
-				return [ 'test-provider', 'duplicate-provider' ];
-			}
-			return originalModule.getSetting( setting, ...rest );
-		},
+		getSetting: jest
+			.fn()
+			.mockImplementation( ( setting: string, ...rest: unknown[] ) => {
+				if ( setting === 'addressAutocompleteProviders' ) {
+					return [ 'test-provider', 'duplicate-provider' ];
+				}
+				return originalModule.getSetting( setting, ...rest );
+			} ),
 	};
 } );
 
@@ -109,5 +116,53 @@ describe( 'Address Autocomplete Registry', () => {
 		expect( console ).toHaveErroredWith(
 			`A provider with the ID "${ provider.id }" is already registered.`
 		);
+	} );
+
+	it( 'should remove a registered provider', () => {
+		const provider = {
+			id: 'test-provider',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		__experimentalRegisterAddressAutocompleteProvider( provider );
+		let providers = __experimentalGetAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBe( provider );
+
+		__experimentalRemoveAddressAutocompleteProvider( provider.id );
+		providers = __experimentalGetAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBeUndefined();
+	} );
+
+	it( 'should return all registered providers', () => {
+		jest.mocked( settings.getSetting ).mockImplementation( ( setting ) => {
+			if ( setting === 'addressAutocompleteProviders' ) {
+				return [ 'provider-1', 'provider-2' ];
+			}
+			return settings.getSetting( setting );
+		} );
+		const provider1 = {
+			id: 'provider-1',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test 1', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		const provider2 = {
+			id: 'provider-2',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test 2', id: '2' } } ),
+			select: () => ( { address1: '456 Test Ave' } ),
+		};
+
+		__experimentalRegisterAddressAutocompleteProvider( provider1 );
+		__experimentalRegisterAddressAutocompleteProvider( provider2 );
+
+		const providers = __experimentalGetAddressAutocompleteProviders();
+		expect( Object.keys( providers ) ).toContain( provider1.id );
+		expect( Object.keys( providers ) ).toContain( provider2.id );
+		expect( providers[ provider1.id ] ).toBe( provider1 );
+		expect( providers[ provider2.id ] ).toBe( provider2 );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/address-autocomplete/test/registry.ts
@@ -1,0 +1,113 @@
+/**
+ * Internal dependencies
+ */
+import {
+	registerAddressAutocompleteProvider,
+	getAddressAutocompleteProviders,
+	removeAddressAutocompleteProvider,
+} from '../registry';
+
+jest.mock( '@woocommerce/settings', () => {
+	const originalModule = jest.requireActual( '@woocommerce/settings' );
+
+	return {
+		...originalModule,
+		getSetting: ( setting: string, ...rest: unknown[] ) => {
+			if ( setting === 'addressAutocompleteProviders' ) {
+				return [ 'test-provider', 'duplicate-provider' ];
+			}
+			return originalModule.getSetting( setting, ...rest );
+		},
+	};
+} );
+
+describe( 'Address Autocomplete Registry', () => {
+	afterEach( () => {
+		const providers = getAddressAutocompleteProviders();
+		Object.keys( providers ).forEach( ( id ) => {
+			removeAddressAutocompleteProvider( id );
+		} );
+	} );
+
+	it( 'should register a valid provider', () => {
+		const provider = {
+			id: 'test-provider',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		registerAddressAutocompleteProvider( provider );
+
+		const providers = getAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBe( provider );
+	} );
+
+	it( 'should not register a provider with an empty ID', () => {
+		const provider = {
+			id: '',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		registerAddressAutocompleteProvider( provider );
+
+		const providers = getAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBeUndefined();
+		expect( console ).toHaveErroredWith(
+			'The provider ID must be a non-empty string.'
+		);
+	} );
+
+	it( 'should not register a provider without a canSearch function', () => {
+		const provider = {
+			id: 'invalid-provider',
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		registerAddressAutocompleteProvider( provider as any );
+
+		const providers = getAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBeUndefined();
+		expect( console ).toHaveErroredWith(
+			`The "canSearch" method for provider "${ provider.id }" must be a function.`
+		);
+	} );
+
+	it( 'should not register a provider if server-side provider is missing', () => {
+		const provider = {
+			id: 'missing-server-provider',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		registerAddressAutocompleteProvider( provider );
+
+		const providers = getAddressAutocompleteProviders();
+		expect( providers[ provider.id ] ).toBeUndefined();
+		expect( console ).toHaveErroredWith(
+			`No server-side provider is registered with the ID "${ provider.id }".`
+		);
+	} );
+
+	it( 'should not register a duplicate provider', () => {
+		const provider = {
+			id: 'duplicate-provider',
+			canSearch: () => true,
+			search: () => ( { result: { text: 'Test', id: '1' } } ),
+			select: () => ( { address1: '123 Test St' } ),
+		};
+
+		registerAddressAutocompleteProvider( provider );
+		registerAddressAutocompleteProvider( provider );
+
+		const providers = getAddressAutocompleteProviders();
+		expect( Object.keys( providers ).length ).toBe( 1 );
+		expect( console ).toHaveErroredWith(
+			`A provider with the ID "${ provider.id }" is already registered.`
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks-registry/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks-registry/index.js
@@ -1,3 +1,4 @@
+export * from './address-autocomplete';
 export * from './payment-methods';
 export * from './block-components';
 export * from './product-collection/register-product-collection';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\StoreApi\Utilities\PaymentUtils;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFieldsSchema\Validation;
+use Automattic\WooCommerce\Blocks\Domain\Services\AddressAutocomplete;
 
 /**
  * Checkout class.
@@ -542,6 +543,10 @@ class Checkout extends AbstractBlock {
 			$this->asset_data_registry->hydrate_data_from_api_request( 'checkoutData', '/wc/store/v1/checkout' );
 			$this->hydrate_customer_payment_methods();
 		}
+
+		// Enqueue address autocomplete providers.
+		$address_autocomplete_service = Package::container()->get( AddressAutocomplete::class );
+		$this->asset_data_registry->add( 'addressAutocompleteProviders', $address_autocomplete_service->get_registered_providers() );
 
 		/**
 		 * Fires after checkout block data is registered.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Checkout.php
@@ -544,9 +544,11 @@ class Checkout extends AbstractBlock {
 			$this->hydrate_customer_payment_methods();
 		}
 
-		// Enqueue address autocomplete providers.
-		$address_autocomplete_service = Package::container()->get( AddressAutocomplete::class );
-		$this->asset_data_registry->add( 'addressAutocompleteProviders', $address_autocomplete_service->get_registered_providers() );
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			// Enqueue address autocomplete providers if experimental-blocks.
+			$address_autocomplete_service = Package::container()->get( AddressAutocomplete::class );
+			$this->asset_data_registry->add( 'addressAutocompleteProviders', $address_autocomplete_service->get_registered_providers() );
+		}
 
 		/**
 		 * Fires after checkout block data is registered.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is based on `56715-implement-a-way-for-developers-to-register-an-address-autocomplete-provider-in-php` - https://github.com/woocommerce/woocommerce/pull/56986

Closes WOOPLUG-3616

(For Bug Fixes) Bug introduced in PR # .

This change introduces an address autocomplete provider registry that allows third-party developers to register the JavaScript portion of address autocomplete providers.

- Outputs PHP registered providers to the frontend
- Creates a new registry for address autocomplete providers, similar to payment methods registry
- Implements type checks during provider registration
- Adds TypeScript interface for `AddressAutocompleteProvider`
- Add TypeScript interface for `SearchResult` which is based on the way Google returns results: https://developers.google.com/maps/documentation/places/web-service/autocomplete#place_autocomplete_responses - specifically `main_text_matched_substrings`
- Adds utility functions to register, remove, and retrieve address autocomplete providers
- Adds complete test coverage for the registry functionality

### Screenshots or screen recordings:

No UI changes

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following PHP snippet:


3.
4.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
