### PR TITLE
WOOPLUG-3979: Fix PMs display logic to accommodate older versions of WooPayments.

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
@@ -9,7 +9,7 @@ import { ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import sanitizeHTML from '~/lib/sanitize-html';
-import { shouldRenderPaymentMethod } from '~/settings-payments/utils';
+import { shouldRenderPaymentMethodInMainList } from '~/settings-payments/utils';
 
 type PaymentMethodListItemProps = {
 	/**
@@ -45,8 +45,10 @@ export const PaymentMethodListItem = ( {
 	// If the category is primary, render the method regardless of the state.
 	// If the category is secondary, render the method if the list is expanded or the method is enabled.
 	const shouldRender =
-		shouldRenderPaymentMethod( method, paymentMethodsState[ method.id ] ) ||
-		isExpanded;
+		shouldRenderPaymentMethodInMainList(
+			method,
+			paymentMethodsState[ method.id ]
+		) || isExpanded;
 
 	if ( ! shouldRender ) {
 		return null;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -17,7 +17,7 @@ import {
 	combineRequestMethods,
 	combinePaymentMethodsState,
 	decouplePaymentMethodsState,
-	shouldRenderPaymentMethod,
+	shouldRenderPaymentMethodInMainList,
 } from '~/settings-payments/utils';
 import './style.scss';
 
@@ -120,7 +120,7 @@ export default function PaymentMethodsSelection() {
 									__( 'Show more (%s)', 'woocommerce' ),
 									recommendedPaymentMethods?.filter(
 										( method ) =>
-											! shouldRenderPaymentMethod(
+											! shouldRenderPaymentMethodInMainList(
 												method,
 												paymentMethodsState[ method.id ]
 											)

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -288,7 +288,7 @@ export const decouplePaymentMethodsState = (
 /**
  * Checks whether a payment method should be rendered.
  */
-export const shouldRenderPaymentMethod = (
+export const shouldRenderPaymentMethodInMainList = (
 	method: RecommendedPaymentMethod,
 	method_enabled: boolean
 ) => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -292,7 +292,13 @@ export const shouldRenderPaymentMethod = (
 	method: RecommendedPaymentMethod,
 	method_enabled: boolean
 ) => {
+	// Starting from WooPayments 9.2, the method has a category which we use to determine if it should be rendered.
 	if ( method.category === 'primary' ) {
+		return true;
+	}
+
+	// However, in WooPayments < 9.2, we use the `enabled` property (retured from the server) to determine if the method should be rendered.
+	if ( method.enabled ) {
 		return true;
 	}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -297,7 +297,7 @@ export const shouldRenderPaymentMethod = (
 		return true;
 	}
 
-	// However, in WooPayments < 9.2, we use the `enabled` property (retured from the server) to determine if the method should be rendered.
+	// However, in WooPayments < 9.2, we use the `enabled` property (returned from the server) to determine if the method should be rendered.
 	if ( method.enabled ) {
 		return true;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With the NOX In-context work, we made some changes to the PMs' selections screen that did not account for older versions of WooPayments. This change will fix the issue described in #57368 

Closes #57368 
Closes WOOPLUG-3979

### Screenshots or screen recordings:

Before:

https://github.com/user-attachments/assets/e49c373e-c3c7-4b04-ace2-b343ecb286ef

After:

https://github.com/user-attachments/assets/6cfa8e70-095e-4db1-83b3-391bb999de97

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR
2. Open WooPayment's `woocommerce-payments.php` and change the version to 9.1.0 (if not changed already)
3. Navigate to WooCommerce > Settings > Payments, make sure you don't have a connected account
4. Click Complete Setup, and you should be redirected to a new page (not NOX)
5. Check some PMs on and off, the PM should stay in place (it was removed before)
6. Now, go back to WooCommerce > Settings > Payments
7. Open WooPayment's `woocommerce-payments.php` and change the version to 9.2.0
8. Refresh the Payments page and click Complete Setup, the NOX modal should open
9. Interact with the PMs and make sure everything is working as expected
10. Close the modal and open it again, make sure your prior changes are saved

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This change does not require a changelog, as it has not been merged into the trunk.

</details>
