### PR TITLE
Product Gallery: make thumbnails scrolling gradient color-agnostic

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3796-product-gallery-make-thumbnails-scrolling-gradient-color
+++ b/plugins/woocommerce/changelog/wooplug-3796-product-gallery-make-thumbnails-scrolling-gradient-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Gallery: Make Thumbnails gradient color-agnostic

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -117,10 +117,6 @@ $dialog-padding: 20px;
 	}
 }
 
-@mixin gradient($direction) {
-	background: linear-gradient(to $direction, var(--wp--preset--color--base) 25%, transparent);
-}
-
 @mixin horizontal-thumbnails {
 	.wc-block-product-gallery-thumbnails__thumbnail {
 		height: 100%;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -162,8 +162,8 @@ $dialog-padding: 20px;
 		$gradient-mid-step-size: 12%;
 		$gradient-mid-step: rgba(0, 0, 0, 0.4);
 
-		$gradient: transparent 0,  $gradient-mid-step $gradient-mid-step-size, black $gradient-size;
-		$gradient-end: black calc(100% - $gradient-size), $gradient-mid-step calc(100% - $gradient-mid-step-size), transparent;
+		$gradient: transparent 0,  $gradient-mid-step $gradient-mid-step-size, rgb(0, 0, 0) $gradient-size;
+		$gradient-end: rgb(0, 0, 0) calc(100% - $gradient-size), $gradient-mid-step calc(100% - $gradient-mid-step-size), transparent;
 
 		&-top {
 			mask-image: linear-gradient(to bottom, $gradient);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -146,6 +146,22 @@ $dialog-padding: 20px;
 	}
 
 
+	&__thumbnail {
+		border: $thumbnails-border-width solid rgba($color: #000, $alpha: 0.1);
+		box-sizing: border-box;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		aspect-ratio: 1 / 1;
+	}
+
+	&__thumbnail__image {
+		cursor: pointer;
+		max-width: 100%;
+		aspect-ratio: 1 / 1;
+		object-fit: contain;
+	}
+
 	&.wc-block-product-gallery-thumbnails--overflow {
 		$gradient-size: 20%;
 		$gradient-mid-step-size: 12%;
@@ -177,22 +193,6 @@ $dialog-padding: 20px;
 		&-left.wc-block-product-gallery-thumbnails--overflow-right {
 			mask-image: linear-gradient(to right, $gradient, $gradient-end);
 		}
-	}
-
-	&__thumbnail {
-		border: $thumbnails-border-width solid rgba($color: #000, $alpha: 0.1);
-		box-sizing: border-box;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		aspect-ratio: 1 / 1;
-	}
-
-	&__thumbnail__image {
-		cursor: pointer;
-		max-width: 100%;
-		aspect-ratio: 1 / 1;
-		object-fit: contain;
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -147,37 +147,35 @@ $dialog-padding: 20px;
 
 
 	&.wc-block-product-gallery-thumbnails--overflow {
-		$mid-gradient-size: 4%;
-		$mid-gradient-start: rgba(0, 0, 0, 0.6) $mid-gradient-size;
-		$mid-gradient-end: rgba(0, 0, 0, 0.6) calc(100% - $mid-gradient-size);
 		$gradient-size: 20%;
-		$gradient-start: black $gradient-size;
-		$gradient-end: black calc(100% - $gradient-size);
-		$gradient-top: transparent $mid-gradient-start $gradient-start;
-		$gradient-bottom: $gradient-end $mid-gradient-end transparent;
+		$gradient-mid-step-size: 12%;
+		$gradient-mid-step: rgba(0, 0, 0, 0.4);
+
+		$gradient: transparent 0,  $gradient-mid-step $gradient-mid-step-size, black $gradient-size;
+		$gradient-end: black calc(100% - $gradient-size), $gradient-mid-step calc(100% - $gradient-mid-step-size), transparent;
 
 		&-top {
-			mask-image: linear-gradient(to bottom, $gradient-top, black 100%);
+			mask-image: linear-gradient(to bottom, $gradient);
 		}
 
 		&-bottom {
-			mask-image: linear-gradient(to bottom, black 0, $gradient-end, $mid-gradient-end, transparent);
+			mask-image: linear-gradient(to top, $gradient);
 		}
 
 		&-top.wc-block-product-gallery-thumbnails--overflow-bottom {
-			mask-image: linear-gradient(to bottom, transparent, $mid-gradient-start $gradient-start, transparent);
+			mask-image: linear-gradient(to bottom, $gradient, $gradient-end);
 		}
 
 		&-left {
-			mask-image: linear-gradient(to right, transparent, black $gradient-size, black 100%);
+			mask-image: linear-gradient(to right, $gradient);
 		}
 
 		&-right {
-			mask-image: linear-gradient(to right, black 0, black calc(100% - $gradient-size), transparent);
+			mask-image: linear-gradient(to left, $gradient);
 		}
 
 		&-left.wc-block-product-gallery-thumbnails--overflow-right {
-			mask-image: linear-gradient(to right, transparent, black $gradient-size, black calc(100% - $gradient-size), transparent);
+			mask-image: linear-gradient(to right, $gradient, $gradient-end);
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -145,7 +145,6 @@ $dialog-padding: 20px;
 		pointer-events: auto;
 	}
 
-
 	&__thumbnail {
 		border: $thumbnails-border-width solid rgba($color: #000, $alpha: 0.1);
 		box-sizing: border-box;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -145,6 +145,42 @@ $dialog-padding: 20px;
 		pointer-events: auto;
 	}
 
+
+	&.wc-block-product-gallery-thumbnails--overflow {
+		$mid-gradient-size: 4%;
+		$mid-gradient-start: rgba(0, 0, 0, 0.6) $mid-gradient-size;
+		$mid-gradient-end: rgba(0, 0, 0, 0.6) calc(100% - $mid-gradient-size);
+		$gradient-size: 20%;
+		$gradient-start: black $gradient-size;
+		$gradient-end: black calc(100% - $gradient-size);
+		$gradient-top: transparent $mid-gradient-start $gradient-start;
+		$gradient-bottom: $gradient-end $mid-gradient-end transparent;
+
+		&-top {
+			mask-image: linear-gradient(to bottom, $gradient-top, black 100%);
+		}
+
+		&-bottom {
+			mask-image: linear-gradient(to bottom, black 0, $gradient-end, $mid-gradient-end, transparent);
+		}
+
+		&-top.wc-block-product-gallery-thumbnails--overflow-bottom {
+			mask-image: linear-gradient(to bottom, transparent, $mid-gradient-start $gradient-start, transparent);
+		}
+
+		&-left {
+			mask-image: linear-gradient(to right, transparent, black $gradient-size, black 100%);
+		}
+
+		&-right {
+			mask-image: linear-gradient(to right, black 0, black calc(100% - $gradient-size), transparent);
+		}
+
+		&-left.wc-block-product-gallery-thumbnails--overflow-right {
+			mask-image: linear-gradient(to right, transparent, black $gradient-size, black calc(100% - $gradient-size), transparent);
+		}
+	}
+
 	&__thumbnail {
 		border: $thumbnails-border-width solid rgba($color: #000, $alpha: 0.1);
 		box-sizing: border-box;
@@ -159,53 +195,6 @@ $dialog-padding: 20px;
 		max-width: 100%;
 		aspect-ratio: 1 / 1;
 		object-fit: contain;
-	}
-
-	&::before,
-	&::after {
-		content: "";
-		position: absolute;
-		opacity: 0;
-		transition: opacity 0.2s linear;
-		pointer-events: none;
-	}
-
-	&.wc-block-product-gallery-thumbnails--overflow {
-		&-top::before,
-		&-bottom::after {
-			left: 0;
-			height: $thumbnails-gradient-size;
-			width: 100%;
-			opacity: 1;
-		}
-
-		&-top::before {
-			top: 0;
-			@include gradient(bottom);
-		}
-
-		&-bottom::after {
-			bottom: 0;
-			@include gradient(top);
-		}
-
-		&-right::after,
-		&-left::before {
-			top: 0;
-			height: 100%;
-			width: $thumbnails-gradient-size;
-			opacity: 1;
-		}
-
-		&-left::before {
-			left: 0;
-			@include gradient(right);
-		}
-
-		&-right::after {
-			right: 0;
-			@include gradient(left);
-		}
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -158,9 +158,9 @@ $dialog-padding: 20px;
 	}
 
 	&.wc-block-product-gallery-thumbnails--overflow {
-		$gradient-size: 20%;
-		$gradient-mid-step-size: 12%;
-		$gradient-mid-step: rgba(0, 0, 0, 0.4);
+		$gradient-size: 14%;
+		$gradient-mid-step-size: 6%;
+		$gradient-mid-step: rgba(0, 0, 0, 0.3);
 
 		$gradient: transparent 0,  $gradient-mid-step $gradient-mid-step-size, rgb(0, 0, 0) $gradient-size;
 		$gradient-end: rgb(0, 0, 0) calc(100% - $gradient-size), $gradient-mid-step calc(100% - $gradient-mid-step-size), transparent;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR changes the Thumbnails gradient implementation from color variable based to color-agnostic using `mask-image`. [Feature is widely supported](https://caniuse.com/?search=mask-image).

Closes WOOPLUG-3796

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="663" alt="image" src="https://github.com/user-attachments/assets/4dcdc6da-f491-4824-baba-16bfc9d87ebb" />      |    <img width="663" alt="image" src="https://github.com/user-attachments/assets/4afd3ed5-514f-4851-998b-48d3242303e4" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Editor > Single Product template.
2. Replace the Product Image Gallery block with the Product Gallery (beta) block.
3. **Expected:** The preview shows "gradient" at the bottom indicating there's more thumbnail
5. Save and go to the frontend to product with multiple images exceeding the available space
6. **Expected:** Gradient shows up at the bottom and top when there's space to scroll and disappears when you reach the edge
7. Go back to Editor
8. Focus on Gallery Area and transform from Row to Stack (see settings on the screenshot) - Thumbnails should be horizontal now

<img width="288" alt="image" src="https://github.com/user-attachments/assets/d8ef1d6c-1cce-4f04-8059-e5b968b7aafe" />

9. Repeat steps 3 to 5
10. Go back to Editor
11. Change the global styles color scheme

<img width="284" alt="image" src="https://github.com/user-attachments/assets/c28ceb09-2e65-4c11-a7f2-54bf6ce0d808" />

12. Make sure the gradient adjusts to the base color in editor and frontend (see screenshots above)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
