### PR TITLE
NOX In-Context: Improve the embedded KYC styling to be consistent and closer to WPDS

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/appearance.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/components/embedded/appearance.ts
@@ -50,13 +50,16 @@ export default {
 		headingLgFontWeight: '400',
 		headingMdFontSize: '20px',
 		headingMdFontWeight: '400',
-		headingSmFontSize: '16px',
+		headingSmFontSize: '13px',
 		headingSmFontWeight: '600',
 		headingXsFontSize: '12px',
 		headingXsFontWeight: '600',
 		bodyMdFontWeight: '400',
 		bodyMdFontSize: '16px',
-		bodySmFontSize: '14px',
+		bodySmFontSize: '13px',
 		bodySmFontWeight: '400',
+		labelSmFontSize: '12px', // badge font size to match WPDS
+		labelSmFontWeight: '200', // badges font weight to match WPDS
+		labelMdFontSize: '13px',
 	},
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to WOOPMNT-4909.

Improved styling of Embedded KYC component in NOX In-Context flows to be consistent with https://github.com/Automattic/woocommerce-payments/pull/10703

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
|-----|-----|
| ![image](https://github.com/user-attachments/assets/783b6ea4-ce90-47f2-a5fd-de93e494f077) | ![image](https://github.com/user-attachments/assets/52ddbbdf-635d-4a2f-bc32-7454c5ad46f3) |
| ![image](https://github.com/user-attachments/assets/1bd05ad0-b1a8-4d03-8e47-1cc1daa426af) | ![image](https://github.com/user-attachments/assets/5d5e7e93-c6ed-4f51-97ea-df2788c74a49) |
| ![image](https://github.com/user-attachments/assets/857fd559-b567-4af8-8504-8f8c45007625) | ![image](https://github.com/user-attachments/assets/f3c685ab-b0c9-4622-bd3f-31ee0d4d82dd) |
| ![image](https://github.com/user-attachments/assets/15918f86-c338-47d1-809d-2763c37b5ef7) |  ![image](https://github.com/user-attachments/assets/304a3184-949c-45e6-b1c6-3e8132d47603) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `fix/nox-in-context-embedded-kyc-styling` locally.
1. Change WooPayments version to 9.3.0 locally.
1. Make sure you have Jetpack connection set up.
1. Remove the current account if you have one. You may need to clean the `woocommerce_woopayments_nox_profile` db option.
1. Kick off new in-context onboarding, pick some payment methods, and continue with test drive onboarding.
1. During the Stripe embedded KYC, provide `1111` as last 4 SSN and `11111111111` as SSN.
1. Observe the font size and weight of the embedded KYC component as described in the screenshots above.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
