### PR TITLE
[WC Payments NOX in-context flows] Update FE state and store handling

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
@@ -5,7 +5,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { paymentSettingsStore } from '@woocommerce/data';
+import {
+	paymentSettingsStore,
+	woopaymentsOnboardingStore,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -40,6 +43,9 @@ export const WooPaymentsResetAccountModal = ( {
 	const [ isResettingAccount, setIsResettingAccount ] = useState( false );
 	const { invalidateResolutionForStoreSelector: invalidatePaymentGateways } =
 		useDispatch( paymentSettingsStore );
+	const {
+		invalidateResolutionForStoreSelector: invalidateWooPaymentsOnboarding,
+	} = useDispatch( woopaymentsOnboardingStore );
 	const { createNotice } = useDispatch( 'core/notices' );
 
 	/**
@@ -51,8 +57,10 @@ export const WooPaymentsResetAccountModal = ( {
 
 		resetWooPaymentsAccount()
 			.then( () => {
-				// Refresh the store
+				// Refresh the providers store.
 				invalidatePaymentGateways( 'getPaymentProviders' );
+				// Refresh the WooPayments in-context onboarding store.
+				invalidateWooPaymentsOnboarding( 'getOnboardingData' );
 			} )
 			.catch( () => {
 				createNotice(

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import {
 	PaymentProvider,
 	paymentSettingsStore,
+	woopaymentsOnboardingStore,
 	WC_ADMIN_NAMESPACE,
 } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
@@ -64,7 +65,11 @@ export const PaymentGateways = ( {
 	setBusinessRegistrationCountry,
 	setIsOnboardingModalOpen,
 }: PaymentGatewaysProps ) => {
-	const { invalidateResolution } = useDispatch( paymentSettingsStore );
+	const { invalidateResolution: invalidateMainStore } =
+		useDispatch( paymentSettingsStore );
+	const { invalidateResolution: invalidateWooPaymentsOnboardingStore } = useDispatch(
+		woopaymentsOnboardingStore
+	);
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const storeCountryCode = (
 		window.wcSettings?.admin?.preloadSettings?.general
@@ -142,9 +147,13 @@ export const PaymentGateways = ( {
 
 								// Update UI.
 								setBusinessRegistrationCountry( value );
-								invalidateResolution( 'getPaymentProviders', [
+								invalidateMainStore( 'getPaymentProviders', [
 									value,
 								] );
+								invalidateWooPaymentsOnboardingStore(
+									'getOnboardingData',
+									[]
+								);
 							} );
 						} }
 					/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateways/payment-gateways.tsx
@@ -67,9 +67,8 @@ export const PaymentGateways = ( {
 }: PaymentGatewaysProps ) => {
 	const { invalidateResolution: invalidateMainStore } =
 		useDispatch( paymentSettingsStore );
-	const { invalidateResolution: invalidateWooPaymentsOnboardingStore } = useDispatch(
-		woopaymentsOnboardingStore
-	);
+	const { invalidateResolution: invalidateWooPaymentsOnboardingStore } =
+		useDispatch( woopaymentsOnboardingStore );
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
 	const storeCountryCode = (
 		window.wcSettings?.admin?.preloadSettings?.general

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/onboarding/index.tsx
@@ -16,9 +16,9 @@ import { useOnboardingContext } from '../../data/onboarding-context';
  * WooPaymentsOnboarding component for the WooPayments onboarding modal.
  */
 export default function WooPaymentsOnboarding(): React.ReactNode {
-	const { steps, isLoading, currentStep } = useOnboardingContext();
+	const { steps, isLoading, currentStep, navigateToStep } =
+		useOnboardingContext();
 
-	const { navigateToStep } = useOnboardingContext();
 	const location = useLocation();
 
 	// Forces navigation to the current step only if the URL does not already match.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -56,12 +56,11 @@ export const OnboardingProvider: React.FC< {
 		WooPaymentsProviderOnboardingStep[]
 	>( [] );
 
-	const { invalidateResolutionForStoreSelector } = useDispatch(
-		woopaymentsOnboardingStore
-	);
+	const {
+		invalidateResolutionForStoreSelector: invalidateWooPaymentsOnboarding,
+	} = useDispatch( woopaymentsOnboardingStore );
 
-	// Make UI refresh when plugin is installed.
-	const { invalidateResolutionForStoreSelector: invalidatePaymentGateways } =
+	const { invalidateResolutionForStoreSelector: invalidatePaymentProviders } =
 		useDispatch( paymentSettingsStore );
 
 	// Initial data fetch from store
@@ -230,6 +229,12 @@ export const OnboardingProvider: React.FC< {
 		);
 	}, [ stateStoreSteps, areStepDependenciesCompleted ] );
 
+	const resetLocalState = () => {
+		setStateStoreSteps( [] );
+		setIsStateStoreLoading( true );
+		setAllSteps( [] );
+	};
+
 	return (
 		<OnboardingContext.Provider
 			value={ {
@@ -242,13 +247,16 @@ export const OnboardingProvider: React.FC< {
 				getStepByKey,
 				closeModal: () => {
 					closeModal();
-					// Refresh the onboarding steps to get the latest data after closing the modal.
-					// This is to avoid showing the loader next time, but still have fresh data.
-					refreshOnboardingSteps();
+
+					// Reset the onboarding data both in the store and local state.
+					// This is important to ensure that the onboarding data is cleared when the modal is closed.
+					// This is to avoid stale data when the modal is opened again.
+					resetLocalState();
+					invalidateWooPaymentsOnboarding( 'getOnboardingData' );
 
 					// Invalidate the getPaymentProviders store selector to ensure the latest data is fetched.
 					// This is important to ensure that the payment providers buttons are up to date.
-					invalidatePaymentGateways( 'getPaymentProviders' );
+					invalidatePaymentProviders( 'getPaymentProviders' );
 				},
 			} }
 		>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -36,7 +36,6 @@ const OnboardingContext = createContext< OnboardingContextType >( {
 	navigateToStep: () => undefined,
 	navigateToNextStep: () => undefined,
 	getStepByKey: () => undefined,
-	refreshOnboardingSteps: () => undefined,
 	closeModal: () => undefined,
 } );
 
@@ -162,10 +161,6 @@ export const OnboardingProvider: React.FC< {
 		areStepDependenciesCompleted,
 	] );
 
-	const refreshOnboardingSteps = useCallback( () => {
-		invalidateResolutionForStoreSelector( 'getOnboardingData' );
-	}, [ invalidateResolutionForStoreSelector ] );
-
 	/**
 	 * useEffect functions
 	 */
@@ -245,7 +240,6 @@ export const OnboardingProvider: React.FC< {
 				navigateToStep,
 				navigateToNextStep,
 				getStepByKey,
-				refreshOnboardingSteps,
 				closeModal: () => {
 					closeModal();
 					// Refresh the onboarding steps to get the latest data after closing the modal.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -106,6 +106,23 @@ export default function PaymentMethodsSelection() {
 		// Depend on the state map now
 	}, [ recommendedPaymentMethods, isExpanded, initialVisibilityMap ] );
 
+	const savePaymentMethodsState = ( state: Record< string, boolean > ) => {
+		// Update the local state
+		setPaymentMethodsState( state );
+
+		// Send the updated state to the server
+		const href = currentStep?.actions?.save?.href;
+		if ( href ) {
+			apiFetch( {
+				url: href,
+				method: 'POST',
+				data: {
+					payment_methods: decouplePaymentMethodsState( state ),
+				},
+			} );
+		}
+	};
+
 	return (
 		<div className="settings-payments-onboarding-modal__step--content">
 			<div className="woocommerce-layout__header woocommerce-recommended-payment-methods">
@@ -146,23 +163,8 @@ export default function PaymentMethodsSelection() {
 											// Update the local state
 											setPaymentMethodsState( state );
 
-											// Send the updated state to the server
-											const href =
-												currentStep?.actions?.save
-													?.href;
-											// Send POST request to the href with the payment methods state
-											if ( href ) {
-												apiFetch( {
-													url: href,
-													method: 'POST',
-													data: {
-														payment_methods:
-															decouplePaymentMethodsState(
-																state
-															),
-													},
-												} );
-											}
+											// Persist the state on the backend.
+											savePaymentMethodsState( state );
 										} }
 										// Pass down the calculated initial visibility for this specific method from state
 										initialVisibilityStatus={
@@ -202,14 +204,20 @@ export default function PaymentMethodsSelection() {
 						className="components-button is-primary"
 						onClick={ () => {
 							const href = currentStep?.actions?.finish?.href;
-							if ( href ) {
-								apiFetch( {
-									url: href,
-									method: 'POST',
-								} );
-
-								navigateToNextStep();
+							if ( ! href ) {
+								return;
 							}
+
+							// Persist the final state on the backend, just in case the user didn't change anything.
+							savePaymentMethodsState( paymentMethodsState );
+
+							// Mark the step as completed.
+							apiFetch( {
+								url: href,
+								method: 'POST',
+							} ).then( () => {
+								navigateToNextStep();
+							} );
 						} }
 						isBusy={ false }
 						disabled={ false }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -64,9 +64,9 @@ const TestAccountStep = () => {
 	const loaderProgressRef = useRef( testDriveLoaderProgress );
 	loaderProgressRef.current = testDriveLoaderProgress;
 
-	const updateLoaderProgress = ( maxPercent: number, step: number ) => {
+	const updateLoaderProgress = ( maxPercent: number, progressBy: number ) => {
 		if ( loaderProgressRef.current < maxPercent ) {
-			const newProgress = loaderProgressRef.current + step;
+			const newProgress = loaderProgressRef.current + progressBy;
 			setTestDriveLoaderProgress( newProgress );
 		}
 	};
@@ -88,7 +88,7 @@ const TestAccountStep = () => {
 			// Create a polling function to check the status of the test account setup.
 			const checkTestAccountStatus = () => {
 				// Add progress
-				updateLoaderProgress( 100, 6 );
+				updateLoaderProgress( 100, 5 );
 
 				apiFetch( {
 					url: currentStep?.actions?.check?.href,
@@ -109,8 +109,8 @@ const TestAccountStep = () => {
 				} );
 			};
 
-			// Check the status of the test account setup every 2.5 seconds.
-			const interval = setInterval( checkTestAccountStatus, 2500 );
+			// Check the status of the test account setup every 3 seconds.
+			const interval = setInterval( checkTestAccountStatus, 3000 );
 			return () => clearInterval( interval );
 		}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -76,7 +76,8 @@ const TestAccountStep = () => {
 			currentStep?.status === 'not_started' &&
 			! testAccountCreationSuccess
 		) {
-			// Send a request to the server to start the test account setup.
+			// Send a request to the server to initialize the test account setup.
+			// We don't wait for the response here, as we want to start the polling immediately.
 			apiFetch( {
 				url: currentStep?.actions?.init?.href,
 				method: 'POST',

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
@@ -130,6 +130,5 @@ export interface OnboardingContextType {
 	getStepByKey: (
 		stepKey: string
 	) => WooPaymentsProviderOnboardingStep | undefined;
-	refreshOnboardingSteps: () => void;
 	closeModal: () => void;
 }

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.tsx
@@ -122,7 +122,7 @@ export const SettingsPaymentsMain = () => {
 		return select( pluginsStore ).getInstalledPlugins();
 	}, [] );
 
-	// Make UI refresh when plugin is installed.
+	// Used to invalidate the API data for the Payments Settings page.
 	const { invalidateResolutionForStoreSelector } =
 		useDispatch( paymentSettingsStore );
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -798,14 +798,16 @@ class WooPaymentsService {
 			$location
 		);
 
-		// Try to get the pre-KYC fields.
-		try {
-			$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields();
-		} catch ( Exception $e ) {
-			$business_verification_step['errors'][] = array(
-				'code'    => 'fields_error',
-				'message' => $e->getMessage(),
-			);
+		// Try to get the pre-KYC fields, but only if the required step is completed.
+		if ( $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ) ) {
+			try {
+				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields();
+			} catch ( Exception $e ) {
+				$business_verification_step['errors'][] = array(
+					'code'    => 'fields_error',
+					'message' => $e->getMessage(),
+				);
+			}
 		}
 
 		// If the step is not completed, we need to add the actions.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -799,6 +799,7 @@ class WooPaymentsService {
 		);
 
 		// Try to get the pre-KYC fields, but only if the required step is completed.
+		// This is because WooPayments needs a working WPCOM connection to be able to fetch the fields.
 		if ( $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ) ) {
 			try {
 				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields();

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -481,6 +481,7 @@ class WooPaymentsService {
 			'rest_endpoint_post_request',
 			'/wc/v3/payments/onboarding/test_drive_account/init',
 			array(
+				'country'     => $location,
 				'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
 				'source'       => ! empty( $source ) ? $source : self::FROM_NOX_IN_CONTEXT,
 				'from'         => self::FROM_NOX_IN_CONTEXT,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -481,7 +481,7 @@ class WooPaymentsService {
 			'rest_endpoint_post_request',
 			'/wc/v3/payments/onboarding/test_drive_account/init',
 			array(
-				'country'     => $location,
+				'country'      => $location,
 				'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
 				'source'       => ! empty( $source ) ? $source : self::FROM_NOX_IN_CONTEXT,
 				'from'         => self::FROM_NOX_IN_CONTEXT,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -171,8 +171,8 @@ class WooPaymentsService {
 			case self::ONBOARDING_STEP_TEST_ACCOUNT:
 				// The step can only be completed if the requirements are met.
 				if ( $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-					// If the account is a valid test account, the step is completed.
-					if ( $this->has_valid_account() && $this->has_test_account() ) {
+					// If the account is a valid, working test account, the step is completed.
+					if ( $this->has_test_account() && $this->has_valid_account() && $this->has_working_account() ) {
 						return self::ONBOARDING_STEP_STATUS_COMPLETED;
 					}
 
@@ -1218,6 +1218,24 @@ class WooPaymentsService {
 		$account_service = $this->proxy->call_static( '\WC_Payments', 'get_account_service' );
 
 		return $account_service->is_stripe_account_valid();
+	}
+
+	/**
+	 * Determine if WooPayments has a working account set up.
+	 *
+	 * This is a more specific check than has_valid_account() and checks if payments are enabled for the account.
+	 *
+	 * @return bool Whether WooPayments has a working account set up.
+	 */
+	private function has_working_account(): bool {
+		if ( ! $this->has_account() ) {
+			return false;
+		}
+
+		$account_service = $this->proxy->call_static( '\WC_Payments', 'get_account_service' );
+		$account_status  = $account_service->get_account_status_data();
+
+		return ! empty( $account_status['paymentsEnabled'] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -499,9 +499,6 @@ class WooPaymentsService {
 			throw new Exception( esc_html__( 'Failed to initialize the test account.', 'woocommerce' ) );
 		}
 
-		// Mark the test account step as completed.
-		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
-
 		return $response;
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -381,7 +381,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				'status'         => $expected_step_statuses[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ] ?? WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				'errors'         => array(),
 				'context'        => array(
-					'fields'          => array(
+					// Only with a working WPCOM connection we include the fields.
+					'fields'          => ( $wpcom_connection['is_store_connected'] && $wpcom_connection['has_connected_owner'] ) ? array(
 						'business_types'      => $this->get_mock_onboarding_fields_business_types(),
 						'mccs_display_tree'   => array(
 							array(
@@ -443,7 +444,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 							'electronics_and_computers' => 'digital_products__other_digital_goods',
 						),
 						'available_countries' => $this->get_woopayments_supported_countries(),
-					),
+					) : array(),
 					'sub_steps'       => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['sub_steps'] ?? array(),
 					'self_assessment' => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['self_assessment'] ?? array(),
 				),
@@ -4045,7 +4046,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertEquals( $expected_response, $result );
 		$this->assertCount( 1, $requests_made );
-		$this->assertCount( 3, $updated_stored_profiles );
+		$this->assertCount( 2, $updated_stored_profiles );
 		// The in_progress flag should have been set first to true, then to false.
 		$this->assertEquals(
 			array(
@@ -4059,19 +4060,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			$updated_stored_profiles[1]['onboarding'][ $location ]['steps'][ $step_id ]['data']
 		);
-		// The step status should have been set to completed.
-		$this->assertEquals(
-			array(
-				'statuses' => array(
-					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $started_timestamp,
-					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $this->current_time,
-				),
-				'data'     => array(
-					'in_progress' => false,
-				),
-			),
-			$updated_stored_profiles[2]['onboarding'][ $location ]['steps'][ $step_id ]
-		);
+		// There is no automatic completion of the step due to its async nature.
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes and improves NOX in-context flows state management in relation to various user actions (changing the Payments Settings business location, closing and opening the modal, resetting the account/onboarding).

When it comes to the NOX in-context store, we prefer having loading states when opening the modal but a reliable&predictable state, as opposed to trying to keep the local state in sync with the store.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Contributes to [WOOPLUG-3599](https://linear.app/a8c/issue/WOOPLUG-3599/[wc-payments-nox-in-context-flows]-battle-testing-the-onboarding-flows) .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

* The code changes should make sense
* Smoke test the NOX in-context flows:
  * Change the business location and make sure the PMs shown on the first step reflect the selected country.
  * Open the modal, change some PMs enablement, close the modal, reopen and the PMs should be in the same state.
  * With a clean slate (delete the `woocommerce_woopayments_nox_profile` WP option), open the modal, don't change any PMs, click on Continue and the PMs state should be persisted in the DB (in the `woocommerce_woopayments_nox_profile` WP option)
  * Try to onboard a test account and check with the WCPay Dev Tools that the created account has country selected on the Payments Settings page, not the WC base location (use WooPayments on [this PR](https://github.com/Automattic/woocommerce-payments/pull/10720))

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
