### PR TITLE
Improved flaky "can manage stock levels" E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
@@ -4,6 +4,7 @@
 import { variableProducts as utils } from '../../utils';
 import { tags, test, expect } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
+const { uiUnblocked} = require( '@woocommerce/e2e-utils' );
 
 const {
 	createVariableProduct,
@@ -410,10 +411,13 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 
 		await test.step( 'Click "Save changes"', async () => {
 			await page.getByRole( 'button', { name: 'Save changes' } ).click();
+			await uiUnblocked();
 		} );
 
 		await test.step( 'Expand all variations', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const expandButton = page.getByRole( 'link', { name: 'Expand' } ).first();
+			await expandButton.waitFor( { state: 'visible' } );
+			await expandButton.click();
 		} );
 
 		await test.step( 'Expect the stock quantity to be saved correctly', async () => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
@@ -4,7 +4,6 @@
 import { variableProducts as utils } from '../../utils';
 import { tags, test, expect } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
-const { uiUnblocked} = require( '@woocommerce/e2e-utils' );
 
 const {
 	createVariableProduct,
@@ -366,7 +365,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Expand all variations', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const expandButton = page
+				.getByRole( 'link', { name: 'Expand' } )
+				.first();
+			await expandButton.waitFor( { state: 'visible' } );
+			await expandButton.click();
 		} );
 
 		const variationContainer = page.locator(
@@ -411,11 +414,15 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 
 		await test.step( 'Click "Save changes"', async () => {
 			await page.getByRole( 'button', { name: 'Save changes' } ).click();
-			await uiUnblocked();
+			await page.waitForFunction(
+				() => ! Boolean( document.querySelector( '.blockUI' ) )
+			);
 		} );
 
 		await test.step( 'Expand all variations', async () => {
-			const expandButton = page.getByRole( 'link', { name: 'Expand' } ).first();
+			const expandButton = page
+				.getByRole( 'link', { name: 'Expand' } )
+				.first();
 			await expandButton.waitFor( { state: 'visible' } );
 			await expandButton.click();
 		} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js
@@ -132,7 +132,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Expand all variations.', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const expandButton = page
+				.getByRole( 'link', { name: 'Expand' } )
+				.first();
+			await expandButton.waitFor( { state: 'visible' } );
+			await expandButton.click();
 		} );
 
 		await test.step( 'Edit the first variation.', async () => {
@@ -215,7 +219,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Expand all variations.', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const expandButton = page
+				.getByRole( 'link', { name: 'Expand' } )
+				.first();
+			await expandButton.waitFor( { state: 'visible' } );
+			await expandButton.click();
 		} );
 
 		await test.step( 'Expect the first variation to be virtual.', async () => {
@@ -312,7 +320,11 @@ test.describe( 'Update variations', { tag: tags.GUTENBERG }, () => {
 		} );
 
 		await test.step( 'Expand all variations.', async () => {
-			await page.getByRole( 'link', { name: 'Expand' } ).first().click();
+			const expandButton = page
+				.getByRole( 'link', { name: 'Expand' } )
+				.first();
+			await expandButton.waitFor( { state: 'visible' } );
+			await expandButton.click();
 		} );
 
 		await test.step( 'Expect all "Downloadable" checkboxes to be checked.', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR improves the 'can manage stock levels' flaky test from `/plugins/woocommerce/tests/e2e-pw/tests/product/update-variations.spec.js` by waiting for the block UI element to be hidden, before clicking to expand individual variations.

Closes #55867 

### How to test the changes in this Pull Request:

No manual testing required -- this is an improvement to an E2E test.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is an improvement for E2E tests -- no release required.

</details>
