### PR TITLE
Product Specifications: Add settings to control the visibility of weight/dimensions/attribute

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3844-add-conditional-options-for-displaying-weight-dimensions-and
+++ b/plugins/woocommerce/changelog/wooplug-3844-add-conditional-options-for-displaying-weight-dimensions-and
@@ -1,4 +1,4 @@
 Significance: patch
 Type: add
 
-Add settings to control the visibility of weight/dimensions/attribute.
+Product Specifications: Add settings to control the visibility of weight/dimensions/attribute.

--- a/plugins/woocommerce/changelog/wooplug-3844-add-conditional-options-for-displaying-weight-dimensions-and
+++ b/plugins/woocommerce/changelog/wooplug-3844-add-conditional-options-for-displaying-weight-dimensions-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add settings to control the visibility of weight/dimensions/attribute.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/block.json
@@ -14,10 +14,6 @@
 		"core/post-template"
 	],
 	"attributes": {
-		"fontSize": {
-			"type": "string",
-			"default": "medium"
-		},
 		"showWeight": {
 			"type": "boolean",
 			"default": true

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/block.json
@@ -17,6 +17,18 @@
 		"fontSize": {
 			"type": "string",
 			"default": "medium"
+		},
+		"showWeight": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDimensions": {
+			"type": "boolean",
+			"default": true
+		},
+		"showAttributes": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useQueryLoopProductContextValidation } from '@woocommerce/base-hooks';
 import { useSelect } from '@wordpress/data';
 import { optionsStore, Product, productsStore } from '@woocommerce/data';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -39,7 +40,10 @@ const getFormattedDimensions = (
 const Edit = ( {
 	context: { postId, postType },
 	clientId,
+	attributes,
+	setAttributes,
 }: ProductSpecificationsEditProps ) => {
+	const { showWeight, showDimensions, showAttributes } = attributes;
 	const blockProps = useBlockProps( {
 		className: 'wc-block-product-specifications',
 	} );
@@ -150,27 +154,72 @@ const Edit = ( {
 		};
 	}
 
+	if ( ! showWeight ) {
+		productData.weight.value = '';
+	}
+	if ( ! showDimensions ) {
+		productData.dimensions.value = '';
+	}
+	if ( ! showAttributes ) {
+		Object.entries( productData ).forEach( ( [ key, data ] ) => {
+			if ( key !== 'weight' && key !== 'dimensions' ) {
+				data.value = '';
+			}
+		} );
+	}
+
 	return (
-		<table { ...blockProps }>
-			<tbody>
-				{ Object.entries( productData ).map(
-					( [ key, data ] ) =>
-						data.value && (
-							<tr
-								key={ key }
-								className={ `wc-block-product-specifications-item wc-block-product-specifications-item__${ key }` }
-							>
-								<th className="wc-block-product-specifications-item__label">
-									{ data.label }
-								</th>
-								<td className="wc-block-product-specifications-item__value">
-									{ data.value }
-								</td>
-							</tr>
-						)
-				) }
-			</tbody>
-		</table>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Display Settings', 'woocommerce' ) }>
+					<ToggleControl
+						label={ __( 'Show Weight', 'woocommerce' ) }
+						checked={ showWeight }
+						onChange={ () =>
+							setAttributes( { showWeight: ! showWeight } )
+						}
+					/>
+					<ToggleControl
+						label={ __( 'Show Dimensions', 'woocommerce' ) }
+						checked={ showDimensions }
+						onChange={ () =>
+							setAttributes( {
+								showDimensions: ! showDimensions,
+							} )
+						}
+					/>
+					<ToggleControl
+						label={ __( 'Show Attributes', 'woocommerce' ) }
+						checked={ showAttributes }
+						onChange={ () =>
+							setAttributes( {
+								showAttributes: ! showAttributes,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<table { ...blockProps }>
+				<tbody>
+					{ Object.entries( productData ).map(
+						( [ key, data ] ) =>
+							data.value && (
+								<tr
+									key={ key }
+									className={ `wc-block-product-specifications-item wc-block-product-specifications-item__${ key }` }
+								>
+									<th className="wc-block-product-specifications-item__label">
+										{ data.label }
+									</th>
+									<td className="wc-block-product-specifications-item__value">
+										{ data.value }
+									</td>
+								</tr>
+							)
+					) }
+				</tbody>
+			</table>
+		</>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
@@ -136,11 +136,6 @@ const Edit = ( {
 		} else {
 			productData.weight.value = `10 ${ weightUnit }`;
 		}
-
-		productData.weight.value =
-			isSpecificProductContext && product.weight
-				? `${ product.weight } ${ weightUnit }`
-				: `10 ${ weightUnit }`;
 	}
 
 	if ( showDimensions ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/edit.tsx
@@ -121,51 +121,59 @@ const Edit = ( {
 		);
 	}
 
-	const productData: Record< string, { label: string; value: string } > = {
-		weight: {
+	const productData: Record< string, { label: string; value: string } > = {};
+
+	if ( showWeight ) {
+		productData.weight = {
 			label: __( 'Weight', 'woocommerce' ),
 			value: '',
-		},
-		dimensions: {
+		};
+
+		if ( isSpecificProductContext ) {
+			productData.weight.value = product.weight
+				? `${ product.weight } ${ weightUnit }`
+				: '';
+		} else {
+			productData.weight.value = `10 ${ weightUnit }`;
+		}
+
+		productData.weight.value =
+			isSpecificProductContext && product.weight
+				? `${ product.weight } ${ weightUnit }`
+				: `10 ${ weightUnit }`;
+	}
+
+	if ( showDimensions ) {
+		productData.dimensions = {
 			label: __( 'Dimensions', 'woocommerce' ),
 			value: '',
-		},
-	};
-
-	if ( isSpecificProductContext ) {
-		productData.weight.value = product?.weight
-			? `${ product.weight } ${ weightUnit }`
-			: '';
-		productData.dimensions.value = product?.dimensions
-			? getFormattedDimensions( product.dimensions, dimensionUnit )
-			: '';
-		product?.attributes?.forEach( ( attribute ) => {
-			productData[ attribute.name.toLowerCase() ] = {
-				label: attribute.name,
-				value: attribute.options.join( ', ' ),
-			};
-		} );
-	} else {
-		productData.weight.value = `10 ${ weightUnit }`;
-		productData.dimensions.value = `10 × 10 × 10 ${ dimensionUnit }`;
-		productData.test_attribute = {
-			label: __( 'Test Attribute', 'woocommerce' ),
-			value: __( 'First, Second, Third', 'woocommerce' ),
 		};
+
+		if ( isSpecificProductContext ) {
+			productData.dimensions.value = product.dimensions
+				? getFormattedDimensions( product.dimensions, dimensionUnit )
+				: '';
+		} else {
+			productData.dimensions.value = `10 × 10 × 10 ${ dimensionUnit }`;
+		}
 	}
 
-	if ( ! showWeight ) {
-		productData.weight.value = '';
-	}
-	if ( ! showDimensions ) {
-		productData.dimensions.value = '';
-	}
-	if ( ! showAttributes ) {
-		Object.entries( productData ).forEach( ( [ key, data ] ) => {
-			if ( key !== 'weight' && key !== 'dimensions' ) {
-				data.value = '';
+	if ( showAttributes ) {
+		if ( isSpecificProductContext ) {
+			if ( product.attributes ) {
+				product.attributes.forEach( ( attribute ) => {
+					productData[ attribute.name.toLowerCase() ] = {
+						label: attribute.name,
+						value: attribute.options.join( ', ' ),
+					};
+				} );
 			}
-		} );
+		} else {
+			productData.test_attribute = {
+				label: __( 'Test Attribute', 'woocommerce' ),
+				value: __( 'First, Second, Third', 'woocommerce' ),
+			};
+		}
 	}
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/test/block.ts
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import type { BlockAttributes } from '@wordpress/blocks';
+import '@testing-library/jest-dom';
+import { fireEvent, screen, within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	initializeEditor,
+	selectBlock,
+} from '../../../../../tests/integration/helpers/integration-test-editor';
+import '../';
+
+async function setup( attributes: BlockAttributes ) {
+	const testBlock = [
+		{
+			name: 'woocommerce/product-specifications',
+			attributes,
+		},
+	];
+	return initializeEditor( testBlock );
+}
+
+describe( 'Product Specifications block', () => {
+	describe( 'Display settings', () => {
+		beforeEach( async () => {
+			await setup( {} );
+			await selectBlock( /Block: Product Specifications/i );
+
+			// Open display settings panel
+			const displaySettings = screen.getByRole( 'button', {
+				name: /Display Settings/i,
+			} );
+			if ( displaySettings.getAttribute( 'aria-expanded' ) !== 'true' ) {
+				fireEvent.click( displaySettings );
+			}
+		} );
+
+		test( 'should handle section visibility toggles correctly', () => {
+			const block = within(
+				screen.getByLabelText( /Block: Product Specifications/i )
+			);
+
+			// Test initial state - all sections should be visible by default
+			expect( block.getByText( /Weight/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Dimensions/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Test Attribute/i ) ).toBeInTheDocument();
+
+			// Verify toggle controls are checked by default
+			expect(
+				screen.getByRole( 'checkbox', { name: /Show Weight/i } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'checkbox', {
+					name: /Show Dimensions/i,
+				} )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'checkbox', {
+					name: /Show Attributes/i,
+				} )
+			).toBeChecked();
+
+			// Test hiding weight section
+			fireEvent.click(
+				screen.getByRole( 'checkbox', { name: /Show Weight/i } )
+			);
+			expect( block.queryByText( /Weight/i ) ).not.toBeInTheDocument();
+			expect( block.getByText( /Dimensions/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Test Attribute/i ) ).toBeInTheDocument();
+
+			// Test hiding dimensions section
+			fireEvent.click(
+				screen.getByRole( 'checkbox', {
+					name: /Show Dimensions/i,
+				} )
+			);
+			expect( block.queryByText( /Weight/i ) ).not.toBeInTheDocument();
+			expect(
+				block.queryByText( /Dimensions/i )
+			).not.toBeInTheDocument();
+			expect( block.getByText( /Test Attribute/i ) ).toBeInTheDocument();
+
+			// Test hiding attributes section
+			fireEvent.click(
+				screen.getByRole( 'checkbox', {
+					name: /Show Attributes/i,
+				} )
+			);
+			expect( block.queryByText( /Weight/i ) ).not.toBeInTheDocument();
+			expect(
+				block.queryByText( /Dimensions/i )
+			).not.toBeInTheDocument();
+			expect(
+				block.queryByText( /Test Attribute/i )
+			).not.toBeInTheDocument();
+
+			// Test restoring visibility by toggling all sections back on
+			fireEvent.click(
+				screen.getByRole( 'checkbox', { name: /Show Weight/i } )
+			);
+			fireEvent.click(
+				screen.getByRole( 'checkbox', {
+					name: /Show Dimensions/i,
+				} )
+			);
+			fireEvent.click(
+				screen.getByRole( 'checkbox', {
+					name: /Show Attributes/i,
+				} )
+			);
+
+			// Verify all sections are visible again
+			expect( block.getByText( /Weight/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Dimensions/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Test Attribute/i ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/types.ts
@@ -8,7 +8,6 @@ type Context = {
 };
 
 interface ProductSpecificationsAttributes {
-	fontSize?: string;
 	showWeight: boolean;
 	showDimensions: boolean;
 	showAttributes: boolean;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-specifications/types.ts
@@ -7,4 +7,12 @@ type Context = {
 	context: { postId: string; postType: string };
 };
 
-export type ProductSpecificationsEditProps = BlockEditProps< object > & Context;
+interface ProductSpecificationsAttributes {
+	fontSize?: string;
+	showWeight: boolean;
+	showDimensions: boolean;
+	showAttributes: boolean;
+}
+
+export type ProductSpecificationsEditProps =
+	BlockEditProps< ProductSpecificationsAttributes > & Context;

--- a/plugins/woocommerce/client/blocks/tests/js/jest.config.json
+++ b/plugins/woocommerce/client/blocks/tests/js/jest.config.json
@@ -9,6 +9,7 @@
 	"moduleDirectories": [ "node_modules" ],
 	"moduleNameMapper": {
 		"@wordpress/private-apis": "<rootDir>/node_modules/@wordpress/private-apis",
+		"@wordpress/core-data/build/(.*)$": "<rootDir>/node_modules/@wordpress/core-data/build/$1",
 		"@wordpress/core-data": "<rootDir>/node_modules/@wordpress/core-data",
 		"@wordpress/components": "<rootDir>/node_modules/@wordpress/components",
 		"@woocommerce/atomic-blocks": "assets/js/atomic/blocks",

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -44,7 +44,7 @@ class ProductSpecifications extends AbstractBlock {
 
 		$product_data = array();
 
-		// Get display settings with defaults
+		// Get display settings with defaults.
 		$show_weight     = isset( $attributes['showWeight'] ) ? $attributes['showWeight'] : true;
 		$show_dimensions = isset( $attributes['showDimensions'] ) ? $attributes['showDimensions'] : true;
 		$show_attributes = isset( $attributes['showAttributes'] ) ? $attributes['showAttributes'] : true;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -44,48 +44,55 @@ class ProductSpecifications extends AbstractBlock {
 
 		$product_data = array();
 
-		if ( $product->has_weight() ) {
+		// Get display settings with defaults
+		$show_weight     = isset( $attributes['showWeight'] ) ? $attributes['showWeight'] : true;
+		$show_dimensions = isset( $attributes['showDimensions'] ) ? $attributes['showDimensions'] : true;
+		$show_attributes = isset( $attributes['showAttributes'] ) ? $attributes['showAttributes'] : true;
+
+		if ( $show_weight && $product->has_weight() ) {
 			$product_data['weight'] = array(
 				'label' => __( 'Weight', 'woocommerce' ),
 				'value' => wc_format_weight( $product->get_weight() ),
 			);
 		}
 
-		if ( $product->has_dimensions() ) {
+		if ( $show_dimensions && $product->has_dimensions() ) {
 			$product_data['dimensions'] = array(
 				'label' => __( 'Dimensions', 'woocommerce' ),
 				'value' => wc_format_dimensions( $product->get_dimensions( false ) ),
 			);
 		}
 
-		foreach ( $product->get_attributes() as $attribute ) {
-			$values = array();
+		if ( $show_attributes ) {
+			foreach ( $product->get_attributes() as $attribute ) {
+				$values = array();
 
-			if ( $attribute->is_taxonomy() ) {
-				$attribute_taxonomy = $attribute->get_taxonomy_object();
-				$attribute_values   = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
+				if ( $attribute->is_taxonomy() ) {
+					$attribute_taxonomy = $attribute->get_taxonomy_object();
+					$attribute_values   = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
 
-				foreach ( $attribute_values as $attribute_value ) {
-					$value_name = esc_html( $attribute_value->name );
+					foreach ( $attribute_values as $attribute_value ) {
+						$value_name = esc_html( $attribute_value->name );
 
-					if ( $attribute_taxonomy->attribute_public ) {
-						$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
-					} else {
-						$values[] = $value_name;
+						if ( $attribute_taxonomy->attribute_public ) {
+							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
+						} else {
+							$values[] = $value_name;
+						}
+					}
+				} else {
+					$values = $attribute->get_options();
+
+					foreach ( $values as &$value ) {
+						$value = make_clickable( esc_html( $value ) );
 					}
 				}
-			} else {
-				$values = $attribute->get_options();
 
-				foreach ( $values as &$value ) {
-					$value = make_clickable( esc_html( $value ) );
-				}
+				$product_data[ 'attribute_' . sanitize_title_with_dashes( $attribute->get_name() ) ] = array(
+					'label' => wc_attribute_label( $attribute->get_name() ),
+					'value' => wpautop( wptexturize( implode( ', ', $values ) ) ),
+				);
 			}
-
-			$product_data[ 'attribute_' . sanitize_title_with_dashes( $attribute->get_name() ) ] = array(
-				'label' => wc_attribute_label( $attribute->get_name() ),
-				'value' => wpautop( wptexturize( implode( ', ', $values ) ) ),
-			);
 		}
 
 		if ( empty( $product_data ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds conditional display options for weight, dimensions, and attributes in the Product Specifications block. Users can now selectively show/hide these elements through the block's settings panel.

Closes #57111.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
|     <img width="1497" alt="image" src="https://github.com/user-attachments/assets/e9deb9dd-8923-499d-acfb-46e6c85d1e2f" />   |    <img width="1497" alt="image" src="https://github.com/user-attachments/assets/d9805f82-2bea-4c87-8ee2-b8aadd5c5a87" />   |

### How to test the changes in this Pull Request:

1. Edit the Single Product template.
2. Add the "Blockified Product Details" block to the template.
3. Select the "Product Specifications" block and open block settings.
4. Verify that there are three new toggle controls under "Display Settings":
    - Show Weight
    - Show Dimensions
    - Show Attributes
5. Test each toggle control:
    - Toggle "Show Weight" off and verify the weight information disappears
    - Toggle "Show Dimensions" off and verify the dimensions information disappears
    - Toggle "Show Attributes" off and verify all product attributes disappear
6. Toggle multiple controls and verify combinations work correctly.
7. Save the page and view it on the frontend.
8. Verify that the display settings persist and work correctly on the frontend.
9. Note that when all settings are toggled off, the block is empty but the Additional Information accordion items are still visible. This is a known issue and belongs to https://github.com/woocommerce/woocommerce/issues/54730 scope.
