### PR TITLE
[Blueprint] Add restrictions for options in Blueprint importer

### DIFF
--- a/packages/php/blueprint/changelog/wooplug-3964-blueprint-protect-critical-options
+++ b/packages/php/blueprint/changelog/wooplug-3964-blueprint-protect-critical-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Implement restricted options handling in ImportSetSiteOptions

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -51,7 +51,7 @@ class ImportSetSiteOptions implements StepProcessor {
 		foreach ( $schema->options as $key => $value ) {
 			// Skip if the option should not be modified.
 			if ( in_array( $key, self::RESTRICTED_OPTIONS, true ) ) {
-				$result->add_warn( "Cannot modify '{$key}' option: restricted for security reasons." );
+				$result->add_warn( "Cannot modify '{$key}' option: Modifying is restricted for this key." );
 				continue;
 			}
 

--- a/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
+++ b/packages/php/blueprint/src/Importers/ImportSetSiteOptions.php
@@ -18,6 +18,28 @@ class ImportSetSiteOptions implements StepProcessor {
 	use UseWPFunctions;
 
 	/**
+	 * List of WordPress options that should not be modified.
+	 *
+	 * @var array<string>
+	 */
+	private const RESTRICTED_OPTIONS = array(
+		'siteurl',
+		'home',
+		'active_plugins',
+		'template',
+		'stylesheet',
+		'admin_email',
+		'unfiltered_html',
+		'users_can_register',
+		'default_role',
+		'db_version',
+		'cron',
+		'rewrite_rules',
+		'wp_user_roles',
+	);
+
+
+	/**
 	 * Process the step.
 	 *
 	 * @param object $schema The schema to process.
@@ -27,16 +49,23 @@ class ImportSetSiteOptions implements StepProcessor {
 	public function process( $schema ): StepProcessorResult {
 		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
 		foreach ( $schema->options as $key => $value ) {
+			// Skip if the option should not be modified.
+			if ( in_array( $key, self::RESTRICTED_OPTIONS, true ) ) {
+				$result->add_warn( "Cannot modify '{$key}' option: restricted for security reasons." );
+				continue;
+			}
+
 			$value   = json_decode( wp_json_encode( $value ), true );
 			$updated = $this->wp_update_option( $key, $value );
 
 			if ( $updated ) {
-				$result->add_info( "{$key} has been updated" );
-			} else {
-				$current_value = $this->wp_get_option( $key );
-				if ( $current_value === $value ) {
-					$result->add_info( "{$key} has not been updated because the current value is already up to date." );
-				}
+				$result->add_info( "{$key} has been updated." );
+				continue;
+			}
+
+			$current_value = $this->wp_get_option( $key );
+			if ( $current_value === $value ) {
+				$result->add_info( "{$key} has not been updated because the current value is already up to date." );
 			}
 		}
 

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -116,8 +116,8 @@ class ImportSetSiteOptionsTest extends TestCase {
 
 		$messages = $result->get_messages( 'warn' );
 		$this->assertCount( 2, $messages );
-		$this->assertEquals( "Cannot modify 'admin_email' option: restricted for security reasons.", $messages[0]['message'] );
-		$this->assertEquals( "Cannot modify 'active_plugins' option: restricted for security reasons.", $messages[1]['message'] );
+		$this->assertEquals( "Cannot modify 'admin_email' option: Modifying is restricted for this key.", $messages[0]['message'] );
+		$this->assertEquals( "Cannot modify 'active_plugins' option: Modifying is restricted for this key.", $messages[1]['message'] );
 		$this->assertNotEquals( get_option( 'admin_email' ), 'danger@example.com' );
 		$this->assertNotEquals( get_option( 'active_plugins' ), array( 'fake-plugin/fake-plugin.php' ) );
 	}

--- a/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
+++ b/packages/php/blueprint/tests/Unit/Importers/ImportSetSiteOptionsTest.php
@@ -32,8 +32,8 @@ class ImportSetSiteOptionsTest extends TestCase {
 	public function test_process_updates_options_successfully() {
 		$schema          = Mockery::mock();
 		$schema->options = array(
-			'site_name'   => 'My New Site',
-			'admin_email' => 'admin@example.com',
+			'site_name'                   => 'My New Site',
+			'woocommerce_default_country' => 'JP',
 		);
 
 		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
@@ -45,7 +45,7 @@ class ImportSetSiteOptionsTest extends TestCase {
 			->with( 'site_name', 'My New Site' )
 			->andReturn( true );
 		$import_set_site_options->shouldReceive( 'wp_update_option' )
-			->with( 'admin_email', 'admin@example.com' )
+			->with( 'woocommerce_default_country', 'JP' )
 			->andReturn( true );
 
 		$result = $import_set_site_options->process( $schema );
@@ -55,8 +55,8 @@ class ImportSetSiteOptionsTest extends TestCase {
 
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 2, $messages );
-		$this->assertEquals( 'site_name has been updated', $messages[0]['message'] );
-		$this->assertEquals( 'admin_email has been updated', $messages[1]['message'] );
+		$this->assertEquals( 'site_name has been updated.', $messages[0]['message'] );
+		$this->assertEquals( 'woocommerce_default_country has been updated.', $messages[1]['message'] );
 	}
 
 	/**
@@ -92,6 +92,34 @@ class ImportSetSiteOptionsTest extends TestCase {
 		$messages = $result->get_messages( 'info' );
 		$this->assertCount( 1, $messages );
 		$this->assertEquals( 'site_name has not been updated because the current value is already up to date.', $messages[0]['message'] );
+	}
+
+	/**
+	 * Test when restricted options are attempted to be updated.
+	 *
+	 * @return void
+	 */
+	public function test_process_restricted_options() {
+		$schema                  = Mockery::mock();
+		$schema->options         = array(
+			'admin_email'    => 'danger@example.com',
+			'active_plugins' => array( 'fake-plugin/fake-plugin.php' ),
+		);
+		$import_set_site_options = Mockery::mock( ImportSetSiteOptions::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$result = $import_set_site_options->process( $schema );
+
+		$this->assertInstanceOf( StepProcessorResult::class, $result );
+		$this->assertTrue( $result->is_success() );
+
+		$messages = $result->get_messages( 'warn' );
+		$this->assertCount( 2, $messages );
+		$this->assertEquals( "Cannot modify 'admin_email' option: restricted for security reasons.", $messages[0]['message'] );
+		$this->assertEquals( "Cannot modify 'active_plugins' option: restricted for security reasons.", $messages[1]['message'] );
+		$this->assertNotEquals( get_option( 'admin_email' ), 'danger@example.com' );
+		$this->assertNotEquals( get_option( 'active_plugins' ), array( 'fake-plugin/fake-plugin.php' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-3964

Adds security restrictions to prevent modification of sensitive WordPress core options in the Blueprint importer. This includes:

* Added a list of restricted WordPress core options that should not be modified
* Fixed formatting of info messages for consistency

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. pnpm install
2. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
3. Download this [blueprint.json](https://github.com/user-attachments/files/19807294/blueprint.json)
 file
4. Run `wp wc blueprint import blueprint.json --show-messages=all`
5. Confirm that some critical options are not modified



<img width="986" alt="Screenshot 2025-04-18 at 10 33 49" src="https://github.com/user-attachments/assets/0c9551c9-c3e7-4a23-903e-0b2223cb3ab2" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
