### PR TITLE
[NOX in-context flows] UI & UX adjustments & improvements

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -286,7 +286,7 @@ export const SettingsPaymentsMethods = () => {
 export const SettingsPaymentsMainWrapper = () => {
 	return (
 		<>
-			<Header title={ __( 'WooCommerce Settings', 'woocommerce' ) } />
+			<Header title={ __( 'Settings', 'woocommerce' ) } />
 			<HistoryRouter history={ getHistory() }>
 				<Routes>
 					<Route
@@ -343,7 +343,7 @@ export const SettingsPaymentsOfflineWrapper = () => {
 export const SettingsPaymentsWooCommercePaymentsWrapper = () => {
 	return (
 		<>
-			<Header title={ __( 'WooCommerce Settings', 'woocommerce' ) } />
+			<Header title={ __( 'Settings', 'woocommerce' ) } />
 			<Suspense fallback={ <div>Loading WooPayments settings...</div> }>
 				<SettingsPaymentsWooCommercePaymentsChunk />
 			</Suspense>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
@@ -3,12 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import StripeSpinner from '../stripe-spinner';
 import { useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
+import StripeSpinner from '../stripe-spinner';
 import Stepper from '~/settings-payments/onboarding/components/stepper';
 import { useOnboardingContext } from '../../data/onboarding-context';
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { Spinner } from '@wordpress/components';
+import StripeSpinner from '../stripe-spinner';
 import { useEffect } from 'react';
 
 /**
@@ -35,7 +35,7 @@ export default function WooPaymentsOnboarding(): React.ReactNode {
 	if ( isLoading ) {
 		return (
 			<div className="settings-payments-onboarding-modal__loading">
-				<Spinner />
+				<StripeSpinner />
 			</div>
 		);
 	}

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -62,9 +62,8 @@ export const OnboardingProvider: React.FC< {
 	);
 
 	// Make UI refresh when plugin is installed.
-	const { invalidateResolutionForStoreSelector: invalidatePaymentGateways } = useDispatch(
-		paymentSettingsStore
-	);
+	const { invalidateResolutionForStoreSelector: invalidatePaymentGateways } =
+		useDispatch( paymentSettingsStore );
 
 	// Initial data fetch from store
 	const { storeData, isStoreLoading } = useSelect(

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -12,6 +12,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	woopaymentsOnboardingStore,
 	WooPaymentsOnboardingStepContent,
+	paymentSettingsStore,
 } from '@woocommerce/data';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 
@@ -58,6 +59,11 @@ export const OnboardingProvider: React.FC< {
 
 	const { invalidateResolutionForStoreSelector } = useDispatch(
 		woopaymentsOnboardingStore
+	);
+
+	// Make UI refresh when plugin is installed.
+	const { invalidateResolutionForStoreSelector: invalidatePaymentGateways } = useDispatch(
+		paymentSettingsStore
 	);
 
 	// Initial data fetch from store
@@ -246,6 +252,10 @@ export const OnboardingProvider: React.FC< {
 					// Refresh the onboarding steps to get the latest data after closing the modal.
 					// This is to avoid showing the loader next time, but still have fresh data.
 					refreshOnboardingSteps();
+
+					// Invalidate the getPaymentProviders store selector to ensure the latest data is fetched.
+					// This is important to ensure that the payment providers buttons are up to date.
+					invalidatePaymentGateways( 'getPaymentProviders' );
 				},
 			} }
 		>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/style.scss
@@ -130,24 +130,9 @@ $gutenberg-blueberry-focus: #1d35b4;
 				width: 100%;
 				height: 40px; // Matching the updated WP Component. We can remove this when we update Components version.
 				margin-top: $gap-large;
-				background: var(--wp-components-color-accent, $gutenberg-blueberry); // override the MOX CTA to use Gutenberg Blueberry.
-				&:hover {
-					background: var(--wp-components-color-accent, $gutenberg-blueberry-focus);
-				}
 				&.inline {
 					width: auto; // Adjust the button width not to take 100%.
 					margin-top: 0; // No need to have margin in this case.
-				}
-				// Support busy/disabled state for gutenberg blueberry MOX button.
-				&.components-button.is-primary.is-busy,
-				&.components-button.is-primary.is-busy:disabled,
-				&.components-button.is-primary.is-busy[aria-disabled="true"] {
-					background: linear-gradient(-45deg, var(--wp-components-color-accent, $gutenberg-blueberry)
-					33%, var(--wp-components-color-accent-darker-20, $gutenberg-blueberry-focus)
-					33%, var(--wp-components-color-accent-darker-20, $gutenberg-blueberry-focus)
-					70%, var(--wp-components-color-accent, var(--wp-components-color-accent, $gutenberg-blueberry))
-					70%);
-					background-size: 100px 100%;
 				}
 			}
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/finish/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/finish/index.tsx
@@ -13,11 +13,11 @@ import WooPaymentsStepHeader from '../../components/header';
 import './style.scss';
 
 export const FinishStep: React.FC = () => {
-	const { context } = useOnboardingContext();
+	const { context, closeModal } = useOnboardingContext();
 
 	return (
 		<>
-			<WooPaymentsStepHeader onClose={ () => {} } />
+			<WooPaymentsStepHeader onClose={ closeModal } />
 			<div className="settings-payments-onboarding-modal__step--content">
 				<div className="settings-payments-onboarding-modal__step--content-finish">
 					<h1 className="settings-payments-onboarding-modal__step--content-finish-title">
@@ -52,7 +52,7 @@ export const FinishStep: React.FC = () => {
 					<Button
 						variant="secondary"
 						className="settings-payments-onboarding-modal__step--content-finish-secondary-button"
-						onClick={ () => {} }
+						onClick={ closeModal }
 					>
 						{ __( 'Close this window', 'woocommerce' ) }
 					</Button>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -1,3 +1,7 @@
+#payment_methods.settings-payments-onboarding-modal__step .settings-payments-onboarding-modal__step--content {
+	padding: 16px 32px 16px 0;
+}
+
 .settings-payments-onboarding-modal__step--content {
 	.settings-payments-methods__container {
 		width: 100%;
@@ -180,7 +184,7 @@
 				}
 
 				@media screen and (max-width: $break-medium) {
-					padding: $gap;
+					padding: 0;
 				}
 
 				.woocommerce-list {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/wpcom-connection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/wpcom-connection/index.tsx
@@ -13,11 +13,11 @@ import WooPaymentsStepHeader from '../../components/header';
 import './style.scss';
 
 export const JetpackStep: React.FC = () => {
-	const { currentStep } = useOnboardingContext();
+	const { currentStep, closeModal } = useOnboardingContext();
 
 	return (
 		<>
-			<WooPaymentsStepHeader onClose={ () => {} } />
+			<WooPaymentsStepHeader onClose={ closeModal } />
 			<div className="settings-payments-onboarding-modal__step--content">
 				<div className="settings-payments-onboarding-modal__step--content-jetpack">
 					<h1 className="settings-payments-onboarding-modal__step--content-jetpack-title">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR introduces a series of improvements and refinements to the UI and UX of the NOX In-context flows, addressing issues and enhancements identified during recent design reviews.


Closes #57327 | WOOPLUG-3956 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="757" alt="Screenshot 2025-04-17 at 17 48 12" src="https://github.com/user-attachments/assets/7fd9fad1-8536-4eb1-a128-7123f01e0258" /> | <img width="750" alt="Screenshot 2025-04-17 at 17 51 33" src="https://github.com/user-attachments/assets/95ebbb55-2414-4620-bda4-b317a778ed8b" /> |
| <img width="889" alt="Screenshot 2025-04-17 at 17 47 54" src="https://github.com/user-attachments/assets/6554e5db-b8c0-407e-b2ce-e6573b0998c3" /> | <img width="842" alt="Screenshot 2025-04-17 at 17 52 18" src="https://github.com/user-attachments/assets/85dff1f0-fea4-4324-a7f5-29a7e7c838d2" /> |
| <img width="725" alt="Screenshot 2025-04-17 at 17 50 27" src="https://github.com/user-attachments/assets/5d0ad4fa-6988-490e-a70d-107b819460d4" /> | <img width="720" alt="Screenshot 2025-04-17 at 17 53 12" src="https://github.com/user-attachments/assets/c8e65553-4437-4b98-885a-7837b4e06101" /> ||

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Prerequisites**
1. Check out this PR locally.
2. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
3. If you have a WooPayments account connected, please disconnect it.
4. Remove `woocommerce_woopayments_nox_profile` option to reset the NOX progress.

**Update the new Payments Settings title**
- Navigate to WooCommerce -> Settings -> Payments.
-  Ensure the page title in the top right corner is "Settings".

**Update the NOX In-context flow spinner**
- Click on the Enable or Complete setup button on the WooPayments Gateway section.
- Ensure the displayed spinner during the loading matches the Stripe spinner.

**Update the NOX In-context payment methods select spacings**
- Ensure the dividers of the payment methods are full width on both Desktop, Tablet and Mobile screens.

**Fix close button on the WPCOM connection step**
- Click Continue and ensure you're navigated to the WPCOM connection step.
- Click the X button on the top right corner and ensure the modal is closed.

**Invalidate the providers store when we close the onboarding modal**
- Verify the payment gateways are refreshed and the preloading placeholders are displayed.

**Business verification buttons should use the default WP buttons**
- Click on the Complete setup button on the WooPayments Gateway section to open the modal again.
- Proceed with WPCOM connection and test-drive account onboarding.
- Once the test account is connected, click the "Activate payments" button.
- Verify the button colors on "Activate payments" step are matching the others.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
