### PR TITLE
[Blueprint]  Add security restriction to only allow blueprint imports in Coming Soon mode

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3965-blueprint-restrict-blueprint-imports-to-coming-soon-mode
+++ b/plugins/woocommerce/changelog/wooplug-3965-blueprint-restrict-blueprint-imports-to-coming-soon-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Restrict blueprint imports to coming soon mode

--- a/plugins/woocommerce/client/admin/client/blueprint/components/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/style.scss
@@ -1,4 +1,4 @@
-
+.blueprint-upload-dropzone-notice,
 .blueprint-upload-dropzone-error {
 	margin-top: 16px;
 }

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -161,9 +161,7 @@
 		margin-top: 14px;
 	}
 
-	.components-notice.is-error {
-		background: #fce2e4;
-		border-left-color: #cc1818;
+	.components-notice {
 		padding: 12px;
 
 		button.components-notice__dismiss {
@@ -174,16 +172,18 @@
 			}
 		}
 
-		.components-notice__content {
+		.components-notice__content,
+		&.is-error .components-notice__content pre {
 			margin: 0;
-
-			pre {
-				color: $gray-900;
-				line-height: 24px; /* 184.615% */
-				margin: 0;
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			}
+			color: $gray-900;
+			line-height: 24px; /* 184.615% */
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		}
+	}
+
+	.components-notice.is-error {
+		background: #fce2e4;
+		border-left-color: #cc1818;
 	}
 }
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -338,12 +338,12 @@ class RestApi {
 	 * @return bool Returns true if imports are allowed, false otherwise.
 	 */
 	private function can_import_blueprint() {
-		// Check if override constant is defined and true
+		// Check if override constant is defined and true.
 		if ( defined( 'ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE' ) && ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE ) {
 			return true;
 		}
 
-		// Only allow imports in coming soon mode
+		// Only allow imports in coming soon mode.
 		if ( $this->coming_soon_helper->is_site_live() ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -291,6 +291,17 @@ class RestApi {
 	 * @return array
 	 */
 	public function import_step( \WP_REST_Request $request ) {
+		if ( ! $this->can_import_blueprint() ) {
+			return array(
+				'success'  => false,
+				'messages' => array(
+					array(
+						'message' => __( 'Blueprint imports are disabled', 'woocommerce' ),
+						'type'    => 'error',
+					),
+				),
+			);
+		}
 		// Get the raw body size.
 		$body_size = strlen( $request->get_body() );
 		if ( $body_size > $this->get_max_file_size() ) {

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -7,13 +7,10 @@ namespace Automattic\WooCommerce\Admin\Features\Blueprint;
 use Automattic\WooCommerce\Blueprint\Exporters\ExportInstallPluginSteps;
 use Automattic\WooCommerce\Blueprint\Exporters\ExportInstallThemeSteps;
 use Automattic\WooCommerce\Blueprint\ExportSchema;
-use Automattic\WooCommerce\Blueprint\ImportSchema;
-use Automattic\WooCommerce\Blueprint\ResultFormatters\JsonResultFormatter;
 use Automattic\WooCommerce\Blueprint\ImportStep;
-use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use Automattic\WooCommerce\Blueprint\ZipExportedSchema;
-use RecursiveArrayIterator;
-use RecursiveIteratorIterator;
+use Automattic\WooCommerce\Internal\ComingSoon\ComingSoonHelper;
+use WP_Error;
 
 /**
  * Class RestApi
@@ -34,6 +31,20 @@ class RestApi {
 	 * @var string
 	 */
 	protected $namespace = 'wc-admin';
+
+	/**
+	 * ComingSoonHelper instance.
+	 *
+	 * @var ComingSoonHelper
+	 */
+	protected $coming_soon_helper;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->coming_soon_helper = new ComingSoonHelper();
+	}
 
 	/**
 	 * Get maximum allowed file size for blueprint uploads.
@@ -119,6 +130,21 @@ class RestApi {
 					),
 				),
 				'schema' => array( $this, 'get_import_step_response_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/blueprint/import-allowed',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_import_allowed' ),
+					'permission_callback' => function () {
+						return current_user_can( 'manage_woocommerce' );
+					},
+				),
+				'schema' => array( $this, 'get_import_allowed_schema' ),
 			)
 		);
 	}
@@ -295,6 +321,60 @@ class RestApi {
 	}
 
 
+	/**
+	 * Check if blueprint imports are allowed based on site status and configuration.
+	 *
+	 * @return bool Returns true if imports are allowed, false otherwise.
+	 */
+	private function can_import_blueprint() {
+		// Check if override constant is defined and true
+		if ( defined( 'ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE' ) && ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE ) {
+			return true;
+		}
+
+		// Only allow imports in coming soon mode
+		if ( $this->coming_soon_helper->is_site_live() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get whether blueprint imports are allowed.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function get_import_allowed() {
+		$can_import = $this->can_import_blueprint();
+
+		return rest_ensure_response(
+			array(
+				'import_allowed' => $can_import,
+			)
+		);
+	}
+
+	/**
+	 * Get the schema for the import-allowed endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_import_allowed_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'blueprint-import-allowed',
+			'type'       => 'object',
+			'properties' => array(
+				'import_allowed' => array(
+					'description' => __( 'Whether blueprint imports are currently allowed', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+	}
 
 	/**
 	 * Get the schema for the queue endpoint.

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
@@ -3,6 +3,8 @@
  * Unit tests for RestApi class.
  */
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint;
 
 use Automattic\WooCommerce\Admin\Features\Blueprint\RestApi;
@@ -30,57 +32,139 @@ class RestApiTest extends WP_Test_REST_TestCase {
 		parent::setUp();
 		$this->rest_api = new RestApi();
 
-		// Create a temporary test file with valid Blueprint schema
-		$this->temp_file = wp_tempnam('blueprint_test_');
-		$blueprint_content = json_encode([
-			'steps' => [
-				[
-					'step' => 'setWCSettings',
-					'settings' => [
-						'woocommerce_store_address' => '123 Test St',
-						'woocommerce_store_city' => 'Test City'
-					]
-				]
-			]
-		]);
-		file_put_contents($this->temp_file, $blueprint_content);
-	}
-
-	/**
-	 * Test file size validation in import_step endpoint.
-	 */
-	public function test_import_step_file_size_validation() {
-		// Create a large request body
-		$large_value = str_repeat('X', RestApi::MAX_FILE_SIZE + 1024); // Slightly over limit
-		$request = new \WP_REST_Request('POST', '/wc-admin/blueprint/import-step');
-		$request->set_body(json_encode(array(
-			'step_definition' => array(
-				'step' => 'setWCSettings',
-				'settings' => array(
-					'large_setting' => $large_value
-				)
+		// Create a temporary test file with valid Blueprint schema.
+		$this->temp_file   = wp_tempnam( 'blueprint_test_' );
+		$blueprint_content = wp_json_encode(
+			array(
+				'steps' => array(
+					array(
+						'step'     => 'setWCSettings',
+						'settings' => array(
+							'woocommerce_store_address' => '123 Test St',
+							'woocommerce_store_city'    => 'Test City',
+						),
+					),
+				),
 			)
-		)));
-
-		$response = $this->rest_api->import_step($request);
-
-		$this->assertFalse($response['success']);
-		$this->assertCount(1, $response['messages']);
-		$this->assertEquals('error', $response['messages'][0]['type']);
-		$this->assertStringContainsString('50 MB', $response['messages'][0]['message']);
+		);
+		file_put_contents( $this->temp_file, $blueprint_content );
 	}
+
 
 	/**
 	 * Clean up after each test.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
-		// Clean up global state
-		unset($_FILES['file']);
+		// Clean up global state.
+		unset( $_FILES['file'] );
 
-		// Clean up temporary file
-		if (file_exists($this->temp_file)) {
-			unlink($this->temp_file);
+		// Clean up temporary file.
+		if ( file_exists( $this->temp_file ) ) {
+			unlink( $this->temp_file );
 		}
+
+		remove_all_filters( 'pre_option_woocommerce_coming_soon' );
 	}
-} 
+
+	/**
+	 * Test that blueprint imports are disabled in live mode.
+	 */
+	public function test_cannot_import_blueprint_in_live_mode() {
+		add_filter(
+			'pre_option_woocommerce_coming_soon',
+			function () {
+				return 'no';
+			}
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc-admin/blueprint/import-step' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'step_definition' => array(
+						'step'    => 'setSiteOptions',
+						'options' => array(
+							'woocommerce_store_address' => '123 Test St',
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->rest_api->import_step( $request );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertCount( 1, $response['messages'] );
+		$this->assertEquals( 'error', $response['messages'][0]['type'] );
+		$this->assertStringContainsString( 'Blueprint imports are disabled', $response['messages'][0]['message'] );
+	}
+
+	/**
+	 * Test file size validation in import_step endpoint.
+	 */
+	public function test_import_step_file_size_validation() {
+		add_filter(
+			'pre_option_woocommerce_coming_soon',
+			function () {
+				return 'yes';
+			}
+		);
+
+		// Create a large request body.
+		$large_value = str_repeat( 'X', RestApi::MAX_FILE_SIZE + 1024 ); // Slightly over limit.
+		$request     = new \WP_REST_Request( 'POST', '/wc-admin/blueprint/import-step' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'step_definition' => array(
+						'step'    => 'setSiteOptions',
+						'options' => array(
+							'large_setting' => $large_value,
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->rest_api->import_step( $request );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertCount( 1, $response['messages'] );
+		$this->assertEquals( 'error', $response['messages'][0]['type'] );
+		$this->assertStringContainsString( '50 MB', $response['messages'][0]['message'] );
+	}
+
+	/**
+	 * Test that import blueprint endpoint is working.
+	 */
+	public function test_import_blueprint() {
+		add_filter(
+			'pre_option_woocommerce_coming_soon',
+			function () {
+				return 'yes';
+			}
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wc-admin/blueprint/import-step' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'step_definition' => array(
+						'step'    => 'setSiteOptions',
+						'options' => array(
+							'woocommerce_store_address' => '123 Test St',
+						),
+					),
+				)
+			)
+		);
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $this->rest_api->import_step( $request );
+
+		$this->assertTrue( $response['success'], $response['messages'][0]['message'] );
+		$this->assertCount( 1, $response['messages'] );
+		$this->assertStringContainsString( 'woocommerce_store_address has been updated', $response['messages'][0]['message'] );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
@@ -47,7 +47,9 @@ class RestApiTest extends WP_Test_REST_TestCase {
 				),
 			)
 		);
-		file_put_contents( $this->temp_file, $blueprint_content );
+		global $wp_filesystem;
+		WP_Filesystem();
+		$wp_filesystem->put_contents( $this->temp_file, $blueprint_content );
 	}
 
 
@@ -61,7 +63,7 @@ class RestApiTest extends WP_Test_REST_TestCase {
 
 		// Clean up temporary file.
 		if ( file_exists( $this->temp_file ) ) {
-			unlink( $this->temp_file );
+			wp_delete_file( $this->temp_file );
 		}
 
 		remove_all_filters( 'pre_option_woocommerce_coming_soon' );


### PR DESCRIPTION
  ### Submission Review Guidelines:

  -   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
  -   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
  -   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
  -   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

  <!-- You can erase any parts of this template not applicable to your Pull Request. -->

  ### Changes proposed in this Pull Request:

  <!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

  <!-- Describe the changes made to this Pull Request and the reason for such changes. -->

  <!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
  <!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
  <!-- If the PR that introduced the bug is known, please also add its link below. -->

  Closes WOOPLUG-3965

  This PR adds a security measure to restrict blueprint imports to only be allowed when the site is in Coming Soon mode. This helps prevent accidental or unauthorized imports on live sites that could disrupt the store's operation.


  ### Key Changes

  - Add a security check to only allow blueprint imports when the site is in Coming Soon mode
  - Add new REST API endpoint `/blueprint/import-allowed` to check import permissions
  - Update frontend to check import permissions and show appropriate UI feedback
  - Add `ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE` constant for override capability

  <!-- Begin testing instructions -->

  ### How to test the changes in this Pull Request:

  <!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

  Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

  1. Enable the Blueprint feature `wp option set woocommerce_feature_blueprint_enabled yes`
  2. Change site visibility to Live
  3. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
  4. Confirm that Blueprint imports are disabled and a notice is shown
  5. Confirm that the "Coming Soon mode" link should redirect to the site visibility settings page
  6. Set `ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE` constant to true
  7. Confirm that Blueprint imports are allowed
  8. Remove the constant and change the site visibility to Coming Soon
  9. Confirm that Blueprint imports are allowed

<img width="558" alt="Screenshot 2025-04-18 at 11 59 53" src="https://github.com/user-attachments/assets/99943839-7ad1-4d85-8b54-f1fd0ae7f190" />


  <!-- End testing instructions -->

  ### Testing that has already taken place:

  <!-- Detail any testing that has already been conducted. -->
  <!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
  <!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
  <!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

  ### Changelog entry

  <!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
  <!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

  <!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
  <!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
  <!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

  -   [ ] Automatically create a changelog entry from the details below.

  <!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

  -   [ ] This Pull Request does not require a changelog entry. (Comment required below)

  <details>

  <summary>Changelog Entry Details</summary>

  #### Significance

  <!-- Choose only one -->

  -   [ ] Patch
  -   [ ] Minor
  -   [ ] Major

  #### Type

  <!-- Choose only one -->

  -   [ ] Fix - Fixes an existing bug
  -   [ ] Add - Adds functionality
  -   [ ] Update - Update existing functionality
  -   [ ] Dev - Development related task
  -   [ ] Tweak - A minor adjustment to the codebase
  -   [ ] Performance - Address performance issues
  -   [ ] Enhancement - Improvement to existing functionality

  #### Message <!-- Add a changelog message here -->

  </details>

  <details>

  <summary>Changelog Entry Comment</summary>

  #### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

  </details>
