### PR TITLE
Improved flaky "can delete a product review" E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -313,9 +313,9 @@ test.describe( 'Product Reviews', () => {
 			await reviewRow.hover();
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
-			await expect(
-				page.locator( '.trash-undo-inside' )
-			).toContainText( `Comment by ${ review.reviewer } moved to the Trash` );
+			await expect( page.locator( '.trash-undo-inside' ) ).toContainText(
+				`Comment by ${ review.reviewer } moved to the Trash`
+			);
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
 
 			await expect(
@@ -324,9 +324,9 @@ test.describe( 'Product Reviews', () => {
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
 
-			await expect(
-				page.locator( '.trash-undo-inside' )
-			).toContainText( `Comment by ${ review.reviewer } moved to the Trash` );
+			await expect( page.locator( '.trash-undo-inside' ) ).toContainText(
+				`Comment by ${ review.reviewer } moved to the Trash`
+			);
 
 			await page.click( 'a[href*="comment_status=trash"]' );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -313,7 +313,9 @@ test.describe( 'Product Reviews', () => {
 			await reviewRow.hover();
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
-			await expect( page.locator( '.trash-undo-inside' ).first() ).toContainText(
+			await expect(
+				page.locator( '.trash-undo-inside' ).first()
+			).toContainText(
 				`Comment by ${ review.reviewer } moved to the Trash`
 			);
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
@@ -324,7 +326,9 @@ test.describe( 'Product Reviews', () => {
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
 
-			await expect( page.locator( '.trash-undo-inside' ).first() ).toContainText(
+			await expect(
+				page.locator( '.trash-undo-inside' ).first()
+			).toContainText(
 				`Comment by ${ review.reviewer } moved to the Trash`
 			);
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -313,7 +313,7 @@ test.describe( 'Product Reviews', () => {
 			await reviewRow.hover();
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
-			await expect( page.locator( '.trash-undo-inside' ) ).toContainText(
+			await expect( page.locator( '.trash-undo-inside' ).first() ).toContainText(
 				`Comment by ${ review.reviewer } moved to the Trash`
 			);
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
@@ -324,7 +324,7 @@ test.describe( 'Product Reviews', () => {
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
 
-			await expect( page.locator( '.trash-undo-inside' ) ).toContainText(
+			await expect( page.locator( '.trash-undo-inside' ).first() ).toContainText(
 				`Comment by ${ review.reviewer } moved to the Trash`
 			);
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js
@@ -314,10 +314,8 @@ test.describe( 'Product Reviews', () => {
 
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
 			await expect(
-				page.getByText(
-					`Comment by ${ review.reviewer } moved to the Trash`
-				)
-			).toBeVisible();
+				page.locator( '.trash-undo-inside' )
+			).toContainText( `Comment by ${ review.reviewer } moved to the Trash` );
 			await page.getByRole( 'button', { name: 'Undo' } ).click();
 
 			await expect(
@@ -327,10 +325,8 @@ test.describe( 'Product Reviews', () => {
 			await reviewRow.getByRole( 'button', { name: 'Trash' } ).click();
 
 			await expect(
-				page.getByText(
-					`Comment by ${ review.reviewer } moved to the Trash`
-				)
-			).toBeVisible();
+				page.locator( '.trash-undo-inside' )
+			).toContainText( `Comment by ${ review.reviewer } moved to the Trash` );
 
 			await page.click( 'a[href*="comment_status=trash"]' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the 'can delete a product review' flaky test from `/plugins/woocommerce/tests/e2e-pw/tests/product/product-reviews.spec.js`.

This test was using `getByText` to find a notice in the page that said that the review has been deleted and this often led to timeouts due to the amount of texts in that page.

Now, it uses `page.locator('.trash-undo-inside')` to specifically find the HTML element that has the class `trash-undo-inside` first, as this is where the message we are expecting will be printed.

Closes #56876 

### Screenshots or screen recordings:

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

No manual testing required -- this is an improvement to an E2E test.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a change affecting only E2E tests, nothing to be released.
</details>
