### PR TITLE
Refactor WooCommerce email management to use options table for email type association

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3685-refactor-storing-association-between-transactional-email-and-post
+++ b/plugins/woocommerce/changelog/wooplug-3685-refactor-storing-association-between-transactional-email-and-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use only wp options table for saving WooCommerce email type - email editor post association

--- a/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Integration.php
@@ -23,8 +23,6 @@ defined( 'ABSPATH' ) || exit;
 class Integration {
 	const EMAIL_POST_TYPE = 'woo_email';
 
-	const WC_EMAIL_TYPE_ID_POST_META_KEY = '_wc_email_type';
-
 	/**
 	 * The email editor page renderer instance.
 	 *
@@ -181,13 +179,15 @@ class Integration {
 			return;
 		}
 
-		$email_type = get_post_meta( $post_id, self::WC_EMAIL_TYPE_ID_POST_META_KEY, true );
+		$post_manager = WCTransactionalEmailPostsManager::get_instance();
+
+		$email_type = $post_manager->get_email_type_from_post_id( $post_id );
 
 		if ( empty( $email_type ) ) {
 			return;
 		}
 
-		WCTransactionalEmailPostsManager::get_instance()->delete_email_template( $email_type );
+		$post_manager->delete_email_template( $email_type );
 	}
 
 	/**
@@ -258,7 +258,7 @@ class Integration {
 			if ( json_last_error() === JSON_ERROR_NONE && isset( $decoded_body->postId ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$post_id = absint( $decoded_body->postId ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-				$email_type = get_post_meta( $post_id, self::WC_EMAIL_TYPE_ID_POST_META_KEY, true );
+				$email_type = WCTransactionalEmailPostsManager::get_instance()->get_email_type_from_post_id( $post_id );
 				if ( ! empty( $email_type ) ) {
 					return $this->update_email_preview_data( $data, $email_type );
 				}

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsGenerator.php
@@ -250,7 +250,6 @@ class WCTransactionalEmailPostsGenerator {
 			'post_excerpt' => $email_data->get_description(),
 			'post_content' => $this->get_email_template( $email_data ),
 			'meta_input'   => array(
-				Integration::WC_EMAIL_TYPE_ID_POST_META_KEY => $email_type,
 				'_wp_page_template' => ( new WooEmailTemplate() )->get_slug(),
 			),
 		);

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManager.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManager.php
@@ -8,6 +8,8 @@ namespace Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails;
  * Class responsible for managing WooCommerce email editor post templates.
  */
 class WCTransactionalEmailPostsManager {
+	const WC_OPTION_NAME = 'woocommerce_email_templates_%_post_id';
+
 	/**
 	 * Singleton instance of the class.
 	 *
@@ -52,6 +54,35 @@ class WCTransactionalEmailPostsManager {
 	}
 
 	/**
+	 * Retrieves the WooCommerce email type from the options table when post ID is provided.
+	 *
+	 * @param int|string $post_id The post ID.
+	 * @return string|null The WooCommerce email type if found, null otherwise.
+	 */
+	public function get_email_type_from_post_id( $post_id ) {
+		// Early return if post_id is invalid.
+		if ( empty( $post_id ) ) {
+			return null;
+		}
+
+		global $wpdb;
+
+		$option_name = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s AND option_value = %s LIMIT 1",
+				self::WC_OPTION_NAME,
+				$post_id
+			)
+		);
+
+		if ( empty( $option_name ) ) {
+			return null;
+		}
+
+		return $this->get_email_type_from_option_name( $option_name );
+	}
+
+	/**
 	 * Checks if an email template exists for the given type.
 	 *
 	 * Type here refers to the email type, e.g. 'customer_new_account' from the WC_Email->id property.
@@ -70,7 +101,7 @@ class WCTransactionalEmailPostsManager {
 	 * @param int    $post_id    The post ID to save.
 	 */
 	public function save_email_template_post_id( $email_type, $post_id ) {
-		$option_name = 'woocommerce_email_templates_' . $email_type . '_post_id';
+		$option_name = $this->get_option_name( $email_type );
 		update_option( $option_name, $post_id );
 	}
 
@@ -81,7 +112,7 @@ class WCTransactionalEmailPostsManager {
 	 * @return int|false The post ID if found, false otherwise.
 	 */
 	public function get_email_template_post_id( $email_type ) {
-		$option_name = 'woocommerce_email_templates_' . $email_type . '_post_id';
+		$option_name = $this->get_option_name( $email_type );
 		return get_option( $option_name );
 	}
 
@@ -91,10 +122,37 @@ class WCTransactionalEmailPostsManager {
 	 * @param string $email_type The type of email template e.g. 'customer_new_account' from the WC_Email->id property.
 	 */
 	public function delete_email_template( $email_type ) {
-		$option_name = 'woocommerce_email_templates_' . $email_type . '_post_id';
+		$option_name = $this->get_option_name( $email_type );
 		if ( ! get_option( $option_name ) ) {
 			return;
 		}
 		delete_option( $option_name );
+	}
+
+	/**
+	 * Gets the option name for a specific email type.
+	 *
+	 * @param string $email_type The type of email template e.g. 'customer_new_account' from the WC_Email->id property.
+	 * @return string The option name e.g. 'woocommerce_email_templates_customer_new_account_post_id'
+	 */
+	private function get_option_name( $email_type ) {
+		return str_replace( '%', $email_type, self::WC_OPTION_NAME );
+	}
+
+	/**
+	 * Gets the email type from the option name.
+	 *
+	 * @param string $option_name The option name e.g. 'woocommerce_email_templates_customer_new_account_post_id'.
+	 * @return string The email type e.g. 'customer_new_account'
+	 */
+	private function get_email_type_from_option_name( $option_name ) {
+		return str_replace(
+			array(
+				'woocommerce_email_templates_',
+				'_post_id',
+			),
+			'',
+			$option_name
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmailPostsManagerTest.php
@@ -102,6 +102,16 @@ class WCTransactionalEmailPostsManagerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that get_email_type_from_post_id returns the correct email type.
+	 */
+	public function testGetEmailTypeFromPostIdReturnsCorrectEmailType(): void {
+		$post_id = $this->factory->post->create();
+		$this->template_manager->save_email_template_post_id( 'my_test_email', $post_id );
+
+		$this->assertEquals( 'my_test_email', $this->template_manager->get_email_type_from_post_id( $post_id ) );
+	}
+
+	/**
 	 * Cleanup after test.
 	 */
 	public function tearDown(): void {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR refactors how WooCommerce stores the association between transactional email types (e.g., `customer_new_account`) and their corresponding email editor post (`woo_email` post type).

Previously, this association was stored both in the `wp_options` table and as post meta (`_wc_email_type`) on the `woo_email` post. This PR removes the usage of the post meta key `_wc_email_type` and relies solely on the `wp_options` table for storing and retrieving this association.

The main changes include:
-   Removing the `WC_EMAIL_TYPE_ID_POST_META_KEY` constant and its usage in `Integration.php`.
-   Introducing `WCTransactionalEmailPostsManager::get_email_type_from_post_id()` to retrieve the email type based on the post ID by querying the options table.
-   Updating `Integration.php` to use `WCTransactionalEmailPostsManager::get_email_type_from_post_id()` instead of `get_post_meta()`.
-   Removing the addition of `_wc_email_type` meta when generating email posts in `WCTransactionalEmailPostsGenerator.php`.
-   Adding helper methods `get_option_name()` and `get_email_type_from_option_name()` to `WCTransactionalEmailPostsManager` for better code structure.
-   Adding a unit test `testGetEmailTypeFromPostIdReturnsCorrectEmailType` in `WCTransactionalEmailPostsManagerTest.php` to cover the new functionality.

This change simplifies the data storage mechanism and makes the options table the single source of truth for the email type to post ID association.

Closes WOOPLUG-3685 #56831

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->



(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  **Verify Existing Email Templates:** Go to WooCommerce -> Settings -> Emails. Ensure all standard email templates are listed and function correctly (e.g., sending test emails).
2.  **Send test email:** Select an email template (e.g., New Order) from the listing `/wp-admin/admin.php?page=wc-settings&tab=email` page and click on edit. Make a small change, save, click on preview, and select "Send a test email". Confirm that you received the test email.
3. **Delete a post:**  Select an email template from the listing `/wp-admin/admin.php?page=wc-settings&tab=email` page and click on edit. Click on Trash and ensure the post is trashed. Visit  `/wp-admin/edit.php?post_type=woo_email`, select the Trash tab, and permanently delete the post. Check the Database and ensure you don't find the association in wp options table.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
