### PR TITLE
Product Details: only render non-empty accordion items

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3047-product-details-block-only-render-item-when-relevant-content
+++ b/plugins/woocommerce/changelog/wooplug-3047-product-details-block-only-render-item-when-relevant-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Product Details: Hide empty accordion items on the front end.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -2,6 +2,9 @@
 declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use WP_Block;
+use WP_HTML_Tag_Processor;
+
 /**
  * BlockifiedProductDetails class.
  */
@@ -32,6 +35,67 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		return $content;
+		return $this->hide_empty_accordion_items( $content, $block );
+	}
+
+	/**
+	 * Hide empty accordion items.
+	 *
+	 * @param string $content Block content.
+	 * @param WP_Block $block Block instance.
+	 *
+	 * @return string Rendered block output.
+	 */
+	private function hide_empty_accordion_items( $content, $block ) {
+		$accordion_items = $this->find_accordion_items( $block->parsed_block );
+
+		if ( ! $accordion_items ) {
+			return $content;
+		}
+
+		$accordion_items_visibility = array_map(
+			function ( $item ) use ( $block ) {
+				$content_block          = end( $item['innerBlocks'] );
+				$rendered_content_block = ( new WP_Block( $content_block, $block->context ) )->render();
+				$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
+
+				return $p->next_tag( 'img' ) || $p->next_tag( 'video' ) || $p->next_tag( 'iframe' ) || ! empty( wp_strip_all_tags( $rendered_content_block, true ) );
+			},
+			$accordion_items
+		);
+
+		$p = new WP_HTML_Tag_Processor( $content );
+
+		$counter = 0;
+		while ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-accordion-item' ) ) ) {
+			if ( ! $accordion_items_visibility[ $counter ] ) {
+				$p->set_attribute( 'style', 'display:none;' );
+			}
+			++$counter;
+		}
+
+		return $p->get_updated_html();
+	}
+
+	/**
+	 * Find accordion items.
+	 *
+	 * @param array $block Block instance.
+	 *
+	 * @return array|false Accordion items.
+	 */
+	private function find_accordion_items( $block ) {
+		if ( 'woocommerce/accordion-group' === $block['blockName'] ) {
+			return $block['innerBlocks'];
+		}
+
+		foreach ( $block['innerBlocks'] as $inner_block ) {
+			$items = $this->find_accordion_items( $inner_block );
+			if ( $items ) {
+				return $items;
+			}
+		}
+
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -41,7 +41,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 	/**
 	 * Hide empty accordion items.
 	 *
-	 * @param string $content Block content.
+	 * @param string   $content Block content.
 	 * @param WP_Block $block Block instance.
 	 *
 	 * @return string Rendered block output.
@@ -59,7 +59,11 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$rendered_content_block = ( new WP_Block( $content_block, $block->context ) )->render();
 				$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
 
-				return $p->next_tag( 'img' ) || $p->next_tag( 'video' ) || $p->next_tag( 'iframe' ) || ! empty( wp_strip_all_tags( $rendered_content_block, true ) );
+				return $p->next_tag( 'img' ) ||
+					$p->next_tag( 'iframe' ) ||
+					$p->next_tag( 'video' ) ||
+					$p->next_tag( 'meter' ) ||
+					! empty( wp_strip_all_tags( $rendered_content_block, true ) );
 			},
 			$accordion_items
 		);
@@ -70,6 +74,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 		while ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-accordion-item' ) ) ) {
 			if ( ! $accordion_items_visibility[ $counter ] ) {
 				$p->set_attribute( 'style', 'display:none;' );
+				$p->set_attribute( 'hidden', true );
 			}
 			++$counter;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR improves the Product Details block by hiding empty accordion items when they have no relevant content to display. Accordion Item can have inner blocks but those blocks can return empty string or empty tags.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1457" alt="image" src="https://github.com/user-attachments/assets/feac1117-0e37-4754-b1e4-cbeae84142d4" /> |   <img width="1448" alt="image" src="https://github.com/user-attachments/assets/1a8ae844-ca6d-4785-a1b1-704e0f11b50b" />    | 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add `Blockified Product Details` block to the Single Product template.
2. View a product that doesn't have any weight/dimensions/attribute.
3. Doesn't see the Additional Information item.
4. View another product that has weight/dimensions/attribute.
5. See the Additional Information item is visible and clicking on the header expands the item's content.
6. Clear the description of a product.
7. On the frontend, see the Description tab is hidden.

<!-- End testing instructions -->
