### PR TITLE
Local Pickup labels are inconsistent on confirmation page

### DIFF
--- a/plugins/woocommerce/changelog/fix-57506
+++ b/plugins/woocommerce/changelog/fix-57506
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure local pickup cost is displayed on the order confirmation page when a fee is configured. Show pickup location name and merchant-provided details even if the pickup address is incomplete or missing.

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -129,16 +129,40 @@ class ShippingController {
 		$details         = $shipping_method->get_meta( 'pickup_details' );
 		$location        = $shipping_method->get_meta( 'pickup_location' );
 		$address         = $shipping_method->get_meta( 'pickup_address' );
+		$cost            = $shipping_method->get_total();
 
-		if ( ! $address ) {
+		$section = '';
+
+		if ( $location ) {
+			$section .= sprintf(
+				// Translators: %s location name.
+				__( 'Collection from <strong>%s</strong>:', 'woocommerce' ),
+				$location
+			);
+		}
+
+		if ( $address ) {
+			$section .= '<br/><address>' . nl2br( esc_html( str_replace( ',', ', ', $address ) ) ) . '</address>';
+		}
+
+		if ( $details ) {
+			$section .= '<br/>' . wp_kses_post( $details );
+		}
+
+		if ( $cost > 0 ) {
+			$section .= '<br/>' . sprintf(
+				// Translators: %s is the formatted price.
+				__( 'Pickup cost: %s', 'woocommerce' ),
+				wc_price( $cost, array( 'currency' => $order->get_currency() ) )
+			);
+		}
+
+		// If nothing is available, return original.
+		if ( empty( $section ) ) {
 			return $return_value;
 		}
 
-		return sprintf(
-			// Translators: %s location name.
-			__( 'Collection from <strong>%s</strong>:', 'woocommerce' ),
-			$location
-		) . '<br/><address>' . str_replace( ',', ',<br/>', $address ) . '</address><br/>' . $details;
+		return $section;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -150,10 +150,41 @@ class ShippingController {
 		}
 
 		if ( $cost > 0 ) {
+			$tax_display = get_option( 'woocommerce_tax_display_cart' );
+			$tax = $shipping_method->get_total_tax();
+
+			// Format cost with tax handling
+			if ( 'excl' === $tax_display ) {
+				// Show pickup cost excluding tax
+				$formatted_cost = wc_price( $cost, array( 'currency' => $order->get_currency() ) );
+				if ( (float) $tax > 0 && $order->get_prices_include_tax() ) {
+					$formatted_cost .= apply_filters( 
+						'woocommerce_order_shipping_to_display_tax_label', 
+						'&nbsp;<small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>', 
+						$order, 
+						$tax_display 
+					);
+				}
+			} else {
+				// Show pickup cost including tax
+				$formatted_cost = wc_price( 
+					(float) $cost + (float) $tax, 
+					array( 'currency' => $order->get_currency() ) 
+				);
+				if ( (float) $tax > 0 && ! $order->get_prices_include_tax() ) {
+					$formatted_cost .= apply_filters( 
+						'woocommerce_order_shipping_to_display_tax_label', 
+						'&nbsp;<small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>', 
+						$order, 
+						$tax_display 
+					);
+				}
+			}
+
 			$lines[] = '<br>' . sprintf(
 				// Translators: %s is the formatted price.
 				__( 'Pickup cost: %s', 'woocommerce' ),
-				wc_price( $cost, array( 'currency' => $order->get_currency() ) )
+				$formatted_cost
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -142,7 +142,7 @@ class ShippingController {
 		}
 
 		if ( $address ) {
-			$lines[] = '<address>' . nl2br( esc_html( str_replace( ',', ', ', $address ) ) );
+			$lines[] = nl2br( esc_html( str_replace( ',', ', ', $address ) ) );
 		}
 
 		if ( $details ) {
@@ -150,7 +150,7 @@ class ShippingController {
 		}
 
 		if ( $cost > 0 ) {
-			$lines[] = sprintf(
+			$lines[] = '<br>' . sprintf(
 				// Translators: %s is the formatted price.
 				__( 'Pickup cost: %s', 'woocommerce' ),
 				wc_price( $cost, array( 'currency' => $order->get_currency() ) )
@@ -163,7 +163,7 @@ class ShippingController {
 		}
 
 		// Join all the lines with a <br> separator.
-		return implode( '<br/>', $lines );
+		return implode( '<br>', $lines );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -131,10 +131,10 @@ class ShippingController {
 		$address         = $shipping_method->get_meta( 'pickup_address' );
 		$cost            = $shipping_method->get_total();
 
-		$section = '';
+		$lines = array();
 
 		if ( $location ) {
-			$section .= sprintf(
+			$lines[] = sprintf(
 				// Translators: %s location name.
 				__( 'Collection from <strong>%s</strong>:', 'woocommerce' ),
 				$location
@@ -142,15 +142,15 @@ class ShippingController {
 		}
 
 		if ( $address ) {
-			$section .= '<br/><address>' . nl2br( esc_html( str_replace( ',', ', ', $address ) ) ) . '</address>';
+			$lines[] = '<address>' . nl2br( esc_html( str_replace( ',', ', ', $address ) ) );
 		}
 
 		if ( $details ) {
-			$section .= '<br/>' . wp_kses_post( $details );
+			$lines[] = wp_kses_post( $details );
 		}
 
 		if ( $cost > 0 ) {
-			$section .= '<br/>' . sprintf(
+			$lines[] = sprintf(
 				// Translators: %s is the formatted price.
 				__( 'Pickup cost: %s', 'woocommerce' ),
 				wc_price( $cost, array( 'currency' => $order->get_currency() ) )
@@ -158,11 +158,12 @@ class ShippingController {
 		}
 
 		// If nothing is available, return original.
-		if ( empty( $section ) ) {
+		if ( empty( $lines ) ) {
 			return $return_value;
 		}
 
-		return $section;
+		// Join all the lines with a <br> separator.
+		return implode( '<br/>', $lines );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -153,11 +153,20 @@ class ShippingController {
 			$tax_display = get_option( 'woocommerce_tax_display_cart' );
 			$tax         = $shipping_method->get_total_tax();
 
-			// Format cost with tax handling
+			// Format cost with tax handling.
 			if ( 'excl' === $tax_display ) {
-				// Show pickup cost excluding tax
+				// Show pickup cost excluding tax.
 				$formatted_cost = wc_price( $cost, array( 'currency' => $order->get_currency() ) );
 				if ( (float) $tax > 0 && $order->get_prices_include_tax() ) {
+					/**
+					 * Hook to add tax label to pickup cost.
+					 *
+					 * @since 6.0.0
+					 * @param string $tax_label Tax label.
+					 * @param \WC_Order $order Order object.
+					 * @param string $tax_display Tax display.
+					 * @return string
+					 */
 					$formatted_cost .= apply_filters(
 						'woocommerce_order_shipping_to_display_tax_label',
 						'&nbsp;<small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>',
@@ -166,12 +175,21 @@ class ShippingController {
 					);
 				}
 			} else {
-				// Show pickup cost including tax
+				// Show pickup cost including tax.
 				$formatted_cost = wc_price(
 					(float) $cost + (float) $tax,
 					array( 'currency' => $order->get_currency() )
 				);
 				if ( (float) $tax > 0 && ! $order->get_prices_include_tax() ) {
+					/**
+					 * Hook to add tax label to pickup cost.
+					 *
+					 * @since 6.0.0
+					 * @param string $tax_label Tax label.
+					 * @param \WC_Order $order Order object.
+					 * @param string $tax_display Tax display.
+					 * @return string
+					 */
 					$formatted_cost .= apply_filters(
 						'woocommerce_order_shipping_to_display_tax_label',
 						'&nbsp;<small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>',

--- a/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
+++ b/plugins/woocommerce/src/Blocks/Shipping/ShippingController.php
@@ -151,32 +151,32 @@ class ShippingController {
 
 		if ( $cost > 0 ) {
 			$tax_display = get_option( 'woocommerce_tax_display_cart' );
-			$tax = $shipping_method->get_total_tax();
+			$tax         = $shipping_method->get_total_tax();
 
 			// Format cost with tax handling
 			if ( 'excl' === $tax_display ) {
 				// Show pickup cost excluding tax
 				$formatted_cost = wc_price( $cost, array( 'currency' => $order->get_currency() ) );
 				if ( (float) $tax > 0 && $order->get_prices_include_tax() ) {
-					$formatted_cost .= apply_filters( 
-						'woocommerce_order_shipping_to_display_tax_label', 
-						'&nbsp;<small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>', 
-						$order, 
-						$tax_display 
+					$formatted_cost .= apply_filters(
+						'woocommerce_order_shipping_to_display_tax_label',
+						'&nbsp;<small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>',
+						$order,
+						$tax_display
 					);
 				}
 			} else {
 				// Show pickup cost including tax
-				$formatted_cost = wc_price( 
-					(float) $cost + (float) $tax, 
-					array( 'currency' => $order->get_currency() ) 
+				$formatted_cost = wc_price(
+					(float) $cost + (float) $tax,
+					array( 'currency' => $order->get_currency() )
 				);
 				if ( (float) $tax > 0 && ! $order->get_prices_include_tax() ) {
-					$formatted_cost .= apply_filters( 
-						'woocommerce_order_shipping_to_display_tax_label', 
-						'&nbsp;<small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>', 
-						$order, 
-						$tax_display 
+					$formatted_cost .= apply_filters(
+						'woocommerce_order_shipping_to_display_tax_label',
+						'&nbsp;<small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>',
+						$order,
+						$tax_display
 					);
 				}
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #57506  .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before  |

|     
![Screenshot from 2025-04-24 23-49-38](https://github.com/user-attachments/assets/0f400737-bee0-4f14-be74-8001553a155c)

![Screenshot from 2025-04-24 23-41-38](https://github.com/user-attachments/assets/cdcf0d33-2812-48dc-8863-c39f38fdac62)
|  
|   After |
![Screenshot from 2025-04-24 23-43-34](https://github.com/user-attachments/assets/cc355c62-ac4a-43ef-bef6-84fe2f941264)
![Screenshot from 2025-04-24 23-43-45](https://github.com/user-attachments/assets/56ddfda7-698e-4f47-b0df-9b9c8bc4e8dc)

|  
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Settings > Shipping > Local Pickup
2. Enter cost
3. Create pickup locations with/without addresses
4. Place order and view confirmation


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Ensure local pickup cost is displayed on the order confirmation page when a fee is configured. 
Show pickup location name and merchant-provided details even if the pickup address is incomplete or missing.

</details>
