### PR TITLE
Fix mobile unresponsiveness of product gallery after ‘Reviews’ tab click

### DIFF
--- a/plugins/woocommerce/changelog/57373-wooplug-3943-product-image-slide-becomes-unresponsive-on-mobile-after
+++ b/plugins/woocommerce/changelog/57373-wooplug-3943-product-image-slide-becomes-unresponsive-on-mobile-after
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix mobile unresponsiveness of product gallery after ‘Reviews’ tab click.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -43,6 +43,27 @@ test.describe( `${ blockData.name }`, () => {
 		);
 	} );
 
+	test( 'should not switch to the next image when the user cursor is focused on the tabs', async ( {
+		page,
+	} ) => {
+		await page.goto( blockData.productPage );
+
+		const activeImageSrc = await page
+			.locator( '.flex-active' )
+			.getAttribute( 'src' );
+
+		await page.getByRole( 'tab', { name: 'Reviews' } ).focus();
+
+		await page.keyboard.press( 'ArrowRight' );
+
+		const newActiveImage = page.locator( '.flex-active' );
+
+		await expect( newActiveImage ).toHaveAttribute(
+			'src',
+			activeImageSrc as string
+		);
+	} );
+
 	test( 'should switch to the next image when the user cursor is focused on tabs', async ( {
 		page,
 	} ) => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -18,7 +18,7 @@ const blockData = {
 test.use( { ...devices[ 'Pixel 7' ] } );
 
 test.describe( `${ blockData.name }`, () => {
-	test( 'should not switch to the next image when the user cursor is focused on the rating', async ( {
+	test( 'should not switch to the next image when the user cursor is focused on the rating with keyboard', async ( {
 		page,
 	} ) => {
 		await page.goto( blockData.productPage );
@@ -43,7 +43,7 @@ test.describe( `${ blockData.name }`, () => {
 		);
 	} );
 
-	test( 'should not switch to the next image when the user cursor is focused on the tabs', async ( {
+	test( 'should not switch to the next image when the user cursor is focused on the tabs with keyboard', async ( {
 		page,
 	} ) => {
 		await page.goto( blockData.productPage );
@@ -64,7 +64,7 @@ test.describe( `${ blockData.name }`, () => {
 		);
 	} );
 
-	test( 'should switch to the next image when the user cursor is focused on tabs', async ( {
+	test( 'should switch to the next image when the user cursor is focused on tabs with touch event', async ( {
 		page,
 	} ) => {
 		await page.goto( blockData.productPage );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -18,7 +18,7 @@ const blockData = {
 test.use( { ...devices[ 'Pixel 7' ] } );
 
 test.describe( `${ blockData.name }`, () => {
-	test( 'should not switch to the next image when the user has focused on the rating or tabs', async ( {
+	test( 'should not switch to the next image when the user cursor is focused on the rating', async ( {
 		page,
 	} ) => {
 		await page.goto( blockData.productPage );
@@ -43,7 +43,7 @@ test.describe( `${ blockData.name }`, () => {
 		);
 	} );
 
-	test( 'should switch to the next image when the user has focused on tabs but it is on mobile', async ( {
+	test( 'should switch to the next image when the user cursor is focused on tabs', async ( {
 		page,
 	} ) => {
 		await page.goto( blockData.productPage );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { devices } from '@playwright/test';
+import { test, expect } from '@woocommerce/e2e-utils';
+
+const blockData = {
+	name: 'woocommerce/product-image-gallery',
+	productPage: '/product/hoodie/',
+};
+
+/**
+ * Note: These tests are run on a mobile device because the tap() method is required,
+ * which is not supported on desktop devices.
+ *
+ * @see https://playwright.dev/docs/api/class-locator#locator-tap
+ */
+test.use( { ...devices[ 'Pixel 7' ] } );
+
+test.describe( `${ blockData.name }`, () => {
+	test( 'should not switch to the next image when the user has focused on the rating or tabs', async ( {
+		page,
+	} ) => {
+		await page.goto( blockData.productPage );
+
+		const activeImageSrc = await page
+			.locator( '.flex-active' )
+			.getAttribute( 'src' );
+
+		await page.getByRole( 'tab', { name: 'Reviews' } ).click();
+
+		const rating = page.locator( '.star-3' );
+		await rating.click();
+		await rating.focus();
+
+		await page.keyboard.press( 'ArrowRight' );
+
+		const newActiveImage = page.locator( '.flex-active' );
+
+		await expect( newActiveImage ).toHaveAttribute(
+			'src',
+			activeImageSrc as string
+		);
+	} );
+
+	test( 'should switch to the next image when the user has focused on tabs but it is on mobile', async ( {
+		page,
+	} ) => {
+		await page.goto( blockData.productPage );
+
+		const activeImageSrc = await page
+			.locator( '.flex-active' )
+			.getAttribute( 'src' );
+
+		await page.getByRole( 'tab', { name: 'Description' } ).click();
+		await page.getByRole( 'tab', { name: 'Reviews' } ).click();
+
+		await page
+			.locator( '.flex-control-nav.flex-control-thumbs' )
+			.locator( 'img' )
+			.nth( 2 )
+			.tap();
+
+		const newActiveImage = page.locator( '.flex-active' );
+
+		await expect( newActiveImage ).not.toHaveAttribute(
+			'src',
+			activeImageSrc as string
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -73,12 +73,6 @@ jQuery( function( $ ) {
 			
 			$tabs.eq( targetIndex ).focus();
 		} )
-		.on( 'focusout', '.wc-tabs li a, ul.tabs li a, #respond p.stars a', function() {
-			if ( ! productGalleryElement.data( 'flexslider' ) ) {
-				// Don't do anything if gallery does not exist.
-				return;
-			}
-		} )
 		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {
 			$( '.reviews_tab a' ).trigger( 'click' );
@@ -143,7 +137,7 @@ jQuery( function( $ ) {
 		 * Handle keyup events for tabs, tabs li a, and respond p.stars a.
 		 * The stopPropagation is used to prevent the keyup event from being triggered on the flexslider.
 		 */
-		.on( 'keyup', '.wc-tabs li a, ul.tabs li a,#respond p.stars a', function( e ) {
+		.on( 'keyup', '.wc-tabs li a, ul.tabs li a, #respond p.stars a', function( e ) {
 			var direction = e.key;
 			var next = [ 'ArrowRight', 'ArrowDown' ];
 			var prev = [ 'ArrowLeft', 'ArrowUp' ];

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -78,19 +78,6 @@ jQuery( function( $ ) {
 				// Don't do anything if gallery does not exist.
 				return;
 			}
-			setTimeout( function () {
-				var $activeElement = $( document.activeElement );
-				var sliderKeyupBlockers = [ '.stars', '.tabs', '.wc-tabs'];
-				var $closestBlocker = $activeElement.closest( sliderKeyupBlockers.join( ', ' ) );
-		
-				if ( $closestBlocker.length ) {
-					// Prevent keyup events from being triggered on the flexslider when the focus is on the stars or tabs.
-					productGalleryElement.data('flexslider').animating = true;
-					return;
-				}
-		
-				productGalleryElement.data('flexslider').animating = false;
-			}, 0);
 		} )
 		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {
@@ -152,7 +139,7 @@ jQuery( function( $ ) {
 				return false;
 			}
 		} )
-		.on( 'keydown', '#respond p.stars a', function( e ) {
+		.on( 'keyup', '#respond p.stars a', function( e ) {
 			var direction = e.key;
 			var next = [ 'ArrowRight', 'ArrowDown' ];
 			var prev = [ 'ArrowLeft', 'ArrowUp' ];
@@ -163,6 +150,7 @@ jQuery( function( $ ) {
 			}
 			
 			e.preventDefault();
+			e.stopPropagation();
 
 			if ( next.includes( direction ) ) {
 				$( this ).next().focus().click();

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -139,7 +139,11 @@ jQuery( function( $ ) {
 				return false;
 			}
 		} )
-		.on( 'keyup', '#respond p.stars a', function( e ) {
+		/**
+		 * Handle keyup events for tabs, tabs li a, and respond p.stars a.
+		 * The stopPropagation is used to prevent the keyup event from being triggered on the flexslider.
+		 */
+		.on( 'keyup', '.wc-tabs li a, ul.tabs li a,#respond p.stars a', function( e ) {
 			var direction = e.key;
 			var next = [ 'ArrowRight', 'ArrowDown' ];
 			var prev = [ 'ArrowLeft', 'ArrowUp' ];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->


This PR addresses a regression introduced in [#53158](https://github.com/woocommerce/woocommerce/pull/53158), where, in mobile view, the touch event on the description and reviews tabs sets the animation to `true` without resetting it. This prevents the animation logic in [jquery.flexslider.js](https://github.com/woocommerce/woocommerce/blob/f3eac49e1d8bd39fbfde10bc9a037e5131a27775/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js#L619-L724) from executing, causing the animation to fail.

Additionally, this PR resolves the issue noted in [#53018](https://github.com/woocommerce/woocommerce/pull/53018#issuecomment-2498921373). After investigation, the following fixes were implemented:

- Use the `keyup` event, consistent with [FlexSlider's implementation](https://github.com/woocommerce/woocommerce/blob/297c33addb4d0e7faa9e4e4b1fd2400c2c84b2b8/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js#L140-L154), to handle keyboard interactions.
- Now, that the same event is used, prevent event bubbling to the gallery via `stopPropagation`, ensuring that keyboard updates to the stars do not trigger unintended gallery behavior.

Given that there is a back and forth with these changes, I created E2E tests to covere these scenario.

These changes fix the regression and ensure proper behavior for both touch and keyboard interactions.

I'm going to see how we can fix it, but sharing in case you have a better idea to avoid setting animating to true.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #57292 (WOOPLUG-3943) .

(For Bug Fixes) Bug introduced in PR #53158 .



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Visit a product that has multiple images.
2. Click on the reviews tab.
3. Click on stars.
4. Update stars via directional keys
5. Ensure that the stars are updated.
6. Ensure that the active image isn't updated.
7. Click on the Reviews tab
8. Move across tabs via directional keys.
9. Ensure that the focused tab is updated.
10. Ensure that the active image isn't updated.
11. Visit a product that has multiple images in browser mobile view.
12. Tap the ‘Description’ tab (or any other tab except Reviews).
13. Then tap the ‘Reviews’ tab.
14. Try tapping a gallery image to slide or switch.
15. Ensure that the active image is updated.

## Run test

1. Run `plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts` E2E tests against trunk.
2. See that the second test fail
3. Run `plugins/woocommerce/client/blocks/tests/e2e/tests/product-image-gallery/product-image-gallery.block_theme.spec.ts` E2E tests against this branch.
4. See that all tests pass

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix mobile unresponsiveness of product gallery after ‘Reviews’ tab click.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
