### PR TITLE
[Experimental] Blockified Add to Cart with Options block: disable Variation Selector options conditionally

### DIFF
--- a/plugins/woocommerce/changelog/fix-57535-variation-selector-dynamic-options
+++ b/plugins/woocommerce/changelog/fix-57535-variation-selector-dynamic-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Disable Variation Selector options based on current selected ones in the blockified Add to Cart with Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -6,9 +6,14 @@ import { store, getContext } from '@wordpress/interactivity';
 import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
 import type { CartVariationItem } from '@woocommerce/types';
 
-type Context = {
+export type AvailableVariation = {
+	attributes: Record< string, string >;
+};
+
+export type Context = {
 	productId: number;
 	variation: CartVariationItem[];
+	availableVariations: AvailableVariation[];
 	quantity: number;
 	tempQuantity: number;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -54,6 +54,68 @@ function setDefaultSelectedAttribute() {
 	setAttribute( context.name, context.selectedValue );
 }
 
+const isAttributeDisabled = ( {
+	attributeName,
+	attributeValue,
+	selectedAttributes,
+	availableVariations,
+} ) => {
+	if ( ! selectedAttributes || selectedAttributes.length === 0 ) {
+		return false;
+	}
+
+	const isCurrentAttributeSelected = selectedAttributes.some(
+		( selectedAttribute ) => selectedAttribute.attribute === attributeName
+	);
+	const attributesToMatch = isCurrentAttributeSelected
+		? selectedAttributes.length - 1
+		: selectedAttributes.length;
+
+	return ! availableVariations.some( ( availableVariation ) => {
+		// Skip variations that don't match the current pills.
+		if (
+			availableVariation.attributes[
+				'attribute_' + attributeName.toLowerCase()
+			] !== attributeValue &&
+			availableVariation.attributes[
+				'attribute_' + attributeName.toLowerCase()
+			] !== '' // "" is used for "any".
+		) {
+			return false;
+		}
+
+		// Count how many attributes from the variation match the
+		// currently selected attributes.
+		const matchingAttributes = selectedAttributes.filter(
+			( selectedAttribute ) => {
+				const availableVariationAttributeValue =
+					availableVariation.attributes[
+						'attribute_' + selectedAttribute.attribute.toLowerCase()
+					];
+				// If the current available variation matches the selected value.
+				if (
+					availableVariationAttributeValue === selectedAttribute.value
+				) {
+					return true;
+				}
+				// If the current available variation has an empty value (matching any),
+				// only count variations that match the currently selected
+				if ( availableVariationAttributeValue === '' ) {
+					if (
+						selectedAttribute.attribute !== attributeName ||
+						attributeValue === selectedAttribute.value
+					) {
+						return true;
+					}
+				}
+				return false;
+			}
+		).length;
+
+		return matchingAttributes >= attributesToMatch;
+	} );
+};
+
 const { state, actions } = store(
 	'woocommerce/add-to-cart-with-options-variation-selector-attribute-options__pills',
 	{
@@ -68,55 +130,11 @@ const { state, actions } = store(
 					'woocommerce/add-to-cart-with-options'
 				);
 
-				if ( ! variation || variation.length === 0 ) {
-					return false;
-				}
-
-				const isCurrentAttributeSelected = variation.some(
-					( attr ) => attr.attribute === name
-				);
-				const attributesToMatch = isCurrentAttributeSelected
-					? variation.length - 1
-					: variation.length;
-
-				return ! availableVariations.some( ( availableVariation ) => {
-					// Skip variations that don't match the current pills.
-					if (
-						availableVariation.attributes[
-							'attribute_' + name.toLowerCase()
-						] !== option.value &&
-						availableVariation.attributes[
-							'attribute_' + name.toLowerCase()
-						] !== '' // "" is used for "any".
-					) {
-						return false;
-					}
-
-					// Count how many attributes from the variation match the
-					// currently selected attributes.
-					const matchingAttributes = variation.filter( ( attr ) => {
-						const availableVariationAttributeValue =
-							availableVariation.attributes[
-								'attribute_' + attr.attribute.toLowerCase()
-							];
-						// If the current available variation matches the selected value.
-						if ( availableVariationAttributeValue === attr.value ) {
-							return true;
-						}
-						// If the current available variation has an empty value (matching any),
-						// only count variations that match the currently selected
-						if ( availableVariationAttributeValue === '' ) {
-							if (
-								attr.attribute !== name ||
-								option.value === attr.value
-							) {
-								return true;
-							}
-						}
-						return false;
-					} ).length;
-
-					return matchingAttributes >= attributesToMatch;
+				return isAttributeDisabled( {
+					attributeName: name,
+					attributeValue: option.value,
+					selectedAttributes: variation,
+					availableVariations: availableVariations,
 				} );
 			},
 			get pillTabIndex() {
@@ -164,30 +182,49 @@ const { state, actions } = store(
 				setAttribute( context.name, context.selectedValue );
 			},
 			handleKeyDown( event: KeyboardEvent< HTMLElement > ) {
-				let keyWasProcessed = false;
-
 				switch ( event.key ) {
 					case ' ':
+						event.stopPropagation();
+						event.preventDefault();
 						actions.toggleSelected();
-						keyWasProcessed = true;
 						break;
 
-					// @todo fix arrow navigation.
 					case 'Up':
 					case 'ArrowUp':
 					case 'Left':
 					case 'ArrowLeft': {
+						event.stopPropagation();
+						event.preventDefault();
 						const context = getContext< PillsContext >();
-						const index = state.index;
-						if ( index === -1 ) return;
-						const at =
-							index > 0 ? index - 1 : context.options.length - 1;
+						const { variation, availableVariations } = getContext(
+							'woocommerce/add-to-cart-with-options'
+						);
+						const { index } = state;
+						if ( index <= 0 ) {
+							return;
+						}
 
-						context.selectedValue = context.options[ at ].value;
-						context.focused = context.selectedValue;
+						for ( let i = index - 1; i >= 0; i-- ) {
+							if (
+								! isAttributeDisabled( {
+									attributeName: context.name,
+									attributeValue: context.options[ i ].value,
+									selectedAttributes: variation,
+									availableVariations: availableVariations,
+								} )
+							) {
+								context.selectedValue =
+									context.options[ i ].value;
+								context.focused = context.selectedValue;
 
-						setAttribute( context.name, context.selectedValue );
-						keyWasProcessed = true;
+								setAttribute(
+									context.name,
+									context.selectedValue
+								);
+
+								return;
+							}
+						}
 						break;
 					}
 
@@ -195,26 +232,46 @@ const { state, actions } = store(
 					case 'ArrowDown':
 					case 'Right':
 					case 'ArrowRight': {
+						event.stopPropagation();
+						event.preventDefault();
 						const context = getContext< PillsContext >();
-						const index = state.index;
-						if ( index === -1 ) return;
-						const at =
-							index < context.options.length - 1 ? index + 1 : 0;
+						const { variation, availableVariations } = getContext(
+							'woocommerce/add-to-cart-with-options'
+						);
+						const { index } = state;
+						if ( index >= context.options.length - 1 ) {
+							return;
+						}
 
-						context.selectedValue = context.options[ at ].value;
-						context.focused = context.selectedValue;
+						for (
+							let i = index + 1;
+							i < context.options.length;
+							i++
+						) {
+							if (
+								! isAttributeDisabled( {
+									attributeName: context.name,
+									attributeValue: context.options[ i ].value,
+									selectedAttributes: variation,
+									availableVariations: availableVariations,
+								} )
+							) {
+								context.selectedValue =
+									context.options[ i ].value;
+								context.focused = context.selectedValue;
 
-						setAttribute( context.name, context.selectedValue );
-						keyWasProcessed = true;
+								setAttribute(
+									context.name,
+									context.selectedValue
+								);
+
+								return;
+							}
+						}
 						break;
 					}
 					default:
 						break;
-				}
-
-				if ( keyWasProcessed ) {
-					event.stopPropagation();
-					event.preventDefault();
 				}
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -306,7 +306,7 @@ store(
 			get isOptionDisabled() {
 				const { name, option } = getContext< PillsContext >();
 				if ( option.value === '' ) {
-					return true;
+					return false;
 				}
 				const { variation, availableVariations } =
 					getContext< AddToCartWithOptionsStoreContext >(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -141,7 +141,7 @@ const { state, actions } = store(
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes: variation,
-					availableVariations: availableVariations,
+					availableVariations,
 				} );
 			},
 			get pillTabIndex() {
@@ -176,10 +176,10 @@ const { state, actions } = store(
 		},
 		actions: {
 			toggleSelected() {
-				const context = getContext< PillsContext >();
 				if ( state.isPillDisabled ) {
 					return;
 				}
+				const context = getContext< PillsContext >();
 				if ( context.selectedValue === context.option.value ) {
 					context.selectedValue = '';
 				} else {
@@ -218,7 +218,7 @@ const { state, actions } = store(
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,
-									availableVariations: availableVariations,
+									availableVariations,
 								} )
 							) {
 								context.selectedValue =
@@ -262,7 +262,7 @@ const { state, actions } = store(
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,
-									availableVariations: availableVariations,
+									availableVariations,
 								} )
 							) {
 								context.selectedValue =
@@ -317,7 +317,7 @@ store(
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes: variation,
-					availableVariations: availableVariations,
+					availableVariations,
 				} );
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -60,10 +60,6 @@ const isAttributeDisabled = ( {
 	selectedAttributes,
 	availableVariations,
 } ) => {
-	if ( ! selectedAttributes || selectedAttributes.length === 0 ) {
-		return false;
-	}
-
 	const isCurrentAttributeSelected = selectedAttributes.some(
 		( selectedAttribute ) => selectedAttribute.attribute === attributeName
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -22,7 +22,6 @@ type Option = {
 };
 
 type Context = {
-	attribute: string;
 	name: string;
 	selectedValue: string | null;
 	option: Option;
@@ -59,7 +58,15 @@ function setDefaultSelectedAttribute() {
 	setAttribute( context.name, context.selectedValue );
 }
 
-const isTermDisabled = ( {
+/**
+ * Check if the attribute value is valid given the other selected attributes and
+ * the available variations.
+ *
+ * To know if an attribute value is valid given the other selected attributes,
+ * we make sure there is at least one available variation matching the current
+ * selected attributes and the attribute value being checked.
+ */
+const isAttributeValueValid = ( {
 	attributeName,
 	attributeValue,
 	selectedAttributes,
@@ -70,6 +77,11 @@ const isTermDisabled = ( {
 	selectedAttributes: CartVariationItem[];
 	availableVariations: AvailableVariation[];
 } ) => {
+	// If the current attribute is selected, we require one less attribute to
+	// match, this allows shoppers to switch between attributes. For example,
+	// if "Blue" and "Small" are selected, we want "Blue" and "Medium" to be
+	// valid, that's why we subtract one from the total number of attributes to
+	// match.
 	const isCurrentAttributeSelected = selectedAttributes.some(
 		( selectedAttribute ) => selectedAttribute.attribute === attributeName
 	);
@@ -77,8 +89,10 @@ const isTermDisabled = ( {
 		? selectedAttributes.length - 1
 		: selectedAttributes.length;
 
-	return ! availableVariations.some( ( availableVariation ) => {
-		// Skip variations that don't match the current pills.
+	// Check if there is at least one available variation matching the current
+	// selected attributes and the attribute value being checked.
+	return availableVariations.some( ( availableVariation ) => {
+		// Skip variations that don't match the current attribute value.
 		if (
 			availableVariation.attributes[
 				'attribute_' + attributeName.toLowerCase()
@@ -90,25 +104,28 @@ const isTermDisabled = ( {
 			return false;
 		}
 
-		// Count how many attributes from the variation match the
-		// currently selected attributes.
+		// Count how many of the selected attributes match the variation.
 		const matchingAttributes = selectedAttributes.filter(
 			( selectedAttribute ) => {
 				const availableVariationAttributeValue =
 					availableVariation.attributes[
 						'attribute_' + selectedAttribute.attribute.toLowerCase()
 					];
-				// If the current available variation matches the selected value.
+				// If the current available variation matches the selected
+				// value, count it.
 				if (
 					availableVariationAttributeValue === selectedAttribute.value
 				) {
 					return true;
 				}
-				// If the current available variation has an empty value (matching any),
-				// only count variations that match the currently selected
+				// If the current available variation has an empty value
+				// (matching any), count it if it refers to a different
+				// attribute or the attribute it refers matches the current
+				// selection.
 				if ( availableVariationAttributeValue === '' ) {
 					if (
-						selectedAttribute.attribute !== attributeName ||
+						selectedAttribute.attribute.toLowerCase() !==
+							attributeName.toLowerCase() ||
 						attributeValue === selectedAttribute.value
 					) {
 						return true;
@@ -137,7 +154,7 @@ const { state, actions } = store(
 						'woocommerce/add-to-cart-with-options'
 					);
 
-				return isTermDisabled( {
+				return ! isAttributeValueValid( {
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes: variation,
@@ -189,10 +206,11 @@ const { state, actions } = store(
 				setAttribute( context.name, context.selectedValue );
 			},
 			handleKeyDown( event: KeyboardEvent< HTMLElement > ) {
+				let keyWasProcessed = false;
+
 				switch ( event.key ) {
 					case ' ':
-						event.stopPropagation();
-						event.preventDefault();
+						keyWasProcessed = true;
 						actions.toggleSelected();
 						break;
 
@@ -200,8 +218,7 @@ const { state, actions } = store(
 					case 'ArrowUp':
 					case 'Left':
 					case 'ArrowLeft': {
-						event.stopPropagation();
-						event.preventDefault();
+						keyWasProcessed = true;
 						const context = getContext< PillsContext >();
 						const { variation, availableVariations } =
 							getContext< AddToCartWithOptionsStoreContext >(
@@ -214,7 +231,7 @@ const { state, actions } = store(
 
 						for ( let i = index - 1; i >= 0; i-- ) {
 							if (
-								! isTermDisabled( {
+								isAttributeValueValid( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,
@@ -240,8 +257,7 @@ const { state, actions } = store(
 					case 'ArrowDown':
 					case 'Right':
 					case 'ArrowRight': {
-						event.stopPropagation();
-						event.preventDefault();
+						keyWasProcessed = true;
 						const context = getContext< PillsContext >();
 						const { variation, availableVariations } =
 							getContext< AddToCartWithOptionsStoreContext >(
@@ -258,7 +274,7 @@ const { state, actions } = store(
 							i++
 						) {
 							if (
-								! isTermDisabled( {
+								isAttributeValueValid( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,
@@ -281,6 +297,11 @@ const { state, actions } = store(
 					}
 					default:
 						break;
+				}
+
+				if ( keyWasProcessed ) {
+					event.stopPropagation();
+					event.preventDefault();
 				}
 			},
 		},
@@ -305,15 +326,17 @@ store(
 		state: {
 			get isOptionDisabled() {
 				const { name, option } = getContext< PillsContext >();
+
 				if ( option.value === '' ) {
 					return false;
 				}
+
 				const { variation, availableVariations } =
 					getContext< AddToCartWithOptionsStoreContext >(
 						'woocommerce/add-to-cart-with-options'
 					);
 
-				return isTermDisabled( {
+				return ! isAttributeValueValid( {
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes: variation,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -3,11 +3,16 @@
  */
 import type { ChangeEvent, KeyboardEvent } from 'react';
 import { store, getContext, getElement } from '@wordpress/interactivity';
+import type { CartVariationItem } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
-import type { AddToCartWithOptionsStore } from '../../frontend';
+import type {
+	AddToCartWithOptionsStore,
+	Context as AddToCartWithOptionsStoreContext,
+	AvailableVariation,
+} from '../../frontend';
 import setStyles from './set-styles';
 
 type Option = {
@@ -59,6 +64,11 @@ const isAttributeDisabled = ( {
 	attributeValue,
 	selectedAttributes,
 	availableVariations,
+}: {
+	attributeName: string;
+	attributeValue: string;
+	selectedAttributes: CartVariationItem[];
+	availableVariations: AvailableVariation[];
 } ) => {
 	const isCurrentAttributeSelected = selectedAttributes.some(
 		( selectedAttribute ) => selectedAttribute.attribute === attributeName
@@ -122,9 +132,10 @@ const { state, actions } = store(
 			},
 			get isPillDisabled() {
 				const { name, option } = getContext< PillsContext >();
-				const { variation, availableVariations } = getContext(
-					'woocommerce/add-to-cart-with-options'
-				);
+				const { variation, availableVariations } =
+					getContext< AddToCartWithOptionsStoreContext >(
+						'woocommerce/add-to-cart-with-options'
+					);
 
 				return isAttributeDisabled( {
 					attributeName: name,
@@ -192,9 +203,10 @@ const { state, actions } = store(
 						event.stopPropagation();
 						event.preventDefault();
 						const context = getContext< PillsContext >();
-						const { variation, availableVariations } = getContext(
-							'woocommerce/add-to-cart-with-options'
-						);
+						const { variation, availableVariations } =
+							getContext< AddToCartWithOptionsStoreContext >(
+								'woocommerce/add-to-cart-with-options'
+							);
 						const { index } = state;
 						if ( index <= 0 ) {
 							return;
@@ -231,9 +243,10 @@ const { state, actions } = store(
 						event.stopPropagation();
 						event.preventDefault();
 						const context = getContext< PillsContext >();
-						const { variation, availableVariations } = getContext(
-							'woocommerce/add-to-cart-with-options'
-						);
+						const { variation, availableVariations } =
+							getContext< AddToCartWithOptionsStoreContext >(
+								'woocommerce/add-to-cart-with-options'
+							);
 						const { index } = state;
 						if ( index >= context.options.length - 1 ) {
 							return;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -59,7 +59,7 @@ function setDefaultSelectedAttribute() {
 	setAttribute( context.name, context.selectedValue );
 }
 
-const isAttributeDisabled = ( {
+const isTermDisabled = ( {
 	attributeName,
 	attributeValue,
 	selectedAttributes,
@@ -137,7 +137,7 @@ const { state, actions } = store(
 						'woocommerce/add-to-cart-with-options'
 					);
 
-				return isAttributeDisabled( {
+				return isTermDisabled( {
 					attributeName: name,
 					attributeValue: option.value,
 					selectedAttributes: variation,
@@ -214,7 +214,7 @@ const { state, actions } = store(
 
 						for ( let i = index - 1; i >= 0; i-- ) {
 							if (
-								! isAttributeDisabled( {
+								! isTermDisabled( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,
@@ -258,7 +258,7 @@ const { state, actions } = store(
 							i++
 						) {
 							if (
-								! isAttributeDisabled( {
+								! isTermDisabled( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
 									selectedAttributes: variation,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -17,6 +17,7 @@ type Option = {
 };
 
 type Context = {
+	attribute: string;
 	name: string;
 	selectedValue: string | null;
 	option: Option;
@@ -61,9 +62,70 @@ const { state, actions } = store(
 				const { selectedValue, option } = getContext< PillsContext >();
 				return selectedValue === option.value;
 			},
+			get isPillDisabled() {
+				const { name, option } = getContext< PillsContext >();
+				const { variation, availableVariations } = getContext(
+					'woocommerce/add-to-cart-with-options'
+				);
+
+				if ( ! variation || variation.length === 0 ) {
+					return false;
+				}
+
+				const isCurrentAttributeSelected = variation.some(
+					( attr ) => attr.attribute === name
+				);
+				const attributesToMatch = isCurrentAttributeSelected
+					? variation.length - 1
+					: variation.length;
+
+				return ! availableVariations.some( ( availableVariation ) => {
+					// Skip variations that don't match the current pills.
+					if (
+						availableVariation.attributes[
+							'attribute_' + name.toLowerCase()
+						] !== option.value &&
+						availableVariation.attributes[
+							'attribute_' + name.toLowerCase()
+						] !== '' // "" is used for "any".
+					) {
+						return false;
+					}
+
+					// Count how many attributes from the variation match the
+					// currently selected attributes.
+					const matchingAttributes = variation.filter( ( attr ) => {
+						const availableVariationAttributeValue =
+							availableVariation.attributes[
+								'attribute_' + attr.attribute.toLowerCase()
+							];
+						// If the current available variation matches the selected value.
+						if ( availableVariationAttributeValue === attr.value ) {
+							return true;
+						}
+						// If the current available variation has an empty value (matching any),
+						// only count variations that match the currently selected
+						if ( availableVariationAttributeValue === '' ) {
+							if (
+								attr.attribute !== name ||
+								option.value === attr.value
+							) {
+								return true;
+							}
+						}
+						return false;
+					} ).length;
+
+					return matchingAttributes >= attributesToMatch;
+				} );
+			},
 			get pillTabIndex() {
 				const { selectedValue, focused, option, options } =
 					getContext< PillsContext >();
+
+				if ( state.isPillDisabled ) {
+					return -1;
+				}
 
 				// Allow the first pill to be focused when no option is selected.
 				if (
@@ -90,6 +152,9 @@ const { state, actions } = store(
 		actions: {
 			toggleSelected() {
 				const context = getContext< PillsContext >();
+				if ( state.isPillDisabled ) {
+					return;
+				}
 				if ( context.selectedValue === context.option.value ) {
 					context.selectedValue = '';
 				} else {
@@ -107,6 +172,7 @@ const { state, actions } = store(
 						keyWasProcessed = true;
 						break;
 
+					// @todo fix arrow navigation.
 					case 'Up':
 					case 'ArrowUp':
 					case 'Left':

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -302,6 +302,25 @@ const { state, actions } = store(
 store(
 	'woocommerce/add-to-cart-with-options-variation-selector-attribute-options__dropdown',
 	{
+		state: {
+			get isOptionDisabled() {
+				const { name, option } = getContext< PillsContext >();
+				if ( option.value === '' ) {
+					return true;
+				}
+				const { variation, availableVariations } =
+					getContext< AddToCartWithOptionsStoreContext >(
+						'woocommerce/add-to-cart-with-options'
+					);
+
+				return isTermDisabled( {
+					attributeName: name,
+					attributeValue: option.value,
+					selectedAttributes: variation,
+					availableVariations: availableVariations,
+				} );
+			},
+		},
 		actions: {
 			handleChange( event: ChangeEvent< HTMLSelectElement > ) {
 				const context = getContext< Context >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -35,7 +35,7 @@
 		border-color: currentColor;
 	}
 
-	&--disabled {
+	&[aria-disabled="true"] {
 		border-color: var(--wc-subtext);
 		color: var(--wc-subtext);
 		text-decoration: line-through;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -89,24 +89,7 @@ test.describe( 'Add to Cart with Options Block', () => {
 	} ) => {
 		await pageObject.setFeatureFlags();
 
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		const addToCartFormBlock = await editor.getBlockByName(
-			'woocommerce/add-to-cart-form'
-		);
-		await editor.selectBlocks( addToCartFormBlock );
-
-		await page
-			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
-			.click();
-
-		await editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
+		await pageObject.updateSingleProductTemplate();
 
 		await page.goto( '/beanie' );
 
@@ -125,5 +108,27 @@ test.describe( 'Add to Cart with Options Block', () => {
 		await addToCartButton.click();
 
 		await expect( addToCartButton ).toHaveText( '6 in cart' );
+	} );
+
+	test( "doesn't allow selecting invalid variations", async ( {
+		page,
+		pageObject,
+	} ) => {
+		await pageObject.setFeatureFlags();
+
+		await pageObject.updateSingleProductTemplate();
+
+		await page.goto( '/hoodie' );
+
+		const logoYesOption = page.getByRole( 'radio', { name: 'Yes' } );
+		const colorGreenOption = page.getByRole( 'radio', {
+			name: 'Green',
+		} );
+
+		await expect( colorGreenOption ).toBeEnabled();
+
+		await logoYesOption.click();
+
+		await expect( colorGreenOption ).toBeDisabled();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -85,11 +85,14 @@ test.describe( 'Add to Cart with Options Block', () => {
 		page,
 		pageObject,
 		editor,
-		admin,
 	} ) => {
 		await pageObject.setFeatureFlags();
 
 		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
 
 		await page.goto( '/beanie' );
 
@@ -110,24 +113,67 @@ test.describe( 'Add to Cart with Options Block', () => {
 		await expect( addToCartButton ).toHaveText( '6 in cart' );
 	} );
 
-	test( "doesn't allow selecting invalid variations", async ( {
+	test( "doesn't allow selecting invalid variations in pills mode", async ( {
 		page,
 		pageObject,
+		editor,
 	} ) => {
 		await pageObject.setFeatureFlags();
 
 		await pageObject.updateSingleProductTemplate();
 
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
 		await page.goto( '/hoodie' );
 
-		const logoYesOption = page.getByRole( 'radio', { name: 'Yes' } );
+		const logoYesOption = page.getByRole( 'radio', {
+			name: 'Yes',
+			exact: true,
+		} );
 		const colorGreenOption = page.getByRole( 'radio', {
 			name: 'Green',
+			exact: true,
 		} );
 
 		await expect( colorGreenOption ).toBeEnabled();
 
 		await logoYesOption.click();
+
+		await expect( colorGreenOption ).toBeDisabled();
+	} );
+
+	test( "doesn't allow selecting invalid variations in dropdown mode", async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		await pageObject.setFeatureFlags();
+
+		await pageObject.updateSingleProductTemplate();
+
+		await pageObject.switchProductType( 'Variable Product' );
+
+		const attributeOptionsBlock = await editor.getBlockByName(
+			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
+		);
+		await editor.selectBlocks( attributeOptionsBlock.first() );
+
+		await page.getByRole( 'radio', { name: 'Dropdown' } ).click();
+
+		await editor.saveSiteEditorEntities();
+
+		await page.goto( '/hoodie' );
+
+		const colorGreenOption = page.getByRole( 'option', {
+			name: 'Green',
+			exact: true,
+		} );
+
+		await expect( colorGreenOption ).toBeEnabled();
+
+		await page.getByLabel( 'Logo', { exact: true } ).selectOption( 'Yes' );
 
 		await expect( colorGreenOption ).toBeDisabled();
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -95,10 +95,6 @@ class AddToCartWithOptionsPage {
 		await this.page
 			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
 			.click();
-
-		await this.editor.saveSiteEditorEntities( {
-			isOnlyCurrentEntityDirty: true,
-		} );
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -79,6 +79,27 @@ class AddToCartWithOptionsPage {
 			{ clientId: parentClientId }
 		);
 	}
+
+	async updateSingleProductTemplate() {
+		await this.admin.visitSiteEditor( {
+			postId: 'woocommerce/woocommerce//single-product',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		const addToCartFormBlock = await this.editor.getBlockByName(
+			'woocommerce/add-to-cart-form'
+		);
+		await this.editor.selectBlocks( addToCartFormBlock );
+
+		await this.page
+			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.click();
+
+		await this.editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+	}
 }
 
 export default AddToCartWithOptionsPage;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -169,8 +169,12 @@ class AddToCartWithOptions extends AbstractBlock {
 			$context = array(
 				'productId' => $product->get_id(),
 				'quantity'  => $default_quantity,
-				'variation' => array(),
 			);
+
+			if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+				$context['variation']           = array();
+				$context['availableVariations'] = $product->get_available_variations();
+			}
 
 			$wrapper_attributes = get_block_wrapper_attributes(
 				array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -21,25 +21,6 @@ class VariationSelector extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-variation-selector';
 
 	/**
-	 * Get variations data.
-	 *
-	 * @param WC_Product $product Product instance.
-	 * @return array|false
-	 */
-	private function get_variations_data( $product ) {
-		/**
-		 * Filter the number of variations threshold.
-		 *
-		 * @since 9.7.0
-		 *
-		 * @param int        $threshold Maximum number of variations to load upfront.
-		 * @param WC_Product $product   Product object.
-		 */
-		$get_variations = count( $product->get_children() ) <= apply_filters( 'woocommerce_ajax_variation_threshold', 30, $product );
-		return $get_variations ? $product->get_available_variations() : false;
-	}
-
-	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -51,17 +32,6 @@ class VariationSelector extends AbstractBlock {
 		global $product;
 
 		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
-			$variation_attributes = $product->get_variation_attributes();
-
-			if ( empty( $variation_attributes ) ) {
-				return '';
-			}
-
-			$variations = $this->get_variations_data( $product );
-			if ( empty( $variations ) ) {
-				return '';
-			}
-
 			add_filter( 'woocommerce_product_supports', array( $this, 'check_product_supports' ), 10, 3 );
 
 			return $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -147,14 +147,15 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'<div %s>%s</div>',
 				$this->get_normalized_attributes(
 					array(
-						'role'                       => 'radio',
-						'class'                      => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill',
-						'data-wp-bind--tabindex'     => 'state.pillTabIndex',
-						'data-wp-bind--aria-checked' => 'state.isPillSelected',
-						'data-wp-watch'              => 'callbacks.watchSelected',
-						'data-wp-on--click'          => 'actions.toggleSelected',
-						'data-wp-on--keydown'        => 'actions.handleKeyDown',
-						'data-wp-context'            => array(
+						'role'                        => 'radio',
+						'class'                       => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill',
+						'data-wp-bind--tabindex'      => 'state.pillTabIndex',
+						'data-wp-bind--aria-checked'  => 'state.isPillSelected',
+						'data-wp-bind--aria-disabled' => 'state.isPillDisabled',
+						'data-wp-watch'               => 'callbacks.watchSelected',
+						'data-wp-on--click'           => 'actions.toggleSelected',
+						'data-wp-on--keydown'         => 'actions.handleKeyDown',
+						'data-wp-context'             => array(
 							'option' => $attribute_term,
 						),
 					),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -215,10 +215,12 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'<option %s>%s</option>',
 				$this->get_normalized_attributes(
 					array(
-						'value'           => $attribute_term['value'],
-						'selected'        => $attribute_term['isSelected'] ? 'selected' : null,
-						'data-wp-context' => array(
-							'option' => $attribute_term,
+						'value'                  => $attribute_term['value'],
+						'data-wp-bind--disabled' => 'state.isOptionDisabled',
+						'data-wp-context'        => array(
+							'option'  => $attribute_term,
+							'name'    => $attribute_name,
+							'options' => $attribute_terms,
 						),
 					),
 				),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
@@ -98,7 +98,12 @@ class VariationSelectorItemTemplate extends AbstractBlock {
 	 *
 	 * @param string $attribute_name Product Attribute Name.
 	 * @param array  $attribute_terms Product Attribute Terms.
-	 * @return srtring
+	 * @return array[] Array of term data with structure:
+	 *                 [
+	 *                     'label'      => (string) Display label for the term.
+	 *                     'value'      => (string) Internal value/slug for the term.
+	 *                     'isSelected' => (bool)   Whether this term is the default selection.
+	 *                 ]
 	 */
 	protected function get_terms( $attribute_name, $attribute_terms ) {
 		global $product;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
@@ -39,7 +39,7 @@ class VariationSelectorItemTemplate extends AbstractBlock {
 		$product_attributes = $product->get_variation_attributes();
 
 		foreach ( $product_attributes as $product_attribute_name => $product_attribute_terms ) {
-			$content .= $this->get_product_row( $product_attribute_name, $product_attribute_terms, $attributes, $block );
+			$content .= $this->get_product_row( $product_attribute_name, $product_attribute_terms, $block );
 		}
 
 		return $content;
@@ -48,15 +48,31 @@ class VariationSelectorItemTemplate extends AbstractBlock {
 	/**
 	 * Get product row HTML.
 	 *
-	 * @param string   $product_attribute_name Product Attribute Name.
-	 * @param array    $product_attribute_terms Product Attribute Terms.
-	 * @param array    $attributes Block attributes.
+	 * @param string   $attribute_name Product Attribute Name.
+	 * @param array    $attribute_terms Product Attribute Terms.
 	 * @param WP_Block $block The Block.
 	 * @return string Row HTML
 	 */
-	private function get_product_row( $product_attribute_name, $product_attribute_terms, $attributes, $block ): string {
-		$attribute_name  = $product_attribute_name;
-		$attribute_terms = $this->get_terms( $product_attribute_name, $product_attribute_terms );
+	private function get_product_row( $attribute_name, $attribute_terms, $block ): string {
+		global $product;
+
+		$attribute_terms    = $this->get_terms( $attribute_name, $attribute_terms );
+		$product_variations = $product->get_available_variations();
+
+		// Filter out terms which are not available in the product variations.
+		$attribute_terms = array_filter(
+			$attribute_terms,
+			function ( $term ) use ( $product_variations, $attribute_name, $attribute_terms ) {
+				foreach ( $product_variations as $product_variation ) {
+					if (
+						$term['value'] === $product_variation['attributes'][ 'attribute_' . strtolower( $attribute_name ) ] ||
+						'' === $product_variation['attributes'][ 'attribute_' . strtolower( $attribute_name ) ]
+					) {
+						return true;
+					}
+				}
+			}
+		);
 
 		if ( empty( $attribute_terms ) ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorItemTemplate.php
@@ -48,18 +48,19 @@ class VariationSelectorItemTemplate extends AbstractBlock {
 	/**
 	 * Get product row HTML.
 	 *
-	 * @param string   $attribute_name Product Attribute Name.
-	 * @param array    $attribute_terms Product Attribute Terms.
+	 * @param string   $product_attribute_name Product Attribute Name.
+	 * @param array    $product_attribute_terms Product Attribute Terms.
 	 * @param WP_Block $block The Block.
 	 * @return string Row HTML
 	 */
-	private function get_product_row( $attribute_name, $attribute_terms, $block ): string {
+	private function get_product_row( $product_attribute_name, $product_attribute_terms, $block ): string {
 		global $product;
 
-		$attribute_terms    = $this->get_terms( $attribute_name, $attribute_terms );
+		$attribute_name     = $product_attribute_name;
+		$attribute_terms    = $this->get_terms( $attribute_name, $product_attribute_terms );
 		$product_variations = $product->get_available_variations();
 
-		// Filter out terms which are not available in the product variations.
+		// Filter out terms which are not available in any product variation.
 		$attribute_terms = array_filter(
 			$attribute_terms,
 			function ( $term ) use ( $product_variations, $attribute_name, $attribute_terms ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #57535.
Closes WOOPLUG-4073.

This PR makes it so pills and dropdown items are disabled in the Variation Selector block depending on the other selected attributes.

### How to test the changes in this Pull Request:

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.
3. Create a variable product. Try to get complex scenarios with the possible variations, like making combinations where one variation allows "any" while another variation only allows one term, terms which are only used by one variation, but that variation has no price, or whatever you can think of. For example, this is how I set it up:

Variations | Variation with no price
--- | ---
![imatge](https://github.com/user-attachments/assets/a8713c41-9352-4999-8908-c8a56ee20f4c) | ![imatge](https://github.com/user-attachments/assets/42ea934d-2926-4ea1-b86c-580f6876c53a)

4. Visit the product on the frontend. Verify you can select all valid variations, while you can't select any invalid combination of attributes.
5. Try using the keyboard to select some of the attributes, verify the invalid ones can't be selected.

https://github.com/user-attachments/assets/f2a93117-6900-4e65-825d-d4f7b9f49095

6. Go to the _Single Product_ template and change the display style to _Dropdown_. Repeat step 4.
