### PR TITLE
[Checkout] Ensure tax status is copied to shipping line items if shipping method does not support them through options

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3735-australia-post-possibly-other-shipping-plugin-tax-rate-on
+++ b/plugins/woocommerce/changelog/wooplug-3735-australia-post-possibly-other-shipping-plugin-tax-rate-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure tax status is copied to shipping line items if shipping method does not support them through options.

--- a/plugins/woocommerce/includes/class-wc-order-item-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-shipping.php
@@ -280,14 +280,16 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	}
 
 	/**
-	 * Get tax status.
+	 * Get tax status for the shipping method.
+	 *
+	 * This looks up the tax status for the shipping method based on the instance ID, and falls back to the default tax status.
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
 	 * @return string
 	 */
 	public function get_tax_status( $context = 'view' ) {
-		$shipping_method = WC_Shipping_Zones::get_shipping_method( $this->get_instance_id() );
-		return $shipping_method ? $shipping_method->get_option( 'tax_status' ) : ProductTaxStatus::TAXABLE;
+		$shipping_method = \WC_Shipping_Zones::get_shipping_method( $this->get_instance_id() );
+		return $shipping_method instanceof \WC_Shipping_Method ? $shipping_method->tax_status : ProductTaxStatus::TAXABLE;
 	}
 
 	/*


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shipping methods may not implement `get_option( 'tax_status' )` so using that will be unreliable. However, all shipping methods extend `WC_Shipping_Method` which defines a method property `tax_status`, so we can use that instead.

Core methods are not impacted by this issue because they all have the tax_status option. Some 3rd party methods are however, such as Australia Post. 

Closes #56931

(For Bug Fixes) Bug introduced in PR #54200

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

You can test this with a 3rd party shipping plugin affected by the issue, or do as I did and modify core to simulate the behaviour.  For this I just edited:

https://github.com/woocommerce/woocommerce/blob/e43215101eec102d92abe8d55ef3ed97d43dadd6/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php#L63

And comment out the line:

```php
		// $this->tax_status           = $this->get_option( 'tax_status' );
```

With this in place:

1. Ensure flat rate shipping is enabled
2. Add an item to your cart
3. Checkout, taxes should be a applied. Note the values.
4. Place order, taxes should remain the same on the confirmation page.

Without this patch, taxes will change after checkout.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
