### PR TITLE
Hide 'View Cart' button when the cart page is not defined

### DIFF
--- a/plugins/woocommerce/changelog/57495-wooplug-3535-cart-link-shown-when-adding-to-the-cart-on-store-with-no
+++ b/plugins/woocommerce/changelog/57495-wooplug-3535-cart-link-shown-when-adding-to-the-cart-on-store-with-no
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Hide 'View Cart' button when the cart page is not defined.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -9,6 +9,7 @@
  * @version 2.1.0
  */
 
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Utilities\DiscountsUtil;
@@ -1193,7 +1194,13 @@ class WC_Cart extends WC_Legacy_Cart {
 					$message         = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
 					$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
-					throw new Exception( sprintf( '%s <a href="%s" class="button wc-forward%s">%s</a>', $message, esc_url( wc_get_cart_url() ), esc_attr( $wp_button_class ), __( 'View cart', 'woocommerce' ) ) );
+					if ( ! CartCheckoutUtils::has_cart_page() ) {
+						$message = sprintf( '%s', esc_html( $message ) );
+					} else {
+						$message = sprintf( '%s <a href="%s" class="button wc-forward%s">%s</a>', $message, esc_url( wc_get_cart_url() ), esc_attr( $wp_button_class ), __( 'View cart', 'woocommerce' ) );
+					}
+
+					throw new Exception( $message );
 				}
 			}
 
@@ -1254,13 +1261,17 @@ class WC_Cart extends WC_Legacy_Cart {
 					$stock_quantity_in_cart = $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ];
 					$wp_button_class        = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
-					$message = sprintf(
+					$message = CartCheckoutUtils::has_cart_page() ? sprintf(
 						'%s <a href="%s" class="button wc-forward%s">%s</a>',
 						/* translators: 1: quantity in stock 2: current quantity */
 						sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_quantity, $product_data ), wc_format_stock_quantity_for_display( $stock_quantity_in_cart, $product_data ) ),
 						esc_url( wc_get_cart_url() ),
 						esc_attr( $wp_button_class ),
 						__( 'View cart', 'woocommerce' )
+					) : sprintf(
+						'%s',
+						/* translators: 1: quantity in stock 2: current quantity */
+						sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_quantity, $product_data ), wc_format_stock_quantity_for_display( $stock_quantity_in_cart, $product_data ) )
 					);
 
 					/**

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
@@ -101,6 +102,8 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
 		$message   = sprintf( '%s <a href="%s" class="button wc-forward%s">%s</a>', esc_html( $added_text ), esc_url( $return_to ), esc_attr( $wp_button_class ), esc_html__( 'Continue shopping', 'woocommerce' ) );
+	} elseif ( ! CartCheckoutUtils::has_cart_page() ) {
+		$message = sprintf( '%s', esc_html( $added_text ) );
 	} else {
 		$message = sprintf( '%s <a href="%s" class="button wc-forward%s">%s</a>', esc_html( $added_text ), esc_url( wc_get_cart_url() ), esc_attr( $wp_button_class ), esc_html__( 'View cart', 'woocommerce' ) );
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
@@ -2468,6 +2469,9 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_button_view_cart' ) ) 
 	 */
 	function woocommerce_widget_shopping_cart_button_view_cart() {
 		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+		if ( ! CartCheckoutUtils::has_cart_page() ) {
+			echo '';
+		}
 		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward' . esc_attr( $wp_button_class ) . '">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -3,6 +3,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use Automattic\WooCommerce\Enums\ProductType;
 
@@ -275,7 +276,7 @@ class ProductButton extends AbstractBlock {
 					'{div_directives}'         => $is_ajax_button ? $div_directives : '',
 					'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
 					'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',
-					'{view_cart_html}'         => $is_ajax_button ? $this->get_view_cart_html() : '',
+					'{view_cart_html}'         => $is_ajax_button && CartCheckoutUtils::has_cart_page() ? $this->get_view_cart_html() : '',
 				)
 			),
 			$product,

--- a/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/CartCheckoutUtils.php
@@ -453,4 +453,13 @@ class CartCheckoutUtils {
 			}
 		}
 	}
+
+	/**
+	 * Check if the cart page is defined.
+	 *
+	 * @return bool True if the cart page is defined, false otherwise.
+	 */
+	public static function has_cart_page() {
+		return wc_get_page_permalink( 'cart', -1 ) !== -1;
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
@@ -134,28 +134,60 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test wc_add_to_cart_message
+	 * Test wc_add_to_cart_message with cart page defined.
 	 */
-	public function test_wc_add_to_cart_message() {
-		$product         = WC_Helper_Product::create_simple_product();
+	public function test_wc_add_to_cart_message_with_cart_page_defined() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', '' );
+
+		$cart_page_url = wc_get_page_permalink( 'cart' );
+
 		$wp_button_class = esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), false, true );
-		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), false, true );
-		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), true, true );
-		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), true, true );
-		$this->assertEquals( '3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), false, true );
-		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), true, true );
-		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="http://' . WP_TESTS_DOMAIN . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart. <a href="' . $cart_page_url . '" class="button wc-forward' . $wp_button_class . '">View cart</a>', $message );
+
+		delete_option( 'woocommerce_cart_page_id' );
+	}
+
+	/**
+	 * Test wc_add_to_cart_message with cart page not defined.
+	 */
+	public function test_wc_add_to_cart_message_with_cart_page_not_defined() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), false, true );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+
+		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), false, true );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+
+		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), true, true );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+
+		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), true, true );
+		$this->assertEquals( '3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart.', $message );
+
+		$message = wc_add_to_cart_message( $product->get_id(), false, true );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+
+		$message = wc_add_to_cart_message( $product->get_id(), true, true );
+		$this->assertEquals( '&ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/CartCheckoutUtilsTest.php
@@ -76,4 +76,14 @@ class CartCheckoutUtilsTest extends WP_UnitTestCase {
 		$this->assertEquals( 'required', get_option( 'woocommerce_checkout_company_field' ) );
 		$this->assertEquals( 'required', get_option( 'woocommerce_checkout_address_2_field' ) );
 	}
+
+	/**
+	 * Test has_cart_page() function.
+	 */
+	public function test_has_cart_page() {
+		wc_create_page( 'cart', 'woocommerce_cart_page_id', 'Cart', '' );
+		$this->assertTrue( CartCheckoutUtils::has_cart_page() );
+		delete_option( 'woocommerce_cart_page_id' );
+		$this->assertFalse( CartCheckoutUtils::has_cart_page() );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR hides the `View Cart` button when the cart page is not defined. I created `has_cart_page` util to avoid replicating the same check across the codebase. I added a unit test to ensure that the behavior is the expected one.

> [!IMPORTANT]
> I used the "View Cart" string across the PHP codebase to ensure that I updated all the cases, but in case you think that I missed some use cases, please let me know.

Closes https://github.com/woocommerce/woocommerce/issues/56563 (WOOPLUG-3535) .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

## Block Theme

1. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced`.
2. Remove the Cart Page:
![image](https://github.com/user-attachments/assets/179ec60b-ef1d-4a06-b5a7-0c718eb6ad62)
3. Install and enable a block theme (like TT5).
5. Visit a Single Product page
6. Add the product to the cart.
7. Ensure that the notice on top doesn't have the `View Cart` link.

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/4ef2626a-a8b2-4e40-8111-d5a0e8139205)| ![image](https://github.com/user-attachments/assets/c73474d6-53fd-4151-a2d3-9f90373b884b)|


8. Edit the product and enable the `Limit purchases to 1 item per order` option.
9. Re-add the product.
10. Ensure that the notice on top doesn't have the `View Cart` link.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0801bae7-9159-4108-8e9e-c16e39d2a2f4)| ![image](https://github.com/user-attachments/assets/d470967f-103d-4e30-b3b0-2d696ec11edc)| 

11. Visit the `/shop` page.
12. Add a product to the cart.
13. Ensure that the `view cart` link isn't rendered.

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/a10dca12-d7eb-49fb-a2e8-dc207c27fbb2) | ![image](https://github.com/user-attachments/assets/a0aed9ac-062e-487b-b336-c1f1c3391606) | 


## Classic Theme

1. Visit `/wp-admin/admin.php?page=wc-settings&tab=advanced`.
2. Remove the Cart Page:
![image](https://github.com/user-attachments/assets/179ec60b-ef1d-4a06-b5a7-0c718eb6ad62)
3. Install and enable Storefront (or another classic theme)
5. Visit a Single Product page
6. Add the product to the cart.
7. Ensure that the notice on top doesn't have the `View Cart` link.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a65578f1-6bd3-434f-ab15-1d32e4ad7de6) |![image](https://github.com/user-attachments/assets/a0e50523-111b-4841-bc24-68024d98abf5) | 

8. Edit the product and enable the `Limit purchases to 1 item per order` option.
9. Re-add the product.
10. Ensure that the notice on top doesn't have the `View Cart` link.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ee4a2320-737a-494d-8a1a-d334d4e5ace1) | ![image](https://github.com/user-attachments/assets/0d471cbe-d90d-4b56-b8fb-267eebeb2b8e)| 


> [!WARNING]
> The /shop page in the Classic theme wasn’t updated because, with the current UI/UX, removing the “View Cart” link leaves users without clear feedback that a product was added. Happy to implement it if you think it’s worth doing.


https://github.com/user-attachments/assets/bc8f2a95-7d56-40be-847f-9d3845978510



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Hide 'View Cart' button when the cart page is not defined.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
