### PR TITLE
fix: regression in #55305

### DIFF
--- a/plugins/woocommerce/changelog/57507-patch-7
+++ b/plugins/woocommerce/changelog/57507-patch-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix warning in ProductQuery where no result would be returned if passing a term id
+

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -123,7 +123,7 @@ class ProductQuery {
 		// Set tax_query for each passed arg.
 		foreach ( $taxonomies as $taxonomy => $key ) {
 			if ( ! empty( $request[ $key ] ) ) {
-				$type        = is_numeric( $request[ $key ][0] ) ? 'term_id' : 'slug';
+				$type        = is_numeric( is_array($request[$key] ) ? current( $request[ $key ] ) : $request[ $key ] ) ? 'term_id' : 'slug';
 				$operator    = $request->get_param( $key . '_operator' ) && isset( $operator_mapping[ $request->get_param( $key . '_operator' ) ] ) ? $operator_mapping[ $request->get_param( $key . '_operator' ) ] : 'IN';
 				$tax_query[] = array(
 					'taxonomy' => $taxonomy,


### PR DESCRIPTION
Fixes Bug introduced in PR #55305 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    PHP Warning:  Trying to access array offset on int in plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php on line 128 ![image](https://github.com/user-attachments/assets/fd1c6c83-64cc-47e8-8ce2-3a41bd7e0332)   |    No warning  and ![image](https://github.com/user-attachments/assets/aec4e85b-9d48-4fa7-9aa1-a313915eb360)  |

Before this PR passing an id like ?category=1 to the request would not return any result anymore because the check would use `slug` instead of `term_id` which would never match anything

It now correctly handles both arrays or simple fields

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix warning in ProductQuery where no result would be returned if passing a term id
</details>
