### PR TITLE
[dev] CI: Fix failing blocks E2E tests dependencies setup

### DIFF
--- a/plugins/woocommerce/changelog/fix-failing-blocks-e2e-deps-install
+++ b/plugins/woocommerce/changelog/fix-failing-blocks-e2e-deps-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: fix failing blocks E2E tests dependencies setup.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -28,7 +28,7 @@
 		"env:performance-init": "./tests/performance/bin/init-sample-products.sh",
 		"env:restart": "pnpm wp-env destroy && pnpm wp-env start --update",
 		"env:start": "pnpm wp-env start",
-		"env:start:blocks": "pnpm --filter='@woocommerce/block-library' env:start && pnpm playwright install chromium --with-deps",
+		"env:start:blocks": "pnpm --filter='@woocommerce/block-library' env:start && pnpm playwright install chromium",
 		"env:stop": "pnpm wp-env stop",
 		"env:test": "pnpm env:dev",
 		"env:perf": "pnpm env:dev && pnpm env:performance-init",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1745830817047219-slack-C03CPM3UXDJ

Fix failing CI caused by blocks E2E tests dependencies setup.

### How to test the changes in this Pull Request:

CI-checks shall pass