### PR TITLE
Add line break to billing address email in order emails

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1533-add-line-break-to-billing-address-email-in-order-emails
+++ b/plugins/woocommerce/changelog/wooplug-1533-add-line-break-to-billing-address-email-in-order-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow customer's email in billing address in order emails to break line when too long

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -354,6 +354,7 @@ body {
 		color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 		border: 1px solid <?php echo esc_attr( $body_darker_10 ); ?>;
 	<?php } ?>
+	word-break: break-all;
 }
 
 .additional-fields {

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -357,6 +357,12 @@ body {
 	word-break: break-all;
 }
 
+<?php if ( $email_improvements_enabled ) : ?>
+#addresses td + td {
+	padding-<?php echo is_rtl() ? 'right' : 'left'; ?>: 10px !important;
+}
+<?php endif; ?>
+
 .additional-fields {
 	padding: 12px 12px 0;
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Adds a line break for the customer email.
2. Adds spacing between addresses when `Email improvements` feature is enabled.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #40530, closes WOOPLUG-1533.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="304" alt="Screenshot 2025-04-22 at 10 46 34" src="https://github.com/user-attachments/assets/c4cd471a-1557-446d-bd3f-e467fe5c7aae" />   |   <img width="299" alt="Screenshot 2025-04-22 at 10 46 48" src="https://github.com/user-attachments/assets/43cbd611-4da7-44c0-b4d2-ba4aebad6103" />    |
|    <img width="308" alt="Screenshot 2025-04-22 at 10 47 20" src="https://github.com/user-attachments/assets/d53ceedf-e5e0-4d72-842d-65afc654559a" />    |   <img width="307" alt="Screenshot 2025-04-22 at 10 47 31" src="https://github.com/user-attachments/assets/50b45841-f954-4eb5-9602-2d5ff0f352e1" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Emails**.
2. Inspect the email preview code, and change the email address in the Billing address to something super long.
3. Observe that the Shipping address is not squashed and the customer's email is on multiple lines.

Alternatively:
1. Make an order with a super-long email address.
2. Check your email client where you received an order confirmation.
3. Observe that the Shipping address is not squashed and the customer's email is on multiple lines.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
