### PR TITLE
Create address autocomplete registration JS function

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3616-implement-a-way-for-autocomplete-providers-to-register-in
+++ b/plugins/woocommerce/changelog/wooplug-3616-implement-a-way-for-autocomplete-providers-to-register-in
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add suggestions component to shortcode checkout

--- a/plugins/woocommerce/changelog/wooplug-3616-implement-a-way-for-autocomplete-providers-to-register-in
+++ b/plugins/woocommerce/changelog/wooplug-3616-implement-a-way-for-autocomplete-providers-to-register-in
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add suggestions component to shortcode checkout
+Add suggestions component to shortcode checkout.

--- a/plugins/woocommerce/client/blocks/tests/js/jest.config.json
+++ b/plugins/woocommerce/client/blocks/tests/js/jest.config.json
@@ -52,6 +52,10 @@
 		"<rootDir>/vendor/",
 		"<rootDir>/tests/"
 	],
+	"roots": [
+		"<rootDir>",
+		"<rootDir>/../legacy/js"
+	],
 	"resolver": "<rootDir>/tests/js/scripts/resolver.js",
 	"transform": {
 		"^.+\\.(js|ts|tsx)$": "<rootDir>/tests/js/scripts/babel-transformer.js"

--- a/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
+++ b/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
@@ -1,0 +1,70 @@
+.woocommerce-address-suggestions {
+	position: absolute;
+	z-index: 1000;
+	width: 100%;
+	max-width: 100%;
+	margin-top: 4px;
+	background: #fff;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	box-sizing: border-box;
+	display: none;
+
+	.suggestions-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		max-height: 200px;
+		overflow-y: auto;
+
+		li {
+			padding: 8px 12px;
+			font-size: 14px;
+			cursor: pointer;
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+
+			&:last-child {
+				border-bottom: none;
+			}
+
+			&:hover,
+			&.active {
+				background-color: #0073aa;
+				color: #fff;
+			}
+
+			&:focus {
+				outline: none;
+				background-color: #0073aa;
+				color: #fff;
+			}
+		}
+	}
+}
+
+// Ensure the input container has relative positioning
+.woocommerce-input-wrapper:has(#billing_address_1, #shipping_address_1) {
+	position: relative;
+}
+
+// Search icon styles
+.address-search-icon {
+	position: absolute;
+	inset-inline-end: 16px;
+	top: 50%;
+	transform: translateY(-50%);
+	pointer-events: none;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
+	z-index: 1;
+
+	svg {
+		fill: none;
+		stroke: var(--wc-form-color-text, #444);
+		stroke-width: 1;
+	}
+}

--- a/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
+++ b/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
@@ -48,6 +48,7 @@
 // Ensure the input container has relative positioning
 .woocommerce-input-wrapper:has(#billing_address_1, #shipping_address_1) {
 	position: relative;
+	display: block;
 }
 
 // Search icon styles

--- a/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
+++ b/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
@@ -72,6 +72,8 @@
 			height: 16px;
 			line-height: 16px;
 			z-index: 1;
+
+			// Mask needed to ensure the SVG has the correct color.
 			background-color: var(--wc-form-color-text, #444);
 			mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCIgZm9jdXNhYmxlPSJmYWxzZSIgYXJpYS1oaWRkZW49InRydWUiPgogIDxjaXJjbGUgY3g9IjYiIGN5PSI2IiByPSI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSI+PC9jaXJjbGU+CiAgPHBhdGggc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgZD0ibTkuMjUgOS4yNSAyLjUgMi41Ij48L3BhdGg+Cjwvc3ZnPg==') no-repeat center;
 			mask-size: contain;

--- a/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
+++ b/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
@@ -72,12 +72,13 @@
 			height: 16px;
 			line-height: 16px;
 			z-index: 1;
+			background-color: var(--wc-form-color-text, #444);
+			mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCIgZm9jdXNhYmxlPSJmYWxzZSIgYXJpYS1oaWRkZW49InRydWUiPgogIDxjaXJjbGUgY3g9IjYiIGN5PSI2IiByPSI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSI+PC9jaXJjbGU+CiAgPHBhdGggc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgZD0ibTkuMjUgOS4yNSAyLjUgMi41Ij48L3BhdGg+Cjwvc3ZnPg==') no-repeat center;
+			mask-size: contain;
 
-			svg {
-				fill: none;
-				stroke: var(--wc-form-color-text, #444);
-				stroke-width: 1;
-			}
+			// Safari support.
+			-webkit-mask: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCIgZm9jdXNhYmxlPSJmYWxzZSIgYXJpYS1oaWRkZW49InRydWUiPgogIDxjaXJjbGUgY3g9IjYiIGN5PSI2IiByPSI0IiBmaWxsPSJub25lIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSI+PC9jaXJjbGU+CiAgPHBhdGggc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEuNSIgZD0ibTkuMjUgOS4yNSAyLjUgMi41Ij48L3BhdGg+Cjwvc3ZnPg==') no-repeat center;
+			-webkit-mask-size: contain;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
+++ b/plugins/woocommerce/client/legacy/css/address-autocomplete.scss
@@ -49,23 +49,35 @@
 .woocommerce-input-wrapper:has(#billing_address_1, #shipping_address_1) {
 	position: relative;
 	display: block;
-}
 
-// Search icon styles
-.address-search-icon {
-	position: absolute;
-	inset-inline-end: 16px;
-	top: 50%;
-	transform: translateY(-50%);
-	pointer-events: none;
-	width: 16px;
-	height: 16px;
-	line-height: 16px;
-	z-index: 1;
+	// Default to showing nothing if autocomplete is not available.
+	.address-search-icon {
+		display: none;
+	}
 
-	svg {
-		fill: none;
-		stroke: var(--wc-form-color-text, #444);
-		stroke-width: 1;
+	// Search icon styles
+	&.autocomplete-available {
+		input#billing_address_1, input#shipping_address_1 {
+			padding-right: calc(1.1rem + 16px); // Adjust padding for icon
+		}
+
+		.address-search-icon {
+			display: block;
+			position: absolute;
+			inset-inline-end: 16px;
+			top: 50%;
+			transform: translateY(-50%);
+			pointer-events: none;
+			width: 16px;
+			height: 16px;
+			line-height: 16px;
+			z-index: 1;
+
+			svg {
+				fill: none;
+				stroke: var(--wc-form-color-text, #444);
+				stroke-width: 1;
+			}
+		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -38,7 +38,11 @@ function registerAddressAutocompleteProvider( provider ) {
 
 	// Check if provider is registered on server
 	var serverProviders = [];
-	if ( window && window.wc_checkout_params && window.wc_checkout_params.address_providers ) {
+	if (
+		window &&
+		window.wc_checkout_params &&
+		window.wc_checkout_params.address_providers
+	) {
 		serverProviders = window.wc_checkout_params.address_providers;
 	}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -48,7 +48,12 @@ function registerAddressAutocompleteProvider( provider ) {
 	}
 
 	var isRegistered = serverProviders.some( function ( serverProvider ) {
-		return serverProvider.id === provider.id;
+		return (
+			serverProvider &&
+			typeof serverProvider === 'object' &&
+			typeof serverProvider.id === 'string' &&
+			serverProvider.id === provider.id
+		);
 	} );
 	if ( ! isRegistered ) {
 		console.error(

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -1,0 +1,55 @@
+/**
+ * Simple address provider registration for WooCommerce checkout
+ */
+var wooAddressProviders = {};
+
+/**
+ * Register an address autocomplete provider
+ *
+ * @param {Object} provider The provider object
+ */
+function registerAddressAutocompleteProvider( provider ) {
+	// Check required properties
+	if ( ! provider.id || typeof provider.id !== 'string' ) {
+		console.error( 'Address provider must have a valid ID' );
+		return false;
+	}
+
+	if ( typeof provider.canSearch !== 'function' ) {
+		console.error( 'Address provider must have a canSearch function' );
+		return false;
+	}
+
+	if ( typeof provider.search !== 'function' ) {
+		console.error( 'Address provider must have a search function' );
+		return false;
+	}
+
+	if ( typeof provider.select !== 'function' ) {
+		console.error( 'Address provider must have a select function' );
+		return false;
+	}
+
+	// Check if provider is registered on server
+	var serverProviders = window.wc_checkout_params.address_providers || [];
+	console.log( JSON.stringify( serverProviders ) );
+	var isRegistered = serverProviders.some( function ( serverProvider ) {
+		return serverProvider.id === provider.id;
+	} );
+	if ( ! isRegistered ) {
+		console.error(
+			'Provider ' + provider.id + ' not registered on server'
+		);
+		return false;
+	}
+
+	// Add provider to registry
+	wooAddressProviders[ provider.id ] = provider;
+	return true;
+}
+
+// Make functions available globally
+window.wc = window.wc || {};
+window.wc.addressAutocomplete = {
+	registerAddressAutocompleteProvider: registerAddressAutocompleteProvider,
+};

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -57,7 +57,8 @@ function registerAddressAutocompleteProvider( provider ) {
 		return false;
 	}
 
-	// Add provider to registry
+	// Freeze and add provider to registry.
+	Object.freeze( provider );
 	wooAddressProviders[ provider.id ] = provider;
 	return true;
 }

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -10,66 +10,66 @@ var wooAddressProviders = {};
  * @return {boolean} Whether the registration was successful
  */
 function registerAddressAutocompleteProvider( provider ) {
-	// Check required properties
-	if ( ! provider || typeof provider !== 'object' ) {
-		console.error( 'Address provider must be a valid object' );
+	try {
+		// Check required properties
+		if ( ! provider || typeof provider !== 'object' ) {
+			throw new Error( 'Address provider must be a valid object' );
+		}
+
+		if ( ! provider.id || typeof provider.id !== 'string' ) {
+			throw new Error( 'Address provider must have a valid ID' );
+		}
+
+		if ( typeof provider.canSearch !== 'function' ) {
+			throw new Error(
+				'Address provider must have a canSearch function'
+			);
+		}
+
+		if ( typeof provider.search !== 'function' ) {
+			throw new Error( 'Address provider must have a search function' );
+		}
+
+		if ( typeof provider.select !== 'function' ) {
+			throw new Error( 'Address provider must have a select function' );
+		}
+
+		// Check if provider is registered on server
+		var serverProviders = [];
+		if (
+			window &&
+			window.wc_checkout_params &&
+			window.wc_checkout_params.address_providers
+		) {
+			serverProviders = window.wc_checkout_params.address_providers;
+		}
+
+		if ( ! Array.isArray( serverProviders ) ) {
+			throw new Error( 'Server providers configuration is invalid' );
+		}
+
+		var isRegistered = serverProviders.some( function ( serverProvider ) {
+			return (
+				serverProvider &&
+				typeof serverProvider === 'object' &&
+				typeof serverProvider.id === 'string' &&
+				serverProvider.id === provider.id
+			);
+		} );
+		if ( ! isRegistered ) {
+			throw new Error(
+				'Provider ' + provider.id + ' not registered on server'
+			);
+		}
+
+		// Freeze and add provider to registry.
+		Object.freeze( provider );
+		wooAddressProviders[ provider.id ] = provider;
+		return true;
+	} catch ( error ) {
+		console.error( 'Error registering address provider:', error.message );
 		return false;
 	}
-
-	if ( ! provider.id || typeof provider.id !== 'string' ) {
-		console.error( 'Address provider must have a valid ID' );
-		return false;
-	}
-
-	if ( typeof provider.canSearch !== 'function' ) {
-		console.error( 'Address provider must have a canSearch function' );
-		return false;
-	}
-
-	if ( typeof provider.search !== 'function' ) {
-		console.error( 'Address provider must have a search function' );
-		return false;
-	}
-
-	if ( typeof provider.select !== 'function' ) {
-		console.error( 'Address provider must have a select function' );
-		return false;
-	}
-
-	// Check if provider is registered on server
-	var serverProviders = [];
-	if (
-		window &&
-		window.wc_checkout_params &&
-		window.wc_checkout_params.address_providers
-	) {
-		serverProviders = window.wc_checkout_params.address_providers;
-	}
-
-	if ( ! Array.isArray( serverProviders ) ) {
-		console.error( 'Server providers configuration is invalid' );
-		return false;
-	}
-
-	var isRegistered = serverProviders.some( function ( serverProvider ) {
-		return (
-			serverProvider &&
-			typeof serverProvider === 'object' &&
-			typeof serverProvider.id === 'string' &&
-			serverProvider.id === provider.id
-		);
-	} );
-	if ( ! isRegistered ) {
-		console.error(
-			'Provider ' + provider.id + ' not registered on server'
-		);
-		return false;
-	}
-
-	// Freeze and add provider to registry.
-	Object.freeze( provider );
-	wooAddressProviders[ provider.id ] = provider;
-	return true;
 }
 
 // Make functions available globally

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -7,9 +7,15 @@ var wooAddressProviders = {};
  * Register an address autocomplete provider
  *
  * @param {Object} provider The provider object
+ * @return {boolean} Whether the registration was successful
  */
 function registerAddressAutocompleteProvider( provider ) {
 	// Check required properties
+	if ( ! provider || typeof provider !== 'object' ) {
+		console.error( 'Address provider must be a valid object' );
+		return false;
+	}
+
 	if ( ! provider.id || typeof provider.id !== 'string' ) {
 		console.error( 'Address provider must have a valid ID' );
 		return false;
@@ -31,8 +37,16 @@ function registerAddressAutocompleteProvider( provider ) {
 	}
 
 	// Check if provider is registered on server
-	var serverProviders = window.wc_checkout_params.address_providers || [];
-	console.log( JSON.stringify( serverProviders ) );
+	var serverProviders = [];
+	if ( window && window.wc_checkout_params && window.wc_checkout_params.address_providers ) {
+		serverProviders = window.wc_checkout_params.address_providers;
+	}
+
+	if ( ! Array.isArray( serverProviders ) ) {
+		console.error( 'Server providers configuration is invalid' );
+		return false;
+	}
+
 	var isRegistered = serverProviders.some( function ( serverProvider ) {
 		return serverProvider.id === provider.id;
 	} );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -96,20 +96,20 @@ window.wc.addressAutocomplete = {
 	function setActiveProvider( country, type ) {
 		// Get server providers list (already ordered by preference).
 		const serverProviders =
-		( window &&
-			window.wc_checkout_params &&
-			window.wc_checkout_params.address_providers ) ||
-		[];
+			( window &&
+				window.wc_checkout_params &&
+				window.wc_checkout_params.address_providers ) ||
+			[];
 
-	// Check providers in preference order (server handles preferred provider ordering).
-	for ( const serverProvider of serverProviders ) {
-		const provider = addressProviders[ serverProvider.id ];
+		// Check providers in preference order (server handles preferred provider ordering).
+		for ( const serverProvider of serverProviders ) {
+			const provider = addressProviders[ serverProvider.id ];
 
-		if ( provider && provider.canSearch( country ) ) {
-			activeAddressProvider[ type ] = provider;
-			return;
+			if ( provider && provider.canSearch( country ) ) {
+				activeAddressProvider[ type ] = provider;
+				return;
+			}
 		}
-	}
 
 		// No provider can search for this country.
 		activeAddressProvider[ type ] = null;
@@ -490,7 +490,7 @@ window.wc.addressAutocomplete = {
 			} catch ( error ) {
 				console.error(
 					'Error selecting address from provider',
-					activeProviderId,
+					activeAddressProvider[ type ].id,
 					error
 				);
 				return; // Exit early if address selection fails.
@@ -505,16 +505,16 @@ window.wc.addressAutocomplete = {
 				return;
 			}
 
-			// First pass - set all available fields immediately.
+			// Set all available fields.
 			// Only set fields if the address data property exists and has a value.
-			if ( addressData.address1 ) {
-				setFieldValue( addressInput, addressData.address1 );
+			if ( addressData.address_1 ) {
+				setFieldValue( addressInput, addressData.address_1 );
+			}
+			if ( addressData.address_2 ) {
+				setFieldValue( address2Input, addressData.address_2 );
 			}
 			if ( addressData.city ) {
 				setFieldValue( cityInput, addressData.city );
-			}
-			if ( addressData.country ) {
-				setFieldValue( countryInput, addressData.country );
 			}
 			if ( addressData.postcode ) {
 				setFieldValue( postcodeInput, addressData.postcode );
@@ -522,66 +522,13 @@ window.wc.addressAutocomplete = {
 			if ( addressData.state ) {
 				setFieldValue( stateInput, addressData.state );
 			}
-
-			// Second pass after a delay to verify all fields and fix any that don't match.
-			setTimeout( () => {
-				const updatedAddressInput = document.getElementById(
-					`${ type }_address_1`
-				);
-				const updatedCityInput = document.getElementById(
-					`${ type }_city`
-				);
-				const updatedCountryInput = document.getElementById(
-					`${ type }_country`
-				);
-				const updatedPostcodeInput = document.getElementById(
-					`${ type }_postcode`
-				);
-				const updatedStateInput = document.getElementById(
-					`${ type }_state`
-				);
-
-				// Verify and fix any fields that don't match the expected values.
-				if (
-					updatedAddressInput &&
-					addressData.address1 &&
-					getFieldValue( updatedAddressInput ) !==
-						addressData.address1
-				) {
-					setFieldValue( updatedAddressInput, addressData.address1 );
-				}
-				if (
-					updatedCityInput &&
-					addressData.city &&
-					getFieldValue( updatedCityInput ) !== addressData.city
-				) {
-					setFieldValue( updatedCityInput, addressData.city );
-				}
-				if (
-					updatedCountryInput &&
-					addressData.country &&
-					getFieldValue( updatedCountryInput ) !== addressData.country
-				) {
-					setFieldValue( updatedCountryInput, addressData.country );
-				}
-				if (
-					updatedPostcodeInput &&
-					addressData.postcode &&
-					getFieldValue( updatedPostcodeInput ) !==
-						addressData.postcode
-				) {
-					setFieldValue( updatedPostcodeInput, addressData.postcode );
-				}
-				if (
-					updatedStateInput &&
-					addressData.state &&
-					getFieldValue( updatedStateInput ) !== addressData.state
-				) {
-					setFieldValue( updatedStateInput, addressData.state );
-				}
-			}, 100 );
 		}
 
+		/**
+		 * Set the active suggestion in the suggestions list, highlights it.
+		 * @param type {string} The address type ('billing' or 'shipping').
+		 * @param index {number} The index of the suggestion to set as active.
+		 */
 		function setActiveSuggestion( type, index ) {
 			const suggestionsList = suggestionsLists[ type ];
 			const addressInput = addressInputs[ type ][ 'address_1' ];

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -466,7 +466,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					`address_suggestions_${ type }_list`
 				);
 				suggestionsList.id = `address_suggestions_${ type }_list`;
-				setActiveSuggestion( type, 0 );
+				// Don't auto-highlight first suggestion for better screen reader accessibility
+				activeSuggestionIndices[ type ] = -1;
 			} catch ( error ) {
 				console.error( 'Address search error:', error );
 				hideSuggestions( type );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -123,16 +123,37 @@ window.wc.addressAutocomplete = {
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
 
-		// Initialize for both billing and shipping.
-		addressTypes.forEach( ( type ) => {
-			const addressInput = document.getElementById(
+		/**
+		 * Cache address fields for a given type, will re-run when country changes.
+		 * @param type
+		 * @return {{address_2: HTMLElement, city: HTMLElement, country: HTMLElement, postcode: HTMLElement}}
+		 */
+		function cacheAddressFields( type ) {
+			addressInputs[ type ] = {};
+			addressInputs[ type ][ 'address_1' ] = document.getElementById(
 				`${ type }_address_1`
 			);
-			const cityInput = document.getElementById( `${ type }_city` );
-			const countryInput = document.getElementById( `${ type }_country` );
-			const postcodeInput = document.getElementById(
+			addressInputs[ type ][ 'city' ] = document.getElementById(
+				`${ type }_city`
+			);
+			addressInputs[ type ][ 'country' ] = document.getElementById(
+				`${ type }_country`
+			);
+			addressInputs[ type ][ 'postcode' ] = document.getElementById(
 				`${ type }_postcode`
 			);
+			addressInputs[ type ][ 'state' ] = document.getElementById(
+				`${ type }_state`
+			);
+		}
+
+		// Initialize for both billing and shipping.
+		addressTypes.forEach( ( type ) => {
+			cacheAddressFields( type );
+			const addressInput = addressInputs[ type ][ 'address_1' ];
+			const cityInput = addressInputs[ type ][ 'city' ];
+			const countryInput = addressInputs[ type ][ 'country' ];
+			const postcodeInput = addressInputs[ type ][ 'postcode' ];
 
 			if ( addressInput ) {
 				// Create suggestions container if it doesn't exist.
@@ -198,6 +219,7 @@ window.wc.addressAutocomplete = {
 				 * Handle both regular change events and Select2 events.
 				 */
 				const handleCountryChange = function () {
+					cacheAddressFields( type );
 					setActiveProvider( countryInput.value, type );
 					if ( addressInputs[ type ][ 'address_1' ] ) {
 						hideSuggestions( type );
@@ -476,12 +498,6 @@ window.wc.addressAutocomplete = {
 		 * @return {Promise<void>}
 		 */
 		async function selectAddress( type, addressId ) {
-			const addressInput = addressInputs[ type ][ 'address_1' ];
-			const address2Input = addressInputs[ type ][ 'address_2' ];
-			const cityInput = addressInputs[ type ][ 'city' ];
-			const postcodeInput = addressInputs[ type ][ 'postcode' ];
-			const stateInput = document.getElementById( `${ type }_state` );
-
 			let addressData;
 			try {
 				addressData = await activeAddressProvider[ type ].select(
@@ -505,23 +521,50 @@ window.wc.addressAutocomplete = {
 				return;
 			}
 
-			// Set all available fields.
-			// Only set fields if the address data property exists and has a value.
-			if ( addressData.address_1 ) {
-				setFieldValue( addressInput, addressData.address_1 );
+			if ( addressData.country ) {
+				setFieldValue(
+					addressInputs[ type ][ 'country' ],
+					addressData.country
+				);
 			}
-			if ( addressData.address_2 ) {
-				setFieldValue( address2Input, addressData.address_2 );
-			}
-			if ( addressData.city ) {
-				setFieldValue( cityInput, addressData.city );
-			}
-			if ( addressData.postcode ) {
-				setFieldValue( postcodeInput, addressData.postcode );
-			}
-			if ( addressData.state ) {
-				setFieldValue( stateInput, addressData.state );
-			}
+
+			setTimeout( function () {
+				// Cache address fields again as they may have updated following the country change.
+				cacheAddressFields( type );
+
+				// Set all available fields.
+				// Only set fields if the address data property exists and has a value.
+				if ( addressData.address_1 ) {
+					setFieldValue(
+						addressInputs[ type ][ 'address_1' ],
+						addressData.address_1
+					);
+				}
+				if ( addressData.address_2 ) {
+					setFieldValue(
+						addressInputs[ type ][ 'address_2' ],
+						addressData.address_2
+					);
+				}
+				if ( addressData.city ) {
+					setFieldValue(
+						addressInputs[ type ][ 'city' ],
+						addressData.city
+					);
+				}
+				if ( addressData.postcode ) {
+					setFieldValue(
+						addressInputs[ type ][ 'postcode' ],
+						addressData.postcode
+					);
+				}
+				if ( addressData.state ) {
+					setFieldValue(
+						addressInputs[ type ][ 'state' ],
+						addressData.state
+					);
+				}
+			}, 200 );
 		}
 
 		/**

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -84,9 +84,18 @@ window.wc.addressAutocomplete = {
 	registerAddressAutocompleteProvider: registerAddressAutocompleteProvider,
 };
 
-function setActiveProvider( country, type ) {
-	// Get server providers list (already ordered by preference).
-	const serverProviders =
+( function () {
+	'use strict';
+
+	/**
+	 * Set the active address provider based on which providers' (queried in order) canSearch returns true.
+	 * Triggers when country changes.
+	 * @param country {string} country code.
+	 * @param type {string} type 'billing' or 'shipping'
+	 */
+	function setActiveProvider( country, type ) {
+		// Get server providers list (already ordered by preference).
+		const serverProviders =
 		( window &&
 			window.wc_checkout_params &&
 			window.wc_checkout_params.address_providers ) ||
@@ -102,12 +111,9 @@ function setActiveProvider( country, type ) {
 		}
 	}
 
-	// No provider can search for this country.
-	activeAddressProvider[ type ] = null;
-}
-
-( function () {
-	'use strict';
+		// No provider can search for this country.
+		activeAddressProvider[ type ] = null;
+	}
 
 	document.addEventListener( 'DOMContentLoaded', function () {
 		// This script would not be enqueued if the feature was not enabled.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -265,13 +265,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param input {HTMLInputElement} The input element to disable autofill for.
 		 */
 		function disableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
+			if ( input.getAttribute( 'autocomplete' ) === 'off' ) {
 				return;
 			}
 
-			input.setAttribute( 'autocomplete', 'none' );
-			input.setAttribute( 'data-1p-ignore', 'true' );
-			input.setAttribute( 'data-lpignore', 'true' );
+			input.setAttribute( 'autocomplete', 'off' );
+			input.setAttribute( 'data-lpignore', '' );
 
 			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element.
 			// This is achieved by removing and re-adding the element to trigger browser updates.
@@ -287,13 +286,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param input {HTMLInputElement} The input element to enable autofill for.
 		 */
 		function enableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
+			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
 				return;
 			}
 
 			input.setAttribute( 'autocomplete', 'address-line1' );
-			input.removeAttribute( 'data-1p-ignore' );
-			input.removeAttribute( 'data-lpignore' );
+			input.setAttribute( 'data-lpignore', 'false' );
 		}
 
 		/**
@@ -678,6 +676,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 							);
 							// Hide suggestions immediately for better UX.
 							hideSuggestions( type );
+							enableBrowserAutofill( addressInput );
 							await selectAddress(
 								type,
 								selectedItem.dataset.id
@@ -685,6 +684,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 						}
 					} else if ( e.key === 'Escape' ) {
 						hideSuggestions( type );
+						enableBrowserAutofill( addressInput );
 					}
 				} );
 			}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -44,7 +44,7 @@ function registerAddressAutocompleteProvider( provider ) {
 			throw new Error( 'Address provider must have a select function' );
 		}
 
-		// Check if provider is registered on server
+		// Check if provider is registered on server.
 		var serverProviders = [];
 		if (
 			window &&
@@ -75,7 +75,7 @@ function registerAddressAutocompleteProvider( provider ) {
 
 		// Freeze and add provider to registry.
 		Object.freeze( provider );
-		wooAddressProviders[ provider.id ] = provider;
+		addressProviders[ provider.id ] = provider;
 		return true;
 	} catch ( error ) {
 		console.error( 'Error registering address provider:', error.message );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -340,6 +340,8 @@ function setActiveProvider( country, type ) {
 
 				disableBrowserAutofill( addressInput );
 				suggestionsContainer.style.display = 'block';
+				suggestionsContainer.style.marginTop =
+					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
 				addressInput.setAttribute( 'aria-expanded', 'true' );
 				addressInput.setAttribute(
 					'aria-owns',

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -85,14 +85,14 @@ window.wc.addressAutocomplete = {
 };
 
 function setActiveProvider( country, type ) {
-	// Get server providers list (already ordered by preference)
+	// Get server providers list (already ordered by preference).
 	const serverProviders =
 		( window &&
 			window.wc_checkout_params &&
 			window.wc_checkout_params.address_providers ) ||
 		[];
 
-	// Check providers in preference order (server handles preferred provider ordering)
+	// Check providers in preference order (server handles preferred provider ordering).
 	for ( const serverProvider of serverProviders ) {
 		const provider = addressProviders[ serverProvider.id ];
 
@@ -102,7 +102,7 @@ function setActiveProvider( country, type ) {
 		}
 	}
 
-	// No provider can search for this country
+	// No provider can search for this country.
 	activeAddressProvider[ type ] = null;
 }
 
@@ -116,7 +116,7 @@ function setActiveProvider( country, type ) {
 		const suggestionsContainers = {};
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
-		let searchControllers = {}; // Track AbortControllers for search requests
+		let searchControllers = {}; // Track AbortControllers for search requests.
 
 		// Initialize for both billing and shipping.
 		addressTypes.forEach( ( type ) => {
@@ -130,7 +130,7 @@ function setActiveProvider( country, type ) {
 			);
 
 			if ( addressInput ) {
-				// Create suggestions container if it doesn't exist
+				// Create suggestions container if it doesn't exist.
 				if (
 					! document.getElementById( `address_suggestions_${ type }` )
 				) {
@@ -189,11 +189,11 @@ function setActiveProvider( country, type ) {
 			if ( countryInput ) {
 				setActiveProvider( countryInput.value, type );
 
-				// Listen for country changes to re-evaluate provider availability
-				// Handle both regular change events and Select2 events
+				// Listen for country changes to re-evaluate provider availability.
+				// Handle both regular change events and Select2 events.
 				const handleCountryChange = function () {
 					setActiveProvider( countryInput.value, type );
-					// Cancel any inflight search and hide suggestions when country changes
+					// Cancel any inflight search and hide suggestions when country changes.
 					if ( searchControllers[ type ] ) {
 						searchControllers[ type ].abort();
 						searchControllers[ type ] = null;
@@ -205,7 +205,7 @@ function setActiveProvider( country, type ) {
 
 				countryInput.addEventListener( 'change', handleCountryChange );
 
-				// Also listen for Select2 change event if jQuery and Select2 are available
+				// Also listen for Select2 change event if jQuery and Select2 are available.
 				if ( window.jQuery && window.jQuery( countryInput ).select2 ) {
 					window
 						.jQuery( countryInput )
@@ -223,8 +223,8 @@ function setActiveProvider( country, type ) {
 			input.setAttribute( 'data-1p-ignore', 'true' );
 			input.setAttribute( 'data-lpignore', 'true' );
 
-			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element
-			// This is achieved by removing and re-adding the element to trigger browser updates
+			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element.
+			// This is achieved by removing and re-adding the element to trigger browser updates.
 			const parentElement = input.parentElement;
 			if ( parentElement ) {
 				parentElement.appendChild( parentElement.removeChild( input ) );
@@ -243,6 +243,7 @@ function setActiveProvider( country, type ) {
 		}
 
 		function getHighlightedLabel( label, matches ) {
+			// Security: Sanitize label for display.
 			const parts = [];
 			let lastIndex = 0;
 
@@ -256,7 +257,7 @@ function setActiveProvider( country, type ) {
 					);
 				}
 
-				// Add bold matched text
+				// Add bold matched text.
 				const bold = document.createElement( 'strong' );
 				bold.textContent = label.slice(
 					match.offset,
@@ -288,19 +289,19 @@ function setActiveProvider( country, type ) {
 				return;
 			}
 
-			// Check if we have an active provider for this address type
+			// Check if we have an active provider for this address type.
 			if ( ! activeAddressProvider[ type ] ) {
 				hideSuggestions( type );
 				enableBrowserAutofill( addressInput );
 				return;
 			}
 
-			// Cancel any existing search request for this type
+			// Cancel any existing search request for this type.
 			if ( searchControllers[ type ] ) {
 				searchControllers[ type ].abort();
 			}
 
-			// Create new AbortController for this search
+			// Create new AbortController for this search.
 			searchControllers[ type ] = new AbortController();
 			const controller = searchControllers[ type ];
 
@@ -309,7 +310,7 @@ function setActiveProvider( country, type ) {
 					type
 				].search( type, inputValue );
 
-				// Check if this request was aborted
+				// Check if this request was aborted.
 				if ( controller.signal.aborted ) {
 					return;
 				}
@@ -319,7 +320,7 @@ function setActiveProvider( country, type ) {
 					return;
 				}
 
-				// Clear existing suggestions only when we have new results to show
+				// Clear existing suggestions only when we have new results to show.
 				suggestionsList.innerHTML = '';
 
 				filteredSuggestions.forEach( ( suggestion, index ) => {
@@ -329,7 +330,7 @@ function setActiveProvider( country, type ) {
 					li.dataset.id = suggestion.id;
 					li.setAttribute( 'tabindex', '-1' );
 
-					li.textContent = ''; // Clear existing content
+					li.textContent = ''; // Clear existing content.
 					const labelParts = getHighlightedLabel(
 						suggestion.label,
 						suggestion.matchedSubstrings || []
@@ -337,7 +338,7 @@ function setActiveProvider( country, type ) {
 					labelParts.forEach( ( part ) => li.appendChild( part ) );
 
 					li.addEventListener( 'click', async function () {
-						// Hide suggestions immediately for better UX
+						// Hide suggestions immediately for better UX.
 						hideSuggestions( type );
 						await selectAddress( type, this.dataset.id );
 						addressInput.focus();
@@ -362,17 +363,17 @@ function setActiveProvider( country, type ) {
 				suggestionsList.id = `address_suggestions_${ type }_list`;
 				setActiveSuggestion( type, 0 );
 			} catch ( error ) {
-				// Handle search errors (including AbortError from cancelled requests)
+				// Handle search errors (including AbortError from cancelled requests).
 				if ( error.name === 'AbortError' ) {
-					// Request was aborted - keep existing suggestions visible
-					// Silently ignore AbortError as it's expected when cancelling requests
+					// Request was aborted - keep existing suggestions visible.
+					// Silently ignore AbortError as it's expected when cancelling requests.
 				} else {
 					console.error( 'Address search error:', error );
 					hideSuggestions( type );
 					enableBrowserAutofill( addressInput );
 				}
 			} finally {
-				// Clear the controller reference if this was the active request
+				// Clear the controller reference if this was the active request.
 				if ( searchControllers[ type ] === controller ) {
 					searchControllers[ type ] = null;
 				}
@@ -384,7 +385,7 @@ function setActiveProvider( country, type ) {
 			const suggestionsContainer = suggestionsContainers[ type ];
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 
-			// Cancel any inflight search requests
+			// Cancel any inflight search requests.
 			if ( searchControllers[ type ] ) {
 				searchControllers[ type ].abort();
 				searchControllers[ type ] = null;
@@ -398,13 +399,13 @@ function setActiveProvider( country, type ) {
 			activeSuggestionIndices[ type ] = -1;
 		}
 
-		// Helper function to get field value, accounting for Select2
+		// Helper function to get field value, accounting for Select2.
 		const getFieldValue = ( input ) => {
 			if ( ! input ) {
 				return '';
 			}
 
-			// For Select2 fields, get the value using jQuery if available
+			// For Select2 fields, get the value using jQuery if available.
 			if (
 				window.jQuery &&
 				window.jQuery( input ).hasClass( 'select2-hidden-accessible' )
@@ -412,11 +413,11 @@ function setActiveProvider( country, type ) {
 				return window.jQuery( input ).val() || '';
 			}
 
-			// For regular inputs, use the standard value property
+			// For regular inputs, use the standard value property.
 			return input.value || '';
 		};
 
-		// Helper function to set field value and trigger events
+		// Helper function to set field value and trigger events.
 		const setFieldValue = ( input, value ) => {
 			if (
 				input &&
@@ -427,7 +428,7 @@ function setActiveProvider( country, type ) {
 				input.value = value;
 				input.dispatchEvent( new Event( 'change' ) );
 
-				// Also trigger Select2 update if it's a Select2 field
+				// Also trigger Select2 update if it's a Select2 field.
 				if (
 					window.jQuery &&
 					window
@@ -464,7 +465,7 @@ function setActiveProvider( country, type ) {
 					activeProviderId,
 					error
 				);
-				return; // Exit early if address selection fails
+				return; // Exit early if address selection fails.
 			}
 
 			// Validate that we received valid address data
@@ -476,8 +477,8 @@ function setActiveProvider( country, type ) {
 				return;
 			}
 
-			// First pass - set all available fields immediately
-			// Only set fields if the address data property exists and has a value
+			// First pass - set all available fields immediately.
+			// Only set fields if the address data property exists and has a value.
 			if ( addressData.address1 ) {
 				setFieldValue( addressInput, addressData.address1 );
 			}
@@ -494,7 +495,7 @@ function setActiveProvider( country, type ) {
 				setFieldValue( stateInput, addressData.state );
 			}
 
-			// Second pass after a delay to verify all fields and fix any that don't match
+			// Second pass after a delay to verify all fields and fix any that don't match.
 			setTimeout( () => {
 				const updatedAddressInput = document.getElementById(
 					`${ type }_address_1`
@@ -512,7 +513,7 @@ function setActiveProvider( country, type ) {
 					`${ type }_state`
 				);
 
-				// Verify and fix any fields that don't match the expected values
+				// Verify and fix any fields that don't match the expected values.
 				if (
 					updatedAddressInput &&
 					addressData.address1 &&
@@ -578,7 +579,7 @@ function setActiveProvider( country, type ) {
 			}
 		}
 
-		// Initialize event handlers for each address type
+		// Initialize event handlers for each address type.
 		addressTypes.forEach( ( type ) => {
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			if ( addressInput ) {
@@ -627,7 +628,7 @@ function setActiveProvider( country, type ) {
 							].querySelector(
 								`li#suggestion-item-${ type }-${ activeSuggestionIndices[ type ] }`
 							);
-							// Hide suggestions immediately for better UX
+							// Hide suggestions immediately for better UX.
 							hideSuggestions( type );
 							await selectAddress(
 								type,
@@ -641,7 +642,7 @@ function setActiveProvider( country, type ) {
 			}
 		} );
 
-		// Hide suggestions when clicking outside
+		// Hide suggestions when clicking outside.
 		document.addEventListener( 'click', function ( event ) {
 			addressTypes.forEach( ( type ) => {
 				const target = event.target;

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -629,10 +629,16 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		addressTypes.forEach( ( type ) => {
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			if ( addressInput ) {
+				let inputTimeout;
+
 				addressInput.addEventListener( 'input', function () {
-					if ( document.activeElement === this ) {
-						displaySuggestions( type, this.value );
-					}
+					clearTimeout( inputTimeout );
+					const inputElement = this;
+					inputTimeout = setTimeout( () => {
+						if ( document.activeElement === inputElement ) {
+							displaySuggestions( type, inputElement.value );
+						}
+					}, 100 );
 				} );
 
 				addressInput.addEventListener( 'keydown', async function ( e ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -205,8 +205,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					container.id = `address_suggestions_${ type }`;
 					container.className = 'woocommerce-address-suggestions';
 					container.style.display = 'none';
-					container.setAttribute( 'role', 'region' );
-					container.setAttribute( 'aria-live', 'polite' );
 
 					const list = document.createElement( 'ul' );
 					list.className = 'suggestions-list';
@@ -815,7 +813,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 						// Hide suggestions immediately for better UX.
 						hideSuggestions( type );
 						await selectAddress( type, this.dataset.id );
-						addressInput.focus();
+						// Focus is handled in selectAddress after all fields are updated
 					} );
 
 					li.addEventListener( 'mouseenter', function () {
@@ -831,15 +829,56 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					addressInputs[ type ][ 'address_1' ] = updatedInput;
 				}
 
+				// Update the listbox aria-label with item count
+				const itemCount = safeSuggestions.length;
+				const itemText = itemCount === 1 ? 'item' : 'items';
+				
+				suggestionsList.setAttribute( 
+					'aria-label', 
+					`${itemCount} ${itemText} found` 
+				);
+
 				suggestionsContainer.style.display = 'block';
 				suggestionsContainer.style.marginTop =
 					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
+				
+				// Set up ARIA attributes for combobox pattern
+				updatedInput.setAttribute( 'role', 'combobox' );
 				updatedInput.setAttribute( 'aria-expanded', 'true' );
+				updatedInput.setAttribute( 'aria-autocomplete', 'list' );
+				updatedInput.setAttribute( 'aria-haspopup', 'listbox' );
 				updatedInput.setAttribute(
-					'aria-owns',
+					'aria-controls',
 					`address_suggestions_${ type }_list`
 				);
+				
 				suggestionsList.id = `address_suggestions_${ type }_list`;
+				
+				// Create or update status region for announcements
+				let statusRegion = document.getElementById( `${type}-autocomplete-status` );
+				if ( ! statusRegion ) {
+					statusRegion = document.createElement( 'div' );
+					statusRegion.id = `${type}-autocomplete-status`;
+					statusRegion.className = 'screen-reader-text';
+					statusRegion.setAttribute( 'role', 'status' );
+					statusRegion.setAttribute( 'aria-live', 'assertive' );
+					statusRegion.setAttribute( 'aria-atomic', 'true' );
+					updatedInput.parentNode.insertBefore( statusRegion, updatedInput.nextSibling );
+				}
+				
+				// Update aria-describedby to include the status region
+				const existingDescribedBy = updatedInput.getAttribute( 'aria-describedby' ) || '';
+				const statusId = `${type}-autocomplete-status`;
+				if ( ! existingDescribedBy.includes( statusId ) ) {
+					const newDescribedBy = existingDescribedBy ? `${existingDescribedBy} ${statusId}` : statusId;
+					updatedInput.setAttribute( 'aria-describedby', newDescribedBy );
+				}
+				
+				// Clear and announce with proper timing
+				statusRegion.textContent = '';
+				setTimeout( () => {
+					statusRegion.textContent = `${itemCount} ${itemText} available. Use up and down arrows to navigate.`;
+				}, 100 );
 				// Don't auto-highlight first suggestion for better screen reader accessibility
 				activeSuggestionIndices[ type ] = -1;
 
@@ -895,7 +934,32 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			suggestionsContainer.style.display = 'none';
 			addressInput.setAttribute( 'aria-expanded', 'false' );
 			addressInput.removeAttribute( 'aria-activedescendant' );
-			addressInput.removeAttribute( 'aria-owns' );
+			addressInput.removeAttribute( 'aria-controls' );
+			addressInput.removeAttribute( 'role' );
+			addressInput.removeAttribute( 'aria-autocomplete' );
+			addressInput.removeAttribute( 'aria-haspopup' );
+			
+			// Remove status region from aria-describedby
+			const describedBy = addressInput.getAttribute( 'aria-describedby' );
+			const statusId = `${type}-autocomplete-status`;
+			if ( describedBy && describedBy.includes( statusId ) ) {
+				const newDescribedBy = describedBy
+					.split( ' ' )
+					.filter( id => id !== statusId )
+					.join( ' ' );
+				if ( newDescribedBy ) {
+					addressInput.setAttribute( 'aria-describedby', newDescribedBy );
+				} else {
+					addressInput.removeAttribute( 'aria-describedby' );
+				}
+			}
+			
+			// Clear the status region
+			const statusRegion = document.getElementById( statusId );
+			if ( statusRegion ) {
+				statusRegion.textContent = '';
+			}
+			
 			activeSuggestionIndices[ type ] = -1;
 
 			// Remove blur event listener when suggestions are hidden
@@ -1008,6 +1072,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 						addressInputs[ type ][ 'state' ],
 						addressData.state
 					);
+				}
+
+				// Ensure focus returns to address_1 field after all updates
+				// This is important for screen reader users, especially VoiceOver
+				if ( addressInputs[ type ][ 'address_1' ] ) {
+					addressInputs[ type ][ 'address_1' ].focus();
 				}
 			}, 200 );
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -418,7 +418,12 @@ function setActiveProvider( country, type ) {
 
 		// Helper function to set field value and trigger events
 		const setFieldValue = ( input, value ) => {
-			if ( input && value ) {
+			if (
+				input &&
+				value !== null &&
+				value !== undefined &&
+				value !== ''
+			) {
 				input.value = value;
 				input.dispatchEvent( new Event( 'change' ) );
 
@@ -440,55 +445,110 @@ function setActiveProvider( country, type ) {
 			const countryInput = addressInputs[ type ][ 'country' ];
 			const postcodeInput = addressInputs[ type ][ 'postcode' ];
 			const stateInput = document.getElementById( `${ type }_state` );
-			const addressData = await activeAddressProvider[ type ].select(
-				addressId
-			);
+
+			const activeProviderId =
+				activeAddressProvider &&
+				activeAddressProvider[ type ] &&
+				activeAddressProvider[ type ].id
+					? activeAddressProvider[ type ].id
+					: '';
+
+			let addressData;
+			try {
+				addressData = await activeAddressProvider[ type ].select(
+					addressId
+				);
+			} catch ( error ) {
+				console.error(
+					'Error selecting address from provider',
+					activeProviderId,
+					error
+				);
+				return; // Exit early if address selection fails
+			}
+
+			// Validate that we received valid address data
+			if ( ! addressData || typeof addressData !== 'object' ) {
+				console.error(
+					'Invalid address data received from provider',
+					activeProviderId
+				);
+				return;
+			}
 
 			// First pass - set all available fields immediately
-			if ( addressData ) {
+			// Only set fields if the address data property exists and has a value
+			if ( addressData.address1 ) {
 				setFieldValue( addressInput, addressData.address1 );
+			}
+			if ( addressData.city ) {
 				setFieldValue( cityInput, addressData.city );
+			}
+			if ( addressData.country ) {
 				setFieldValue( countryInput, addressData.country );
+			}
+			if ( addressData.postcode ) {
 				setFieldValue( postcodeInput, addressData.postcode );
+			}
+			if ( addressData.state ) {
 				setFieldValue( stateInput, addressData.state );
 			}
 
 			// Second pass after a delay to verify all fields and fix any that don't match
 			setTimeout( () => {
-				if ( addressData ) {
-					const updatedCityInput = document.getElementById(
-						`${ type }_city`
-					);
-					const updatedPostcodeInput = document.getElementById(
-						`${ type }_postcode`
-					);
-					const updatedStateInput = document.getElementById(
-						`${ type }_state`
-					);
+				const updatedAddressInput = document.getElementById(
+					`${ type }_address_1`
+				);
+				const updatedCityInput = document.getElementById(
+					`${ type }_city`
+				);
+				const updatedCountryInput = document.getElementById(
+					`${ type }_country`
+				);
+				const updatedPostcodeInput = document.getElementById(
+					`${ type }_postcode`
+				);
+				const updatedStateInput = document.getElementById(
+					`${ type }_state`
+				);
 
-					// Verify and fix any fields that don't match the expected values
-					if (
-						updatedCityInput &&
-						getFieldValue( updatedCityInput ) !== addressData.city
-					) {
-						setFieldValue( updatedCityInput, addressData.city );
-					}
-					if (
-						updatedPostcodeInput &&
-						getFieldValue( updatedPostcodeInput ) !==
-							addressData.postcode
-					) {
-						setFieldValue(
-							updatedPostcodeInput,
-							addressData.postcode
-						);
-					}
-					if (
-						updatedStateInput &&
-						getFieldValue( updatedStateInput ) !== addressData.state
-					) {
-						setFieldValue( updatedStateInput, addressData.state );
-					}
+				// Verify and fix any fields that don't match the expected values
+				if (
+					updatedAddressInput &&
+					addressData.address1 &&
+					getFieldValue( updatedAddressInput ) !==
+						addressData.address1
+				) {
+					setFieldValue( updatedAddressInput, addressData.address1 );
+				}
+				if (
+					updatedCityInput &&
+					addressData.city &&
+					getFieldValue( updatedCityInput ) !== addressData.city
+				) {
+					setFieldValue( updatedCityInput, addressData.city );
+				}
+				if (
+					updatedCountryInput &&
+					addressData.country &&
+					getFieldValue( updatedCountryInput ) !== addressData.country
+				) {
+					setFieldValue( updatedCountryInput, addressData.country );
+				}
+				if (
+					updatedPostcodeInput &&
+					addressData.postcode &&
+					getFieldValue( updatedPostcodeInput ) !==
+						addressData.postcode
+				) {
+					setFieldValue( updatedPostcodeInput, addressData.postcode );
+				}
+				if (
+					updatedStateInput &&
+					addressData.state &&
+					getFieldValue( updatedStateInput ) !== addressData.state
+				) {
+					setFieldValue( updatedStateInput, addressData.state );
 				}
 			}, 100 );
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -447,32 +447,13 @@ window.wc.addressAutocomplete = {
 			activeSuggestionIndices[ type ] = -1;
 		}
 
-		// Helper function to get field value, accounting for Select2.
-		const getFieldValue = ( input ) => {
-			if ( ! input ) {
-				return '';
-			}
-
-			// For Select2 fields, get the value using jQuery if available.
-			if (
-				window.jQuery &&
-				window.jQuery( input ).hasClass( 'select2-hidden-accessible' )
-			) {
-				return window.jQuery( input ).val() || '';
-			}
-
-			// For regular inputs, use the standard value property.
-			return input.value || '';
-		};
-
-		// Helper function to set field value and trigger events.
+		/**
+		 * Helper function to set field value and trigger events.
+		 * @param input {HTMLInputElement} The input element to set the value for.
+		 * @param value {string} The value to set.
+		 */
 		const setFieldValue = ( input, value ) => {
-			if (
-				input &&
-				value !== null &&
-				value !== undefined &&
-				value !== ''
-			) {
+			if ( input ) {
 				input.value = value;
 				input.dispatchEvent( new Event( 'change' ) );
 
@@ -520,10 +501,7 @@ window.wc.addressAutocomplete = {
 				addressData === null ||
 				! addressData
 			) {
-				console.error(
-					'Invalid address data returned by provider',
-					activeProviderId
-				);
+				// Return without setting the address since response was invalid.
 				return;
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -78,3 +78,372 @@ window.wc = window.wc || {};
 window.wc.addressAutocomplete = {
 	registerAddressAutocompleteProvider: registerAddressAutocompleteProvider,
 };
+
+function setActiveProvider( country, type ) {
+	// Check preferred provider's canSearch first
+	const preferredProvider = addressProviders[ preferredAddressProviderId ];
+	if ( preferredProvider && preferredProvider.canSearch( country ) ) {
+		activeAddressProvider[ type ] = preferredProvider;
+		return;
+	}
+
+	// If preferred provider can't search, find first available provider that can search
+	for ( const provider of Object.values( addressProviders ) ) {
+		if ( provider.canSearch( country ) ) {
+			activeAddressProvider[ type ] = provider;
+			return;
+		}
+	}
+}
+
+( function () {
+	'use strict';
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		// This script would not be enqueued if the feature was not enabled.
+		const addressTypes = [ 'billing', 'shipping' ];
+		const addressInputs = {};
+		const suggestionsContainers = {};
+		const suggestionsLists = {};
+		let activeSuggestionIndices = {};
+
+		// Initialize for both billing and shipping.
+		addressTypes.forEach( ( type ) => {
+			const addressInput = document.getElementById(
+				`${ type }_address_1`
+			);
+
+			if ( addressInput ) {
+				// Create suggestions container if it doesn't exist
+				if (
+					! document.getElementById( `address_suggestions_${ type }` )
+				) {
+					const container = document.createElement( 'div' );
+					container.id = `address_suggestions_${ type }`;
+					container.className = 'woocommerce-address-suggestions';
+					container.style.display = 'none';
+					container.setAttribute( 'role', 'region' );
+					container.setAttribute( 'aria-live', 'polite' );
+
+					const list = document.createElement( 'ul' );
+					list.className = 'suggestions-list';
+					list.setAttribute( 'role', 'listbox' );
+					list.setAttribute( 'aria-label', 'Address suggestions' );
+
+					container.appendChild( list );
+					addressInput.parentNode.insertBefore(
+						container,
+						addressInput.nextSibling
+					);
+
+					// Add search icon.
+					const searchIcon = document.createElement( 'div' );
+					searchIcon.className = 'address-search-icon';
+					searchIcon.innerHTML =
+						'<svg xmlns="http://www.w3.org/2000/svg" ' +
+						'viewBox="0 0 14 14" ' +
+						'focusable="false" ' +
+						'aria-hidden="true">' +
+						'<circle cx="6" cy="6" r="4"></circle>' +
+						'<path stroke-linecap="round" ' +
+						'stroke-linejoin="round" ' +
+						'd="m9.25 9.25 2.5 2.5"></path>' +
+						'</svg>';
+					addressInput.parentNode.appendChild( searchIcon );
+				}
+
+				addressInputs[ type ] = addressInput;
+				suggestionsContainers[ type ] = document.getElementById(
+					`address_suggestions_${ type }`
+				);
+				suggestionsLists[ type ] =
+					suggestionsContainers[ type ].querySelector(
+						'.suggestions-list'
+					);
+				activeSuggestionIndices[ type ] = -1;
+			}
+
+			// Get country value and set active address provider based on it.
+			const countryInput = document.getElementById( `${ type }_country` );
+			if ( countryInput ) {
+				setActiveProvider( countryInput.value, type );
+			}
+		} );
+
+		console.log( { activeAddressProvider } );
+
+		const mockAddressData = {
+			'01971ca5-35d2-7514-adaf-d4ab97c02c19': {
+				address1: '10 Downing Street',
+				city: 'London',
+				postcode: 'SW1A 2AA',
+				country: 'GB',
+			},
+			'01971ca5-35d2-7514-adaf-da427f3b640f': {
+				address1: '1600 Amphitheatre Parkway',
+				city: 'Mountain View',
+				postcode: '94043',
+				country: 'US',
+			},
+			'01971ca5-35d2-7514-adaf-dfa0a03f1e49': {
+				address1: 'Eiffel Tower',
+				city: 'Paris',
+				postcode: '75007',
+				country: 'FR',
+			},
+			'01971ca5-35d2-7514-adaf-e3bd0086bea9': {
+				address1: '1 Hacker Way',
+				city: 'Menlo Park',
+				postcode: '94025',
+				country: 'US',
+			},
+			'01971ca5-35d2-7514-adaf-e3bd0086bea6': {
+				address1: 'Very long address in the middle of the screen',
+				city: 'Menlo Park',
+				postcode: '98000',
+				country: 'US',
+			},
+		};
+
+		function disableBrowserAutofill( input ) {
+			if ( input.getAttribute( 'autocomplete' ) === 'off' ) {
+				return;
+			}
+
+			input.setAttribute( 'autocomplete', 'off' );
+			input.setAttribute( 'data-1p-ignore', '' );
+			input.setAttribute( 'data-lpignore', '' );
+
+			// We need to refocus the element so that the browser can reset the autocomplete attribute.
+			const parentElement = input.parentElement;
+			if ( parentElement ) {
+				parentElement.insertBefore( input, parentElement.firstChild );
+				input.focus();
+			}
+		}
+
+		function enableBrowserAutofill( input ) {
+			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
+				return;
+			}
+
+			input.setAttribute( 'autocomplete', 'address-line1' );
+			input.removeAttribute( 'data-1p-ignore' );
+			input.removeAttribute( 'data-lpignore' );
+		}
+
+		function getHighlightedLabel( label, matches ) {
+			const parts = [];
+			let lastIndex = 0;
+
+			matches.forEach( ( match ) => {
+				// Add text before match
+				if ( match.offset > lastIndex ) {
+					parts.push(
+						document.createTextNode(
+							label.slice( lastIndex, match.offset )
+						)
+					);
+				}
+
+				// Add bold matched text
+				const bold = document.createElement( 'strong' );
+				bold.textContent = label.slice(
+					match.offset,
+					match.offset + match.length
+				);
+				parts.push( bold );
+
+				lastIndex = match.offset + match.length;
+			} );
+
+			// Add remaining text
+			if ( lastIndex < label.length ) {
+				parts.push(
+					document.createTextNode( label.slice( lastIndex ) )
+				);
+			}
+
+			return parts;
+		}
+
+		async function displaySuggestions( type, inputValue ) {
+			const addressInput = addressInputs[ type ];
+			const suggestionsList = suggestionsLists[ type ];
+			const suggestionsContainer = suggestionsContainers[ type ];
+
+			if ( inputValue.length < 3 ) {
+				hideSuggestions( type );
+				enableBrowserAutofill( addressInput );
+				return;
+			}
+
+			suggestionsList.innerHTML = '';
+			console.log( { wooAddressProviders: addressProviders } );
+			const filteredSuggestions = await activeAddressProvider[
+				type
+			].search( type, inputValue );
+			console.log( { filteredSuggestions } );
+
+			if ( filteredSuggestions.length === 0 ) {
+				hideSuggestions( type );
+				return;
+			}
+
+			filteredSuggestions.forEach( ( suggestion, index ) => {
+				const li = document.createElement( 'li' );
+				li.setAttribute( 'role', 'option' );
+				li.id = `suggestion-item-${ type }-${ index }`;
+				li.dataset.id = suggestion.id;
+				li.setAttribute( 'tabindex', '-1' );
+
+				li.textContent = ''; // Clear existing content
+				const labelParts = getHighlightedLabel(
+					suggestion.label,
+					suggestion.matchedSubstrings || []
+				);
+				labelParts.forEach( ( part ) => li.appendChild( part ) );
+
+				li.addEventListener( 'click', function () {
+					selectAddress( type, this.dataset.id );
+					hideSuggestions( type );
+					addressInput.focus();
+				} );
+
+				li.addEventListener( 'mouseenter', function () {
+					setActiveSuggestion( type, index );
+				} );
+
+				suggestionsList.appendChild( li );
+			} );
+
+			disableBrowserAutofill( addressInput );
+			suggestionsContainer.style.display = 'block';
+			addressInput.setAttribute( 'aria-expanded', 'true' );
+			addressInput.setAttribute(
+				'aria-owns',
+				`address_suggestions_${ type }_list`
+			);
+			suggestionsList.id = `address_suggestions_${ type }_list`;
+			setActiveSuggestion( type, 0 );
+		}
+
+		function hideSuggestions( type ) {
+			const suggestionsList = suggestionsLists[ type ];
+			const suggestionsContainer = suggestionsContainers[ type ];
+			const addressInput = addressInputs[ type ];
+
+			suggestionsList.innerHTML = '';
+			suggestionsContainer.style.display = 'none';
+			addressInput.setAttribute( 'aria-expanded', 'false' );
+			addressInput.removeAttribute( 'aria-activedescendant' );
+			addressInput.removeAttribute( 'aria-owns' );
+			activeSuggestionIndices[ type ] = -1;
+		}
+
+		function selectAddress( type, addressId ) {
+			const addressInput = addressInputs[ type ];
+			const addressData = mockAddressData[ addressId ];
+			addressInput.value = addressData.address1;
+			addressInput.dispatchEvent( new Event( 'change' ) );
+			hideSuggestions( type );
+		}
+
+		function setActiveSuggestion( type, index ) {
+			const suggestionsList = suggestionsLists[ type ];
+			const addressInput = addressInputs[ type ];
+
+			const activeLi = suggestionsList.querySelector( 'li.active' );
+			if ( activeLi ) {
+				activeLi.classList.remove( 'active' );
+				activeLi.setAttribute( 'aria-selected', 'false' );
+			}
+
+			const newActiveLi = suggestionsList.querySelector(
+				`li#suggestion-item-${ type }-${ index }`
+			);
+
+			if ( newActiveLi ) {
+				newActiveLi.classList.add( 'active' );
+				newActiveLi.setAttribute( 'aria-selected', 'true' );
+				addressInput.setAttribute(
+					'aria-activedescendant',
+					newActiveLi.id
+				);
+				activeSuggestionIndices[ type ] = index;
+			}
+		}
+
+		// Initialize event handlers for each address type
+		addressTypes.forEach( ( type ) => {
+			const addressInput = addressInputs[ type ];
+			if ( addressInput ) {
+				let inputTimeout;
+
+				addressInput.addEventListener( 'input', function () {
+					clearTimeout( inputTimeout );
+					inputTimeout = window.setTimeout( async () => {
+						if ( document.activeElement === this ) {
+							await displaySuggestions( type, this.value );
+						}
+					}, 100 );
+				} );
+
+				addressInput.addEventListener( 'keydown', function ( e ) {
+					const items =
+						suggestionsLists[ type ].querySelectorAll( 'li' );
+					if (
+						items.length === 0 ||
+						suggestionsContainers[ type ].style.display === 'none'
+					) {
+						return;
+					}
+
+					let newIndex = activeSuggestionIndices[ type ];
+
+					if ( e.key === 'ArrowDown' ) {
+						e.preventDefault();
+						newIndex =
+							( activeSuggestionIndices[ type ] + 1 ) %
+							items.length;
+						setActiveSuggestion( type, newIndex );
+					} else if ( e.key === 'ArrowUp' ) {
+						e.preventDefault();
+						newIndex =
+							( activeSuggestionIndices[ type ] -
+								1 +
+								items.length ) %
+							items.length;
+						setActiveSuggestion( type, newIndex );
+					} else if ( e.key === 'Enter' ) {
+						if ( activeSuggestionIndices[ type ] > -1 ) {
+							e.preventDefault();
+							const selectedItem = suggestionsLists[
+								type
+							].querySelector(
+								`li#suggestion-item-${ type }-${ activeSuggestionIndices[ type ] }`
+							);
+							selectAddress( type, selectedItem.dataset.id );
+						}
+					} else if ( e.key === 'Escape' ) {
+						hideSuggestions( type );
+					}
+				} );
+			}
+		} );
+
+		// Hide suggestions when clicking outside
+		document.addEventListener( 'click', function ( event ) {
+			addressTypes.forEach( ( type ) => {
+				const target = event.target;
+				if (
+					target !== suggestionsContainers[ type ] &&
+					! suggestionsContainers[ type ].contains( target ) &&
+					target !== addressInputs[ type ]
+				) {
+					hideSuggestions( type );
+				}
+			} );
+		} );
+	} );
+} )();

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -94,6 +94,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 	registerAddressAutocompleteProvider;
 
 ( function () {
+	// Browser detection constants
+	const userAgent = navigator.userAgent.toLowerCase();
+	const isFirefox = userAgent.indexOf( 'firefox' ) > -1;
+	const isSafari =
+		userAgent.indexOf( 'safari' ) > -1 &&
+		userAgent.indexOf( 'chrome' ) === -1 &&
+		userAgent.indexOf( 'chromium' ) === -1;
+	const needsElementCloning = isFirefox || isSafari;
+
 	/**
 	 * Set the active address provider based on which providers' (queried in order) canSearch returns true.
 	 * Triggers when country changes.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -55,7 +55,7 @@ function registerAddressAutocompleteProvider( provider ) {
 			throw new Error( 'Server providers configuration is invalid' );
 		}
 
-		var isRegistered = serverProviders.some( function ( serverProvider ) {
+		let isRegistered = serverProviders.some( function ( serverProvider ) {
 			return (
 				serverProvider &&
 				typeof serverProvider === 'object' &&

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -1,12 +1,13 @@
 /**
- * Simple address provider registration for WooCommerce checkout
+ * Address provider registration for WooCommerce shortcode checkout
  */
-var addressProviders = {};
 
-/**
- * Currently selected address provider. It will be used to search for addresses.
- */
-var activeAddressProvider = { billing: null, shipping: null };
+// Make functions and state available globally under window.wc.addressAutocomplete
+window.wc = window.wc || {};
+window.wc.addressAutocomplete = window.wc.addressAutocomplete || {
+	providers: {},
+	activeProvider: { billing: null, shipping: null },
+};
 
 /**
  * Register an address autocomplete provider
@@ -70,7 +71,7 @@ function registerAddressAutocompleteProvider( provider ) {
 
 		// Freeze and add provider to registry.
 		Object.freeze( provider );
-		addressProviders[ provider.id ] = provider;
+		window.wc.addressAutocomplete.providers[ provider.id ] = provider;
 		return true;
 	} catch ( error ) {
 		console.error( 'Error registering address provider:', error.message );
@@ -78,11 +79,9 @@ function registerAddressAutocompleteProvider( provider ) {
 	}
 }
 
-// Make functions available globally
-window.wc = window.wc || {};
-window.wc.addressAutocomplete = {
-	registerAddressAutocompleteProvider: registerAddressAutocompleteProvider,
-};
+// Export the registration function
+window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
+	registerAddressAutocompleteProvider;
 
 ( function () {
 	'use strict';
@@ -103,16 +102,17 @@ window.wc.addressAutocomplete = {
 
 		// Check providers in preference order (server handles preferred provider ordering).
 		for ( const serverProvider of serverProviders ) {
-			const provider = addressProviders[ serverProvider.id ];
+			const provider =
+				window.wc.addressAutocomplete.providers[ serverProvider.id ];
 
 			if ( provider && provider.canSearch( country ) ) {
-				activeAddressProvider[ type ] = provider;
+				window.wc.addressAutocomplete.activeProvider[ type ] = provider;
 				return;
 			}
 		}
 
 		// No provider can search for this country.
-		activeAddressProvider[ type ] = null;
+		window.wc.addressAutocomplete.activeProvider[ type ] = null;
 	}
 
 	document.addEventListener( 'DOMContentLoaded', function () {
@@ -371,16 +371,17 @@ window.wc.addressAutocomplete = {
 			}
 
 			// Check if we have an active provider for this address type.
-			if ( ! activeAddressProvider[ type ] ) {
+			if ( ! window.wc.addressAutocomplete.activeProvider[ type ] ) {
 				hideSuggestions( type );
 				enableBrowserAutofill( addressInput );
 				return;
 			}
 
 			try {
-				const filteredSuggestions = await activeAddressProvider[
-					type
-				].search( type, sanitizedInput );
+				const filteredSuggestions =
+					await window.wc.addressAutocomplete.activeProvider[
+						type
+					].search( type, sanitizedInput );
 
 				// Validate suggestions array.
 				if ( ! Array.isArray( filteredSuggestions ) ) {
@@ -500,13 +501,14 @@ window.wc.addressAutocomplete = {
 		async function selectAddress( type, addressId ) {
 			let addressData;
 			try {
-				addressData = await activeAddressProvider[ type ].select(
-					addressId
-				);
+				addressData =
+					await window.wc.addressAutocomplete.activeProvider[
+						type
+					].select( addressId );
 			} catch ( error ) {
 				console.error(
 					'Error selecting address from provider',
-					activeAddressProvider[ type ].id,
+					window.wc.addressAutocomplete.activeProvider[ type ].id,
 					error
 				);
 				return; // Exit early if address selection fails.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -236,24 +236,25 @@ function setActiveProvider( country, type ) {
 		};
 
 		function disableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) === 'off' ) {
+			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
 				return;
 			}
 
-			input.setAttribute( 'autocomplete', 'off' );
-			input.setAttribute( 'data-1p-ignore', '' );
-			input.setAttribute( 'data-lpignore', '' );
+			input.setAttribute( 'autocomplete', 'none' );
+			input.setAttribute( 'data-1p-ignore', 'true' );
+			input.setAttribute( 'data-lpignore', 'true' );
 
-			// We need to refocus the element so that the browser can reset the autocomplete attribute.
+			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element
+			// This is achieved by removing and re-adding the element to trigger browser updates
 			const parentElement = input.parentElement;
 			if ( parentElement ) {
-				parentElement.insertBefore( input, parentElement.firstChild );
+				parentElement.appendChild( parentElement.removeChild( input ) );
 				input.focus();
 			}
 		}
 
 		function enableBrowserAutofill( input ) {
-			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
+			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
 				return;
 			}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -4,11 +4,6 @@
 var addressProviders = {};
 
 /**
- * Preferred address provider ID.
- */
-var preferredAddressProviderId = null;
-
-/**
  * Currently selected address provider. It will be used to search for addresses.
  */
 var activeAddressProvider = { billing: null, shipping: null };
@@ -90,20 +85,23 @@ window.wc.addressAutocomplete = {
 };
 
 function setActiveProvider( country, type ) {
-	// Check preferred provider's canSearch first
-	const preferredProvider = addressProviders[ preferredAddressProviderId ];
-	if ( preferredProvider && preferredProvider.canSearch( country ) ) {
-		activeAddressProvider[ type ] = preferredProvider;
-		return;
-	}
-
-	// If preferred provider can't search, find first available provider that can search
-	for ( const provider of Object.values( addressProviders ) ) {
-		if ( provider.canSearch( country ) ) {
+	// Get server providers list (already ordered by preference)
+	const serverProviders =
+		( window &&
+			window.wc_checkout_params &&
+			window.wc_checkout_params.address_providers ) ||
+		[];
+	// Check providers in preference order (server handles preferred provider ordering)
+	for ( const serverProvider of serverProviders ) {
+		const provider = addressProviders[ serverProvider.id ];
+		if ( provider && provider.canSearch( country ) ) {
 			activeAddressProvider[ type ] = provider;
 			return;
 		}
 	}
+
+	// No provider can search for this country
+	activeAddressProvider[ type ] = null;
 }
 
 ( function () {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -500,18 +500,30 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 				if ( e.key === 'ArrowDown' ) {
 					e.preventDefault();
+					e.stopPropagation();
 					newIndex =
 						( activeSuggestionIndices[ elementType ] + 1 ) %
 						items.length;
 					setActiveSuggestion( elementType, newIndex );
+					
+					// Move focus to the suggestion for better screen reader support
+					if ( items[ newIndex ] ) {
+						items[ newIndex ].focus();
+					}
 				} else if ( e.key === 'ArrowUp' ) {
 					e.preventDefault();
+					e.stopPropagation();
 					newIndex =
 						( activeSuggestionIndices[ elementType ] -
 							1 +
 							items.length ) %
 						items.length;
 					setActiveSuggestion( elementType, newIndex );
+					
+					// Move focus to the suggestion for better screen reader support
+					if ( items[ newIndex ] ) {
+						items[ newIndex ].focus();
+					}
 				} else if ( e.key === 'Enter' ) {
 					if ( activeSuggestionIndices[ elementType ] > -1 ) {
 						e.preventDefault();
@@ -819,6 +831,36 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					li.addEventListener( 'mouseenter', function () {
 						setActiveSuggestion( type, index );
 					} );
+					
+					// Add focus event to handle keyboard navigation
+					li.addEventListener( 'focus', function () {
+						setActiveSuggestion( type, index );
+					} );
+					
+					// Add keydown handler for navigation when focus is on suggestion
+					li.addEventListener( 'keydown', async function ( e ) {
+						const items = suggestionsLists[ type ].querySelectorAll( 'li' );
+						
+						if ( e.key === 'ArrowDown' ) {
+							e.preventDefault();
+							e.stopPropagation();
+							const nextIndex = ( index + 1 ) % items.length;
+							items[ nextIndex ].focus();
+						} else if ( e.key === 'ArrowUp' ) {
+							e.preventDefault();
+							e.stopPropagation();
+							const prevIndex = ( index - 1 + items.length ) % items.length;
+							items[ prevIndex ].focus();
+						} else if ( e.key === 'Enter' || e.key === ' ' ) {
+							e.preventDefault();
+							hideSuggestions( type );
+							await selectAddress( type, this.dataset.id );
+						} else if ( e.key === 'Escape' ) {
+							e.preventDefault();
+							hideSuggestions( type );
+							addressInputs[ type ][ 'address_1' ].focus();
+						}
+					} );
 
 					suggestionsList.appendChild( li );
 				} );
@@ -884,9 +926,29 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 				// Add blur event listener when suggestions are shown
 				if ( ! blurHandlers[ type ] ) {
-					blurHandlers[ type ] = function () {
+					blurHandlers[ type ] = function ( e ) {
 						// Use a small delay to allow clicks on suggestions to register
+						// and to check where focus moved to
 						setTimeout( () => {
+							// Check if focus moved to the suggestions container or any of its children
+							const suggestionsContainer = suggestionsContainers[ type ];
+							const activeElement = document.activeElement;
+							
+							// Don't hide if focus is within the suggestions container
+							if ( suggestionsContainer && 
+								 ( activeElement === suggestionsContainer || 
+								   suggestionsContainer.contains( activeElement ) ) ) {
+								return;
+							}
+							
+							// Also check if focus is on any suggestion item
+							const suggestionsList = suggestionsLists[ type ];
+							if ( suggestionsList && 
+								 ( activeElement === suggestionsList || 
+								   suggestionsList.contains( activeElement ) ) ) {
+								return;
+							}
+							
 							hideSuggestions( type );
 							const currentInput =
 								addressInputs[ type ][ 'address_1' ];
@@ -1184,18 +1246,30 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 					if ( e.key === 'ArrowDown' ) {
 						e.preventDefault();
+						e.stopPropagation();
 						newIndex =
 							( activeSuggestionIndices[ type ] + 1 ) %
 							items.length;
 						setActiveSuggestion( type, newIndex );
+						
+						// Move focus to the suggestion for better screen reader support
+						if ( items[ newIndex ] ) {
+							items[ newIndex ].focus();
+						}
 					} else if ( e.key === 'ArrowUp' ) {
 						e.preventDefault();
+						e.stopPropagation();
 						newIndex =
 							( activeSuggestionIndices[ type ] -
 								1 +
 								items.length ) %
 							items.length;
 						setActiveSuggestion( type, newIndex );
+						
+						// Move focus to the suggestion for better screen reader support
+						if ( items[ newIndex ] ) {
+							items[ newIndex ].focus();
+						}
 					} else if ( e.key === 'Enter' ) {
 						if ( activeSuggestionIndices[ type ] > -1 ) {
 							e.preventDefault();

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -204,16 +204,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					// Add search icon.
 					const searchIcon = document.createElement( 'div' );
 					searchIcon.className = 'address-search-icon';
-					searchIcon.innerHTML =
-						'<svg xmlns="http://www.w3.org/2000/svg" ' +
-						'viewBox="0 0 14 14" ' +
-						'focusable="false" ' +
-						'aria-hidden="true">' +
-						'<circle cx="6" cy="6" r="4"></circle>' +
-						'<path stroke-linecap="round" ' +
-						'stroke-linejoin="round" ' +
-						'd="m9.25 9.25 2.5 2.5"></path>' +
-						'</svg>';
 					addressInput.parentNode.appendChild( searchIcon );
 				}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -69,6 +69,16 @@ function registerAddressAutocompleteProvider( provider ) {
 			);
 		}
 
+		// Check if a provider with the same ID already exists
+		if ( window.wc.addressAutocomplete.providers[ provider.id ] ) {
+			console.warn(
+				'Address provider with ID "' +
+					provider.id +
+					'" is already registered.'
+			);
+			return false;
+		}
+
 		// Freeze and add provider to registry.
 		Object.freeze( provider );
 		window.wc.addressAutocomplete.providers[ provider.id ] = provider;
@@ -373,11 +383,17 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			}
 
 			// Check if the address section exists (shipping may be disabled/hidden)
-			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+			if (
+				! addressInputs[ type ] ||
+				! addressInputs[ type ][ 'address_1' ]
+			) {
 				return;
 			}
 
-			if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+			if (
+				! suggestionsLists[ type ] ||
+				! suggestionsContainers[ type ]
+			) {
 				return;
 			}
 
@@ -481,11 +497,17 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 */
 		function hideSuggestions( type ) {
 			// Check if the address section exists (shipping may be disabled/hidden)
-			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+			if (
+				! addressInputs[ type ] ||
+				! addressInputs[ type ][ 'address_1' ]
+			) {
 				return;
 			}
 
-			if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+			if (
+				! suggestionsLists[ type ] ||
+				! suggestionsContainers[ type ]
+			) {
 				return;
 			}
 
@@ -612,7 +634,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 */
 		function setActiveSuggestion( type, index ) {
 			// Check if the address section exists (shipping may be disabled/hidden)
-			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+			if (
+				! addressInputs[ type ] ||
+				! addressInputs[ type ][ 'address_1' ]
+			) {
 				return;
 			}
 
@@ -667,7 +692,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 				addressInput.addEventListener( 'keydown', async function ( e ) {
 					// Check if suggestions exist before accessing them
-					if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+					if (
+						! suggestionsLists[ type ] ||
+						! suggestionsContainers[ type ]
+					) {
 						return;
 					}
 
@@ -724,7 +752,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		document.addEventListener( 'click', function ( event ) {
 			addressTypes.forEach( ( type ) => {
 				// Check if the address section exists before accessing elements
-				if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+				if (
+					! addressInputs[ type ] ||
+					! addressInputs[ type ][ 'address_1' ]
+				) {
 					return;
 				}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -122,7 +122,6 @@ window.wc.addressAutocomplete = {
 		const suggestionsContainers = {};
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
-		let searchControllers = {}; // Track AbortControllers for search requests.
 
 		// Initialize for both billing and shipping.
 		addressTypes.forEach( ( type ) => {
@@ -188,22 +187,18 @@ window.wc.addressAutocomplete = {
 						'.suggestions-list'
 					);
 				activeSuggestionIndices[ type ] = -1;
-				searchControllers[ type ] = null;
 			}
 
 			// Get country value and set active address provider based on it.
 			if ( countryInput ) {
 				setActiveProvider( countryInput.value, type );
 
-				// Listen for country changes to re-evaluate provider availability.
-				// Handle both regular change events and Select2 events.
+				/**
+				 * Listen for country changes to re-evaluate provider availability.
+				 * Handle both regular change events and Select2 events.
+				 */
 				const handleCountryChange = function () {
 					setActiveProvider( countryInput.value, type );
-					// Cancel any inflight search and hide suggestions when country changes.
-					if ( searchControllers[ type ] ) {
-						searchControllers[ type ].abort();
-						searchControllers[ type ] = null;
-					}
 					if ( addressInputs[ type ][ 'address_1' ] ) {
 						hideSuggestions( type );
 					}
@@ -360,24 +355,10 @@ window.wc.addressAutocomplete = {
 				return;
 			}
 
-			// Cancel any existing search request for this type.
-			if ( searchControllers[ type ] ) {
-				searchControllers[ type ].abort();
-			}
-
-			// Create new AbortController for this search.
-			searchControllers[ type ] = new AbortController();
-			const controller = searchControllers[ type ];
-
 			try {
 				const filteredSuggestions = await activeAddressProvider[
 					type
 				].search( type, sanitizedInput );
-
-				// Check if this request was aborted.
-				if ( controller.signal.aborted ) {
-					return;
-				}
 
 				// Validate suggestions array.
 				if ( ! Array.isArray( filteredSuggestions ) ) {
@@ -443,33 +424,20 @@ window.wc.addressAutocomplete = {
 				suggestionsList.id = `address_suggestions_${ type }_list`;
 				setActiveSuggestion( type, 0 );
 			} catch ( error ) {
-				// Handle search errors (including AbortError from cancelled requests).
-				if ( error.name === 'AbortError' ) {
-					// Request was aborted - keep existing suggestions visible.
-					// Silently ignore AbortError as it's expected when cancelling requests.
-				} else {
-					console.error( 'Address search error:', error );
-					hideSuggestions( type );
-					enableBrowserAutofill( addressInput );
-				}
-			} finally {
-				// Clear the controller reference if this was the active request.
-				if ( searchControllers[ type ] === controller ) {
-					searchControllers[ type ] = null;
-				}
+				console.error( 'Address search error:', error );
+				hideSuggestions( type );
+				enableBrowserAutofill( addressInput );
 			}
 		}
 
+		/**
+		 * Hide the suggestions container for a given address type.
+		 * @param type {string} The address type ('billing' or 'shipping').
+		 */
 		function hideSuggestions( type ) {
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 			const addressInput = addressInputs[ type ][ 'address_1' ];
-
-			// Cancel any inflight search requests.
-			if ( searchControllers[ type ] ) {
-				searchControllers[ type ].abort();
-				searchControllers[ type ] = null;
-			}
 
 			suggestionsList.innerHTML = '';
 			suggestionsContainer.style.display = 'none';

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -629,15 +629,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		addressTypes.forEach( ( type ) => {
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			if ( addressInput ) {
-				let inputTimeout;
-
 				addressInput.addEventListener( 'input', function () {
-					clearTimeout( inputTimeout );
-					inputTimeout = window.setTimeout( async () => {
-						if ( document.activeElement === this ) {
-							await displaySuggestions( type, this.value );
-						}
-					}, 100 );
+					if ( document.activeElement === this ) {
+						displaySuggestions( type, this.value );
+					}
 				} );
 
 				addressInput.addEventListener( 'keydown', async function ( e ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -107,12 +107,34 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 			if ( provider && provider.canSearch( country ) ) {
 				window.wc.addressAutocomplete.activeProvider[ type ] = provider;
+				// Add autocomplete-available class to parent .woocommerce-input-wrapper
+				const addressInput = document.getElementById(
+					`${ type }_address_1`
+				);
+				if ( addressInput ) {
+					const wrapper = addressInput.closest(
+						'.woocommerce-input-wrapper'
+					);
+					if ( wrapper ) {
+						wrapper.classList.add( 'autocomplete-available' );
+					}
+				}
 				return;
 			}
 		}
 
 		// No provider can search for this country.
 		window.wc.addressAutocomplete.activeProvider[ type ] = null;
+		// Remove autocomplete-available class from parent .woocommerce-input-wrapper
+		const addressInput = document.getElementById( `${ type }_address_1` );
+		if ( addressInput ) {
+			const wrapper = addressInput.closest(
+				'.woocommerce-input-wrapper'
+			);
+			if ( wrapper ) {
+				wrapper.classList.remove( 'autocomplete-available' );
+			}
+		}
 	}
 
 	document.addEventListener( 'DOMContentLoaded', function () {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -121,6 +121,11 @@ function setActiveProvider( country, type ) {
 			const addressInput = document.getElementById(
 				`${ type }_address_1`
 			);
+			const cityInput = document.getElementById( `${ type }_city` );
+			const countryInput = document.getElementById( `${ type }_country` );
+			const postcodeInput = document.getElementById(
+				`${ type }_postcode`
+			);
 
 			if ( addressInput ) {
 				// Create suggestions container if it doesn't exist
@@ -161,7 +166,12 @@ function setActiveProvider( country, type ) {
 					addressInput.parentNode.appendChild( searchIcon );
 				}
 
-				addressInputs[ type ] = addressInput;
+				addressInputs[ type ] = {};
+				addressInputs[ type ][ 'address_1' ] = addressInput;
+				addressInputs[ type ][ 'city' ] = cityInput;
+				addressInputs[ type ][ 'country' ] = countryInput;
+				addressInputs[ type ][ 'postcode' ] = postcodeInput;
+
 				suggestionsContainers[ type ] = document.getElementById(
 					`address_suggestions_${ type }`
 				);
@@ -174,7 +184,6 @@ function setActiveProvider( country, type ) {
 			}
 
 			// Get country value and set active address provider based on it.
-			const countryInput = document.getElementById( `${ type }_country` );
 			if ( countryInput ) {
 				setActiveProvider( countryInput.value, type );
 
@@ -186,7 +195,7 @@ function setActiveProvider( country, type ) {
 						searchControllers[ type ].abort();
 						searchControllers[ type ] = null;
 					}
-					if ( addressInputs[ type ] ) {
+					if ( addressInputs[ type ][ 'address_1' ] ) {
 						hideSuggestions( type );
 					}
 				} );
@@ -289,7 +298,7 @@ function setActiveProvider( country, type ) {
 		}
 
 		async function displaySuggestions( type, inputValue ) {
-			const addressInput = addressInputs[ type ];
+			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 
@@ -314,12 +323,12 @@ function setActiveProvider( country, type ) {
 			// Create new AbortController for this search
 			searchControllers[ type ] = new AbortController();
 			const controller = searchControllers[ type ];
-			
+
 			try {
 				const filteredSuggestions = await activeAddressProvider[
 					type
 				].search( type, inputValue );
-				
+
 				// Check if this request was aborted
 				if ( controller.signal.aborted ) {
 					return;
@@ -370,7 +379,6 @@ function setActiveProvider( country, type ) {
 				);
 				suggestionsList.id = `address_suggestions_${ type }_list`;
 				setActiveSuggestion( type, 0 );
-				
 			} catch ( error ) {
 				// Handle search errors (including AbortError from cancelled requests)
 				if ( error.name === 'AbortError' ) {
@@ -392,7 +400,7 @@ function setActiveProvider( country, type ) {
 		function hideSuggestions( type ) {
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
-			const addressInput = addressInputs[ type ];
+			const addressInput = addressInputs[ type ][ 'address_1' ];
 
 			// Cancel any inflight search requests
 			if ( searchControllers[ type ] ) {
@@ -409,19 +417,34 @@ function setActiveProvider( country, type ) {
 		}
 
 		async function selectAddress( type, addressId ) {
-			const addressInput = addressInputs[ type ];
+			const addressInput = addressInputs[ type ][ 'address_1' ];
+			const cityInput = addressInputs[ type ][ 'city' ];
+			const countryInput = addressInputs[ type ][ 'country' ];
+			const postcodeInput = addressInputs[ type ][ 'postcode' ];
 			const addressData = await activeAddressProvider[ type ].select(
 				addressId
 			);
-			if ( addressData ) {
+			if ( addressData && addressInput ) {
 				addressInput.value = addressData.address1;
 				addressInput.dispatchEvent( new Event( 'change' ) );
+			}
+			if ( addressData && cityInput ) {
+				cityInput.value = addressData.city;
+				cityInput.dispatchEvent( new Event( 'change' ) );
+			}
+			if ( addressData && countryInput ) {
+				countryInput.value = addressData.country;
+				countryInput.dispatchEvent( new Event( 'change' ) );
+			}
+			if ( addressData && postcodeInput ) {
+				postcodeInput.value = addressData.postcode;
+				postcodeInput.dispatchEvent( new Event( 'change' ) );
 			}
 		}
 
 		function setActiveSuggestion( type, index ) {
 			const suggestionsList = suggestionsLists[ type ];
-			const addressInput = addressInputs[ type ];
+			const addressInput = addressInputs[ type ][ 'address_1' ];
 
 			const activeLi = suggestionsList.querySelector( 'li.active' );
 			if ( activeLi ) {
@@ -446,7 +469,7 @@ function setActiveProvider( country, type ) {
 
 		// Initialize event handlers for each address type
 		addressTypes.forEach( ( type ) => {
-			const addressInput = addressInputs[ type ];
+			const addressInput = addressInputs[ type ][ 'address_1' ];
 			if ( addressInput ) {
 				let inputTimeout;
 
@@ -514,7 +537,7 @@ function setActiveProvider( country, type ) {
 				if (
 					target !== suggestionsContainers[ type ] &&
 					! suggestionsContainers[ type ].contains( target ) &&
-					target !== addressInputs[ type ]
+					target !== addressInputs[ type ][ 'address_1' ]
 				) {
 					hideSuggestions( type );
 				}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -175,10 +175,21 @@ function setActiveProvider( country, type ) {
 			const countryInput = document.getElementById( `${ type }_country` );
 			if ( countryInput ) {
 				setActiveProvider( countryInput.value, type );
+
+				// Listen for country changes to re-evaluate provider availability
+				countryInput.addEventListener( 'change', function () {
+					setActiveProvider( this.value, type );
+					// Cancel any inflight search and hide suggestions when country changes
+					if ( searchControllers[ type ] ) {
+						searchControllers[ type ].abort();
+						searchControllers[ type ] = null;
+					}
+					if ( addressInputs[ type ] ) {
+						hideSuggestions( type );
+					}
+				} );
 			}
 		} );
-
-		console.log( { activeAddressProvider } );
 
 		const mockAddressData = {
 			'01971ca5-35d2-7514-adaf-d4ab97c02c19': {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -94,8 +94,6 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 	registerAddressAutocompleteProvider;
 
 ( function () {
-	'use strict';
-
 	/**
 	 * Set the active address provider based on which providers' (queried in order) canSearch returns true.
 	 * Triggers when country changes.

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -39,7 +39,8 @@ function registerAddressAutocompleteProvider( provider ) {
 		if (
 			window &&
 			window.wc_checkout_params &&
-			window.wc_checkout_params.address_providers
+			Array.isArray( window.wc_checkout_params.address_providers ) &&
+			window.wc_checkout_params.address_providers.length > 0
 		) {
 			serverProviders = window.wc_checkout_params.address_providers;
 		}

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -144,6 +144,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		const suggestionsContainers = {};
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
+		let addressSelectionTimeout;
 
 		/**
 		 * Cache address fields for a given type, will re-run when country changes.
@@ -552,7 +553,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				);
 			}
 
-			setTimeout( function () {
+			// Note: Passing an invalid ID to clearTimeout() silently does nothing; no exception is thrown.
+			if ( addressSelectionTimeout ) {
+				clearTimeout( addressSelectionTimeout );
+			}
+
+			addressSelectionTimeout = setTimeout( function () {
 				// Cache address fields again as they may have updated following the country change.
 				cacheAddressFields( type );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -359,12 +359,13 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 		/**
 		 * Handle searching and displaying autocomplete results below the address input if the value meets the criteria
-		 * of 3 or more characters.
-		 * @param type {string} The address type ('billing' or 'shipping').
+		 * of 3 or more characters. No suggestion is initially highlighted to improve screen reader accessibility.
 		 * @param inputValue {string} The value entered into the address input.
+		 * @param country {string} The country code to pass to the provider's search method.
+		 * @param type {string} The address type ('billing' or 'shipping').
 		 * @return {Promise<void>}
 		 */
-		async function displaySuggestions( type, inputValue ) {
+		async function displaySuggestions( inputValue, country, type ) {
 			// Sanitize input value.
 			const sanitizedInput = sanitizeForDisplay( inputValue );
 			if ( sanitizedInput !== inputValue ) {
@@ -392,7 +393,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				const filteredSuggestions =
 					await window.wc.addressAutocomplete.activeProvider[
 						type
-					].search( type, sanitizedInput );
+					].search( sanitizedInput, country, type );
 
 				// Validate suggestions array.
 				if ( ! Array.isArray( filteredSuggestions ) ) {
@@ -619,7 +620,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		// Initialize event handlers for each address type.
 		addressTypes.forEach( ( type ) => {
 			const addressInput = addressInputs[ type ][ 'address_1' ];
-			if ( addressInput ) {
+			const countryInput = addressInputs[ type ][ 'country' ];
+			if ( addressInput && countryInput ) {
 				let inputTimeout;
 
 				addressInput.addEventListener( 'input', function () {
@@ -627,7 +629,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					const inputElement = this;
 					inputTimeout = setTimeout( () => {
 						if ( document.activeElement === inputElement ) {
-							displaySuggestions( type, inputElement.value );
+							displaySuggestions(
+								inputElement.value,
+								countryInput.value,
+								type
+							);
 						}
 					}, 100 );
 				} );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -215,6 +215,10 @@ window.wc.addressAutocomplete = {
 			}
 		} );
 
+		/**
+		 * Disable browser autofill for address inputs to prevent conflicts with autocomplete.
+		 * @param input {HTMLInputElement} The input element to disable autofill for.
+		 */
 		function disableBrowserAutofill( input ) {
 			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
 				return;
@@ -233,6 +237,10 @@ window.wc.addressAutocomplete = {
 			}
 		}
 
+		/**
+		 * Enable browser autofill for address input.
+		 * @param input {HTMLInputElement} The input element to enable autofill for.
+		 */
 		function enableBrowserAutofill( input ) {
 			if ( input.getAttribute( 'autocomplete' ) !== 'none' ) {
 				return;
@@ -243,6 +251,12 @@ window.wc.addressAutocomplete = {
 			input.removeAttribute( 'data-lpignore' );
 		}
 
+		/**
+		 * Get highlighted label parts based on matches returned by `search` results.
+		 * @param label {string} The label to highlight.
+		 * @param matches {*[]} Array of match objects with `offset` and `length`.
+		 * @return {*[]} Array of nodes with highlighted parts.
+		 */
 		function getHighlightedLabel( label, matches ) {
 			// Sanitize label for display.
 			const sanitizedLabel = sanitizeForDisplay( label );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -269,25 +269,272 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		} );
 
 		/**
+		 * Replace an input element with a fresh copy to reset browser state.
+		 * @param {HTMLInputElement} input The input element to replace
+		 * @param {Object} attributes Object containing attributes to set on the new element
+		 * @param {boolean} shouldFocus Whether to focus the new element
+		 * @param {boolean} reattachListeners Whether to reattach event listeners (Firefox only)
+		 * @return {HTMLInputElement} The new input element
+		 */
+		function replaceInputElement( input, attributes, shouldFocus = true, reattachListeners = false ) {
+			const parentElement = input.parentElement;
+			if ( ! parentElement ) {
+				return input;
+			}
+
+			// Store cursor position before replacing element
+			const cursorPosition = input.selectionStart;
+
+			// Clone the element to get a fresh copy
+			const newElement = input.cloneNode( true );
+
+			// Set/remove attributes on the new element
+			Object.entries( attributes ).forEach( ( [ key, value ] ) => {
+				if ( value === null ) {
+					newElement.removeAttribute( key );
+				} else {
+					newElement.setAttribute( key, value );
+				}
+			} );
+
+			// Replace the old element with the new one
+			parentElement.removeChild( input );
+			parentElement.appendChild( newElement );
+
+			// Update references to point to the new element
+			const inputId = input.id;
+			if ( inputId ) {
+				// Update addressInputs cache
+				for ( const type of [ 'billing', 'shipping' ] ) {
+					if (
+						addressInputs[ type ] &&
+						addressInputs[ type ][ 'address_1' ] === input
+					) {
+						addressInputs[ type ][ 'address_1' ] = newElement;
+					}
+				}
+			}
+
+			// Re-attach event listeners if needed (Firefox only)
+			if ( reattachListeners ) {
+				reattachEventListeners( newElement );
+			}
+
+			// Restore focus and cursor position
+			if ( shouldFocus ) {
+				newElement.focus();
+				if (
+					typeof cursorPosition === 'number' &&
+					cursorPosition >= 0
+				) {
+					newElement.setSelectionRange(
+						cursorPosition,
+						cursorPosition
+					);
+				}
+			}
+
+			// Reset active suggestion index to prevent auto-selection
+			const elementType = newElement.id.includes( 'billing' )
+				? 'billing'
+				: 'shipping';
+			if (
+				activeSuggestionIndices[ elementType ] !== undefined
+			) {
+				activeSuggestionIndices[ elementType ] = -1;
+			}
+
+			return newElement;
+		}
+
+		/**
 		 * Disable browser autofill for address inputs to prevent conflicts with autocomplete.
 		 * @param input {HTMLInputElement} The input element to disable autofill for.
 		 */
 		function disableBrowserAutofill( input ) {
 			if ( input.getAttribute( 'autocomplete' ) === 'off' ) {
+				return input;
+			}
+
+			if ( needsElementCloning ) {
+				// Firefox and Safari need element cloning to clear password manager state
+				const attributes = {
+					'autocomplete': 'off',
+					'data-lpignore': 'true',
+					'data-op-ignore': 'true',
+					'data-1p-ignore': 'true'
+				};
+
+				// Safari needs additional attributes to fully disable autofill
+				if ( isSafari ) {
+					attributes['data-form-type'] = null;
+					attributes['data-bwignore'] = 'true';
+					attributes['data-protonpass-ignore'] = 'true';
+					// Safari is very stubborn - use a random autocomplete value
+					attributes['autocomplete'] = 'nope-' + Math.random().toString(36).substr(2, 9);
+					attributes['readonly'] = 'true';
+				}
+
+				const newElement = replaceInputElement(
+					input,
+					attributes,
+					true,
+					needsElementCloning // Both Firefox and Safari need event listeners reattached
+				);
+
+				// Remove readonly after a brief delay for Safari
+				if ( isSafari && newElement.hasAttribute( 'readonly' ) ) {
+					setTimeout( () => {
+						newElement.removeAttribute( 'readonly' );
+					}, 100 );
+				}
+
+				return newElement;
+			} else {
+				// Other browsers can use attribute manipulation with DOM refresh
+				input.setAttribute( 'autocomplete', 'off' );
+				input.setAttribute( 'data-lpignore', 'true' );
+				input.setAttribute( 'data-op-ignore', 'true' );
+				input.setAttribute( 'data-1p-ignore', 'true' );
+
+				// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element.
+				// This is achieved by removing and re-adding the element to trigger browser updates.
+				const parentElement = input.parentElement;
+				if ( parentElement ) {
+					const removedElement = parentElement.removeChild( input );
+
+					// Force browser repaint/reflow while element is removed
+					// This ensures password managers detect the removal before re-adding
+					parentElement.offsetHeight; // Trigger reflow
+					document.body.offsetHeight; // Force global repaint
+
+					parentElement.appendChild( removedElement );
+					input.focus();
+				}
+			}
+
+			return input;
+		}
+
+		/**
+		 * Re-attach event listeners to a new element (used when cloning in Firefox)
+		 * @param {HTMLElement} newElement The new element to attach listeners to
+		 */
+		function reattachEventListeners( newElement ) {
+			// Find which type this element belongs to
+			let elementType = null;
+			for ( const type of [ 'billing', 'shipping' ] ) {
+				if ( newElement.id === `${ type }_address_1` ) {
+					elementType = type;
+					break;
+				}
+			}
+
+			if ( ! elementType ) {
 				return;
 			}
 
-			input.setAttribute( 'autocomplete', 'off' );
-			input.setAttribute( 'data-lpignore', 'true' );
-			input.setAttribute( 'data-op-ignore', 'true' );
-
-			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element.
-			// This is achieved by removing and re-adding the element to trigger browser updates.
-			const parentElement = input.parentElement;
-			if ( parentElement ) {
-				parentElement.appendChild( parentElement.removeChild( input ) );
-				input.focus();
+			const countryInput = addressInputs[ elementType ][ 'country' ];
+			if ( ! countryInput ) {
+				return;
 			}
+
+			let inputTimeout;
+			let isInitialAttachment = true;
+
+			// Re-attach input event listener with initial delay to prevent immediate triggering
+			newElement.addEventListener( 'input', function () {
+				clearTimeout( inputTimeout );
+				const inputElement = this;
+
+				// Immediately hide suggestions if input is too short
+				if ( inputElement.value.length < 3 ) {
+					hideSuggestions( elementType );
+					const updatedElement =
+						enableBrowserAutofill( inputElement );
+					// Update the cached reference if element was replaced
+					if (
+						updatedElement !== inputElement &&
+						addressInputs[ elementType ]
+					) {
+						addressInputs[ elementType ][ 'address_1' ] =
+							updatedElement;
+					}
+					return;
+				}
+
+				// Add extra delay on first attachment to prevent auto-triggering
+				const delay = isInitialAttachment ? 300 : 100;
+				isInitialAttachment = false;
+
+				inputTimeout = setTimeout( () => {
+					if ( document.activeElement === inputElement ) {
+						displaySuggestions(
+							inputElement.value,
+							countryInput.value,
+							elementType
+						);
+					}
+				}, delay );
+			} );
+
+			// Re-attach keydown event listener
+			newElement.addEventListener( 'keydown', async function ( e ) {
+				// Check if suggestions exist before accessing them
+				if (
+					! suggestionsLists[ elementType ] ||
+					! suggestionsContainers[ elementType ]
+				) {
+					return;
+				}
+
+				const items =
+					suggestionsLists[ elementType ].querySelectorAll( 'li' );
+				if (
+					items.length === 0 ||
+					suggestionsContainers[ elementType ].style.display ===
+						'none'
+				) {
+					return;
+				}
+
+				let newIndex = activeSuggestionIndices[ elementType ];
+
+				if ( e.key === 'ArrowDown' ) {
+					e.preventDefault();
+					newIndex =
+						( activeSuggestionIndices[ elementType ] + 1 ) %
+						items.length;
+					setActiveSuggestion( elementType, newIndex );
+				} else if ( e.key === 'ArrowUp' ) {
+					e.preventDefault();
+					newIndex =
+						( activeSuggestionIndices[ elementType ] -
+							1 +
+							items.length ) %
+						items.length;
+					setActiveSuggestion( elementType, newIndex );
+				} else if ( e.key === 'Enter' ) {
+					if ( activeSuggestionIndices[ elementType ] > -1 ) {
+						e.preventDefault();
+						const selectedItem = suggestionsLists[
+							elementType
+						].querySelector(
+							`li#suggestion-item-${ elementType }-${ activeSuggestionIndices[ elementType ] }`
+						);
+						// Hide suggestions immediately for better UX.
+						hideSuggestions( elementType );
+						enableBrowserAutofill( newElement );
+						await selectAddress(
+							elementType,
+							selectedItem.dataset.id
+						);
+					}
+				} else if ( e.key === 'Escape' ) {
+					hideSuggestions( elementType );
+					enableBrowserAutofill( newElement );
+				}
+			} );
 		}
 
 		/**
@@ -296,23 +543,107 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param shouldFocus {boolean} Whether to focus the input after enabling autofill.
 		 */
 		function enableBrowserAutofill( input, shouldFocus = true ) {
-			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
-				return;
-			}
+			const currentAutocomplete = input.getAttribute( 'autocomplete' );
+			
+			// Check if autofill is already enabled (should be 'address-line1' when enabled)
+			if ( currentAutocomplete === 'address-line1' ) {
+				// Still need to check if ignore attributes are present
+				const hasIgnoreAttrs =
+					input.hasAttribute( 'data-lpignore' ) ||
+					input.hasAttribute( 'data-op-ignore' ) ||
+					input.hasAttribute( 'data-1p-ignore' );
 
-			input.setAttribute( 'autocomplete', 'address-line1' );
-			input.setAttribute( 'data-lpignore', 'false' );
-			input.setAttribute( 'data-op-ignore', 'false' );
-
-			// To ensure browser updates and re-enables autofill, we need to refocus the element.
-			// This is achieved by removing and re-adding the element to trigger browser updates.
-			const parentElement = input.parentElement;
-			if ( parentElement ) {
-				parentElement.appendChild( parentElement.removeChild( input ) );
-				if ( shouldFocus ) {
-					input.focus();
+				if ( ! hasIgnoreAttrs ) {
+					return input;
 				}
 			}
+
+			// For Safari, check if we're in disabled state (random autocomplete value starting with 'nope-')
+			if ( isSafari && currentAutocomplete && currentAutocomplete.startsWith( 'nope-' ) ) {
+				// Force re-enable for Safari disabled state
+				// Continue with normal re-enable logic below
+			}
+
+			if ( needsElementCloning ) {
+				// Firefox and Safari need element cloning to properly re-enable password managers
+				const attributes = {
+					'autocomplete': 'address-line1',
+					'data-lpignore': null,
+					'data-op-ignore': null,
+					'data-1p-ignore': null
+				};
+
+				// Safari needs additional cleanup from disable state
+				if ( isSafari ) {
+					attributes['data-bwignore'] = null;
+					attributes['data-protonpass-ignore'] = null;
+					attributes['data-form-type'] = null;
+					attributes['readonly'] = null;
+				}
+
+				return replaceInputElement(
+					input,
+					attributes,
+					shouldFocus,
+					needsElementCloning // Both Firefox and Safari need event listeners reattached
+				);
+			} else {
+				// Other browsers can use attribute manipulation with DOM refresh
+				input.setAttribute( 'autocomplete', 'address-line1' );
+
+				// Remove all password manager ignore attributes
+				const attrsToRemove = [
+					'data-lpignore',
+					'data-op-ignore',
+					'data-1p-ignore',
+					'data-bwignore',
+					'data-protonpass-ignore',
+					'data-form-type',
+				];
+				attrsToRemove.forEach( ( attr ) => {
+					if ( input.hasAttribute( attr ) ) {
+						input.removeAttribute( attr );
+					}
+				} );
+
+				// To ensure browser updates and re-enables autofill, we need to refocus the element.
+				// This is achieved by removing and re-adding the element to trigger browser updates.
+				const parentElement = input.parentElement;
+				if ( parentElement ) {
+					// Store current value and cursor position
+					const currentValue = input.value;
+					const cursorPosition = input.selectionStart;
+
+					const removedElement = parentElement.removeChild( input );
+
+					// Force browser repaint/reflow while element is removed
+					// This ensures password managers detect the removal before re-adding
+					parentElement.offsetHeight; // Trigger reflow
+					document.body.offsetHeight; // Force global repaint
+
+					parentElement.appendChild( removedElement );
+
+					// Restore value in case it was lost
+					if ( removedElement.value !== currentValue ) {
+						removedElement.value = currentValue;
+					}
+
+					if ( shouldFocus ) {
+						removedElement.focus();
+						if (
+							typeof cursorPosition === 'number' &&
+							cursorPosition >= 0
+						) {
+							removedElement.setSelectionRange(
+								cursorPosition,
+								cursorPosition
+							);
+						}
+					}
+				}
+			}
+
+			return input;
 		}
 
 		/**
@@ -494,12 +825,17 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					suggestionsList.appendChild( li );
 				} );
 
-				disableBrowserAutofill( addressInput );
+				const updatedInput = disableBrowserAutofill( addressInput );
+				// Update the cached reference if element was replaced
+				if ( updatedInput !== addressInput && addressInputs[ type ] ) {
+					addressInputs[ type ][ 'address_1' ] = updatedInput;
+				}
+
 				suggestionsContainer.style.display = 'block';
 				suggestionsContainer.style.marginTop =
 					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
-				addressInput.setAttribute( 'aria-expanded', 'true' );
-				addressInput.setAttribute(
+				updatedInput.setAttribute( 'aria-expanded', 'true' );
+				updatedInput.setAttribute(
 					'aria-owns',
 					`address_suggestions_${ type }_list`
 				);
@@ -513,15 +849,21 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 						// Use a small delay to allow clicks on suggestions to register
 						setTimeout( () => {
 							hideSuggestions( type );
-							enableBrowserAutofill( addressInput, false );
+							const currentInput =
+								addressInputs[ type ][ 'address_1' ];
+							enableBrowserAutofill( currentInput, false );
 						}, 200 );
 					};
-					addressInput.addEventListener( 'blur', blurHandlers[ type ] );
+					updatedInput.addEventListener(
+						'blur',
+						blurHandlers[ type ]
+					);
 				}
 			} catch ( error ) {
 				console.error( 'Address search error:', error );
 				hideSuggestions( type );
-				enableBrowserAutofill( addressInput );
+				const currentInput = addressInputs[ type ][ 'address_1' ];
+				enableBrowserAutofill( currentInput );
 			}
 		}
 
@@ -558,7 +900,10 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 
 			// Remove blur event listener when suggestions are hidden
 			if ( blurHandlers[ type ] ) {
-				addressInput.removeEventListener( 'blur', blurHandlers[ type ] );
+				addressInput.removeEventListener(
+					'blur',
+					blurHandlers[ type ]
+				);
 				delete blurHandlers[ type ];
 			}
 		}
@@ -719,6 +1064,23 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				addressInput.addEventListener( 'input', function () {
 					clearTimeout( inputTimeout );
 					const inputElement = this;
+
+					// Immediately hide suggestions if input is too short
+					if ( inputElement.value.length < 3 ) {
+						hideSuggestions( type );
+						const updatedElement =
+							enableBrowserAutofill( inputElement );
+						// Update the cached reference if element was replaced
+						if (
+							updatedElement !== inputElement &&
+							addressInputs[ type ]
+						) {
+							addressInputs[ type ][ 'address_1' ] =
+								updatedElement;
+						}
+						return;
+					}
+
 					inputTimeout = setTimeout( () => {
 						if ( document.activeElement === inputElement ) {
 							displaySuggestions(

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -202,39 +202,6 @@ function setActiveProvider( country, type ) {
 			}
 		} );
 
-		const mockAddressData = {
-			'01971ca5-35d2-7514-adaf-d4ab97c02c19': {
-				address1: '10 Downing Street',
-				city: 'London',
-				postcode: 'SW1A 2AA',
-				country: 'GB',
-			},
-			'01971ca5-35d2-7514-adaf-da427f3b640f': {
-				address1: '1600 Amphitheatre Parkway',
-				city: 'Mountain View',
-				postcode: '94043',
-				country: 'US',
-			},
-			'01971ca5-35d2-7514-adaf-dfa0a03f1e49': {
-				address1: 'Eiffel Tower',
-				city: 'Paris',
-				postcode: '75007',
-				country: 'FR',
-			},
-			'01971ca5-35d2-7514-adaf-e3bd0086bea9': {
-				address1: '1 Hacker Way',
-				city: 'Menlo Park',
-				postcode: '94025',
-				country: 'US',
-			},
-			'01971ca5-35d2-7514-adaf-e3bd0086bea6': {
-				address1: 'Very long address in the middle of the screen',
-				city: 'Menlo Park',
-				postcode: '98000',
-				country: 'US',
-			},
-		};
-
 		function disableBrowserAutofill( input ) {
 			if ( input.getAttribute( 'autocomplete' ) === 'none' ) {
 				return;

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -364,7 +364,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 
-			if ( sanitizedInput.length < 3 || sanitizedInput.length > 200 ) {
+			if ( sanitizedInput.length < 3 ) {
 				hideSuggestions( type );
 				enableBrowserAutofill( addressInput );
 				return;

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -1,7 +1,17 @@
 /**
  * Simple address provider registration for WooCommerce checkout
  */
-var wooAddressProviders = {};
+var addressProviders = {};
+
+/**
+ * Preferred address provider ID.
+ */
+var preferredAddressProviderId = null;
+
+/**
+ * Currently selected address provider. It will be used to search for addresses.
+ */
+var activeAddressProvider = { billing: null, shipping: null };
 
 /**
  * Register an address autocomplete provider

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -153,6 +153,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
 		let addressSelectionTimeout;
+		const blurHandlers = {};
 
 		/**
 		 * Cache address fields for a given type, will re-run when country changes.
@@ -268,7 +269,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			}
 
 			input.setAttribute( 'autocomplete', 'off' );
-			input.setAttribute( 'data-lpignore', '' );
+			input.setAttribute( 'data-lpignore', 'true' );
+			input.setAttribute( 'data-op-ignore', 'true' );
 
 			// To prevent 1Password/LastPass and autocomplete clashes, we need to refocus the element.
 			// This is achieved by removing and re-adding the element to trigger browser updates.
@@ -282,14 +284,26 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		/**
 		 * Enable browser autofill for address input.
 		 * @param input {HTMLInputElement} The input element to enable autofill for.
+		 * @param shouldFocus {boolean} Whether to focus the input after enabling autofill.
 		 */
-		function enableBrowserAutofill( input ) {
+		function enableBrowserAutofill( input, shouldFocus = true ) {
 			if ( input.getAttribute( 'autocomplete' ) !== 'off' ) {
 				return;
 			}
 
 			input.setAttribute( 'autocomplete', 'address-line1' );
 			input.setAttribute( 'data-lpignore', 'false' );
+			input.setAttribute( 'data-op-ignore', 'false' );
+
+			// To ensure browser updates and re-enables autofill, we need to refocus the element.
+			// This is achieved by removing and re-adding the element to trigger browser updates.
+			const parentElement = input.parentElement;
+			if ( parentElement ) {
+				parentElement.appendChild( parentElement.removeChild( input ) );
+				if ( shouldFocus ) {
+					input.focus();
+				}
+			}
 		}
 
 		/**
@@ -399,6 +413,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 
+			// Hide suggestions if input has less than 3 characters
 			if ( sanitizedInput.length < 3 ) {
 				hideSuggestions( type );
 				enableBrowserAutofill( addressInput );
@@ -482,6 +497,18 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				suggestionsList.id = `address_suggestions_${ type }_list`;
 				// Don't auto-highlight first suggestion for better screen reader accessibility
 				activeSuggestionIndices[ type ] = -1;
+
+				// Add blur event listener when suggestions are shown
+				if ( ! blurHandlers[ type ] ) {
+					blurHandlers[ type ] = function () {
+						// Use a small delay to allow clicks on suggestions to register
+						setTimeout( () => {
+							hideSuggestions( type );
+							enableBrowserAutofill( addressInput, false );
+						}, 200 );
+					};
+					addressInput.addEventListener( 'blur', blurHandlers[ type ] );
+				}
 			} catch ( error ) {
 				console.error( 'Address search error:', error );
 				hideSuggestions( type );
@@ -519,6 +546,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			addressInput.removeAttribute( 'aria-activedescendant' );
 			addressInput.removeAttribute( 'aria-owns' );
 			activeSuggestionIndices[ type ] = -1;
+
+			// Remove blur event listener when suggestions are hidden
+			if ( blurHandlers[ type ] ) {
+				addressInput.removeEventListener( 'blur', blurHandlers[ type ] );
+				delete blurHandlers[ type ];
+			}
 		}
 
 		/**

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -205,6 +205,8 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					container.id = `address_suggestions_${ type }`;
 					container.className = 'woocommerce-address-suggestions';
 					container.style.display = 'none';
+					container.setAttribute( 'role', 'region' );
+					container.setAttribute( 'aria-live', 'polite' );
 
 					const list = document.createElement( 'ul' );
 					list.className = 'suggestions-list';
@@ -274,7 +276,12 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param {boolean} reattachListeners Whether to reattach event listeners (Firefox only)
 		 * @return {HTMLInputElement} The new input element
 		 */
-		function replaceInputElement( input, attributes, shouldFocus = true, reattachListeners = false ) {
+		function replaceInputElement(
+			input,
+			attributes,
+			shouldFocus = true,
+			reattachListeners = false
+		) {
 			const parentElement = input.parentElement;
 			if ( ! parentElement ) {
 				return input;
@@ -336,9 +343,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			const elementType = newElement.id.includes( 'billing' )
 				? 'billing'
 				: 'shipping';
-			if (
-				activeSuggestionIndices[ elementType ] !== undefined
-			) {
+			if ( activeSuggestionIndices[ elementType ] !== undefined ) {
 				activeSuggestionIndices[ elementType ] = -1;
 			}
 
@@ -357,20 +362,21 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			if ( needsElementCloning ) {
 				// Firefox and Safari need element cloning to clear password manager state
 				const attributes = {
-					'autocomplete': 'off',
+					autocomplete: 'off',
 					'data-lpignore': 'true',
 					'data-op-ignore': 'true',
-					'data-1p-ignore': 'true'
+					'data-1p-ignore': 'true',
 				};
 
 				// Safari needs additional attributes to fully disable autofill
 				if ( isSafari ) {
-					attributes['data-form-type'] = null;
-					attributes['data-bwignore'] = 'true';
-					attributes['data-protonpass-ignore'] = 'true';
+					attributes[ 'data-form-type' ] = null;
+					attributes[ 'data-bwignore' ] = 'true';
+					attributes[ 'data-protonpass-ignore' ] = 'true';
 					// Safari is very stubborn - use a random autocomplete value
-					attributes['autocomplete'] = 'nope-' + Math.random().toString(36).substr(2, 9);
-					attributes['readonly'] = 'true';
+					attributes[ 'autocomplete' ] =
+						'nope-' + Math.random().toString( 36 ).substr( 2, 9 );
+					attributes[ 'readonly' ] = 'true';
 				}
 
 				const newElement = replaceInputElement(
@@ -554,7 +560,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 */
 		function enableBrowserAutofill( input, shouldFocus = true ) {
 			const currentAutocomplete = input.getAttribute( 'autocomplete' );
-			
+
 			// Check if autofill is already enabled (should be 'address-line1' when enabled)
 			if ( currentAutocomplete === 'address-line1' ) {
 				// Still need to check if ignore attributes are present
@@ -569,7 +575,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			}
 
 			// For Safari, check if we're in disabled state (random autocomplete value starting with 'nope-')
-			if ( isSafari && currentAutocomplete && currentAutocomplete.startsWith( 'nope-' ) ) {
+			if (
+				isSafari &&
+				currentAutocomplete &&
+				currentAutocomplete.startsWith( 'nope-' )
+			) {
 				// Force re-enable for Safari disabled state
 				// Continue with normal re-enable logic below
 			}
@@ -577,18 +587,18 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			if ( needsElementCloning ) {
 				// Firefox and Safari need element cloning to properly re-enable password managers
 				const attributes = {
-					'autocomplete': 'address-line1',
+					autocomplete: 'address-line1',
 					'data-lpignore': null,
 					'data-op-ignore': null,
-					'data-1p-ignore': null
+					'data-1p-ignore': null,
 				};
 
 				// Safari needs additional cleanup from disable state
 				if ( isSafari ) {
-					attributes['data-bwignore'] = null;
-					attributes['data-protonpass-ignore'] = null;
-					attributes['data-form-type'] = null;
-					attributes['readonly'] = null;
+					attributes[ 'data-bwignore' ] = null;
+					attributes[ 'data-protonpass-ignore' ] = null;
+					attributes[ 'data-form-type' ] = null;
+					attributes[ 'readonly' ] = null;
 				}
 
 				return replaceInputElement(
@@ -874,16 +884,16 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				// Update the listbox aria-label with item count
 				const itemCount = safeSuggestions.length;
 				const itemText = itemCount === 1 ? 'item' : 'items';
-				
-				suggestionsList.setAttribute( 
-					'aria-label', 
-					`${itemCount} ${itemText} found` 
+
+				suggestionsList.setAttribute(
+					'aria-label',
+					`${ itemCount } ${ itemText } found`
 				);
 
 				suggestionsContainer.style.display = 'block';
 				suggestionsContainer.style.marginTop =
 					addressInputs[ type ][ 'address_1' ].offsetHeight + 'px';
-				
+
 				// Set up ARIA attributes for combobox pattern
 				updatedInput.setAttribute( 'role', 'combobox' );
 				updatedInput.setAttribute( 'aria-expanded', 'true' );
@@ -893,33 +903,44 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 					'aria-controls',
 					`address_suggestions_${ type }_list`
 				);
-				
+
 				suggestionsList.id = `address_suggestions_${ type }_list`;
-				
+
 				// Create or update status region for announcements
-				let statusRegion = document.getElementById( `${type}-autocomplete-status` );
+				let statusRegion = document.getElementById(
+					`${ type }-autocomplete-status`
+				);
 				if ( ! statusRegion ) {
 					statusRegion = document.createElement( 'div' );
-					statusRegion.id = `${type}-autocomplete-status`;
+					statusRegion.id = `${ type }-autocomplete-status`;
 					statusRegion.className = 'screen-reader-text';
 					statusRegion.setAttribute( 'role', 'status' );
 					statusRegion.setAttribute( 'aria-live', 'assertive' );
 					statusRegion.setAttribute( 'aria-atomic', 'true' );
-					updatedInput.parentNode.insertBefore( statusRegion, updatedInput.nextSibling );
+					updatedInput.parentNode.insertBefore(
+						statusRegion,
+						updatedInput.nextSibling
+					);
 				}
-				
+
 				// Update aria-describedby to include the status region
-				const existingDescribedBy = updatedInput.getAttribute( 'aria-describedby' ) || '';
-				const statusId = `${type}-autocomplete-status`;
+				const existingDescribedBy =
+					updatedInput.getAttribute( 'aria-describedby' ) || '';
+				const statusId = `${ type }-autocomplete-status`;
 				if ( ! existingDescribedBy.includes( statusId ) ) {
-					const newDescribedBy = existingDescribedBy ? `${existingDescribedBy} ${statusId}` : statusId;
-					updatedInput.setAttribute( 'aria-describedby', newDescribedBy );
+					const newDescribedBy = existingDescribedBy
+						? `${ existingDescribedBy } ${ statusId }`
+						: statusId;
+					updatedInput.setAttribute(
+						'aria-describedby',
+						newDescribedBy
+					);
 				}
-				
+
 				// Clear and announce with proper timing
 				statusRegion.textContent = '';
 				setTimeout( () => {
-					statusRegion.textContent = `${itemCount} ${itemText} available. Use up and down arrows to navigate.`;
+					statusRegion.textContent = `${ itemCount } ${ itemText } available. Use up and down arrows to navigate.`;
 				}, 100 );
 				// Don't auto-highlight first suggestion for better screen reader accessibility
 				activeSuggestionIndices[ type ] = -1;
@@ -1000,28 +1021,31 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			addressInput.removeAttribute( 'role' );
 			addressInput.removeAttribute( 'aria-autocomplete' );
 			addressInput.removeAttribute( 'aria-haspopup' );
-			
+
 			// Remove status region from aria-describedby
 			const describedBy = addressInput.getAttribute( 'aria-describedby' );
-			const statusId = `${type}-autocomplete-status`;
+			const statusId = `${ type }-autocomplete-status`;
 			if ( describedBy && describedBy.includes( statusId ) ) {
 				const newDescribedBy = describedBy
 					.split( ' ' )
-					.filter( id => id !== statusId )
+					.filter( ( id ) => id !== statusId )
 					.join( ' ' );
 				if ( newDescribedBy ) {
-					addressInput.setAttribute( 'aria-describedby', newDescribedBy );
+					addressInput.setAttribute(
+						'aria-describedby',
+						newDescribedBy
+					);
 				} else {
 					addressInput.removeAttribute( 'aria-describedby' );
 				}
 			}
-			
+
 			// Clear the status region
 			const statusRegion = document.getElementById( statusId );
 			if ( statusRegion ) {
 				statusRegion.textContent = '';
 			}
-			
+
 			activeSuggestionIndices[ type ] = -1;
 
 			// Remove blur event listener when suggestions are hidden
@@ -1169,6 +1193,7 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			if ( activeLi ) {
 				activeLi.classList.remove( 'active' );
 				activeLi.setAttribute( 'aria-selected', 'false' );
+				activeLi.setAttribute( 'tabindex', '-1' );
 			}
 
 			const newActiveLi = suggestionsList.querySelector(
@@ -1178,11 +1203,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 			if ( newActiveLi ) {
 				newActiveLi.classList.add( 'active' );
 				newActiveLi.setAttribute( 'aria-selected', 'true' );
+				newActiveLi.setAttribute( 'tabindex', '0' );
 				addressInput.setAttribute(
 					'aria-activedescendant',
 					newActiveLi.id
 				);
 				activeSuggestionIndices[ type ] = index;
+				
+				// Focus has been moved to the suggestion item for better
+				// screen reader compatibility across all browsers
 			}
 		}
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -243,23 +243,42 @@ function setActiveProvider( country, type ) {
 		}
 
 		function getHighlightedLabel( label, matches ) {
-			// Security: Sanitize label for display.
+			// Sanitize label for display.
+			const sanitizedLabel = sanitizeForDisplay( label );
 			const parts = [];
 			let lastIndex = 0;
 
-			matches.forEach( ( match ) => {
-				// Add text before match
+			// Validate matches array.
+			if ( ! Array.isArray( matches ) ) {
+				// If matches is invalid, just return plain text.
+				parts.push( document.createTextNode( sanitizedLabel ) );
+				return parts;
+			}
+
+			// Validate matches.
+			const safeMatches = matches.filter(
+				( match ) =>
+					match &&
+					typeof match.offset === 'number' &&
+					typeof match.length === 'number' &&
+					match.offset >= 0 &&
+					match.length > 0 &&
+					match.offset + match.length <= sanitizedLabel.length
+			);
+
+			safeMatches.forEach( ( match ) => {
+				// Add text before match.
 				if ( match.offset > lastIndex ) {
 					parts.push(
 						document.createTextNode(
-							label.slice( lastIndex, match.offset )
+							sanitizedLabel.slice( lastIndex, match.offset )
 						)
 					);
 				}
 
 				// Add bold matched text.
 				const bold = document.createElement( 'strong' );
-				bold.textContent = label.slice(
+				bold.textContent = sanitizedLabel.slice(
 					match.offset,
 					match.offset + match.length
 				);
@@ -268,22 +287,61 @@ function setActiveProvider( country, type ) {
 				lastIndex = match.offset + match.length;
 			} );
 
-			// Add remaining text
-			if ( lastIndex < label.length ) {
+			// Add remaining text.
+			if ( lastIndex < sanitizedLabel.length ) {
 				parts.push(
-					document.createTextNode( label.slice( lastIndex ) )
+					document.createTextNode( sanitizedLabel.slice( lastIndex ) )
 				);
 			}
 
 			return parts;
 		}
 
+		// Sanitize and validate input.
+		const sanitizeInput = ( input ) => {
+			if ( typeof input !== 'string' ) {
+				return '';
+			}
+			// Remove potentially dangerous characters and limit length.
+			return input
+				.replace( /[<>'"&]/g, '' )
+				.trim()
+				.substring( 0, 200 );
+		};
+
+		// Sanitize text content for display (prevent XSS).
+		const sanitizeForDisplay = ( text ) => {
+			if ( typeof text !== 'string' ) {
+				return '';
+			}
+			// Create a temporary textarea to leverage browser's built-in text sanitization.
+			const textarea = document.createElement( 'textarea' );
+			textarea.textContent = text;
+			return textarea.innerHTML;
+		};
+
+		const validateAddressType = ( type ) => {
+			return type === 'billing' || type === 'shipping';
+		};
+
 		async function displaySuggestions( type, inputValue ) {
+			// Validate address type.
+			if ( ! validateAddressType( type ) ) {
+				console.error( 'Invalid address type:', type );
+				return;
+			}
+
+			// Sanitize input value.
+			const sanitizedInput = sanitizeInput( inputValue );
+			if ( sanitizedInput !== inputValue ) {
+				console.warn( 'Input was sanitized for security' );
+			}
+
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 
-			if ( inputValue.length < 3 ) {
+			if ( sanitizedInput.length < 3 || sanitizedInput.length > 200 ) {
 				hideSuggestions( type );
 				enableBrowserAutofill( addressInput );
 				return;
@@ -308,14 +366,30 @@ function setActiveProvider( country, type ) {
 			try {
 				const filteredSuggestions = await activeAddressProvider[
 					type
-				].search( type, inputValue );
+				].search( type, sanitizedInput );
 
 				// Check if this request was aborted.
 				if ( controller.signal.aborted ) {
 					return;
 				}
 
-				if ( filteredSuggestions.length === 0 ) {
+				// Validate suggestions array.
+				if ( ! Array.isArray( filteredSuggestions ) ) {
+					console.error(
+						'Invalid suggestions response - not an array'
+					);
+					hideSuggestions( type );
+					return;
+				}
+
+				// Limit number of suggestions, API may return many results but we should only show the first 5.
+				const maxSuggestions = 5;
+				const safeSuggestions = filteredSuggestions.slice(
+					0,
+					maxSuggestions
+				);
+
+				if ( safeSuggestions.length === 0 ) {
 					hideSuggestions( type );
 					return;
 				}
@@ -323,7 +397,7 @@ function setActiveProvider( country, type ) {
 				// Clear existing suggestions only when we have new results to show.
 				suggestionsList.innerHTML = '';
 
-				filteredSuggestions.forEach( ( suggestion, index ) => {
+				safeSuggestions.forEach( ( suggestion, index ) => {
 					const li = document.createElement( 'li' );
 					li.setAttribute( 'role', 'option' );
 					li.id = `suggestion-item-${ type }-${ index }`;
@@ -441,6 +515,21 @@ function setActiveProvider( country, type ) {
 		};
 
 		async function selectAddress( type, addressId ) {
+			// Validate inputs
+			if ( ! validateAddressType( type ) ) {
+				console.error( 'Invalid address type for selection:', type );
+				return;
+			}
+
+			if (
+				typeof addressId !== 'string' ||
+				addressId.length === 0 ||
+				addressId.length > 100
+			) {
+				console.error( 'Invalid address ID for selection:', addressId );
+				return;
+			}
+
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const cityInput = addressInputs[ type ][ 'city' ];
 			const countryInput = addressInputs[ type ][ 'country' ];
@@ -468,10 +557,13 @@ function setActiveProvider( country, type ) {
 				return; // Exit early if address selection fails.
 			}
 
-			// Validate that we received valid address data
-			if ( ! addressData || typeof addressData !== 'object' ) {
+			if (
+				typeof addressData !== 'object' ||
+				addressData === null ||
+				! addressData
+			) {
 				console.error(
-					'Invalid address data received from provider',
+					'Invalid address data returned by provider',
 					activeProviderId
 				);
 				return;

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -91,11 +91,11 @@ function setActiveProvider( country, type ) {
 			window.wc_checkout_params &&
 			window.wc_checkout_params.address_providers ) ||
 		[];
-	
+
 	// Check providers in preference order (server handles preferred provider ordering)
 	for ( const serverProvider of serverProviders ) {
 		const provider = addressProviders[ serverProvider.id ];
-		
+
 		if ( provider && provider.canSearch( country ) ) {
 			activeAddressProvider[ type ] = provider;
 			return;
@@ -202,12 +202,14 @@ function setActiveProvider( country, type ) {
 						hideSuggestions( type );
 					}
 				};
-				
+
 				countryInput.addEventListener( 'change', handleCountryChange );
-				
+
 				// Also listen for Select2 change event if jQuery and Select2 are available
 				if ( window.jQuery && window.jQuery( countryInput ).select2 ) {
-					window.jQuery( countryInput ).on( 'select2:select', handleCountryChange );
+					window
+						.jQuery( countryInput )
+						.on( 'select2:select', handleCountryChange );
 				}
 			}
 		} );
@@ -396,30 +398,99 @@ function setActiveProvider( country, type ) {
 			activeSuggestionIndices[ type ] = -1;
 		}
 
+		// Helper function to get field value, accounting for Select2
+		const getFieldValue = ( input ) => {
+			if ( ! input ) {
+				return '';
+			}
+
+			// For Select2 fields, get the value using jQuery if available
+			if (
+				window.jQuery &&
+				window.jQuery( input ).hasClass( 'select2-hidden-accessible' )
+			) {
+				return window.jQuery( input ).val() || '';
+			}
+
+			// For regular inputs, use the standard value property
+			return input.value || '';
+		};
+
+		// Helper function to set field value and trigger events
+		const setFieldValue = ( input, value ) => {
+			if ( input && value ) {
+				input.value = value;
+				input.dispatchEvent( new Event( 'change' ) );
+
+				// Also trigger Select2 update if it's a Select2 field
+				if (
+					window.jQuery &&
+					window
+						.jQuery( input )
+						.hasClass( 'select2-hidden-accessible' )
+				) {
+					window.jQuery( input ).trigger( 'change' );
+				}
+			}
+		};
+
 		async function selectAddress( type, addressId ) {
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const cityInput = addressInputs[ type ][ 'city' ];
 			const countryInput = addressInputs[ type ][ 'country' ];
 			const postcodeInput = addressInputs[ type ][ 'postcode' ];
+			const stateInput = document.getElementById( `${ type }_state` );
 			const addressData = await activeAddressProvider[ type ].select(
 				addressId
 			);
-			if ( addressData && addressInput ) {
-				addressInput.value = addressData.address1;
-				addressInput.dispatchEvent( new Event( 'change' ) );
+
+			// First pass - set all available fields immediately
+			if ( addressData ) {
+				setFieldValue( addressInput, addressData.address1 );
+				setFieldValue( cityInput, addressData.city );
+				setFieldValue( countryInput, addressData.country );
+				setFieldValue( postcodeInput, addressData.postcode );
+				setFieldValue( stateInput, addressData.state );
 			}
-			if ( addressData && cityInput ) {
-				cityInput.value = addressData.city;
-				cityInput.dispatchEvent( new Event( 'change' ) );
-			}
-			if ( addressData && countryInput ) {
-				countryInput.value = addressData.country;
-				countryInput.dispatchEvent( new Event( 'change' ) );
-			}
-			if ( addressData && postcodeInput ) {
-				postcodeInput.value = addressData.postcode;
-				postcodeInput.dispatchEvent( new Event( 'change' ) );
-			}
+
+			// Second pass after a delay to verify all fields and fix any that don't match
+			setTimeout( () => {
+				if ( addressData ) {
+					const updatedCityInput = document.getElementById(
+						`${ type }_city`
+					);
+					const updatedPostcodeInput = document.getElementById(
+						`${ type }_postcode`
+					);
+					const updatedStateInput = document.getElementById(
+						`${ type }_state`
+					);
+
+					// Verify and fix any fields that don't match the expected values
+					if (
+						updatedCityInput &&
+						getFieldValue( updatedCityInput ) !== addressData.city
+					) {
+						setFieldValue( updatedCityInput, addressData.city );
+					}
+					if (
+						updatedPostcodeInput &&
+						getFieldValue( updatedPostcodeInput ) !==
+							addressData.postcode
+					) {
+						setFieldValue(
+							updatedPostcodeInput,
+							addressData.postcode
+						);
+					}
+					if (
+						updatedStateInput &&
+						getFieldValue( updatedStateInput ) !== addressData.state
+					) {
+						setFieldValue( updatedStateInput, addressData.state );
+					}
+				}
+			}, 100 );
 		}
 
 		function setActiveSuggestion( type, index ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -372,6 +372,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				console.warn( 'Input was sanitized for security' );
 			}
 
+			// Check if the address section exists (shipping may be disabled/hidden)
+			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+				return;
+			}
+
+			if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+				return;
+			}
+
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
@@ -471,6 +480,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param type {string} The address type ('billing' or 'shipping').
 		 */
 		function hideSuggestions( type ) {
+			// Check if the address section exists (shipping may be disabled/hidden)
+			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+				return;
+			}
+
+			if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+				return;
+			}
+
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 			const addressInput = addressInputs[ type ][ 'address_1' ];
@@ -593,6 +611,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		 * @param index {number} The index of the suggestion to set as active.
 		 */
 		function setActiveSuggestion( type, index ) {
+			// Check if the address section exists (shipping may be disabled/hidden)
+			if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+				return;
+			}
+
+			if ( ! suggestionsLists[ type ] ) {
+				return;
+			}
+
 			const suggestionsList = suggestionsLists[ type ];
 			const addressInput = addressInputs[ type ][ 'address_1' ];
 
@@ -639,6 +666,11 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 				} );
 
 				addressInput.addEventListener( 'keydown', async function ( e ) {
+					// Check if suggestions exist before accessing them
+					if ( ! suggestionsLists[ type ] || ! suggestionsContainers[ type ] ) {
+						return;
+					}
+
 					const items =
 						suggestionsLists[ type ].querySelectorAll( 'li' );
 					if (
@@ -691,6 +723,15 @@ window.wc.addressAutocomplete.registerAddressAutocompleteProvider =
 		// Hide suggestions when clicking outside.
 		document.addEventListener( 'click', function ( event ) {
 			addressTypes.forEach( ( type ) => {
+				// Check if the address section exists before accessing elements
+				if ( ! addressInputs[ type ] || ! addressInputs[ type ][ 'address_1' ] ) {
+					return;
+				}
+
+				if ( ! suggestionsContainers[ type ] ) {
+					return;
+				}
+
 				const target = event.target;
 				if (
 					target !== suggestionsContainers[ type ] &&

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -114,6 +114,7 @@ function setActiveProvider( country, type ) {
 		const suggestionsContainers = {};
 		const suggestionsLists = {};
 		let activeSuggestionIndices = {};
+		let searchControllers = {}; // Track AbortControllers for search requests
 
 		// Initialize for both billing and shipping.
 		addressTypes.forEach( ( type ) => {
@@ -169,6 +170,7 @@ function setActiveProvider( country, type ) {
 						'.suggestions-list'
 					);
 				activeSuggestionIndices[ type ] = -1;
+				searchControllers[ type ] = null;
 			}
 
 			// Get country value and set active address provider based on it.
@@ -297,60 +299,103 @@ function setActiveProvider( country, type ) {
 				return;
 			}
 
-			suggestionsList.innerHTML = '';
-			console.log( { wooAddressProviders: addressProviders } );
-			const filteredSuggestions = await activeAddressProvider[
-				type
-			].search( type, inputValue );
-			console.log( { filteredSuggestions } );
-
-			if ( filteredSuggestions.length === 0 ) {
+			// Check if we have an active provider for this address type
+			if ( ! activeAddressProvider[ type ] ) {
 				hideSuggestions( type );
+				enableBrowserAutofill( addressInput );
 				return;
 			}
 
-			filteredSuggestions.forEach( ( suggestion, index ) => {
-				const li = document.createElement( 'li' );
-				li.setAttribute( 'role', 'option' );
-				li.id = `suggestion-item-${ type }-${ index }`;
-				li.dataset.id = suggestion.id;
-				li.setAttribute( 'tabindex', '-1' );
+			// Cancel any existing search request for this type
+			if ( searchControllers[ type ] ) {
+				searchControllers[ type ].abort();
+			}
 
-				li.textContent = ''; // Clear existing content
-				const labelParts = getHighlightedLabel(
-					suggestion.label,
-					suggestion.matchedSubstrings || []
-				);
-				labelParts.forEach( ( part ) => li.appendChild( part ) );
+			// Create new AbortController for this search
+			searchControllers[ type ] = new AbortController();
+			const controller = searchControllers[ type ];
 
-				li.addEventListener( 'click', function () {
-					selectAddress( type, this.dataset.id );
+			suggestionsList.innerHTML = '';
+			
+			try {
+				const filteredSuggestions = await activeAddressProvider[
+					type
+				].search( type, inputValue );
+				
+				// Check if this request was aborted
+				if ( controller.signal.aborted ) {
+					return;
+				}
+
+				if ( filteredSuggestions.length === 0 ) {
 					hideSuggestions( type );
-					addressInput.focus();
+					return;
+				}
+
+				filteredSuggestions.forEach( ( suggestion, index ) => {
+					const li = document.createElement( 'li' );
+					li.setAttribute( 'role', 'option' );
+					li.id = `suggestion-item-${ type }-${ index }`;
+					li.dataset.id = suggestion.id;
+					li.setAttribute( 'tabindex', '-1' );
+
+					li.textContent = ''; // Clear existing content
+					const labelParts = getHighlightedLabel(
+						suggestion.label,
+						suggestion.matchedSubstrings || []
+					);
+					labelParts.forEach( ( part ) => li.appendChild( part ) );
+
+					li.addEventListener( 'click', async function () {
+						// Hide suggestions immediately for better UX
+						hideSuggestions( type );
+						await selectAddress( type, this.dataset.id );
+						addressInput.focus();
+					} );
+
+					li.addEventListener( 'mouseenter', function () {
+						setActiveSuggestion( type, index );
+					} );
+
+					suggestionsList.appendChild( li );
 				} );
 
-				li.addEventListener( 'mouseenter', function () {
-					setActiveSuggestion( type, index );
-				} );
-
-				suggestionsList.appendChild( li );
-			} );
-
-			disableBrowserAutofill( addressInput );
-			suggestionsContainer.style.display = 'block';
-			addressInput.setAttribute( 'aria-expanded', 'true' );
-			addressInput.setAttribute(
-				'aria-owns',
-				`address_suggestions_${ type }_list`
-			);
-			suggestionsList.id = `address_suggestions_${ type }_list`;
-			setActiveSuggestion( type, 0 );
+				disableBrowserAutofill( addressInput );
+				suggestionsContainer.style.display = 'block';
+				addressInput.setAttribute( 'aria-expanded', 'true' );
+				addressInput.setAttribute(
+					'aria-owns',
+					`address_suggestions_${ type }_list`
+				);
+				suggestionsList.id = `address_suggestions_${ type }_list`;
+				setActiveSuggestion( type, 0 );
+				
+			} catch ( error ) {
+				// Handle search errors (including AbortError from cancelled requests)
+				if ( error.name !== 'AbortError' ) {
+					console.error( 'Address search error:', error );
+					hideSuggestions( type );
+					enableBrowserAutofill( addressInput );
+				}
+				// Silently ignore AbortError as it's expected when cancelling requests
+			} finally {
+				// Clear the controller reference if this was the active request
+				if ( searchControllers[ type ] === controller ) {
+					searchControllers[ type ] = null;
+				}
+			}
 		}
 
 		function hideSuggestions( type ) {
 			const suggestionsList = suggestionsLists[ type ];
 			const suggestionsContainer = suggestionsContainers[ type ];
 			const addressInput = addressInputs[ type ];
+
+			// Cancel any inflight search requests
+			if ( searchControllers[ type ] ) {
+				searchControllers[ type ].abort();
+				searchControllers[ type ] = null;
+			}
 
 			suggestionsList.innerHTML = '';
 			suggestionsContainer.style.display = 'none';
@@ -360,12 +405,15 @@ function setActiveProvider( country, type ) {
 			activeSuggestionIndices[ type ] = -1;
 		}
 
-		function selectAddress( type, addressId ) {
+		async function selectAddress( type, addressId ) {
 			const addressInput = addressInputs[ type ];
-			const addressData = mockAddressData[ addressId ];
-			addressInput.value = addressData.address1;
-			addressInput.dispatchEvent( new Event( 'change' ) );
-			hideSuggestions( type );
+			const addressData = await activeAddressProvider[ type ].select(
+				addressId
+			);
+			if ( addressData ) {
+				addressInput.value = addressData.address1;
+				addressInput.dispatchEvent( new Event( 'change' ) );
+			}
 		}
 
 		function setActiveSuggestion( type, index ) {
@@ -408,7 +456,7 @@ function setActiveProvider( country, type ) {
 					}, 100 );
 				} );
 
-				addressInput.addEventListener( 'keydown', function ( e ) {
+				addressInput.addEventListener( 'keydown', async function ( e ) {
 					const items =
 						suggestionsLists[ type ].querySelectorAll( 'li' );
 					if (
@@ -442,7 +490,12 @@ function setActiveProvider( country, type ) {
 							].querySelector(
 								`li#suggestion-item-${ type }-${ activeSuggestionIndices[ type ] }`
 							);
-							selectAddress( type, selectedItem.dataset.id );
+							// Hide suggestions immediately for better UX
+							hideSuggestions( type );
+							await selectAddress(
+								type,
+								selectedItem.dataset.id
+							);
 						}
 					} else if ( e.key === 'Escape' ) {
 						hideSuggestions( type );

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -488,34 +488,18 @@ window.wc.addressAutocomplete = {
 			}
 		};
 
+		/**
+		 * Select an address from the suggestions list and submit it to the provider's `select` method.
+		 * @param type {string} The address type ('billing' or 'shipping').
+		 * @param addressId {string} The ID of the address to select.
+		 * @return {Promise<void>}
+		 */
 		async function selectAddress( type, addressId ) {
-			// Validate inputs
-			if ( ! validateAddressType( type ) ) {
-				console.error( 'Invalid address type for selection:', type );
-				return;
-			}
-
-			if (
-				typeof addressId !== 'string' ||
-				addressId.length === 0 ||
-				addressId.length > 100
-			) {
-				console.error( 'Invalid address ID for selection:', addressId );
-				return;
-			}
-
 			const addressInput = addressInputs[ type ][ 'address_1' ];
+			const address2Input = addressInputs[ type ][ 'address_2' ];
 			const cityInput = addressInputs[ type ][ 'city' ];
-			const countryInput = addressInputs[ type ][ 'country' ];
 			const postcodeInput = addressInputs[ type ][ 'postcode' ];
 			const stateInput = document.getElementById( `${ type }_state` );
-
-			const activeProviderId =
-				activeAddressProvider &&
-				activeAddressProvider[ type ] &&
-				activeAddressProvider[ type ].id
-					? activeAddressProvider[ type ].id
-					: '';
 
 			let addressData;
 			try {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -314,8 +314,6 @@ function setActiveProvider( country, type ) {
 			// Create new AbortController for this search
 			searchControllers[ type ] = new AbortController();
 			const controller = searchControllers[ type ];
-
-			suggestionsList.innerHTML = '';
 			
 			try {
 				const filteredSuggestions = await activeAddressProvider[
@@ -331,6 +329,9 @@ function setActiveProvider( country, type ) {
 					hideSuggestions( type );
 					return;
 				}
+
+				// Clear existing suggestions only when we have new results to show
+				suggestionsList.innerHTML = '';
 
 				filteredSuggestions.forEach( ( suggestion, index ) => {
 					const li = document.createElement( 'li' );
@@ -372,12 +373,14 @@ function setActiveProvider( country, type ) {
 				
 			} catch ( error ) {
 				// Handle search errors (including AbortError from cancelled requests)
-				if ( error.name !== 'AbortError' ) {
+				if ( error.name === 'AbortError' ) {
+					// Request was aborted - keep existing suggestions visible
+					// Silently ignore AbortError as it's expected when cancelling requests
+				} else {
 					console.error( 'Address search error:', error );
 					hideSuggestions( type );
 					enableBrowserAutofill( addressInput );
 				}
-				// Silently ignore AbortError as it's expected when cancelling requests
 			} finally {
 				// Clear the controller reference if this was the active request
 				if ( searchControllers[ type ] === controller ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -91,9 +91,11 @@ function setActiveProvider( country, type ) {
 			window.wc_checkout_params &&
 			window.wc_checkout_params.address_providers ) ||
 		[];
+	
 	// Check providers in preference order (server handles preferred provider ordering)
 	for ( const serverProvider of serverProviders ) {
 		const provider = addressProviders[ serverProvider.id ];
+		
 		if ( provider && provider.canSearch( country ) ) {
 			activeAddressProvider[ type ] = provider;
 			return;
@@ -188,8 +190,9 @@ function setActiveProvider( country, type ) {
 				setActiveProvider( countryInput.value, type );
 
 				// Listen for country changes to re-evaluate provider availability
-				countryInput.addEventListener( 'change', function () {
-					setActiveProvider( this.value, type );
+				// Handle both regular change events and Select2 events
+				const handleCountryChange = function () {
+					setActiveProvider( countryInput.value, type );
 					// Cancel any inflight search and hide suggestions when country changes
 					if ( searchControllers[ type ] ) {
 						searchControllers[ type ].abort();
@@ -198,7 +201,14 @@ function setActiveProvider( country, type ) {
 					if ( addressInputs[ type ][ 'address_1' ] ) {
 						hideSuggestions( type );
 					}
-				} );
+				};
+				
+				countryInput.addEventListener( 'change', handleCountryChange );
+				
+				// Also listen for Select2 change event if jQuery and Select2 are available
+				if ( window.jQuery && window.jQuery( countryInput ).select2 ) {
+					window.jQuery( countryInput ).on( 'select2:select', handleCountryChange );
+				}
 			}
 		} );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -41,7 +41,7 @@ function registerAddressAutocompleteProvider( provider ) {
 		}
 
 		// Check if provider is registered on server.
-		var serverProviders = [];
+		let serverProviders = [];
 		if (
 			window &&
 			window.wc_checkout_params &&

--- a/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/address-autocomplete.js
@@ -312,42 +312,28 @@ window.wc.addressAutocomplete = {
 			return parts;
 		}
 
-		// Sanitize and validate input.
-		const sanitizeInput = ( input ) => {
-			if ( typeof input !== 'string' ) {
-				return '';
-			}
-			// Remove potentially dangerous characters and limit length.
-			return input
-				.replace( /[<>'"&]/g, '' )
-				.trim()
-				.substring( 0, 200 );
-		};
+		/**
+		 * Sanitize HTML for display by removing any HTML tags.
+		 *
+		 * @param html
+		 * @return {string|string}
+		 */
+		function sanitizeForDisplay( html ) {
+			const doc = document.implementation.createHTMLDocument( '' );
+			doc.body.innerHTML = html;
+			return doc.body.textContent || '';
+		}
 
-		// Sanitize text content for display (prevent XSS).
-		const sanitizeForDisplay = ( text ) => {
-			if ( typeof text !== 'string' ) {
-				return '';
-			}
-			// Create a temporary textarea to leverage browser's built-in text sanitization.
-			const textarea = document.createElement( 'textarea' );
-			textarea.textContent = text;
-			return textarea.innerHTML;
-		};
-
-		const validateAddressType = ( type ) => {
-			return type === 'billing' || type === 'shipping';
-		};
-
+		/**
+		 * Handle searching and displaying autocomplete results below the address input if the value meets the criteria
+		 * of 3 or more characters.
+		 * @param type {string} The address type ('billing' or 'shipping').
+		 * @param inputValue {string} The value entered into the address input.
+		 * @return {Promise<void>}
+		 */
 		async function displaySuggestions( type, inputValue ) {
-			// Validate address type.
-			if ( ! validateAddressType( type ) ) {
-				console.error( 'Invalid address type:', type );
-				return;
-			}
-
 			// Sanitize input value.
-			const sanitizedInput = sanitizeInput( inputValue );
+			const sanitizedInput = sanitizeForDisplay( inputValue );
 			if ( sanitizedInput !== inputValue ) {
 				console.warn( 'Input was sanitized for security' );
 			}

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe( 'Address Autocomplete Provider Registration', () => {
+	beforeEach( () => {
+		// Reset the window object and providers before each test
+		global.window = {};
+		global.window.wc_checkout_params = {
+			address_providers: [
+				{ id: 'test-provider', name: 'Test provider' },
+				{ id: 'wc-payments', name: 'WooCommerce Payments' },
+			],
+		};
+		global.console = {
+			error: jest.fn(),
+		};
+
+		// Reset the module before each test
+		jest.resetModules();
+		require( '../address-autocomplete' );
+	} );
+
+	test( 'should successfully register a valid provider', () => {
+		const validProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				validProvider
+			);
+		expect( result ).toBe( true );
+		expect( console.error ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should reject undefined provider', () => {
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider();
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must be a valid object'
+		);
+	} );
+
+	test( 'should reject null provider', () => {
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider( null );
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must be a valid object'
+		);
+	} );
+
+	test( 'should handle missing wc_checkout_params', () => {
+		delete window.wc_checkout_params;
+		const validProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				validProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Provider test-provider not registered on server'
+		);
+	} );
+
+	test( 'should handle invalid address_providers type', () => {
+		window.wc_checkout_params.address_providers = 'not an array';
+		const validProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				validProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Server providers configuration is invalid'
+		);
+	} );
+
+	test( 'should reject provider without ID', () => {
+		const invalidProvider = {
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				invalidProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must have a valid ID'
+		);
+	} );
+
+	test( 'should reject provider with non-string ID', () => {
+		const invalidProvider = {
+			id: 123,
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				invalidProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must have a valid ID'
+		);
+	} );
+
+	test( 'should reject provider without canSearch function', () => {
+		const invalidProvider = {
+			id: 'test-provider',
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				invalidProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must have a canSearch function'
+		);
+	} );
+
+	test( 'should reject provider without search function', () => {
+		const invalidProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				invalidProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must have a search function'
+		);
+	} );
+
+	test( 'should reject provider without select function', () => {
+		const invalidProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				invalidProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Address provider must have a select function'
+		);
+	} );
+
+	test( 'should reject provider not registered on server', () => {
+		const unregisteredProvider = {
+			id: 'unregistered-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				unregisteredProvider
+			);
+		expect( result ).toBe( false );
+		expect( console.error ).toHaveBeenCalledWith(
+			'Provider unregistered-provider not registered on server'
+		);
+	} );
+} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -42,15 +42,19 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			window.wc.addressAutocomplete.registerAddressAutocompleteProvider();
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must be a valid object'
 		);
 	} );
 
 	test( 'should reject null provider', () => {
 		const result =
-			window.wc.addressAutocomplete.registerAddressAutocompleteProvider( null );
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				null
+			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must be a valid object'
 		);
 	} );
@@ -70,6 +74,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Provider test-provider not registered on server'
 		);
 	} );
@@ -89,6 +94,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Server providers configuration is invalid'
 		);
 	} );
@@ -106,6 +112,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must have a valid ID'
 		);
 	} );
@@ -124,6 +131,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must have a valid ID'
 		);
 	} );
@@ -141,6 +149,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must have a canSearch function'
 		);
 	} );
@@ -158,6 +167,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must have a search function'
 		);
 	} );
@@ -175,6 +185,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Address provider must have a select function'
 		);
 	} );
@@ -193,6 +204,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			);
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
+			'Error registering address provider:',
 			'Provider unregistered-provider not registered on server'
 		);
 	} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -394,7 +394,7 @@ describe( 'Address Suggestions Component', () => {
 		mockProvider = {
 			id: 'test-provider',
 			canSearch: jest.fn( ( country ) => country === 'US' ),
-			search: jest.fn( async ( type, query ) => [
+			search: jest.fn( async ( query, country, type ) => [
 				{
 					id: 'addr1',
 					label: '123 Main Street, City, US',
@@ -589,8 +589,9 @@ describe( 'Address Suggestions Component', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
 
 			expect( mockProvider.search ).toHaveBeenCalledWith(
-				'billing',
-				'123'
+				'123',
+				'US',
+				'billing'
 			);
 
 			const suggestionsList = document.querySelector(
@@ -1047,8 +1048,9 @@ describe( 'Address Suggestions Component', () => {
 				'Input was sanitized for security'
 			);
 			expect( mockProvider.search ).toHaveBeenCalledWith(
-				'billing',
-				'alert("xss")'
+				'alert("xss")',
+				'US',
+				'billing'
 			);
 
 			consoleSpy.mockRestore();

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -80,7 +80,10 @@ describe( 'Address Autocomplete Provider Registration', () => {
 	} );
 
 	test( 'should handle invalid address_providers type', () => {
-		window.wc_checkout_params.address_providers = 'not an array';
+		delete global.window.wc; // ensure fresh load
+		global.window.wc_checkout_params = undefined;
+		jest.resetModules();
+		require( '../address-autocomplete' );
 		const validProvider = {
 			id: 'test-provider',
 			canSearch: () => {},

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -11,6 +11,8 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				address_providers: [
 					{ id: 'test-provider', name: 'Test provider' },
 					{ id: 'wc-payments', name: 'WooCommerce Payments' },
+					{ id: 'provider-1', name: 'Provider 1' },
+					{ id: 'provider-2', name: 'Provider 2' },
 				],
 			},
 		} );
@@ -245,42 +247,98 @@ describe( 'Address Autocomplete Provider Registration', () => {
 	test( 'should not allow duplicate provider registration', () => {
 		const provider1 = {
 			id: 'test-provider',
-			canSearch: () => {},
-			search: () => {},
+			canSearch: () => false,
+			search: () => [ 'original' ],
 			select: () => {},
 		};
 
 		const provider2 = {
 			id: 'test-provider',
-			canSearch: () => {
-				return true;
-			},
-			search: () => {
-				return [];
-			},
-			select: () => {
-				return {};
-			},
+			canSearch: () => true,
+			search: () => [ 'duplicate' ],
+			select: () => {},
 		};
 
+		// Mock console.warn to capture warning message
+		const consoleSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+
 		// Register first provider
-		window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
-			provider1
-		);
+		const firstResult =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				provider1
+			);
+		expect( firstResult ).toBe( true );
 
 		// Try to register second provider with same ID
-		const result =
+		const duplicateResult =
 			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
 				provider2
 			);
-		expect( result ).toBe( true );
+		expect( duplicateResult ).toBe( false );
 
-		// Verify the second provider overwrote the first
+		// Verify warning was logged
+		expect( consoleSpy ).toHaveBeenCalledWith(
+			'Address provider with ID "test-provider" is already registered.'
+		);
+
+		// Verify the original provider is preserved (not overwritten)
 		expect(
 			window.wc.addressAutocomplete.providers[
 				'test-provider'
 			].canSearch()
-		).toBe( true );
+		).toBe( false );
+		expect(
+			window.wc.addressAutocomplete.providers[ 'test-provider' ].search()
+		).toEqual( [ 'original' ] );
+
+		consoleSpy.mockRestore();
+	} );
+
+	test( 'should allow multiple providers with different IDs', () => {
+		const provider1 = {
+			id: 'provider-1',
+			canSearch: () => true,
+			search: () => [ 'provider1-results' ],
+			select: () => {},
+		};
+
+		const provider2 = {
+			id: 'provider-2',
+			canSearch: () => true,
+			search: () => [ 'provider2-results' ],
+			select: () => {},
+		};
+
+		// Register both providers
+		const result1 =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				provider1
+			);
+		const result2 =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				provider2
+			);
+
+		expect( result1 ).toBe( true );
+		expect( result2 ).toBe( true );
+
+		// Verify both providers are registered
+		expect(
+			window.wc.addressAutocomplete.providers[ 'provider-1' ]
+		).toBeDefined();
+		expect(
+			window.wc.addressAutocomplete.providers[ 'provider-2' ]
+		).toBeDefined();
+
+		// Verify they maintain their separate functionality
+		expect(
+			window.wc.addressAutocomplete.providers[ 'provider-1' ].search()
+		).toEqual( [ 'provider1-results' ] );
+		expect(
+			window.wc.addressAutocomplete.providers[ 'provider-2' ].search()
+		).toEqual( [ 'provider2-results' ] );
 	} );
 } );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -4,6 +4,7 @@
 
 describe( 'Address Autocomplete Provider Registration', () => {
 	beforeEach( () => {
+		delete global.window.wc;
 		// Reset the window object and providers before each test
 		Object.assign( global.window, {
 			wc_checkout_params: {
@@ -13,9 +14,6 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				],
 			},
 		} );
-		global.console = {
-			error: jest.fn(),
-		};
 
 		// Reset the module before each test
 		jest.resetModules();
@@ -35,7 +33,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				validProvider
 			);
 		expect( result ).toBe( true );
-		expect( console.error ).not.toHaveBeenCalled();
+		expect( console ).not.toHaveErrored();
 	} );
 
 	test( 'should reject invalid provider (null, undefined, non-object)', () => {
@@ -47,12 +45,11 @@ describe( 'Address Autocomplete Provider Registration', () => {
 					provider
 				);
 			expect( result ).toBe( false );
-			expect( console.error ).toHaveBeenCalledWith(
+			expect( console ).toHaveErroredWith(
 				'Error registering address provider:',
 				'Address provider must be a valid object'
 			);
-			expect( console.error ).toHaveBeenCalledTimes( 1 );
-			console.error.mockClear();
+			expect( console ).toHaveErrored();
 		} );
 	} );
 
@@ -73,7 +70,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				validProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Provider test-provider not registered on server'
 		);
@@ -96,7 +93,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				validProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Provider test-provider not registered on server'
 		);
@@ -114,7 +111,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				invalidProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Address provider must have a valid ID'
 		);
@@ -133,7 +130,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				invalidProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Address provider must have a valid ID'
 		);
@@ -151,7 +148,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				invalidProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Address provider must have a canSearch function'
 		);
@@ -169,7 +166,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				invalidProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Address provider must have a search function'
 		);
@@ -187,7 +184,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				invalidProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Address provider must have a select function'
 		);
@@ -206,7 +203,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				unregisteredProvider
 			);
 		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
+		expect( console ).toHaveErroredWith(
 			'Error registering address provider:',
 			'Provider unregistered-provider not registered on server'
 		);

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -638,6 +638,26 @@ describe( 'Address Suggestions Component', () => {
 			expect( mockProvider.search ).not.toHaveBeenCalled();
 		} );
 
+		test( 'should hide suggestions when input goes from 3+ characters to less than 3', async () => {
+			// First show suggestions with 3+ characters
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+
+			// Now reduce to less than 3 characters
+			billingAddressInput.value = '12';
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
 		test( 'should display suggestions for input with 3 or more characters', async () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
@@ -1201,6 +1221,93 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.click();
 
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
+		} );
+	} );
+
+	describe( 'Blur Event Behavior', () => {
+		test( 'should hide suggestions when input loses focus', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+
+			// Blur the input
+			billingAddressInput.dispatchEvent( new Event( 'blur' ) );
+			
+			// Wait for blur timeout
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
+		test( 'should not refocus input when blurred with suggestions active', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+
+			// Create another element to focus
+			const otherElement = document.createElement( 'input' );
+			document.body.appendChild( otherElement );
+			
+			// Blur the address input and focus the other element
+			billingAddressInput.blur();
+			otherElement.focus();
+			
+			// Wait for blur timeout
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
+			// The other element should still be focused (address input shouldn't refocus)
+			expect( document.activeElement ).toBe( otherElement );
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+
+			document.body.removeChild( otherElement );
+		} );
+
+		test( 'should not have blur event listener when suggestions are not shown', () => {
+			// No suggestions should be shown initially
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+
+			// Blur the input - should not cause any issues
+			expect( () => {
+				billingAddressInput.dispatchEvent( new Event( 'blur' ) );
+			} ).not.toThrow();
+		} );
+
+		test( 'should enable browser autofill without refocusing when suggestions are hidden via blur', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			// Verify autofill is disabled
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'off' );
+
+			// Blur the input
+			billingAddressInput.dispatchEvent( new Event( 'blur' ) );
+			
+			// Wait for blur timeout
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
+			// Autofill should be re-enabled
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'address-line1' );
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( 'false' );
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -1084,7 +1084,7 @@ describe( 'Address Suggestions Component', () => {
 				'off'
 			);
 			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
-				''
+				'true'
 			);
 		} );
 
@@ -1239,7 +1239,7 @@ describe( 'Address Suggestions Component', () => {
 
 			// Blur the input
 			billingAddressInput.dispatchEvent( new Event( 'blur' ) );
-			
+
 			// Wait for blur timeout
 			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
 
@@ -1261,11 +1261,11 @@ describe( 'Address Suggestions Component', () => {
 			// Create another element to focus
 			const otherElement = document.createElement( 'input' );
 			document.body.appendChild( otherElement );
-			
+
 			// Blur the address input and focus the other element
 			billingAddressInput.blur();
 			otherElement.focus();
-			
+
 			// Wait for blur timeout
 			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
 
@@ -1297,17 +1297,23 @@ describe( 'Address Suggestions Component', () => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
 
 			// Verify autofill is disabled
-			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'off' );
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
+				'off'
+			);
 
 			// Blur the input
 			billingAddressInput.dispatchEvent( new Event( 'blur' ) );
-			
+
 			// Wait for blur timeout
 			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
 
 			// Autofill should be re-enabled
-			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'address-line1' );
-			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( 'false' );
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
+				'address-line1'
+			);
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
+				'false'
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -510,9 +510,6 @@ describe( 'Address Suggestions Component', () => {
 				'woocommerce-address-suggestions'
 			);
 			expect( billingSuggestions.style.display ).toBe( 'none' );
-			expect( billingSuggestions.getAttribute( 'role' ) ).toBe(
-				'region'
-			);
 			expect( billingSuggestions.getAttribute( 'aria-live' ) ).toBe(
 				'polite'
 			);

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -1086,6 +1086,12 @@ describe( 'Address Suggestions Component', () => {
 			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
 				'true'
 			);
+			expect( billingAddressInput.getAttribute( 'data-1p-ignore' ) ).toBe(
+				'true'
+			);
+			expect( billingAddressInput.getAttribute( 'data-op-ignore' ) ).toBe(
+				'true'
+			);
 		} );
 
 		test( 'should enable browser autofill when suggestions are hidden', async () => {
@@ -1104,7 +1110,13 @@ describe( 'Address Suggestions Component', () => {
 				'address-line1'
 			);
 			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
-				'false'
+				null
+			);
+			expect( billingAddressInput.getAttribute( 'data-1p-ignore' ) ).toBe(
+				null
+			);
+			expect( billingAddressInput.getAttribute( 'data-op-ignore' ) ).toBe(
+				null
 			);
 		} );
 	} );
@@ -1312,7 +1324,13 @@ describe( 'Address Suggestions Component', () => {
 				'address-line1'
 			);
 			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
-				'false'
+				null
+			);
+			expect( billingAddressInput.getAttribute( 'data-1p-ignore' ) ).toBe(
+				null
+			);
+			expect( billingAddressInput.getAttribute( 'data-op-ignore' ) ).toBe(
+				null
 			);
 		} );
 	} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -283,3 +283,663 @@ describe( 'Address Autocomplete Provider Registration', () => {
 		).toBe( true );
 	} );
 } );
+
+describe( 'Address Suggestions Component', () => {
+	let mockProvider;
+	let billingAddressInput;
+	let shippingAddressInput;
+
+	beforeEach( async () => {
+		// Reset DOM
+		document.body.innerHTML = '';
+		delete global.window.wc;
+		
+		// Mock jQuery
+		global.window.jQuery = jest.fn( ( selector ) => ({
+			hasClass: jest.fn( () => false ),
+			trigger: jest.fn(),
+			select2: jest.fn(),
+			on: jest.fn(),
+		}) );
+		
+		// Setup window object
+		Object.assign( global.window, {
+			wc_checkout_params: {
+				address_providers: [
+					{ id: 'test-provider', name: 'Test provider' },
+				],
+			},
+		} );
+
+		// Create DOM structure
+		const form = document.createElement( 'form' );
+		
+		// Billing fields
+		const billingCountry = document.createElement( 'select' );
+		billingCountry.id = 'billing_country';
+		const billingOption = document.createElement( 'option' );
+		billingOption.value = 'US';
+		billingOption.selected = true;
+		billingCountry.appendChild( billingOption );
+		billingCountry.value = 'US';
+		
+		const billingAddress1 = document.createElement( 'input' );
+		billingAddress1.id = 'billing_address_1';
+		billingAddress1.type = 'text';
+		
+		const billingCity = document.createElement( 'input' );
+		billingCity.id = 'billing_city';
+		billingCity.type = 'text';
+		
+		const billingPostcode = document.createElement( 'input' );
+		billingPostcode.id = 'billing_postcode';
+		billingPostcode.type = 'text';
+		
+		const billingState = document.createElement( 'input' );
+		billingState.id = 'billing_state';
+		billingState.type = 'text';
+
+		// Create wrapper for billing address
+		const billingWrapper = document.createElement( 'div' );
+		billingWrapper.className = 'woocommerce-input-wrapper';
+		billingWrapper.appendChild( billingAddress1 );
+		
+		// Shipping fields
+		const shippingCountry = document.createElement( 'select' );
+		shippingCountry.id = 'shipping_country';
+		const shippingOption = document.createElement( 'option' );
+		shippingOption.value = 'US';
+		shippingOption.selected = true;
+		shippingCountry.appendChild( shippingOption );
+		shippingCountry.value = 'US';
+		
+		const shippingAddress1 = document.createElement( 'input' );
+		shippingAddress1.id = 'shipping_address_1';
+		shippingAddress1.type = 'text';
+		
+		const shippingCity = document.createElement( 'input' );
+		shippingCity.id = 'shipping_city';
+		shippingCity.type = 'text';
+		
+		const shippingPostcode = document.createElement( 'input' );
+		shippingPostcode.id = 'shipping_postcode';
+		shippingPostcode.type = 'text';
+		
+		const shippingState = document.createElement( 'input' );
+		shippingState.id = 'shipping_state';
+		shippingState.type = 'text';
+
+		// Create wrapper for shipping address
+		const shippingWrapper = document.createElement( 'div' );
+		shippingWrapper.className = 'woocommerce-input-wrapper';
+		shippingWrapper.appendChild( shippingAddress1 );
+
+		form.appendChild( billingCountry );
+		form.appendChild( billingWrapper );
+		form.appendChild( billingCity );
+		form.appendChild( billingPostcode );
+		form.appendChild( billingState );
+		form.appendChild( shippingCountry );
+		form.appendChild( shippingWrapper );
+		form.appendChild( shippingCity );
+		form.appendChild( shippingPostcode );
+		form.appendChild( shippingState );
+		
+		document.body.appendChild( form );
+		
+		billingAddressInput = billingAddress1;
+		shippingAddressInput = shippingAddress1;
+
+		// Create mock provider
+		mockProvider = {
+			id: 'test-provider',
+			canSearch: jest.fn( ( country ) => country === 'US' ),
+			search: jest.fn( async ( type, query ) => [
+				{
+					id: 'addr1',
+					label: '123 Main Street, City, US',
+					matchedSubstrings: [ { offset: 0, length: 3 } ],
+				},
+				{
+					id: 'addr2',
+					label: '456 Oak Avenue, Town, US',
+					matchedSubstrings: [ { offset: 0, length: 3 } ],
+				},
+			] ),
+			select: jest.fn( async ( addressId ) => ( {
+				address_1: '123 Main Street',
+				city: 'City',
+				postcode: '12345',
+				country: 'US',
+				state: 'CA',
+			} ) ),
+		};
+
+		// Reset modules and require fresh instance
+		jest.resetModules();
+		require( '../address-autocomplete' );
+		
+		// Register the mock provider
+		window.wc.addressAutocomplete.registerAddressAutocompleteProvider( mockProvider );
+		
+		// Trigger DOMContentLoaded event and wait for initialization
+		const event = new Event( 'DOMContentLoaded' );
+		document.dispatchEvent( event );
+		
+		// Wait a bit for DOM initialization to complete
+		await new Promise( resolve => setTimeout( resolve, 10 ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'DOM Initialization', () => {
+		test( 'should create suggestions container and search icon for address inputs', () => {
+			const billingSuggestions = document.getElementById( 'address_suggestions_billing' );
+			const shippingSuggestions = document.getElementById( 'address_suggestions_shipping' );
+			
+			expect( billingSuggestions ).toBeTruthy();
+			expect( shippingSuggestions ).toBeTruthy();
+			
+			expect( billingSuggestions.className ).toBe( 'woocommerce-address-suggestions' );
+			expect( billingSuggestions.style.display ).toBe( 'none' );
+			expect( billingSuggestions.getAttribute( 'role' ) ).toBe( 'region' );
+			expect( billingSuggestions.getAttribute( 'aria-live' ) ).toBe( 'polite' );
+			
+			// Check suggestions list
+			const billingList = billingSuggestions.querySelector( '.suggestions-list' );
+			expect( billingList ).toBeTruthy();
+			expect( billingList.getAttribute( 'role' ) ).toBe( 'listbox' );
+			expect( billingList.getAttribute( 'aria-label' ) ).toBe( 'Address suggestions' );
+			
+			// Check search icon
+			const billingIcon = document.querySelector( '.address-search-icon' );
+			expect( billingIcon ).toBeTruthy();
+			expect( billingIcon.innerHTML ).toContain( '<svg' );
+		} );
+
+		test( 'should set active provider based on country value', () => {
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( mockProvider );
+			expect( window.wc.addressAutocomplete.activeProvider.shipping ).toBe( mockProvider );
+		} );
+
+		test( 'should add autocomplete-available class when provider is active', () => {
+			const billingWrapper = billingAddressInput.closest( '.woocommerce-input-wrapper' );
+			const shippingWrapper = shippingAddressInput.closest( '.woocommerce-input-wrapper' );
+			
+			expect( billingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( true );
+			expect( shippingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'Active Provider Management', () => {
+		test( 'should set active provider when country matches canSearch criteria', () => {
+			const billingCountry = document.getElementById( 'billing_country' );
+			billingCountry.value = 'US';
+			billingCountry.dispatchEvent( new Event( 'change' ) );
+			
+			expect( mockProvider.canSearch ).toHaveBeenCalledWith( 'US' );
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( mockProvider );
+		} );
+
+		test( 'should clear active provider when country does not match canSearch criteria', () => {
+			const billingCountry = document.getElementById( 'billing_country' );
+			// Create new option and select it
+			const frOption = document.createElement( 'option' );
+			frOption.value = 'FR';
+			billingCountry.appendChild( frOption );
+			billingCountry.value = 'FR';
+			billingCountry.dispatchEvent( new Event( 'change' ) );
+			
+			expect( mockProvider.canSearch ).toHaveBeenCalledWith( 'FR' );
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( null );
+		} );
+
+		test( 'should remove autocomplete-available class when no provider is active', () => {
+			const billingCountry = document.getElementById( 'billing_country' );
+			const billingWrapper = billingAddressInput.closest( '.woocommerce-input-wrapper' );
+			
+			billingCountry.value = 'FR';
+			billingCountry.dispatchEvent( new Event( 'change' ) );
+			
+			expect( billingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( false );
+		} );
+
+		test( 'should handle country change for both billing and shipping', () => {
+			const billingCountry = document.getElementById( 'billing_country' );
+			const shippingCountry = document.getElementById( 'shipping_country' );
+			
+			// Add FR option to billing
+			const frOption = document.createElement( 'option' );
+			frOption.value = 'FR';
+			billingCountry.appendChild( frOption );
+			billingCountry.value = 'FR';
+			
+			billingCountry.dispatchEvent( new Event( 'change' ) );
+			shippingCountry.dispatchEvent( new Event( 'change' ) );
+			
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( null );
+			expect( window.wc.addressAutocomplete.activeProvider.shipping ).toBe( mockProvider );
+		} );
+	} );
+
+	describe( 'Address Suggestions Display', () => {
+		test( 'should not display suggestions for input less than 3 characters', async () => {
+			billingAddressInput.value = 'ab';
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			// Wait for timeout
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			expect( suggestionsList.innerHTML ).toBe( '' );
+			expect( mockProvider.search ).not.toHaveBeenCalled();
+		} );
+
+		test( 'should display suggestions for input with 3 or more characters', async () => {
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			// Wait for timeout and async operations
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			expect( mockProvider.search ).toHaveBeenCalledWith( 'billing', '123' );
+			
+			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			const suggestions = suggestionsList.querySelectorAll( 'li' );
+			
+			expect( suggestions ).toHaveLength( 2 );
+			expect( suggestions[0].textContent ).toContain( '123 Main Street' );
+			expect( suggestions[1].textContent ).toContain( '456 Oak Avenue' );
+		} );
+
+		test( 'should highlight matched text in suggestions', async () => {
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			const firstSuggestion = suggestionsList.querySelector( 'li' );
+			const strongElement = firstSuggestion.querySelector( 'strong' );
+			
+			expect( strongElement ).toBeTruthy();
+			expect( strongElement.textContent ).toBe( '123' );
+		} );
+
+		test( 'should limit suggestions to maximum of 5', async () => {
+			// Mock provider to return more than 5 suggestions
+			mockProvider.search.mockResolvedValue( Array.from( { length: 10 }, ( _, i ) => ( {
+				id: `addr${i}`,
+				label: `${i} Test Street`,
+				matchedSubstrings: [],
+			} ) ) );
+			
+			billingAddressInput.value = 'test';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			const suggestions = suggestionsList.querySelectorAll( 'li' );
+			
+			expect( suggestions ).toHaveLength( 5 );
+		} );
+
+		test( 'should hide suggestions when no results returned', async () => {
+			mockProvider.search.mockResolvedValue( [] );
+			
+			billingAddressInput.value = 'xyz';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
+		test( 'should hide suggestions and log error when search throws exception', async () => {
+			mockProvider.search.mockRejectedValue( new Error( 'Search failed' ) );
+			
+			const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			
+			billingAddressInput.value = 'test';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+			expect( consoleSpy ).toHaveBeenCalledWith( 'Address search error:', expect.any( Error ) );
+			
+			consoleSpy.mockRestore();
+		} );
+
+	} );
+
+	describe( 'Keyboard Navigation', () => {
+		beforeEach( async () => {
+			// Setup suggestions
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+		} );
+
+		test( 'should navigate down with ArrowDown key', () => {
+			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
+			
+			// First suggestion should be active initially
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
+			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( 'true' );
+			
+			// Press ArrowDown
+			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Second suggestion should now be active
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( false );
+			expect( suggestions[1].classList.contains( 'active' ) ).toBe( true );
+			expect( suggestions[1].getAttribute( 'aria-selected' ) ).toBe( 'true' );
+		} );
+
+		test( 'should navigate up with ArrowUp key', () => {
+			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
+			
+			// Navigate to second item first
+			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Press ArrowUp
+			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowUp', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// First suggestion should be active again
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
+			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
+		} );
+
+		test( 'should wrap around when navigating beyond bounds', () => {
+			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
+			
+			// Navigate to last item
+			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Navigate beyond last item - should wrap to first
+			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
+			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
+		} );
+
+		test( 'should select address with Enter key', async () => {
+			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
+			
+			// Press Enter to select first suggestion
+			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Wait for async operations
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+			
+			expect( mockProvider.select ).toHaveBeenCalledWith( 'addr1' );
+			
+			// Suggestions should be hidden
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
+		test( 'should hide suggestions with Escape key', () => {
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+			
+			// Press Escape
+			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
+		test( 'should not handle keyboard events when suggestions are hidden', () => {
+			// Hide suggestions first
+			const escapeEvent = new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } );
+			billingAddressInput.dispatchEvent( escapeEvent );
+			
+			// Try to navigate with ArrowDown - should not throw error
+			const arrowEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			expect( () => {
+				billingAddressInput.dispatchEvent( arrowEvent );
+			} ).not.toThrow();
+		} );
+	} );
+
+	describe( 'Address Selection', () => {
+		test( 'should populate address fields when address is selected', async () => {
+			// Setup suggestions
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			// Click on first suggestion
+			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			firstSuggestion.click();
+			
+			// Wait for async operations and timeout
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+			
+			expect( mockProvider.select ).toHaveBeenCalledWith( 'addr1' );
+			
+			// Check that fields are populated
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123 Main Street' );
+			expect( document.getElementById( 'billing_city' ).value ).toBe( 'City' );
+			expect( document.getElementById( 'billing_postcode' ).value ).toBe( '12345' );
+			expect( document.getElementById( 'billing_country' ).value ).toBe( 'US' );
+			expect( document.getElementById( 'billing_state' ).value ).toBe( 'CA' );
+		} );
+
+		test( 'should handle partial address data from provider', async () => {
+			// Mock provider to return partial data
+			mockProvider.select.mockResolvedValue( {
+				address_1: '123 Main Street',
+				city: 'City',
+				// Missing postcode, country, state
+			} );
+			
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			firstSuggestion.click();
+			
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+			
+			// Only provided fields should be populated
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123 Main Street' );
+			expect( document.getElementById( 'billing_city' ).value ).toBe( 'City' );
+			expect( document.getElementById( 'billing_postcode' ).value ).toBe( '' );
+		} );
+
+		test( 'should handle provider selection errors gracefully', async () => {
+			mockProvider.select.mockRejectedValue( new Error( 'Selection failed' ) );
+			
+			const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			firstSuggestion.click();
+			
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+			
+			expect( consoleSpy ).toHaveBeenCalledWith( 
+				'Error selecting address from provider', 
+				'test-provider', 
+				expect.any( Error ) 
+			);
+			
+			// Fields should remain unchanged
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123' );
+			
+			consoleSpy.mockRestore();
+		} );
+
+		test( 'should handle invalid address data from provider', async () => {
+			mockProvider.select.mockResolvedValue( null );
+			
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			firstSuggestion.click();
+			
+			await new Promise( resolve => setTimeout( resolve, 250 ) );
+			
+			// Fields should remain unchanged
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123' );
+		} );
+	} );
+
+	describe( 'Browser Autofill Management', () => {
+		test( 'should disable browser autofill when suggestions are shown', async () => {
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'off' );
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( '' );
+		} );
+
+		test( 'should enable browser autofill when suggestions are hidden', async () => {
+			// First show suggestions
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			// Then hide them
+			billingAddressInput.value = 'xy';
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'address-line1' );
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( 'false' );
+		} );
+	} );
+
+	describe( 'Security and Sanitization', () => {
+		test( 'should sanitize input values for XSS protection', async () => {
+			const maliciousInput = '<script>alert("xss")</script>';
+			const consoleSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+			
+			billingAddressInput.value = maliciousInput;
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			expect( consoleSpy ).toHaveBeenCalledWith( 'Input was sanitized for security' );
+			expect( mockProvider.search ).toHaveBeenCalledWith( 'billing', 'alert("xss")' );
+			
+			consoleSpy.mockRestore();
+		} );
+
+		test( 'should handle invalid match data safely', async () => {
+			// Mock provider to return invalid match data
+			mockProvider.search.mockResolvedValue( [
+				{
+					id: 'addr1',
+					label: '123 Main Street',
+					matchedSubstrings: [
+						{ offset: -1, length: 5 }, // Invalid offset
+						{ offset: 50, length: 10 }, // Offset beyond string length
+						{ offset: 0, length: -1 }, // Invalid length
+						null, // Null match
+					],
+				},
+			] );
+			
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			const firstSuggestion = suggestionsList.querySelector( 'li' );
+			
+			// Should still render the suggestion without highlighting
+			expect( firstSuggestion.textContent ).toBe( '123 Main Street' );
+			expect( firstSuggestion.querySelector( 'strong' ) ).toBe( null );
+		} );
+	} );
+
+	describe( 'Click Outside Behavior', () => {
+		test( 'should hide suggestions when clicking outside', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+			
+			// Click outside
+			const outsideElement = document.createElement( 'div' );
+			document.body.appendChild( outsideElement );
+			outsideElement.click();
+			
+			expect( suggestionsContainer.style.display ).toBe( 'none' );
+		} );
+
+		test( 'should not hide suggestions when clicking inside suggestions container', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+			
+			// Click inside suggestions container
+			suggestionsContainer.click();
+			
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+		} );
+
+		test( 'should not hide suggestions when clicking address input', async () => {
+			// Show suggestions first
+			billingAddressInput.value = '123';
+			billingAddressInput.focus();
+			billingAddressInput.dispatchEvent( new Event( 'input' ) );
+			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			
+			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+			
+			// Click on address input
+			billingAddressInput.click();
+			
+			expect( suggestionsContainer.style.display ).toBe( 'block' );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -37,26 +37,21 @@ describe( 'Address Autocomplete Provider Registration', () => {
 		expect( console.error ).not.toHaveBeenCalled();
 	} );
 
-	test( 'should reject undefined provider', () => {
-		const result =
-			window.wc.addressAutocomplete.registerAddressAutocompleteProvider();
-		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
-			'Error registering address provider:',
-			'Address provider must be a valid object'
-		);
-	} );
+	test( 'should reject invalid provider (null, undefined, non-object)', () => {
+		const invalidProviders = [ null, undefined, 'string', 123, true ];
 
-	test( 'should reject null provider', () => {
-		const result =
-			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
-				null
+		invalidProviders.forEach( ( provider ) => {
+			const result =
+				window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+					provider
+				);
+			expect( result ).toBe( false );
+			expect( console.error ).toHaveBeenCalledWith(
+				'Error registering address provider:',
+				'Address provider must be a valid object'
 			);
-		expect( result ).toBe( false );
-		expect( console.error ).toHaveBeenCalledWith(
-			'Error registering address provider:',
-			'Address provider must be a valid object'
-		);
+			console.error.mockClear();
+		} );
 	} );
 
 	test( 'should handle missing wc_checkout_params', () => {
@@ -207,5 +202,77 @@ describe( 'Address Autocomplete Provider Registration', () => {
 			'Error registering address provider:',
 			'Provider unregistered-provider not registered on server'
 		);
+	} );
+
+	test( 'should freeze provider after successful registration', () => {
+		const validProvider = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				validProvider
+			);
+		expect( result ).toBe( true );
+
+		// Verify provider is frozen
+		expect(
+			Object.isFrozen(
+				window.wc.addressAutocomplete.providers[ 'test-provider' ]
+			)
+		).toBe( true );
+
+		// Attempt to modify should throw in strict mode
+		expect( () => {
+			'use strict';
+			window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp = 'test';
+		} ).toThrow( TypeError );
+		
+		// Verify the property wasn't added
+		expect( window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp ).toBeUndefined();
+	} );
+
+	test( 'should not allow duplicate provider registration', () => {
+		const provider1 = {
+			id: 'test-provider',
+			canSearch: () => {},
+			search: () => {},
+			select: () => {},
+		};
+
+		const provider2 = {
+			id: 'test-provider',
+			canSearch: () => {
+				return true;
+			},
+			search: () => {
+				return [];
+			},
+			select: () => {
+				return {};
+			},
+		};
+
+		// Register first provider
+		window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+			provider1
+		);
+
+		// Try to register second provider with same ID
+		const result =
+			window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+				provider2
+			);
+		expect( result ).toBe( true );
+
+		// Verify the second provider overwrote the first
+		expect(
+			window.wc.addressAutocomplete.providers[
+				'test-provider'
+			].canSearch()
+		).toBe( true );
 	} );
 } );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -635,25 +635,29 @@ describe( 'Address Suggestions Component', () => {
 		test( 'should navigate down with ArrowDown key', () => {
 			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
 			
-			// First suggestion should be active initially
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
-			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( 'true' );
+			// No suggestion should be active initially
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( false );
+			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( null );
 			
 			// Press ArrowDown
 			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
 			billingAddressInput.dispatchEvent( keydownEvent );
 			
-			// Second suggestion should now be active
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( false );
-			expect( suggestions[1].classList.contains( 'active' ) ).toBe( true );
-			expect( suggestions[1].getAttribute( 'aria-selected' ) ).toBe( 'true' );
+			// First suggestion should now be active
+			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
+			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( 'true' );
+			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
 		} );
 
 		test( 'should navigate up with ArrowUp key', () => {
 			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
 			
-			// Navigate to second item first
+			// Navigate to first item first
 			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Navigate to second item
+			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
 			billingAddressInput.dispatchEvent( keydownEvent );
 			
 			// Press ArrowUp
@@ -668,8 +672,12 @@ describe( 'Address Suggestions Component', () => {
 		test( 'should wrap around when navigating beyond bounds', () => {
 			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
 			
-			// Navigate to last item
+			// Navigate to first item
 			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
+			// Navigate to second (last) item
+			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
 			billingAddressInput.dispatchEvent( keydownEvent );
 			
 			// Navigate beyond last item - should wrap to first
@@ -683,8 +691,12 @@ describe( 'Address Suggestions Component', () => {
 		test( 'should select address with Enter key', async () => {
 			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
 			
+			// Navigate to first suggestion first
+			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			billingAddressInput.dispatchEvent( keydownEvent );
+			
 			// Press Enter to select first suggestion
-			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } );
 			billingAddressInput.dispatchEvent( keydownEvent );
 			
 			// Wait for async operations

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -293,15 +293,15 @@ describe( 'Address Suggestions Component', () => {
 		// Reset DOM
 		document.body.innerHTML = '';
 		delete global.window.wc;
-		
+
 		// Mock jQuery
-		global.window.jQuery = jest.fn( ( selector ) => ({
+		global.window.jQuery = jest.fn( ( selector ) => ( {
 			hasClass: jest.fn( () => false ),
 			trigger: jest.fn(),
 			select2: jest.fn(),
 			on: jest.fn(),
-		}) );
-		
+		} ) );
+
 		// Setup window object
 		Object.assign( global.window, {
 			wc_checkout_params: {
@@ -313,7 +313,7 @@ describe( 'Address Suggestions Component', () => {
 
 		// Create DOM structure
 		const form = document.createElement( 'form' );
-		
+
 		// Billing fields
 		const billingCountry = document.createElement( 'select' );
 		billingCountry.id = 'billing_country';
@@ -322,19 +322,19 @@ describe( 'Address Suggestions Component', () => {
 		billingOption.selected = true;
 		billingCountry.appendChild( billingOption );
 		billingCountry.value = 'US';
-		
+
 		const billingAddress1 = document.createElement( 'input' );
 		billingAddress1.id = 'billing_address_1';
 		billingAddress1.type = 'text';
-		
+
 		const billingCity = document.createElement( 'input' );
 		billingCity.id = 'billing_city';
 		billingCity.type = 'text';
-		
+
 		const billingPostcode = document.createElement( 'input' );
 		billingPostcode.id = 'billing_postcode';
 		billingPostcode.type = 'text';
-		
+
 		const billingState = document.createElement( 'input' );
 		billingState.id = 'billing_state';
 		billingState.type = 'text';
@@ -343,7 +343,7 @@ describe( 'Address Suggestions Component', () => {
 		const billingWrapper = document.createElement( 'div' );
 		billingWrapper.className = 'woocommerce-input-wrapper';
 		billingWrapper.appendChild( billingAddress1 );
-		
+
 		// Shipping fields
 		const shippingCountry = document.createElement( 'select' );
 		shippingCountry.id = 'shipping_country';
@@ -352,19 +352,19 @@ describe( 'Address Suggestions Component', () => {
 		shippingOption.selected = true;
 		shippingCountry.appendChild( shippingOption );
 		shippingCountry.value = 'US';
-		
+
 		const shippingAddress1 = document.createElement( 'input' );
 		shippingAddress1.id = 'shipping_address_1';
 		shippingAddress1.type = 'text';
-		
+
 		const shippingCity = document.createElement( 'input' );
 		shippingCity.id = 'shipping_city';
 		shippingCity.type = 'text';
-		
+
 		const shippingPostcode = document.createElement( 'input' );
 		shippingPostcode.id = 'shipping_postcode';
 		shippingPostcode.type = 'text';
-		
+
 		const shippingState = document.createElement( 'input' );
 		shippingState.id = 'shipping_state';
 		shippingState.type = 'text';
@@ -384,9 +384,9 @@ describe( 'Address Suggestions Component', () => {
 		form.appendChild( shippingCity );
 		form.appendChild( shippingPostcode );
 		form.appendChild( shippingState );
-		
+
 		document.body.appendChild( form );
-		
+
 		billingAddressInput = billingAddress1;
 		shippingAddressInput = shippingAddress1;
 
@@ -418,16 +418,18 @@ describe( 'Address Suggestions Component', () => {
 		// Reset modules and require fresh instance
 		jest.resetModules();
 		require( '../address-autocomplete' );
-		
+
 		// Register the mock provider
-		window.wc.addressAutocomplete.registerAddressAutocompleteProvider( mockProvider );
-		
+		window.wc.addressAutocomplete.registerAddressAutocompleteProvider(
+			mockProvider
+		);
+
 		// Trigger DOMContentLoaded event and wait for initialization
 		const event = new Event( 'DOMContentLoaded' );
 		document.dispatchEvent( event );
-		
+
 		// Wait a bit for DOM initialization to complete
-		await new Promise( resolve => setTimeout( resolve, 10 ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
 	} );
 
 	afterEach( () => {
@@ -435,41 +437,67 @@ describe( 'Address Suggestions Component', () => {
 	} );
 
 	describe( 'DOM Initialization', () => {
-		test( 'should create suggestions container and search icon for address inputs', () => {
-			const billingSuggestions = document.getElementById( 'address_suggestions_billing' );
-			const shippingSuggestions = document.getElementById( 'address_suggestions_shipping' );
-			
+		test( 'should create suggestions container for address inputs', () => {
+			const billingSuggestions = document.getElementById(
+				'address_suggestions_billing'
+			);
+			const shippingSuggestions = document.getElementById(
+				'address_suggestions_shipping'
+			);
+
 			expect( billingSuggestions ).toBeTruthy();
 			expect( shippingSuggestions ).toBeTruthy();
-			
-			expect( billingSuggestions.className ).toBe( 'woocommerce-address-suggestions' );
+
+			expect( billingSuggestions.className ).toBe(
+				'woocommerce-address-suggestions'
+			);
 			expect( billingSuggestions.style.display ).toBe( 'none' );
-			expect( billingSuggestions.getAttribute( 'role' ) ).toBe( 'region' );
-			expect( billingSuggestions.getAttribute( 'aria-live' ) ).toBe( 'polite' );
-			
+			expect( billingSuggestions.getAttribute( 'role' ) ).toBe(
+				'region'
+			);
+			expect( billingSuggestions.getAttribute( 'aria-live' ) ).toBe(
+				'polite'
+			);
+
 			// Check suggestions list
-			const billingList = billingSuggestions.querySelector( '.suggestions-list' );
+			const billingList =
+				billingSuggestions.querySelector( '.suggestions-list' );
 			expect( billingList ).toBeTruthy();
 			expect( billingList.getAttribute( 'role' ) ).toBe( 'listbox' );
-			expect( billingList.getAttribute( 'aria-label' ) ).toBe( 'Address suggestions' );
-			
-			// Check search icon
-			const billingIcon = document.querySelector( '.address-search-icon' );
-			expect( billingIcon ).toBeTruthy();
-			expect( billingIcon.innerHTML ).toContain( '<svg' );
+			expect( billingList.getAttribute( 'aria-label' ) ).toBe(
+				'Address suggestions'
+			);
+
+			// Check search icon container exists
+			const billingIconContainer = document.querySelector(
+				'.address-search-icon'
+			);
+			expect( billingIconContainer ).toBeTruthy();
 		} );
 
 		test( 'should set active provider based on country value', () => {
-			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( mockProvider );
-			expect( window.wc.addressAutocomplete.activeProvider.shipping ).toBe( mockProvider );
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe(
+				mockProvider
+			);
+			expect(
+				window.wc.addressAutocomplete.activeProvider.shipping
+			).toBe( mockProvider );
 		} );
 
 		test( 'should add autocomplete-available class when provider is active', () => {
-			const billingWrapper = billingAddressInput.closest( '.woocommerce-input-wrapper' );
-			const shippingWrapper = shippingAddressInput.closest( '.woocommerce-input-wrapper' );
-			
-			expect( billingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( true );
-			expect( shippingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( true );
+			const billingWrapper = billingAddressInput.closest(
+				'.woocommerce-input-wrapper'
+			);
+			const shippingWrapper = shippingAddressInput.closest(
+				'.woocommerce-input-wrapper'
+			);
+
+			expect(
+				billingWrapper.classList.contains( 'autocomplete-available' )
+			).toBe( true );
+			expect(
+				shippingWrapper.classList.contains( 'autocomplete-available' )
+			).toBe( true );
 		} );
 	} );
 
@@ -478,9 +506,11 @@ describe( 'Address Suggestions Component', () => {
 			const billingCountry = document.getElementById( 'billing_country' );
 			billingCountry.value = 'US';
 			billingCountry.dispatchEvent( new Event( 'change' ) );
-			
+
 			expect( mockProvider.canSearch ).toHaveBeenCalledWith( 'US' );
-			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( mockProvider );
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe(
+				mockProvider
+			);
 		} );
 
 		test( 'should clear active provider when country does not match canSearch criteria', () => {
@@ -491,36 +521,47 @@ describe( 'Address Suggestions Component', () => {
 			billingCountry.appendChild( frOption );
 			billingCountry.value = 'FR';
 			billingCountry.dispatchEvent( new Event( 'change' ) );
-			
+
 			expect( mockProvider.canSearch ).toHaveBeenCalledWith( 'FR' );
-			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( null );
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe(
+				null
+			);
 		} );
 
 		test( 'should remove autocomplete-available class when no provider is active', () => {
 			const billingCountry = document.getElementById( 'billing_country' );
-			const billingWrapper = billingAddressInput.closest( '.woocommerce-input-wrapper' );
-			
+			const billingWrapper = billingAddressInput.closest(
+				'.woocommerce-input-wrapper'
+			);
+
 			billingCountry.value = 'FR';
 			billingCountry.dispatchEvent( new Event( 'change' ) );
-			
-			expect( billingWrapper.classList.contains( 'autocomplete-available' ) ).toBe( false );
+
+			expect(
+				billingWrapper.classList.contains( 'autocomplete-available' )
+			).toBe( false );
 		} );
 
 		test( 'should handle country change for both billing and shipping', () => {
 			const billingCountry = document.getElementById( 'billing_country' );
-			const shippingCountry = document.getElementById( 'shipping_country' );
-			
+			const shippingCountry =
+				document.getElementById( 'shipping_country' );
+
 			// Add FR option to billing
 			const frOption = document.createElement( 'option' );
 			frOption.value = 'FR';
 			billingCountry.appendChild( frOption );
 			billingCountry.value = 'FR';
-			
+
 			billingCountry.dispatchEvent( new Event( 'change' ) );
 			shippingCountry.dispatchEvent( new Event( 'change' ) );
-			
-			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe( null );
-			expect( window.wc.addressAutocomplete.activeProvider.shipping ).toBe( mockProvider );
+
+			expect( window.wc.addressAutocomplete.activeProvider.billing ).toBe(
+				null
+			);
+			expect(
+				window.wc.addressAutocomplete.activeProvider.shipping
+			).toBe( mockProvider );
 		} );
 	} );
 
@@ -528,11 +569,13 @@ describe( 'Address Suggestions Component', () => {
 		test( 'should not display suggestions for input less than 3 characters', async () => {
 			billingAddressInput.value = 'ab';
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
+
 			// Wait for timeout
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsList = document.querySelector(
+				'#address_suggestions_billing .suggestions-list'
+			);
 			expect( suggestionsList.innerHTML ).toBe( '' );
 			expect( mockProvider.search ).not.toHaveBeenCalled();
 		} );
@@ -541,86 +584,111 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
+
 			// Wait for timeout and async operations
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			expect( mockProvider.search ).toHaveBeenCalledWith( 'billing', '123' );
-			
-			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			expect( mockProvider.search ).toHaveBeenCalledWith(
+				'billing',
+				'123'
+			);
+
+			const suggestionsList = document.querySelector(
+				'#address_suggestions_billing .suggestions-list'
+			);
 			const suggestions = suggestionsList.querySelectorAll( 'li' );
-			
+
 			expect( suggestions ).toHaveLength( 2 );
-			expect( suggestions[0].textContent ).toContain( '123 Main Street' );
-			expect( suggestions[1].textContent ).toContain( '456 Oak Avenue' );
+			expect( suggestions[ 0 ].textContent ).toContain(
+				'123 Main Street'
+			);
+			expect( suggestions[ 1 ].textContent ).toContain(
+				'456 Oak Avenue'
+			);
 		} );
 
 		test( 'should highlight matched text in suggestions', async () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsList = document.querySelector(
+				'#address_suggestions_billing .suggestions-list'
+			);
 			const firstSuggestion = suggestionsList.querySelector( 'li' );
 			const strongElement = firstSuggestion.querySelector( 'strong' );
-			
+
 			expect( strongElement ).toBeTruthy();
 			expect( strongElement.textContent ).toBe( '123' );
 		} );
 
 		test( 'should limit suggestions to maximum of 5', async () => {
 			// Mock provider to return more than 5 suggestions
-			mockProvider.search.mockResolvedValue( Array.from( { length: 10 }, ( _, i ) => ( {
-				id: `addr${i}`,
-				label: `${i} Test Street`,
-				matchedSubstrings: [],
-			} ) ) );
-			
+			mockProvider.search.mockResolvedValue(
+				Array.from( { length: 10 }, ( _, i ) => ( {
+					id: `addr${ i }`,
+					label: `${ i } Test Street`,
+					matchedSubstrings: [],
+				} ) )
+			);
+
 			billingAddressInput.value = 'test';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsList = document.querySelector(
+				'#address_suggestions_billing .suggestions-list'
+			);
 			const suggestions = suggestionsList.querySelectorAll( 'li' );
-			
+
 			expect( suggestions ).toHaveLength( 5 );
 		} );
 
 		test( 'should hide suggestions when no results returned', async () => {
 			mockProvider.search.mockResolvedValue( [] );
-			
+
 			billingAddressInput.value = 'xyz';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'none' );
 		} );
 
 		test( 'should hide suggestions and log error when search throws exception', async () => {
-			mockProvider.search.mockRejectedValue( new Error( 'Search failed' ) );
-			
-			const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-			
+			mockProvider.search.mockRejectedValue(
+				new Error( 'Search failed' )
+			);
+
+			const consoleSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => {} );
+
 			billingAddressInput.value = 'test';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'none' );
-			expect( consoleSpy ).toHaveBeenCalledWith( 'Address search error:', expect.any( Error ) );
-			
+			expect( consoleSpy ).toHaveBeenCalledWith(
+				'Address search error:',
+				expect.any( Error )
+			);
+
 			consoleSpy.mockRestore();
 		} );
-
 	} );
 
 	describe( 'Keyboard Navigation', () => {
@@ -629,104 +697,170 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
 		} );
 
 		test( 'should navigate down with ArrowDown key', () => {
-			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
-			
+			const suggestions = document.querySelectorAll(
+				'#address_suggestions_billing .suggestions-list li'
+			);
+
 			// No suggestion should be active initially
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( false );
-			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( null );
-			
+			expect( suggestions[ 0 ].classList.contains( 'active' ) ).toBe(
+				false
+			);
+			expect( suggestions[ 0 ].getAttribute( 'aria-selected' ) ).toBe(
+				null
+			);
+
 			// Press ArrowDown
-			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			const keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// First suggestion should now be active
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
-			expect( suggestions[0].getAttribute( 'aria-selected' ) ).toBe( 'true' );
-			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
+			expect( suggestions[ 0 ].classList.contains( 'active' ) ).toBe(
+				true
+			);
+			expect( suggestions[ 0 ].getAttribute( 'aria-selected' ) ).toBe(
+				'true'
+			);
+			expect( suggestions[ 1 ].classList.contains( 'active' ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should navigate up with ArrowUp key', () => {
-			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
-			
+			const suggestions = document.querySelectorAll(
+				'#address_suggestions_billing .suggestions-list li'
+			);
+
 			// Navigate to first item first
-			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			let keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Navigate to second item
-			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Press ArrowUp
-			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowUp', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowUp',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// First suggestion should be active again
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
-			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
+			expect( suggestions[ 0 ].classList.contains( 'active' ) ).toBe(
+				true
+			);
+			expect( suggestions[ 1 ].classList.contains( 'active' ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should wrap around when navigating beyond bounds', () => {
-			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
-			
+			const suggestions = document.querySelectorAll(
+				'#address_suggestions_billing .suggestions-list li'
+			);
+
 			// Navigate to first item
-			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			let keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Navigate to second (last) item
-			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Navigate beyond last item - should wrap to first
-			keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
-			expect( suggestions[0].classList.contains( 'active' ) ).toBe( true );
-			expect( suggestions[1].classList.contains( 'active' ) ).toBe( false );
+
+			expect( suggestions[ 0 ].classList.contains( 'active' ) ).toBe(
+				true
+			);
+			expect( suggestions[ 1 ].classList.contains( 'active' ) ).toBe(
+				false
+			);
 		} );
 
 		test( 'should select address with Enter key', async () => {
-			const suggestions = document.querySelectorAll( '#address_suggestions_billing .suggestions-list li' );
-			
+			const suggestions = document.querySelectorAll(
+				'#address_suggestions_billing .suggestions-list li'
+			);
+
 			// Navigate to first suggestion first
-			let keydownEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			let keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Press Enter to select first suggestion
-			keydownEvent = new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } );
+			keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			// Wait for async operations
-			await new Promise( resolve => setTimeout( resolve, 250 ) );
-			
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
 			expect( mockProvider.select ).toHaveBeenCalledWith( 'addr1' );
-			
+
 			// Suggestions should be hidden
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'none' );
 		} );
 
 		test( 'should hide suggestions with Escape key', () => {
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
-			
+
 			// Press Escape
-			const keydownEvent = new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } );
+			const keydownEvent = new KeyboardEvent( 'keydown', {
+				key: 'Escape',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( keydownEvent );
-			
+
 			expect( suggestionsContainer.style.display ).toBe( 'none' );
 		} );
 
 		test( 'should not handle keyboard events when suggestions are hidden', () => {
 			// Hide suggestions first
-			const escapeEvent = new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } );
+			const escapeEvent = new KeyboardEvent( 'keydown', {
+				key: 'Escape',
+				bubbles: true,
+			} );
 			billingAddressInput.dispatchEvent( escapeEvent );
-			
+
 			// Try to navigate with ArrowDown - should not throw error
-			const arrowEvent = new KeyboardEvent( 'keydown', { key: 'ArrowDown', bubbles: true } );
+			const arrowEvent = new KeyboardEvent( 'keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+			} );
 			expect( () => {
 				billingAddressInput.dispatchEvent( arrowEvent );
 			} ).not.toThrow();
@@ -739,23 +873,35 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
 			// Click on first suggestion
-			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			const firstSuggestion = document.querySelector(
+				'#address_suggestions_billing .suggestions-list li'
+			);
 			firstSuggestion.click();
-			
+
 			// Wait for async operations and timeout
-			await new Promise( resolve => setTimeout( resolve, 250 ) );
-			
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
 			expect( mockProvider.select ).toHaveBeenCalledWith( 'addr1' );
-			
+
 			// Check that fields are populated
-			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123 Main Street' );
-			expect( document.getElementById( 'billing_city' ).value ).toBe( 'City' );
-			expect( document.getElementById( 'billing_postcode' ).value ).toBe( '12345' );
-			expect( document.getElementById( 'billing_country' ).value ).toBe( 'US' );
-			expect( document.getElementById( 'billing_state' ).value ).toBe( 'CA' );
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe(
+				'123 Main Street'
+			);
+			expect( document.getElementById( 'billing_city' ).value ).toBe(
+				'City'
+			);
+			expect( document.getElementById( 'billing_postcode' ).value ).toBe(
+				'12345'
+			);
+			expect( document.getElementById( 'billing_country' ).value ).toBe(
+				'US'
+			);
+			expect( document.getElementById( 'billing_state' ).value ).toBe(
+				'CA'
+			);
 		} );
 
 		test( 'should handle partial address data from provider', async () => {
@@ -765,65 +911,85 @@ describe( 'Address Suggestions Component', () => {
 				city: 'City',
 				// Missing postcode, country, state
 			} );
-			
+
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const firstSuggestion = document.querySelector(
+				'#address_suggestions_billing .suggestions-list li'
+			);
 			firstSuggestion.click();
-			
-			await new Promise( resolve => setTimeout( resolve, 250 ) );
-			
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
 			// Only provided fields should be populated
-			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123 Main Street' );
-			expect( document.getElementById( 'billing_city' ).value ).toBe( 'City' );
-			expect( document.getElementById( 'billing_postcode' ).value ).toBe( '' );
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe(
+				'123 Main Street'
+			);
+			expect( document.getElementById( 'billing_city' ).value ).toBe(
+				'City'
+			);
+			expect( document.getElementById( 'billing_postcode' ).value ).toBe(
+				''
+			);
 		} );
 
 		test( 'should handle provider selection errors gracefully', async () => {
-			mockProvider.select.mockRejectedValue( new Error( 'Selection failed' ) );
-			
-			const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-			
+			mockProvider.select.mockRejectedValue(
+				new Error( 'Selection failed' )
+			);
+
+			const consoleSpy = jest
+				.spyOn( console, 'error' )
+				.mockImplementation( () => {} );
+
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
-			firstSuggestion.click();
-			
-			await new Promise( resolve => setTimeout( resolve, 250 ) );
-			
-			expect( consoleSpy ).toHaveBeenCalledWith( 
-				'Error selecting address from provider', 
-				'test-provider', 
-				expect.any( Error ) 
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const firstSuggestion = document.querySelector(
+				'#address_suggestions_billing .suggestions-list li'
 			);
-			
+			firstSuggestion.click();
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
+			expect( consoleSpy ).toHaveBeenCalledWith(
+				'Error selecting address from provider',
+				'test-provider',
+				expect.any( Error )
+			);
+
 			// Fields should remain unchanged
-			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123' );
-			
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe(
+				'123'
+			);
+
 			consoleSpy.mockRestore();
 		} );
 
 		test( 'should handle invalid address data from provider', async () => {
 			mockProvider.select.mockResolvedValue( null );
-			
+
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const firstSuggestion = document.querySelector( '#address_suggestions_billing .suggestions-list li' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const firstSuggestion = document.querySelector(
+				'#address_suggestions_billing .suggestions-list li'
+			);
 			firstSuggestion.click();
-			
-			await new Promise( resolve => setTimeout( resolve, 250 ) );
-			
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+
 			// Fields should remain unchanged
-			expect( document.getElementById( 'billing_address_1' ).value ).toBe( '123' );
+			expect( document.getElementById( 'billing_address_1' ).value ).toBe(
+				'123'
+			);
 		} );
 	} );
 
@@ -832,11 +998,15 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'off' );
-			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( '' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
+				'off'
+			);
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
+				''
+			);
 		} );
 
 		test( 'should enable browser autofill when suggestions are hidden', async () => {
@@ -844,32 +1014,43 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
 			// Then hide them
 			billingAddressInput.value = 'xy';
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe( 'address-line1' );
-			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe( 'false' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			expect( billingAddressInput.getAttribute( 'autocomplete' ) ).toBe(
+				'address-line1'
+			);
+			expect( billingAddressInput.getAttribute( 'data-lpignore' ) ).toBe(
+				'false'
+			);
 		} );
 	} );
 
 	describe( 'Security and Sanitization', () => {
 		test( 'should sanitize input values for XSS protection', async () => {
 			const maliciousInput = '<script>alert("xss")</script>';
-			const consoleSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-			
+			const consoleSpy = jest
+				.spyOn( console, 'warn' )
+				.mockImplementation( () => {} );
+
 			billingAddressInput.value = maliciousInput;
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			expect( consoleSpy ).toHaveBeenCalledWith( 'Input was sanitized for security' );
-			expect( mockProvider.search ).toHaveBeenCalledWith( 'billing', 'alert("xss")' );
-			
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			expect( consoleSpy ).toHaveBeenCalledWith(
+				'Input was sanitized for security'
+			);
+			expect( mockProvider.search ).toHaveBeenCalledWith(
+				'billing',
+				'alert("xss")'
+			);
+
 			consoleSpy.mockRestore();
 		} );
 
@@ -887,16 +1068,18 @@ describe( 'Address Suggestions Component', () => {
 					],
 				},
 			] );
-			
+
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsList = document.querySelector( '#address_suggestions_billing .suggestions-list' );
+
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsList = document.querySelector(
+				'#address_suggestions_billing .suggestions-list'
+			);
 			const firstSuggestion = suggestionsList.querySelector( 'li' );
-			
+
 			// Should still render the suggestion without highlighting
 			expect( firstSuggestion.textContent ).toBe( '123 Main Street' );
 			expect( firstSuggestion.querySelector( 'strong' ) ).toBe( null );
@@ -909,16 +1092,18 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
-			
+
 			// Click outside
 			const outsideElement = document.createElement( 'div' );
 			document.body.appendChild( outsideElement );
 			outsideElement.click();
-			
+
 			expect( suggestionsContainer.style.display ).toBe( 'none' );
 		} );
 
@@ -927,14 +1112,16 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
-			
+
 			// Click inside suggestions container
 			suggestionsContainer.click();
-			
+
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
 		} );
 
@@ -943,14 +1130,16 @@ describe( 'Address Suggestions Component', () => {
 			billingAddressInput.value = '123';
 			billingAddressInput.focus();
 			billingAddressInput.dispatchEvent( new Event( 'input' ) );
-			await new Promise( resolve => setTimeout( resolve, 150 ) );
-			
-			const suggestionsContainer = document.getElementById( 'address_suggestions_billing' );
+			await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+
+			const suggestionsContainer = document.getElementById(
+				'address_suggestions_billing'
+			);
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
-			
+
 			// Click on address input
 			billingAddressInput.click();
-			
+
 			expect( suggestionsContainer.style.display ).toBe( 'block' );
 		} );
 	} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -56,7 +56,10 @@ describe( 'Address Autocomplete Provider Registration', () => {
 	} );
 
 	test( 'should handle missing wc_checkout_params', () => {
-		window.wc_checkout_params = undefined;
+		delete global.window.wc; // ensure fresh load
+		global.window.wc_checkout_params = undefined;
+		jest.resetModules();
+		require( '../address-autocomplete' );
 		const validProvider = {
 			id: 'test-provider',
 			canSearch: () => {},

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -5,13 +5,14 @@
 describe( 'Address Autocomplete Provider Registration', () => {
 	beforeEach( () => {
 		// Reset the window object and providers before each test
-		global.window = {};
-		global.window.wc_checkout_params = {
-			address_providers: [
-				{ id: 'test-provider', name: 'Test provider' },
-				{ id: 'wc-payments', name: 'WooCommerce Payments' },
-			],
-		};
+		Object.assign( global.window, {
+			wc_checkout_params: {
+				address_providers: [
+					{ id: 'test-provider', name: 'Test provider' },
+					{ id: 'wc-payments', name: 'WooCommerce Payments' },
+				],
+			},
+		} );
 		global.console = {
 			error: jest.fn(),
 		};

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -55,7 +55,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 	} );
 
 	test( 'should handle missing wc_checkout_params', () => {
-		delete window.wc_checkout_params;
+		window.wc_checkout_params = undefined;
 		const validProvider = {
 			id: 'test-provider',
 			canSearch: () => {},
@@ -227,12 +227,14 @@ describe( 'Address Autocomplete Provider Registration', () => {
 
 		// Attempt to modify should throw in strict mode
 		expect( () => {
-			'use strict';
-			window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp = 'test';
+			window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp =
+				'test';
 		} ).toThrow( TypeError );
-		
+
 		// Verify the property wasn't added
-		expect( window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp ).toBeUndefined();
+		expect(
+			window.wc.addressAutocomplete.providers[ 'test-provider' ].newProp
+		).toBeUndefined();
 	} );
 
 	test( 'should not allow duplicate provider registration', () => {

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -51,6 +51,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 				'Error registering address provider:',
 				'Address provider must be a valid object'
 			);
+			expect( console.error ).toHaveBeenCalledTimes( 1 );
 			console.error.mockClear();
 		} );
 	} );

--- a/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/test/address-autocomplete.js
@@ -95,7 +95,7 @@ describe( 'Address Autocomplete Provider Registration', () => {
 		expect( result ).toBe( false );
 		expect( console.error ).toHaveBeenCalledWith(
 			'Error registering address provider:',
-			'Server providers configuration is invalid'
+			'Provider test-provider not registered on server'
 		);
 	} );
 

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -10,6 +10,7 @@
  // phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Domain\Services\AddressProviderService;
 use Automattic\WooCommerce\Blocks\Package;
 
@@ -256,11 +257,6 @@ class WC_Frontend_Scripts {
 				'deps'    => array( 'jquery', 'woocommerce' ),
 				'version' => $version,
 			),
-			'wc-address-autocomplete'    => array(
-				'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
-				'deps'    => array( 'jquery', 'woocommerce' ),
-				'version' => $version,
-			),
 			'wc-cart'                    => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/cart' . $suffix . '.js' ),
 				'deps'    => array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n' ),
@@ -332,6 +328,15 @@ class WC_Frontend_Scripts {
 				'version' => '1.7.21-wc.' . $version,
 			),
 		);
+
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$register_scripts['wc-address-autocomplete'] = array(
+				'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
+				'deps'    => array( 'jquery', 'woocommerce' ),
+				'version' => $version,
+			);
+		}
+
 		foreach ( $register_scripts as $name => $props ) {
 			self::register_script( $name, $props['src'], $props['deps'], $props['version'] );
 		}
@@ -408,18 +413,13 @@ class WC_Frontend_Scripts {
 		if ( is_checkout() ) {
 			self::enqueue_script( 'wc-checkout' );
 		}
-		if ( is_checkout() ) {
-			try {
-				$address_provider_service = Package::container()->get( AddressProviderService::class );
-				if ( $address_provider_service && method_exists( $address_provider_service, 'get_registered_providers' ) ) {
-					$registered_providers = $address_provider_service->get_registered_providers();
-					if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
-						self::enqueue_script( 'wc-address-autocomplete' );
-					}
+		if ( is_checkout() && Features::is_enabled( 'experimental-blocks' ) ) {
+			$address_provider_service = Package::container()->get( AddressProviderService::class );
+			if ( $address_provider_service && method_exists( $address_provider_service, 'get_registered_providers' ) ) {
+				$registered_providers = $address_provider_service->get_registered_providers();
+				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
+					self::enqueue_script( 'wc-address-autocomplete' );
 				}
-			} catch ( Exception $e ) {
-				// Log the error for debugging purposes.
-				error_log( 'Error fetching registered providers: ' . $e->getMessage() );
 			}
 		}
 		if ( is_add_payment_method_page() ) {
@@ -583,9 +583,10 @@ class WC_Frontend_Scripts {
 					'debug_mode'                => Constants::is_true( 'WP_DEBUG' ),
 					/* translators: %s: Order history URL on My Account section */
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
-					'address_providers'         => Package::container()->get( AddressProviderService::class )->get_registered_providers(),
-
 				);
+				if ( Features::is_enabled( 'experimental-blocks' ) ) {
+					$params['address_providers'] = Package::container()->get( AddressProviderService::class )->get_registered_providers();
+				}
 				break;
 			case 'wc-address-i18n':
 				$params = array(

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -10,6 +10,8 @@
  // phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Blocks\Domain\Services\AddressProviderService;
+use Automattic\WooCommerce\Blocks\Package;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -254,6 +256,11 @@ class WC_Frontend_Scripts {
 				'deps'    => array( 'jquery', 'woocommerce' ),
 				'version' => $version,
 			),
+			'wc-address-autocomplete'    => array(
+				'src'     => self::get_asset_url( 'assets/js/frontend/address-autocomplete' . $suffix . '.js' ),
+				'deps'    => array( 'jquery', 'woocommerce' ),
+				'version' => $version,
+			),
 			'wc-cart'                    => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/cart' . $suffix . '.js' ),
 				'deps'    => array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n' ),
@@ -400,6 +407,9 @@ class WC_Frontend_Scripts {
 		}
 		if ( is_checkout() ) {
 			self::enqueue_script( 'wc-checkout' );
+		}
+		if ( is_checkout() && count( Package::container()->get( AddressProviderService::class )->get_registered_providers() ) > 0 ) {
+			self::enqueue_script( 'wc-address-autocomplete' );
 		}
 		if ( is_add_payment_method_page() ) {
 			self::enqueue_script( 'wc-add-payment-method' );
@@ -562,6 +572,7 @@ class WC_Frontend_Scripts {
 					'debug_mode'                => Constants::is_true( 'WP_DEBUG' ),
 					/* translators: %s: Order history URL on My Account section */
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
+					'address_providers'         => Package::container()->get( AddressProviderService::class )->get_registered_providers(),
 
 				);
 				break;

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Domain\Services\AddressProviderService;
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -414,7 +415,7 @@ class WC_Frontend_Scripts {
 			self::enqueue_script( 'wc-checkout' );
 		}
 		if ( is_checkout() && Features::is_enabled( 'experimental-blocks' ) ) {
-			$address_provider_service = Package::container()->get( AddressProviderService::class );
+			$address_provider_service = wc_get_container()->get( AddressProviderController::class );
 			if ( $address_provider_service && method_exists( $address_provider_service, 'get_registered_providers' ) ) {
 				$registered_providers = $address_provider_service->get_registered_providers();
 				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
@@ -585,7 +586,7 @@ class WC_Frontend_Scripts {
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
 				);
 				if ( Features::is_enabled( 'experimental-blocks' ) ) {
-					$params['address_providers'] = Package::container()->get( AddressProviderService::class )->get_registered_providers();
+					$params['address_providers'] = wc_get_container()->get( AddressProviderController::class )->get_registered_providers();
 				}
 				break;
 			case 'wc-address-i18n':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -408,8 +408,19 @@ class WC_Frontend_Scripts {
 		if ( is_checkout() ) {
 			self::enqueue_script( 'wc-checkout' );
 		}
-		if ( is_checkout() && count( Package::container()->get( AddressProviderService::class )->get_registered_providers() ) > 0 ) {
-			self::enqueue_script( 'wc-address-autocomplete' );
+		if ( is_checkout() ) {
+			try {
+				$address_provider_service = Package::container()->get( AddressProviderService::class );
+				if ( $address_provider_service && method_exists( $address_provider_service, 'get_registered_providers' ) ) {
+					$registered_providers = $address_provider_service->get_registered_providers();
+					if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
+						self::enqueue_script( 'wc-address-autocomplete' );
+					}
+				}
+			} catch ( Exception $e ) {
+				// Log the error for debugging purposes.
+				error_log( 'Error fetching registered providers: ' . $e->getMessage() );
+			}
 		}
 		if ( is_add_payment_method_page() ) {
 			self::enqueue_script( 'wc-add-payment-method' );

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -375,6 +375,16 @@ class WC_Frontend_Scripts {
 				'has_rtl' => true,
 			),
 		);
+
+		if ( Features::is_enabled( 'experimental-blocks' ) ) {
+			$register_styles['wc-address-autocomplete'] = array(
+				'src'     => self::get_asset_url( 'assets/css/address-autocomplete.css' ),
+				'deps'    => array(),
+				'version' => $version,
+				'has_rtl' => false,
+			);
+		}
+
 		foreach ( $register_styles as $name => $props ) {
 			self::register_style( $name, $props['src'], $props['deps'], $props['version'], 'all', $props['has_rtl'] );
 		}
@@ -420,6 +430,7 @@ class WC_Frontend_Scripts {
 				$registered_providers = $address_provider_service->get_providers();
 				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
 					self::enqueue_script( 'wc-address-autocomplete' );
+					self::enqueue_style( 'wc-address-autocomplete' );
 				}
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -416,8 +416,8 @@ class WC_Frontend_Scripts {
 		}
 		if ( is_checkout() && Features::is_enabled( 'experimental-blocks' ) ) {
 			$address_provider_service = wc_get_container()->get( AddressProviderController::class );
-			if ( $address_provider_service && method_exists( $address_provider_service, 'get_registered_providers' ) ) {
-				$registered_providers = $address_provider_service->get_registered_providers();
+			if ( $address_provider_service && method_exists( $address_provider_service, 'get_providers' ) ) {
+				$registered_providers = $address_provider_service->get_providers();
 				if ( is_array( $registered_providers ) && count( $registered_providers ) > 0 ) {
 					self::enqueue_script( 'wc-address-autocomplete' );
 				}
@@ -586,7 +586,7 @@ class WC_Frontend_Scripts {
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
 				);
 				if ( Features::is_enabled( 'experimental-blocks' ) ) {
-					$params['address_providers'] = wc_get_container()->get( AddressProviderController::class )->get_registered_providers();
+					$params['address_providers'] = wc_get_container()->get( AddressProviderController::class )->get_providers();
 				}
 				break;
 			case 'wc-address-i18n':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -11,8 +11,6 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
-use Automattic\WooCommerce\Blocks\Domain\Services\AddressProviderService;
-use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Internal\AddressProvider\AddressProviderController;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -597,13 +595,17 @@ class WC_Frontend_Scripts {
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
 				);
 				if ( Features::is_enabled( 'experimental-blocks' ) ) {
-					$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
-					$params['address_providers'] = array_map( function( $provider ) {
-						return array(
-							'id' => $provider->id,
-							'name' => $provider->name,
-						);
-					}, $providers );
+					$providers                   = wc_get_container()->get( AddressProviderController::class )->get_providers();
+					$params['address_providers'] = array_map(
+						function ( $provider ) {
+							// Sanitize provider data before sending to frontend.
+							return array(
+								'id'   => sanitize_key( $provider->id ),
+								'name' => sanitize_text_field( $provider->name ),
+							);
+						},
+						$providers
+					);
 				}
 				break;
 			case 'wc-address-i18n':

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -597,7 +597,13 @@ class WC_Frontend_Scripts {
 					'i18n_checkout_error'       => sprintf( esc_attr__( 'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.', 'woocommerce' ), esc_url( wc_get_account_endpoint_url( 'orders' ) ) ),
 				);
 				if ( Features::is_enabled( 'experimental-blocks' ) ) {
-					$params['address_providers'] = wc_get_container()->get( AddressProviderController::class )->get_providers();
+					$providers = wc_get_container()->get( AddressProviderController::class )->get_providers();
+					$params['address_providers'] = array_map( function( $provider ) {
+						return array(
+							'id' => $provider->id,
+							'name' => $provider->name,
+						);
+					}, $providers );
 				}
 				break;
 			case 'wc-address-i18n':

--- a/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
@@ -181,7 +181,7 @@ class AddressProviderController {
 			return $this->preferred_provider_option;
 		}
 
-		// Get the first provider's ID by instantiating it.
+		// Get the first provider's ID.
 		return $this->providers[0]->id ?? '';
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is based on `56715-implement-a-way-for-developers-to-register-an-address-autocomplete-provider-in-php` - https://github.com/woocommerce/woocommerce/pull/56986

Closes WOOPLUG-3616
Closes WOOPLUG-3660

(For Bug Fixes) Bug introduced in PR # .

This change introduces an address autocomplete provider registration function for the classic checkout. It also updates the Jest config for blocks to allow legacy JS to be tested.

The JS script is enqueued only when there are valid providers registered, but it is _registered_ unconditionally. Therefore any scripts that list it as a dependency won't crash if there are no PHP providers registered.

**I opted to include the legacy tests in the Blocks infrastructure because it seemed inappropriate to spin up a whole new workflow for testing legacy JS. There is no prior art for legacy JS testing.** 

**Key Features:**
- JavaScript provider registration that validates against server-registered providers  
- Address search functionality (triggers after 3+ characters)
- Suggestion display with match highlighting (max 5 suggestions)
- Address field population on selection with proper `Select2` handling for state/country fields
- Re-checks eligible providers when changing country
- Input sanitization on results from server
- Conditional script/style loading (only when providers exist)
- Legacy JS testing infrastructure integrated with WC Blocks Jest setup

**Technical Implementation:**
- Frontend script registered unconditionally but enqueued only with valid providers
- Provider data passed via `wc_checkout_params` with sanitized output
- Debounced search (100ms) to prevent excessive API calls
- Browser autofill disabled during autocomplete interaction, lastpass/1password also attempt to disable (in some cases it comes back)
- Global state namespaced under `window.wc.addressAutocomplete` to avoid conflicts

### Screenshots or screen recordings:

<img width="496" alt="image" src="https://github.com/user-attachments/assets/274ef1da-17af-4b30-8dfa-d92a7b5a10b5" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites:
- Set up a test site with WooCommerce installed
- Ensure the experimental blocks feature is enabled
- Use Chrome/Firefox with Developer Tools open

#### Part 1: Basic Provider Registration

1. Get the mock provider plugins here:
- [mock-address-provider.zip](https://github.com/user-attachments/files/20726099/mock-address-provider.zip)
- [mock-address-provider-germany.zip](https://github.com/user-attachments/files/20726300/mock-address-provider-germany.zip)

- Install to `wp-content/plugins/mock-address-provider` and `wp-content/plugins/mock-address-provider-germany`
- Enter its directory, `npm i` and `npm run start`
- Activate the plugins, then go to WooCommerce -> Settings -> General and select `Enable predictive address search`. 
- Ensure you see both "Mock address provider" and "Mock address provider" germany in the `Preferred address autocomplete provider` option.

2. Go to the shortcode checkout page and ensure:
   - No JavaScript errors appear in the console
   - The `wc-address-autocomplete` script is loaded (check Network tab)
   - The `wc-address-autocomplete.css` stylesheet is loaded

3. In the browser console, verify the providers are available:
```js
console.log(window.wc_checkout_params.address_providers);
// Should show: [{id: "wp-provider", name: "WordPress provider"}, {id: "woo-provider", name: "Woo provider"}]
```

#### Part 2: JavaScript Provider Registration

4. Register a valid provider in the console (this is done via the Mock address provider plugin)
5. Ensure you get no JS errors when loading the page.

```

6. Try entering the following in the JS console:
```js
const invalidProvider = {
    id: 'invalid-provider',
    canSearch: () => true,
    search: () => Promise.resolve([]),
    select: () => Promise.resolve({})
};

window.wc.addressAutocomplete.registerAddressAutocompleteProvider(invalidProvider);
// Expected: Error "Provider invalid-provider not registered on server", returns false
```

8. Test various invalid provider configurations:
```js
// Missing required properties
window.wc.addressAutocomplete.registerAddressAutocompleteProvider({id: 'woo-provider'});
// Expected: Error "Address provider must have a canSearch function"

window.wc.addressAutocomplete.registerAddressAutocompleteProvider(null);
// Expected: Error "Address provider must be a valid object"

window.wc.addressAutocomplete.registerAddressAutocompleteProvider({
    id: 123, // Wrong type
    canSearch: () => true,
    search: () => Promise.resolve([]),
    select: () => Promise.resolve({})
});
// Expected: Error "Address provider must have a valid ID"
```

#### Part 3: Preferred Provider Settings

9. Go to **WooCommerce → Settings → General** and look for the "Address autocomplete provider" setting
10. Select "Mock address provider Germany" as the preferred provider and save
11. Refresh the checkout page and run:
```js
console.log(window.wc_checkout_params.address_providers);
// Expected: "mock-address-provider-germany" should be first in the array
```

#### Part 4: Address Autocomplete Functionality

13. Test address search:
    - Set country to "United States (US)"
    - Type "Main" in the billing address field
    - Expected: After 3 characters, suggestions appear with different areas highlighted. The locations will not be filtered down to match the input now as it is just a mock provider for testing!
    - Expected: Search icon appears next to the input field

14. Test suggestion selection:
    - Click on a suggestion
    - Expected: All address fields are populated (address, city, state, postcode)
    - Expected: Country remains "US"
    - Expected: Suggestions disappear

15. Test keyboard navigation:
    - Type in address field again
    - Use arrow keys to navigate suggestions
    - Press Enter to select
    - Press Escape to close suggestions

#### Part 5: Country Change Behavior

16. Change country to "Canada":
    - Trigger autocomplete suggestions by typing into address 1.
    - Pick a US address
    - Ensure the fields update correctly including State.

17. Deactivate the "Mock address provider" (disable the plugin). In the "Mock Address Provider Germany" plugin:
	- Modify the `canSearch` function to:
```js
		canSearch: ( country ) => {
			return country === 'DE';
		},
```
18. Change country to USA
19. Type into the address 1 field, ensure no suggestions show as the provider can't search.
20. Change to Germany and repeat, ensure suggestions show and they can be selected and populate the form.
21. Reactivate the "Mock Address Provider" plugin again. Go to WC -> Settings -> General and set "Mock Address Provider Germany" as the preferred provider.
22. Change country back to USA, ensure you see the non-Germany suggestions when typing in address 1.
25. For US addresses, verify state field:
    - After selecting an address, state dropdown should show correct state

#### Part 7: Security Testing

26. Test input sanitization:
```js
// Try to inject malicious content
const input = document.getElementById('billing_address_1');
input.value = '<script>alert("XSS")</script>';
// Expected: No alert appears, suggestions work normally
```

27. Test malformed provider responses - edit the `src/index.js` file of the preferred provider plugin.
```js
const maliciousProvider = {
    id: 'wp-provider',
    canSearch: () => true,
    search: () => '<script>alert("XSS")</script>', // Not an array
    select: () => Promise.resolve({})
};
// Type in address field
// Expected: Error "Invalid suggestions response - not an array"
```

#### Part 8: Edge Cases

28. Test rapid country changes:
    - Quickly switch between countries while typing
    - Expected: No errors, suggestions update correctly

29. Test concurrent searches:
    - Type quickly to trigger multiple searches
    - Expected: Only latest results shown, no errors

30. Remove the PHP snippet and refresh:
    - Expected: `wc-address-autocomplete` script is NOT loaded
    - Expected: Checkout works normally without autocomplete

#### Part 9: Accessibility

31. Test with screen reader:
    - Suggestions should be announced
    - Arrow key navigation should announce selected items
    - ARIA attributes should be properly set

32. Test without JavaScript:
    - Disable JavaScript and refresh
    - Expected: Checkout still works normally

### Expected Results Summary:
- ✅ Providers can only be registered if they exist server-side
- ✅ Preferred provider setting is respected
- ✅ Address autocomplete works with proper country filtering
- ✅ Select2 fields are properly handled
- ✅ Security measures prevent XSS attacks
- ✅ System gracefully handles errors and edge cases
- ✅ Feature can be completely disabled by removing providers

<!-- End testing instructions -->

### Testing that has already taken place:

Implemented legacy JS tests for this.

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced address autocomplete functionality for WooCommerce checkout forms, supporting billing and shipping addresses.
  - Added a suggestions dropdown with keyboard and mouse navigation, including accessibility enhancements.
  - Enabled dynamic provider registration for address autocomplete, with support for multiple providers.
  - New styles for the address autocomplete dropdown and icon.
  - Conditional loading of address autocomplete scripts and styles based on an experimental feature flag.

- **Bug Fixes**
  - Improved error handling and validation during provider registration.

- **Tests**
  - Added comprehensive tests for address autocomplete provider registration and suggestions UI.

- **Chores**
  - Updated test configuration to include legacy JavaScript files.
  - Documented changes in the WooCommerce plugin changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->