### PR TITLE
Add loading indicator in email settings page

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -669,8 +669,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			height: 40px;
 			width: 100%;
 			">
-				<h3> <?php echo esc_html__( 'Loading...', 'woocommerce' ); ?>  </h3>
+				<h3> <?php esc_html_e( 'Loading&hellip;', 'woocommerce' ); ?>  </h3>
 			</div>
+		</div>
 		<div>
 			<p><?php echo wp_kses_post( wpautop( wptexturize( $desc_help_text ) ) ); ?></p>
 		</div>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -660,7 +660,17 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			id="wc_settings_email_listing_slotfill" class="wc-settings-prevent-change-event woocommerce-email-listing-listview"
 			data-email-types="<?php echo esc_attr( wp_json_encode( $email_types ) ); ?>"
 			data-edit-template-url="<?php echo esc_attr( $edit_template_url ); ?>"
-		></div>
+		>
+			<div style="
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 12px;
+			height: 40px;
+			width: 100%;
+			">
+				<h3> <?php echo esc_html__( 'Loading...', 'woocommerce' ); ?>  </h3>
+			</div>
 		<div>
 			<p><?php echo wp_kses_post( wpautop( wptexturize( $desc_help_text ) ) ); ?></p>
 		</div>


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR # .

### Improve Email Settings Page UX with Loading Animation

**Description**

This PR enhances the user experience in the WooCommerce email settings page by adding a loading indicator when email types are being processed. The delay appears to be from when React is rendering the settings slotfill, so I opted for a simple loader text here instead of another React spinner component.

**What's Changed**

- Added a centered "Loading..." message with appropriate styling in the email settings page
- Ensures users receive visual feedback while the email listing is being loaded

**Why**

Previously, the email settings page would appear empty while data was being processed, which could be confusing for users. This improvement provides clear visual feedback that the system is working and content will appear shortly.

**How**

- Modified the HTML structure in `class-wc-settings-emails.php` to include a styled div container
- Added a simple loading message using a properly localized string
- Styled the container to ensure good visibility and proper spacing


**Related Issues**

Fixes: WOOPLUG-3686
Closes #56832 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   ![Screenshot 2025-04-25 at 11 23 47 AM](https://github.com/user-attachments/assets/bda1f3da-8900-4e21-8588-ba1e5efba793) |   ![Screenshot 2025-04-25 at 11 14 15 AM](https://github.com/user-attachments/assets/a4991887-41fd-4935-b912-f6f0463ee220) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to WooCommerce > Settings > Emails
2. Open developer tools and throttle network speed to "Fast 4G" or "3G" anu option
3. Observe the loading indicator that appears while email types are being processed
4. Verify that the loading message is visible and properly centered
5. Confirm that the message is replaced by the actual email list once loading is complete

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Simple UX update. Does not require a changelog.
</details>
