### PR TITLE
[NOX In-context flows] Add onboarding disable test mode REST API endpoint

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
@@ -9,7 +9,10 @@ import { PaymentIncentive } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { getWooPaymentsSetupLiveAccountLink } from '~/settings-payments/utils';
+import {
+	getWooPaymentsSetupLiveAccountLink,
+	disableWooPaymentsTestMode,
+} from '~/settings-payments/utils';
 
 interface ActivatePaymentsButtonProps {
 	/**
@@ -62,6 +65,10 @@ export const ActivatePaymentsButton = ( {
 		}
 
 		if ( onboardingType === 'native_in_context' ) {
+			// Disable test mode.
+			disableWooPaymentsTestMode();
+
+			// Open the onboarding modal.
 			setOnboardingModalOpen( true );
 		} else {
 			window.location.href = getWooPaymentsSetupLiveAccountLink();

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -16,6 +16,7 @@ import { navigateTo, getNewPath } from '@woocommerce/navigation';
 import WooPaymentsStepHeader from '../../components/header';
 import { useOnboardingContext } from '../../data/onboarding-context';
 import { WC_ASSET_URL } from '~/utils/admin-settings';
+import { disableWooPaymentsTestMode } from '~/settings-payments/utils';
 import './style.scss';
 
 interface StepCheckResponse {
@@ -250,6 +251,9 @@ const TestAccountStep = () => {
 							<Button
 								variant="secondary"
 								onClick={ () => {
+									// Disable test mode.
+									disableWooPaymentsTestMode();
+
 									// This will refresh the steps and move the modal to the next step
 									navigateToNextStep();
 								} }

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -128,6 +128,21 @@ export const resetWooPaymentsAccount = async () => {
 	}
 };
 
+/**
+ * Disables the test mode action.
+ */
+export const disableWooPaymentsTestMode = async () => {
+	try {
+		const response = await apiFetch( {
+			url: '/wp-json/wc-admin/settings/payments/woopayments/onboarding/test_mode/disable',
+			method: 'POST',
+		} );
+		return response;
+	} catch ( error ) {
+		throw error;
+	}
+};
+
 export const getWooPaymentsSetupLiveAccountLink = () => {
 	return getAdminLink(
 		'admin.php?wcpay-connect=1&_wpnonce=' +

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -129,12 +129,12 @@ export const resetWooPaymentsAccount = async () => {
 };
 
 /**
- * Disables the test mode action.
+ * Disables the WooPayments test account.
  */
 export const disableWooPaymentsTestMode = async () => {
 	try {
 		const response = await apiFetch( {
-			url: '/wp-json/wc-admin/settings/payments/woopayments/onboarding/test_mode/disable',
+			url: '/wp-json/wc-admin/settings/payments/woopayments/onboarding/test_account/disable',
 			method: 'POST',
 		} );
 		return response;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -706,7 +706,11 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 */
 	protected function handle_test_account_disable( WP_REST_Request $request ) {
 		try {
-			$this->woopayments->disable_test_account( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
+			$this->woopayments->disable_test_account(
+				$this->payments->get_country(),
+				$request->get_param( 'from' ) ?? '',
+				$request->get_param( 'source' ) ?? ''
+			);
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -356,11 +356,11 @@ class WooPaymentsRestController extends RestApiControllerBase {
 		);
 		register_rest_route(
 			$this->route_namespace,
-			'/' . $this->rest_base . '/onboarding/test_mode/disable',
+			'/' . $this->rest_base . '/onboarding/test_account/disable',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'test_mode_account_disable' ),
+					'callback'            => fn( $request ) => $this->run( $request, 'handle_test_account_disable' ),
 					'validation_callback' => 'rest_validate_request_arg',
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
@@ -704,9 +704,9 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @return WP_Error|WP_REST_Response The response.
 	 */
-	protected function test_mode_account_disable( WP_REST_Request $request ) {
+	protected function handle_test_account_disable( WP_REST_Request $request ) {
 		try {
-			$this->woopayments->test_mode_account_disable( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
+			$this->woopayments->disable_test_account( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -360,7 +360,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => fn( $request ) => $this->run( $request, 'test_mode_disable' ),
+					'callback'            => fn( $request ) => $this->run( $request, 'test_mode_account_disable' ),
 					'validation_callback' => 'rest_validate_request_arg',
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
@@ -704,9 +704,9 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @return WP_Error|WP_REST_Response The response.
 	 */
-	protected function test_mode_disable( WP_REST_Request $request ) {
+	protected function test_mode_account_disable( WP_REST_Request $request ) {
 		try {
-			$this->woopayments->test_mode_disable( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
+			$this->woopayments->test_mode_account_disable( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -354,6 +354,33 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			),
 			$override
 		);
+		register_rest_route(
+			$this->route_namespace,
+			'/' . $this->rest_base . '/onboarding/test_mode/disable',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => fn( $request ) => $this->run( $request, 'test_mode_disable' ),
+					'validation_callback' => 'rest_validate_request_arg',
+					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
+					'args'                => array(
+						'from'   => array(
+							'description'       => __( 'Where from in the onboarding flow this request was triggered.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'source' => array(
+							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			),
+			$override
+		);
 	}
 
 	/**
@@ -659,6 +686,27 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	protected function reset_onboarding( WP_REST_Request $request ) {
 		try {
 			$this->woopayments->reset_onboarding( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
+		} catch ( Exception $e ) {
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+			)
+		);
+	}
+
+	/**
+	 * Handle the onboarding test mode disable action.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_Error|WP_REST_Response The response.
+	 */
+	protected function test_mode_disable( WP_REST_Request $request ) {
+		try {
+			$this->woopayments->test_mode_disable( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -677,7 +677,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Disable test mode account during the switch-to-live onboarding flow.
+	 * Disable test account during the switch-to-live onboarding flow.
 	 *
 	 * @param string $from   Optional. Where in the UI the request is coming from.
 	 *                       If not provided, it will identify the origin as the WC Admin Payments settings.
@@ -687,7 +687,7 @@ class WooPaymentsService {
 	 * @return array The response from the WooPayments API.
 	 * @throws Exception If the KYC session could not be finished or there was an error.
 	 */
-	public function test_mode_account_disable( string $from = '', string $source = '' ): array {
+	public function disable_test_account( string $from = '', string $source = '' ): array {
 		// Call the WooPayments API to reset onboarding.
 		$response = $this->proxy->call_static(
 			Utils::class,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -638,7 +638,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Finish the onboarding KYC account session.
+	 * Reset onboarding.
 	 *
 	 * @param string $from   Optional. Where in the UI the request is coming from.
 	 *                       If not provided, it will identify the origin as the WC Admin Payments settings.
@@ -670,6 +670,40 @@ class WooPaymentsService {
 
 		// Remove NOX-specific onboarding data.
 		$this->proxy->call_function( 'delete_option', self::NOX_PROFILE_OPTION_KEY );
+
+		return $response;
+	}
+
+	/**
+	 * Disable test mode during live onboarding.
+	 *
+	 * @param string $from   Optional. Where in the UI the request is coming from.
+	 *                       If not provided, it will identify the origin as the WC Admin Payments settings.
+	 * @param string $source Optional. The source for the current onboarding flow.
+	 *                       If not provided, it will identify the source as the WC Admin Payments settings.
+	 *
+	 * @return array The response from the WooPayments API.
+	 * @throws Exception If the KYC session could not be finished or there was an error.
+	 */
+	public function test_mode_disable( string $from = '', string $source = '' ): array {
+		// Call the WooPayments API to reset onboarding.
+		$response = $this->proxy->call_static(
+			Utils::class,
+			'rest_endpoint_post_request',
+			'/wc/v3/payments/onboarding/test_drive_account/disable',
+			array(
+				'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+				'source' => ! empty( $source ) ? esc_attr( $source ) : self::FROM_PAYMENT_SETTINGS,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			throw new Exception( esc_html( $response->get_error_message() ) );
+		}
+
+		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
+			throw new Exception( esc_html__( 'Failed to disable test mode.', 'woocommerce' ) );
+		}
 
 		return $response;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -675,7 +675,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Disable test mode during live onboarding.
+	 * Disable test mode account during the switch-to-live onboarding flow.
 	 *
 	 * @param string $from   Optional. Where in the UI the request is coming from.
 	 *                       If not provided, it will identify the origin as the WC Admin Payments settings.
@@ -685,7 +685,7 @@ class WooPaymentsService {
 	 * @return array The response from the WooPayments API.
 	 * @throws Exception If the KYC session could not be finished or there was an error.
 	 */
-	public function test_mode_disable( string $from = '', string $source = '' ): array {
+	public function test_mode_account_disable( string $from = '', string $source = '' ): array {
 		// Call the WooPayments API to reset onboarding.
 		$response = $this->proxy->call_static(
 			Utils::class,
@@ -702,7 +702,7 @@ class WooPaymentsService {
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( esc_html__( 'Failed to disable test mode.', 'woocommerce' ) );
+			throw new Exception( esc_html__( 'Failed to disable test mode account.', 'woocommerce' ) );
 		}
 
 		return $response;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -147,7 +147,11 @@ class WooPaymentsService {
 		// First, we check the status of the onboarding step based on the current state of the store.
 		switch ( $step_id ) {
 			case self::ONBOARDING_STEP_PAYMENT_METHODS:
-				// No custom checks, for now.
+				// If there is already a valid account, report the step as completed
+				// since allowing the user to configure payment methods won't have any effect.
+				if ( $this->has_valid_account() ) {
+					return self::ONBOARDING_STEP_STATUS_COMPLETED;
+				}
 				break;
 			case self::ONBOARDING_STEP_WPCOM_CONNECTION:
 				if ( $this->has_working_wpcom_connection() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -679,15 +679,17 @@ class WooPaymentsService {
 	/**
 	 * Disable test account during the switch-to-live onboarding flow.
 	 *
-	 * @param string $from   Optional. Where in the UI the request is coming from.
-	 *                       If not provided, it will identify the origin as the WC Admin Payments settings.
-	 * @param string $source Optional. The source for the current onboarding flow.
-	 *                       If not provided, it will identify the source as the WC Admin Payments settings.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param string $from     Optional. Where in the UI the request is coming from.
+	 *                         If not provided, it will identify the origin as the WC Admin Payments settings.
+	 * @param string $source   Optional. The source for the current onboarding flow.
+	 *                         If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
 	 * @return array The response from the WooPayments API.
 	 * @throws Exception If the KYC session could not be finished or there was an error.
 	 */
-	public function disable_test_account( string $from = '', string $source = '' ): array {
+	public function disable_test_account( string $location, string $from = '', string $source = '' ): array {
 		// Call the WooPayments API to reset onboarding.
 		$response = $this->proxy->call_static(
 			Utils::class,
@@ -704,8 +706,12 @@ class WooPaymentsService {
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( esc_html__( 'Failed to disable test mode account.', 'woocommerce' ) );
+			throw new Exception( esc_html__( 'Failed to disable test account.', 'woocommerce' ) );
 		}
+
+		// For sanity, make sure the payment methods step is marked as completed.
+		// This is to avoid the user being prompted to set up payment methods again.
+		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_PAYMENT_METHODS, $location );
 
 		return $response;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -978,7 +978,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses ignored - Test account completed with requirements met' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The connection is required to be completed.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The stored status is ignored.
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
@@ -1013,7 +1013,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses ignored - Test account not completed due to unmet requirements' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 					// The completed stored status is ignored due to unmet requirements.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
@@ -1121,7 +1121,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses respected - Test account with live, valid account' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The connection is required to be completed.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The stored status is respected.
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
@@ -1157,7 +1157,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses ignored - Business verification completed with requirements met' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The connection is required to be completed.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
@@ -1198,7 +1198,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses ignored - Business verification not completed due to unmet requirements' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED, // The connection is required to be completed.
 					// The completed stored status is ignored due to unmet requirements.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
@@ -1324,7 +1324,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses ignored - Business verification with live, valid account' => array(
 				array(
-					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // Since we have an account, this step is completed.
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The connection is required to be completed.
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED, // The stored status is ignored.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a new REST API endpoint to support the disabling of onboarding test mode:
`POST /wc-admin/settings/payments/woopayments/onboarding/test_drive_account/disable`.

The purpose of this endpoint is to allow us to programmatically deactivate a connected test drive account when the merchant transitions from test mode to live mode during onboarding.

Closes WOOPLUG-4071

### How to test the changes in this Pull Request:
- Checkout the PR's branch on your local installation. I recommend you use your local WooPayments installation (since it is already setup to work with your local Transact server) - make sure it is running the symlinked WooCommerce.
- Make sure your WooPayments version is using https://github.com/Automattic/woocommerce-payments/pull/10719. Verify the WooPayments version is 9.3.0.
- Remove/detach any connected WooPayments account.
- Navigate to WooCommerce > Settings > Advanced > Features and enable the Payments Settings (beta) feature.
- Then go to WooCommerce > Settings > Payments.
- Click Enable or Continue setup on the WooPayments gateway.
- Select any payment methods from the list and click Continue.
- Complete the Test Drive onboarding step.
- After the Test Drive account is successfully onboarded, open your browser’s Dev Tools, go to the Network tab, and click Activate Payments.
- Confirm that the test_mode/disable API endpoint is triggered.
- Proceed to fill in the required onboarding details and click Continue.
- Verify that a new account is successfully created.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
