### PR TITLE
Fix star rating issue for the product review form when multiple Product Reviews blocks are added

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2582-double-rating-shows-up-in-product-reviews-when-another
+++ b/plugins/woocommerce/changelog/wooplug-2582-double-rating-shows-up-in-product-reviews-when-another
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Star rating issue when when there are multiple Product Reviews blocks on the same page.

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -99,7 +99,7 @@ jQuery( function( $ ) {
 		} )
 		// Star ratings for comments
 		.on( 'init', '#rating', function() {
-			$( '#rating' )
+			$( this )
 				.hide()
 				.before(
 					'<p class="stars">\


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is extracted from #56477. Instead of using #rating which targets the first one everytime, we use this to actually target the star rating in the correct context.

Closes #51373 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="1460" alt="image" src="https://github.com/user-attachments/assets/1008c000-0a37-4d10-9435-b2926f5c888d" />   |   <img width="1460" alt="image" src="https://github.com/user-attachments/assets/ff4a658e-cf41-423d-b65f-acbe604ad9ed" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On the Single Product template, add two Product Reviews blocks.
2. On the front end, see the star rating rendered correctly for both block. Previously, the first block will have two sets of star, and the other one only show the dropdown.
