### PR TITLE
Fix parent product display in low stock notifications

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2067-low-stock-notifications-inaccurately-shows-the-variation
+++ b/plugins/woocommerce/changelog/wooplug-2067-low-stock-notifications-inaccurately-shows-the-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix parent product display in low stock notifications for variable products

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -763,6 +763,14 @@ class WC_Emails {
 			return;
 		}
 
+		// If this is a variation but stock is managed at the parent level, use the parent product for the notification.
+		if ( $product->is_type( 'variation' ) && 'parent' === $product->get_manage_stock() ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			if ( $parent_product ) {
+				$product = $parent_product;
+			}
+		}
+
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product low in stock', 'woocommerce' ) );
 		$message = sprintf(
 			/* translators: 1: product name 2: items in stock */
@@ -799,6 +807,14 @@ class WC_Emails {
 		 */
 		if ( false === apply_filters( 'woocommerce_should_send_no_stock_notification', true, $product->get_id() ) ) {
 			return;
+		}
+
+		// If this is a variation but stock is managed at the parent level, use the parent product for the notification.
+		if ( $product->is_type( 'variation' ) && 'parent' === $product->get_manage_stock() ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			if ( $parent_product ) {
+				$product = $parent_product;
+			}
 		}
 
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product out of stock', 'woocommerce' ) );

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -11,6 +11,7 @@
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -810,7 +811,7 @@ class WC_Emails {
 		}
 
 		// If this is a variation but stock is managed at the parent level, use the parent product for the notification.
-		if ( $product->is_type( 'variation' ) && 'parent' === $product->get_manage_stock() ) {
+		if ( $product->is_type( ProductType::VARIATION ) && 'parent' === $product->get_manage_stock() ) {
 			$parent_product = wc_get_product( $product->get_parent_id() );
 			if ( $parent_product ) {
 				$product = $parent_product;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When stock is managed at the parent level for variable products, the system
should show the parent product in stock notifications instead of the specific
variation that triggered the notification.

Closes  WOOPLUG-2067 #45632.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![Screenshot 2025-04-21 at 14 10 49](https://github.com/user-attachments/assets/c61742dd-dfdb-40bf-9349-c773727201f2)  |  ![Screenshot 2025-04-21 at 14 14 05](https://github.com/user-attachments/assets/5fdadfe7-9144-48ed-bfc9-86b73676013a)  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Products > Inventory
2. Enable Stock Management and Low Stock Notifications.
3. Set the Low stock threshold to 3.
4. Create a variable product with 3 different variations in your store.
5. Enable stock management at the **parent** product (not the variation level) level, and set the value to 4.
6. Purchase a specific variation in your store, which will bring the stock to 3.
7. Check the admin email. You will see that the product being referenced is the specific variation, rather than the parent product (which is where stock is enabled).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
