### PR TITLE
WOOPLUG-4054: Fix secondary PMs disappearing when checked off

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
@@ -29,6 +29,11 @@ type PaymentMethodListItemProps = {
 	 * Indicates whether the payment methods list is currently expanded.
 	 */
 	isExpanded: boolean;
+	/**
+	 * The pre-calculated initial visibility status passed from the parent.
+	 * If undefined, the component calculates its own initial visibility.
+	 */
+	initialVisibilityStatus?: boolean | null;
 };
 
 /**
@@ -40,31 +45,34 @@ export const PaymentMethodListItem = ( {
 	paymentMethodsState,
 	setPaymentMethodsState,
 	isExpanded,
+	initialVisibilityStatus,
 	...props
 }: PaymentMethodListItemProps ) => {
+	// Internal ref for fallback mechanism when prop is not provided
 	const shouldRenderRef = useRef< boolean | null >( null );
 
-	// Only initialize the ref once the state for this method is available.
-	if (
-		shouldRenderRef.current === null &&
-		paymentMethodsState[ method.id ] !== undefined
-	) {
-		// Rendering logic
-		// If the category is primary, render the method regardless of the state.
-		// If the category is secondary, render the method if the list is expanded or the method is enabled.
-		const initialShouldRenderBasedOnState =
-			shouldRenderPaymentMethodInMainList(
+	// Fallback: Calculate initial visibility internally if prop is not provided
+	if ( initialVisibilityStatus === undefined ) {
+		// Only initialize the ref once the state for this method is available.
+		if (
+			shouldRenderRef.current === null &&
+			paymentMethodsState[ method.id ] !== undefined
+		) {
+			shouldRenderRef.current = shouldRenderPaymentMethodInMainList(
 				method,
 				paymentMethodsState[ method.id ]
 			);
-		// Calculate the initial render state *based on the available state*.
-		shouldRenderRef.current = initialShouldRenderBasedOnState;
+		}
 	}
 
 	// Determine final rendering decision:
-	// Render if the list is expanded OR if it was initially supposed to be rendered.
-	// This is to prevent the method from being hidden behind the "Show more" button when it was enabled and then disabled.
-	const shouldRender = isExpanded || ( shouldRenderRef.current ?? false );
+	// Prioritize the prop if provided, otherwise use the internal ref state.
+	const baseVisibility =
+		initialVisibilityStatus !== undefined
+			? initialVisibilityStatus ?? false
+			: shouldRenderRef.current ?? false;
+
+	const shouldRender = isExpanded || baseVisibility;
 
 	if ( ! shouldRender ) {
 		return null;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
@@ -49,19 +49,20 @@ export const PaymentMethodListItem = ( {
 	...props
 }: PaymentMethodListItemProps ) => {
 	// Internal ref for fallback mechanism when prop is not provided
-	const shouldRenderRef = useRef< boolean | null >( null );
+	const shouldRenderInMainListRef = useRef< boolean | null >( null );
 
 	// Fallback: Calculate initial visibility internally if prop is not provided
 	if ( initialVisibilityStatus === undefined ) {
 		// Only initialize the ref once the state for this method is available.
 		if (
-			shouldRenderRef.current === null &&
+			shouldRenderInMainListRef.current === null &&
 			paymentMethodsState[ method.id ] !== undefined
 		) {
-			shouldRenderRef.current = shouldRenderPaymentMethodInMainList(
-				method,
-				paymentMethodsState[ method.id ]
-			);
+			shouldRenderInMainListRef.current =
+				shouldRenderPaymentMethodInMainList(
+					method,
+					paymentMethodsState[ method.id ]
+				);
 		}
 	}
 
@@ -70,7 +71,7 @@ export const PaymentMethodListItem = ( {
 	const baseVisibility =
 		initialVisibilityStatus !== undefined
 			? initialVisibilityStatus ?? false
-			: shouldRenderRef.current ?? false;
+			: shouldRenderInMainListRef.current ?? false;
 
 	const shouldRender = isExpanded || baseVisibility;
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-method-list-item/payment-method-list-item.tsx
@@ -4,6 +4,7 @@
 import { decodeEntities } from '@wordpress/html-entities';
 import { type RecommendedPaymentMethod } from '@woocommerce/data';
 import { ToggleControl } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,14 +42,29 @@ export const PaymentMethodListItem = ( {
 	isExpanded,
 	...props
 }: PaymentMethodListItemProps ) => {
-	// Rendering logic
-	// If the category is primary, render the method regardless of the state.
-	// If the category is secondary, render the method if the list is expanded or the method is enabled.
-	const shouldRender =
-		shouldRenderPaymentMethodInMainList(
-			method,
-			paymentMethodsState[ method.id ]
-		) || isExpanded;
+	const shouldRenderRef = useRef< boolean | null >( null );
+
+	// Only initialize the ref once the state for this method is available.
+	if (
+		shouldRenderRef.current === null &&
+		paymentMethodsState[ method.id ] !== undefined
+	) {
+		// Rendering logic
+		// If the category is primary, render the method regardless of the state.
+		// If the category is secondary, render the method if the list is expanded or the method is enabled.
+		const initialShouldRenderBasedOnState =
+			shouldRenderPaymentMethodInMainList(
+				method,
+				paymentMethodsState[ method.id ]
+			);
+		// Calculate the initial render state *based on the available state*.
+		shouldRenderRef.current = initialShouldRenderBasedOnState;
+	}
+
+	// Determine final rendering decision:
+	// Render if the list is expanded OR if it was initially supposed to be rendered.
+	// This is to prevent the method from being hidden behind the "Show more" button when it was enabled and then disabled.
+	const shouldRender = isExpanded || ( shouldRenderRef.current ?? false );
 
 	if ( ! shouldRender ) {
 		return null;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { RecommendedPaymentMethod } from '@woocommerce/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { close } from '@wordpress/icons';
 
@@ -37,15 +37,20 @@ export default function PaymentMethodsSelection() {
 	const contextPaymentMethodsState = currentStep?.context?.pms_state;
 	const contextPaymentMethods = currentStep?.context?.recommended_pms;
 
+	// Memoize the combined recommended payment methods
+	const recommendedPaymentMethods = useMemo( () => {
+		return contextPaymentMethods
+			? combineRequestMethods( contextPaymentMethods )
+			: [];
+	}, [ contextPaymentMethods ] );
+
+	// Update the local payment methods state when the context changes
 	useEffect( () => {
 		if ( contextPaymentMethodsState ) {
 			setPaymentMethodsState( contextPaymentMethodsState );
 		}
 	}, [ contextPaymentMethodsState ] );
 
-	const recommendedPaymentMethods = contextPaymentMethods
-		? combineRequestMethods( contextPaymentMethods )
-		: [];
 
 	// Calculate hidden count based on the stored initial visibility (Memoized)
 	const hiddenCount = useMemo( () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -28,6 +28,11 @@ export default function PaymentMethodsSelection() {
 	const [ paymentMethodsState, setPaymentMethodsState ] = useState< {
 		[ key: string ]: boolean;
 	} >( {} );
+	// Store the calculated initial visibility status in state to trigger re-render
+	const [ initialVisibilityMap, setInitialVisibilityMap ] = useState< Record<
+		string,
+		boolean
+	> | null >( null );
 
 	const contextPaymentMethodsState = currentStep?.context?.pms_state;
 	const contextPaymentMethods = currentStep?.context?.recommended_pms;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -125,6 +125,14 @@ export default function PaymentMethodsSelection() {
 												} );
 											}
 										} }
+										// Pass down the calculated initial visibility for this specific method from state
+										initialVisibilityStatus={
+											initialVisibilityMap
+												? initialVisibilityMap[
+														method.id
+												  ] ?? null
+												: null
+										}
 										isExpanded={ isExpanded }
 										key={ method.id }
 									/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -47,6 +47,21 @@ export default function PaymentMethodsSelection() {
 		? combineRequestMethods( contextPaymentMethods )
 		: [];
 
+	// Calculate hidden count based on the stored initial visibility (Memoized)
+	const hiddenCount = useMemo( () => {
+		// Use the state map now
+		if ( ! initialVisibilityMap || isExpanded ) {
+			return 0;
+		}
+
+		// Filter based on the stored initial visibility status from state
+		return recommendedPaymentMethods.filter(
+			// Count if initial visibility was false
+			( method ) => ! ( initialVisibilityMap[ method.id ] ?? false )
+		).length;
+		// Depend on the state map now
+	}, [ recommendedPaymentMethods, isExpanded, initialVisibilityMap ] );
+
 	return (
 		<div className="settings-payments-onboarding-modal__step--content">
 			<div className="woocommerce-layout__header woocommerce-recommended-payment-methods">
@@ -121,15 +136,9 @@ export default function PaymentMethodsSelection() {
 								aria-expanded={ isExpanded }
 							>
 								{ sprintf(
-									/* translators: %s: number of disabled payment methods */
+									/* translators: %s: number of hidden payment methods */
 									__( 'Show more (%s)', 'woocommerce' ),
-									recommendedPaymentMethods?.filter(
-										( method ) =>
-											! shouldRenderPaymentMethodInMainList(
-												method,
-												paymentMethodsState[ method.id ]
-											)
-									).length ?? 0
+									hiddenCount
 								) }
 							</Button>
 						) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -57,6 +57,39 @@ export default function PaymentMethodsSelection() {
 		[ paymentMethodsState ]
 	);
 
+	// Calculate and store initial visibility *once* when data is ready
+	useEffect( () => {
+		// Only proceed if the map hasn't been populated yet
+		if ( initialVisibilityMap !== null ) {
+			return;
+		}
+
+		// Ensure both methods and state are sufficiently loaded
+		if (
+			recommendedPaymentMethods.length > 0 &&
+			Object.keys( combinedState ).length > 0 // Use combinedState length
+		) {
+			// Check if all necessary state keys are present for the current methods in the *combined* state
+			const allKeysPresent = recommendedPaymentMethods.every( ( m ) => {
+				const isPresent = combinedState[ m.id ] !== undefined; // Check in combinedState
+				return isPresent;
+			} );
+
+			if ( allKeysPresent ) {
+				const calculatedMap: Record< string, boolean > = {};
+				recommendedPaymentMethods.forEach( ( method ) => {
+					calculatedMap[ method.id ] =
+						shouldRenderPaymentMethodInMainList(
+							method,
+							combinedState[ method.id ] // Use combinedState value
+						);
+				} );
+				// Set the state with the calculated initial visibility map
+				setInitialVisibilityMap( calculatedMap );
+			}
+		}
+		// Depend on methods and the *combined* state
+	}, [ recommendedPaymentMethods, combinedState ] );
 
 	// Calculate hidden count based on the stored initial visibility (Memoized)
 	const hiddenCount = useMemo( () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -51,6 +51,12 @@ export default function PaymentMethodsSelection() {
 		}
 	}, [ contextPaymentMethodsState ] );
 
+	// Combine state to match combined methods list
+	const combinedState = useMemo(
+		() => combinePaymentMethodsState( paymentMethodsState ),
+		[ paymentMethodsState ]
+	);
+
 
 	// Calculate hidden count based on the stored initial visibility (Memoized)
 	const hiddenCount = useMemo( () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -131,7 +131,8 @@ export default function PaymentMethodsSelection() {
 								)
 							) }
 						</div>
-						{ ! isExpanded && (
+						{ /* Show button only if not expanded and there are initially hidden items */ }
+						{ ! isExpanded && hiddenCount > 0 && (
 							<Button
 								className="settings-payments-methods__show-more"
 								onClick={ () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a bug where secondary PMs were disappearing when checked off. Watch the video below to learn more.

The primary issue is that we fail to track the initial rendering of the PM. If the PM was rendered initially, turning it off shouldn't make it disappear. This is what this pull request introduces.

Closes WOOPLUG-4054
Closes #57498

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**Before** 

https://github.com/user-attachments/assets/33eb4ad1-3f84-40ca-b256-023c7a55bf4f

**After**

https://github.com/user-attachments/assets/1afb4733-3ee9-4c7b-a27b-ef7251ecc5a8


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR locally
2. Make sure to test both flows below

For WooPayment +9.3.0
1. Clicking the Complete Setup should open the NOX
5. Make sure to interact with the PMs, show the secondary ones, turn some ones on, and close the modal
6. Open the modal again, and the secondary PMs should show in the initial list. Turn some off, these PMs should stay shown in the list.
7. Double-check that the `Show more (X)` button shows the correct number (X)
8. Repeat as much as you prefer

For WooPayments -9.2.0
1. Clicking the Complete Setup button should redirect to the old PMs selection page
2. Interact with the page and turn things on/off
3. Go back and repeat
4. Everything should work as expected, and no regression is introduced

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR doesn't need a changelog, given it's not merged to trunk

</details>
