### PR TITLE
Improved flaky "remove up-sells" E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-linked-products.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-linked-products.spec.js
@@ -155,11 +155,12 @@ test.describe(
 
 			await test.step( 'remove up-sells for a product', async () => {
 				// Using backspace to remove the product because clicking the remove button is flaky
-				await page
+				const upsellTextBoxLocator = page
 					.locator( 'p' )
 					.filter( { hasText: 'Upsells' } )
-					.getByRole( 'textbox' )
-					.click();
+					.getByRole( 'textbox' );
+				await upsellTextBoxLocator.waitFor( { state: 'visible' } );
+				await upsellTextBoxLocator.click();
 				await page.keyboard.press( 'Backspace' );
 
 				await expect(
@@ -270,11 +271,12 @@ test.describe(
 
 			await test.step( 'remove cross-sells for a product', async () => {
 				// Using backspace to remove the product because clicking the remove button is flaky
-				await page
+				const crossSellTextBoxLocator = page
 					.locator( 'p' )
 					.filter( { hasText: 'Cross-sells' } )
-					.getByRole( 'textbox' )
-					.click();
+					.getByRole( 'textbox' );
+				await crossSellTextBoxLocator.waitFor( { state: 'visible' } );
+				await crossSellTextBoxLocator.click();
 				await page.keyboard.press( 'Backspace' );
 
 				await expect(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes the flaky "remove up-sells" and "remove cross-sells" E2E tests in `/plugins/woocommerce/tests/e2e-pw/tests/product/product-linked-products.spec.js` by waiting for the Up-Sells/Cross-Sells field to be visible before removing items from it.

Closes #55207 

### How to test the changes in this Pull Request:

No need for manual testing -- the only change is in E2E tests.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This fixes an E2E test -- no release required.

</details>
