### PR TITLE
Add a 'search_name_or_sku' argument to the REST API products endpoint

### DIFF
--- a/plugins/woocommerce/changelog/pr-57494
+++ b/plugins/woocommerce/changelog/pr-57494
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a search_sku_or_name argument to the REST API products endpoint

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -36,13 +36,21 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	protected $namespace = 'wc/v3';
 
 	/**
-	 * A string to inject into a query to do a partial match SKU search.
+	 * The value of the 'search_sku' argument if present.
 	 *
 	 * See prepare_objects_query()
 	 *
 	 * @var string
 	 */
-	private $search_sku_in_product_lookup_table = '';
+	private $search_sku_arg_value = '';
+
+	/**
+	 * If the 'search_sku_or_name' argument is present this will be set
+	 * to an array of the (space-separated) tokens that form the argument value.
+	 *
+	 * @var array|null
+	 */
+	private $search_sku_or_name_tokens = null;
 
 	/**
 	 * Suggested product ids.
@@ -296,11 +304,22 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			);
 		}
 
-		if ( wc_product_sku_enabled() ) {
-			// Do a partial match for a sku. Supersedes sku parameter that does exact matching.
+		$search_sku_or_name_arg = $request['search_sku_or_name'] ?? '';
+
+		if ( '' !== $search_sku_or_name_arg ) {
+			// Do a tokenized search for name or SKU. Supersedes the 'search', 'search_sku' and 'sku' arguments.
+			$tokens                          = array_filter( array_map( 'trim', explode( ' ', $search_sku_or_name_arg ) ) );
+			$this->search_sku_or_name_tokens = array_map( 'esc_sql', $tokens );
+
+			unset( $request['search'] );
+			unset( $args['s'] );
+			unset( $request['search_sku'] );
+			unset( $request['sku'] );
+		} elseif ( wc_product_sku_enabled() ) {
+			// Do a partial match for a sku. Supersedes the 'sku' argument, that does exact matching.
 			if ( ! empty( $request['search_sku'] ) ) {
 				// Store this for use in the query clause filters.
-				$this->search_sku_in_product_lookup_table = $request['search_sku'];
+				$this->search_sku_arg_value = $request['search_sku'];
 
 				unset( $request['sku'] );
 			}
@@ -375,7 +394,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		}
 
 		// Force the post_type argument, since it's not a user input variable.
-		if ( ! empty( $request['sku'] ) || ! empty( $request['search_sku'] ) ) {
+		if ( ! empty( $request['sku'] ) || ! empty( $request['search_sku'] ) || $this->search_sku_or_name_tokens ) {
 			$args['post_type'] = array( 'product', 'product_variation' );
 		} else {
 			$args['post_type'] = $this->post_type;
@@ -412,8 +431,10 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return array
 	 */
 	protected function get_objects( $query_args ) {
+		$add_search_criteria = $this->search_sku_arg_value || $this->search_sku_or_name_tokens;
+
 		// Add filters for search criteria in product postmeta via the lookup table.
-		if ( ! empty( $this->search_sku_in_product_lookup_table ) ) {
+		if ( $add_search_criteria ) {
 			add_filter( 'posts_join', array( $this, 'add_search_criteria_to_wp_query_join' ) );
 			add_filter( 'posts_where', array( $this, 'add_search_criteria_to_wp_query_where' ) );
 		}
@@ -426,11 +447,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$result = parent::get_objects( $query_args );
 
 		// Remove filters for search criteria in product postmeta via the lookup table.
-		if ( ! empty( $this->search_sku_in_product_lookup_table ) ) {
+		if ( $add_search_criteria ) {
 			remove_filter( 'posts_join', array( $this, 'add_search_criteria_to_wp_query_join' ) );
 			remove_filter( 'posts_where', array( $this, 'add_search_criteria_to_wp_query_where' ) );
 
-			$this->search_sku_in_product_lookup_table = '';
+			$this->search_sku_arg_value = '';
 		}
 
 		// Remove filters for excluding product statuses.
@@ -450,11 +471,20 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return string
 	 */
 	public function add_search_criteria_to_wp_query_join( $join ) {
-		global $wpdb;
-		if ( ! empty( $this->search_sku_in_product_lookup_table ) && ! strstr( $join, 'wc_product_meta_lookup' ) ) {
-			$join .= " LEFT JOIN $wpdb->wc_product_meta_lookup wc_product_meta_lookup
-						ON $wpdb->posts.ID = wc_product_meta_lookup.product_id ";
+		if ( $this->search_sku_or_name_tokens ) {
+			if ( ! wc_product_sku_enabled() ) {
+				// The argument is effectively a tokenized name search: we don't need to join the meta lookup table.
+				return $join;
+			}
+		} elseif ( empty( $this->search_sku_arg_value ) || strstr( $join, 'wc_product_meta_lookup' ) ) {
+			return;
 		}
+
+		global $wpdb;
+
+		$join .= " LEFT JOIN $wpdb->wc_product_meta_lookup wc_product_meta_lookup
+						ON $wpdb->posts.ID = wc_product_meta_lookup.product_id ";
+
 		return $join;
 	}
 
@@ -466,8 +496,28 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 */
 	public function add_search_criteria_to_wp_query_where( $where ) {
 		global $wpdb;
-		if ( ! empty( $this->search_sku_in_product_lookup_table ) ) {
-			$like_search = '%' . $wpdb->esc_like( $this->search_sku_in_product_lookup_table ) . '%';
+
+		if ( $this->search_sku_or_name_tokens ) {
+			$use_sku                  = wc_product_sku_enabled();
+			$posts_clause_parts       = array();
+			$meta_lookup_clause_parts = array();
+			foreach ( $this->search_sku_or_name_tokens as $token ) {
+				$like_search          = '%' . $wpdb->esc_like( $token ) . '%';
+				$posts_clause_parts[] = $wpdb->prepare( "($wpdb->posts.post_title LIKE %s)", $like_search );
+				if ( $use_sku ) {
+					$meta_lookup_clause_parts[] = $wpdb->prepare( '(wc_product_meta_lookup.sku LIKE %s)', $like_search );
+				}
+			}
+			$post_clause = implode( ' AND ', $posts_clause_parts );
+			if ( $use_sku ) {
+				$meta_lookup_clause = implode( ' AND ', $meta_lookup_clause_parts );
+			}
+			$where .=
+				$use_sku ?
+					" AND (($post_clause) OR ($meta_lookup_clause))" :
+					" AND ($post_clause)";
+		} elseif ( ! empty( $this->search_sku_arg_value ) ) {
+			$like_search = '%' . $wpdb->esc_like( $this->search_sku_arg_value ) . '%';
 			$where      .= ' AND ' . $wpdb->prepare( '(wc_product_meta_lookup.sku LIKE %s)', $like_search );
 		}
 		return $where;
@@ -1441,7 +1491,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 						),
 					),
 				),
-				'brands'            => array(
+				'brands'                => array(
 					'description' => __( 'List of brands.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1771,7 +1771,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		);
 
 		$params['search_sku'] = array(
-			'description'       => __( 'Limit results to those with a SKU that partial matches a string.', 'woocommerce' ),
+			'description'       => __( "Limit results to those with a SKU that partial matches a string. This argument takes precedence over 'sku'.", 'woocommerce' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['search_sku_or_name'] = array(
+			'description'       => __( "Limit results to those with a name or SKU that partial matches a string. This argument takes precedence over 'search', 'sku' and 'search_sku'.", 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -45,12 +45,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	private $search_sku_arg_value = '';
 
 	/**
-	 * If the 'search_sku_or_name' argument is present this will be set
+	 * If the 'search_name_or_sku' argument is present this will be set
 	 * to an array of the (space-separated) tokens that form the argument value.
 	 *
 	 * @var array|null
 	 */
-	private $search_sku_or_name_tokens = null;
+	private $search_name_or_sku_tokens = null;
 
 	/**
 	 * Suggested product ids.
@@ -304,12 +304,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			);
 		}
 
-		$search_sku_or_name_arg = $request['search_sku_or_name'] ?? '';
+		$search_name_or_sku_arg = $request['search_name_or_sku'] ?? '';
 
-		if ( '' !== $search_sku_or_name_arg ) {
+		if ( '' !== $search_name_or_sku_arg ) {
 			// Do a tokenized search for name or SKU. Supersedes the 'search', 'search_sku' and 'sku' arguments.
-			$tokens                          = array_filter( array_map( 'trim', explode( ' ', $search_sku_or_name_arg ) ) );
-			$this->search_sku_or_name_tokens = array_map( 'esc_sql', $tokens );
+			$tokens                          = array_filter( array_map( 'trim', explode( ' ', $search_name_or_sku_arg ) ) );
+			$this->search_name_or_sku_tokens = array_map( 'esc_sql', $tokens );
 
 			unset( $request['search'] );
 			unset( $args['s'] );
@@ -394,7 +394,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		}
 
 		// Force the post_type argument, since it's not a user input variable.
-		if ( ! empty( $request['sku'] ) || ! empty( $request['search_sku'] ) || $this->search_sku_or_name_tokens ) {
+		if ( ! empty( $request['sku'] ) || ! empty( $request['search_sku'] ) || $this->search_name_or_sku_tokens ) {
 			$args['post_type'] = array( 'product', 'product_variation' );
 		} else {
 			$args['post_type'] = $this->post_type;
@@ -431,7 +431,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return array
 	 */
 	protected function get_objects( $query_args ) {
-		$add_search_criteria = $this->search_sku_arg_value || $this->search_sku_or_name_tokens;
+		$add_search_criteria = $this->search_sku_arg_value || $this->search_name_or_sku_tokens;
 
 		// Add filters for search criteria in product postmeta via the lookup table.
 		if ( $add_search_criteria ) {
@@ -471,7 +471,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return string
 	 */
 	public function add_search_criteria_to_wp_query_join( $join ) {
-		if ( $this->search_sku_or_name_tokens ) {
+		if ( $this->search_name_or_sku_tokens ) {
 			if ( ! wc_product_sku_enabled() ) {
 				// The argument is effectively a tokenized name search: we don't need to join the meta lookup table.
 				return $join;
@@ -497,11 +497,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	public function add_search_criteria_to_wp_query_where( $where ) {
 		global $wpdb;
 
-		if ( $this->search_sku_or_name_tokens ) {
+		if ( $this->search_name_or_sku_tokens ) {
 			$use_sku                  = wc_product_sku_enabled();
 			$posts_clause_parts       = array();
 			$meta_lookup_clause_parts = array();
-			foreach ( $this->search_sku_or_name_tokens as $token ) {
+			foreach ( $this->search_name_or_sku_tokens as $token ) {
 				$like_search          = '%' . $wpdb->esc_like( $token ) . '%';
 				$posts_clause_parts[] = $wpdb->prepare( "($wpdb->posts.post_title LIKE %s)", $like_search );
 				if ( $use_sku ) {
@@ -1777,7 +1777,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['search_sku_or_name'] = array(
+		$params['search_name_or_sku'] = array(
 			'description'       => __( "Limit results to those with a name or SKU that partial matches a string. This argument takes precedence over 'search', 'sku' and 'search_sku'.", 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -16,7 +16,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public static function wpSetUpBeforeClass() {
-		for ( $i = 1; $i <= 4; $i ++ ) {
+		for ( $i = 1; $i <= 4; $i++ ) {
 			self::$products[] = WC_Helper_Product::create_simple_product();
 		}
 
@@ -133,16 +133,18 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	public function test_product_api_get_all_fields_v2() {
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_fields = array_keys( $response->get_data() );
 
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		$this->assertEmpty( array_diff( $expected_response_fields, $response_fields ), 'These fields were expected but not present in API V2 response: ' . print_r( array_diff( $expected_response_fields, $response_fields ), true ) );
 
 		$this->assertEmpty( array_diff( $response_fields, $expected_response_fields ), 'These fields were not expected in the API V2 response: ' . print_r( array_diff( $response_fields, $expected_response_fields ), true ) );
+		// phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_print_r
 	}
 
 	/**
@@ -156,7 +158,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 		$call_product_data_wrapper = function () use ( $product ) {
 			return $this->get_product_data( $product );
 		};
-		$response = $call_product_data_wrapper->call( new WC_REST_Products_Controller() );
+		$response                  = $call_product_data_wrapper->call( new WC_REST_Products_Controller() );
 		$this->assertArrayHasKey( 'id', $response );
 	}
 
@@ -165,7 +167,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_products_get_each_field_one_by_one_v2() {
 		$expected_response_fields = $this->get_expected_response_fields();
-		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$product                  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() );
@@ -194,7 +196,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 			$this->assertArrayHasKey( 'meta_data', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
-				function( $meta_item ) {
+				function ( $meta_item ) {
 					return $meta_item->get_data()['key'];
 				},
 				$order['meta_data']
@@ -218,7 +220,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
 			$meta_keys = array_map(
-				function( $meta_item ) {
+				function ( $meta_item ) {
 					return $meta_item->get_data()['key'];
 				},
 				$order['meta_data']
@@ -243,7 +245,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
 			$meta_keys = array_map(
-				function( $meta_item ) {
+				function ( $meta_item ) {
 					return $meta_item->get_data()['key'];
 				},
 				$order['meta_data']
@@ -270,7 +272,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 			$this->assertArrayHasKey( 'meta_data', $order );
 			$this->assertEquals( 1, count( $order['meta_data'] ) );
 			$meta_keys = array_map(
-				function( $meta_item ) {
+				function ( $meta_item ) {
 					return $meta_item->get_data()['key'];
 				},
 				$order['meta_data']

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+
 /**
  * class WC_REST_Products_Controller_Tests.
  * Product Controller tests for V2 REST API.
@@ -315,5 +317,110 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$this->assertEquals( 'Сирене', $data['attributes'][0]['name'] );
+	}
+
+	/**
+	 * Data provider for test_search_by_sku_or_name.
+	 *
+	 * @return array[] Array of query string arguments and expected obtained SKUs pairs.
+	 */
+	public function data_provider_for_test_search_by_sku_or_name() {
+		return array(
+			// search_sku_or_name alone.
+
+			array(
+				array( 'search_sku_or_name' => 'shi blu' ),
+				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
+			),
+
+			// search_sku_or_name supersedes search, search_sku and sku.
+
+			array(
+				array(
+					'search_sku_or_name' => 'shi blu',
+					'search'             => 'red',
+				),
+				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
+			),
+			array(
+				array(
+					'search_sku_or_name' => 'shi blu',
+					'search_sku'         => 'the',
+				),
+				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
+			),
+			array(
+				array(
+					'search_sku_or_name' => 'shi blu',
+					'sku'                => 'thesku1',
+				),
+				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
+			),
+
+			// search, search_sku and sku by themselves still work.
+
+			array(
+				array( 'search' => 'red' ),
+				array( 'rs' ),
+			),
+			array(
+				array( 'search_sku' => 'the' ),
+				array( 'thesku1', 'thesku2' ),
+			),
+			array(
+				array(
+					'search_sku' => 'the',
+					'sku'        => 'foo',
+				),
+				array( 'thesku1', 'thesku2' ),
+			),
+			array(
+				array( 'sku' => 'thesku1' ),
+				array( 'thesku1' ),
+			),
+		);
+	}
+
+	/**
+	 * @testdox Tests for the search_by_sku_or_name query string argument.
+	 *
+	 * @dataProvider data_provider_for_test_search_by_sku_or_name
+	 *
+	 * @param array $query_string_args Query string arguments for the products query.
+	 * @param array $expected_obtained_data Expected list of SKUs obtained.
+	 */
+	public function test_search_by_sku_or_name( array $query_string_args, array $expected_obtained_data ) {
+		$skus_and_names = array(
+			'ebs'                => 'Elegant blue shirt',
+			'cbs'                => 'Casual blue shirt',
+			'rs'                 => 'Red shirt',
+			'bm'                 => 'Blue mug',
+			'Elegant blue shirt' => 'Foobar 1',
+			'Casual blue shirt'  => 'Foobar 2',
+			'Red shirt'          => 'Foobar 3',
+			'Blue mug'           => 'Foobar 4',
+			'thesku1'            => 'Foobar 5',
+			'thesku2'            => 'Foobar 6',
+		);
+
+		foreach ( $skus_and_names as $sku => $name ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_name( $name );
+			$product->set_sku( $sku );
+			$product->save();
+		}
+
+		$query_string_args['_fields'] = 'sku';
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_query_params( $query_string_args );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$actual_data = $response->get_data();
+		$actual_data = ArrayUtil::select( $actual_data, 'sku' );
+
+		$this->assertEqualsCanonicalizing( $expected_obtained_data, $actual_data );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -326,32 +326,32 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	 */
 	public function data_provider_for_test_search_by_sku_or_name() {
 		return array(
-			// search_sku_or_name alone.
+			// search_name_or_sku alone.
 
 			array(
-				array( 'search_sku_or_name' => 'shi blu' ),
+				array( 'search_name_or_sku' => 'shi blu' ),
 				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
 			),
 
-			// search_sku_or_name supersedes search, search_sku and sku.
+			// search_name_or_sku supersedes search, search_sku and sku.
 
 			array(
 				array(
-					'search_sku_or_name' => 'shi blu',
+					'search_name_or_sku' => 'shi blu',
 					'search'             => 'red',
 				),
 				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
 			),
 			array(
 				array(
-					'search_sku_or_name' => 'shi blu',
+					'search_name_or_sku' => 'shi blu',
 					'search_sku'         => 'the',
 				),
 				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),
 			),
 			array(
 				array(
-					'search_sku_or_name' => 'shi blu',
+					'search_name_or_sku' => 'shi blu',
 					'sku'                => 'thesku1',
 				),
 				array( 'ebs', 'cbs', 'Elegant blue shirt', 'Casual blue shirt' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new `search_name_or_sku` argument to the REST API products endpoint (`GET wc/v3/products`). It does a tokenized search (the argument is assumed to be composed of space-separated tokens) with `AND` logic (all tokens must be present in the name or SKU) and with partial match (the words containing the token is enough).

Example: an argument value of `shi blu` will match a product with name or SKU `Blue shirt`. It won't match `blue mug` or `red shirt`.

This argument takes precedence over the already existing `search`, `sku` and `search_sku`; that is, these three will be ignored if `search_name_or_sku` is present.

Note that this functionality is added to the v3 REST API products endpoint only.

### How to test the changes in this Pull Request:

1. Create products with the following names:

* Elegant blue shirt
* Casual blue shirt
* Red shirt
* Blue mug

2. Create products with names "Foobar 1", "Foobar 2" etc and the above values for the SKU. Create also products with "thesku1" and "thesku2" as the SKU.

3. Create an application password for your WordPress user in your user profile page from the WP admin area.

4. Perform the following request:

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_name_or_sku=shi+blu"
```

You should get four results: the products named "Elegant blue shirt" and "Casual blue shirt", and the products with the same SKUs.

5. Verify that `search`, `sku` and `search_sku` arguments are ignored when used together with `search_name_or_sku`. All of the following queries should return the same results as the previous one:

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_name_or_sku=shi+blu&search=red"
```

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_name_or_sku=shi+blu&search_sku=the"
```

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_name_or_sku=shi+blu&sku=thesku1"
```

6. Verify that `search`, `sku` and `search_sku` arguments continue working as expected when used alone:

* The following returns the "Red shirt" product:

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search=red"
```

* The following two return the products with SKUs "thesku1" and "thesku2" (`search_sku` still supersedes `sku`):

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_sku=the"
```

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&search_sku=the&sku=foo"
```

* The following returns the product with SKU "thesku1":

```
curl -u <user>:<application password> "https://localhost/wp-json/wc/v3/products?_fields=name,sku&sku=thesku1"
```

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
