### PR TITLE
Update email text not to imply physical package delivery for processing or completed orders

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4048-enhancement-add-filter-on-customer-completed-order-email
+++ b/plugins/woocommerce/changelog/wooplug-4048-enhancement-add-filter-on-customer-completed-order-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update email text not to imply physical package delivery for processing or completed orders

--- a/plugins/woocommerce/client/admin/client/settings-email/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-email/style.scss
@@ -55,7 +55,7 @@ $wc-setting-email-width: 634px;
 	position: relative;
 
 	&.wc-settings-email-improvements-disabled {
-		padding-bottom: 120px;
+		padding-bottom: 160px;
 	}
 }
 

--- a/plugins/woocommerce/templates/emails/block/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-completed-order.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'We’ve successfully processed your order, and it’s on its way to you.', 'woocommerce' ); ?> </p>
+<p> <?php echo esc_html__( 'We have finished processing your order.', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -47,7 +47,7 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p> 
+<p>
 <?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p> <?php echo esc_html__( 'We’ve received your order and will let you know when it’s on its way to you!', 'woocommerce' ); ?> </p>
+<p> <?php echo esc_html__( 'Just to let you know &mdash; we’ve received your order, and it is now being processed.', 'woocommerce' ); ?> </p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -47,7 +47,7 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p> 
+<p>
 <?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -39,11 +39,9 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 }
 ?>
 </p>
+<p><?php esc_html_e( 'We have finished processing your order.', 'woocommerce' ); ?></p>
 <?php if ( $email_improvements_enabled ) : ?>
-	<p><?php esc_html_e( 'We’ve successfully processed your order, and it’s on its way to you.', 'woocommerce' ); ?></p>
 	<p><?php esc_html_e( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?></p>
-<?php else : ?>
-	<p><?php esc_html_e( 'We have finished processing your order.', 'woocommerce' ); ?></p>
 <?php endif; ?>
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -40,7 +40,7 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 ?>
 </p>
 <?php if ( $email_improvements_enabled ) : ?>
-	<p><?php esc_html_e( 'We’ve received your order and will let you know when it’s on its way to you!', 'woocommerce' ); ?></p>
+	<p><?php esc_html_e( 'Just to let you know &mdash; we’ve received your order, and it is now being processed.', 'woocommerce' ); ?></p>
 	<p><?php esc_html_e( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ); ?></p>
 <?php else : ?>
 	<?php /* translators: %s: Order number */ ?>

--- a/plugins/woocommerce/templates/emails/plain/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -27,11 +27,9 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %s: Customer first name */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
+echo esc_html__( 'We have finished processing your order.', 'woocommerce' ) . "\n\n";
 if ( $email_improvements_enabled ) {
-	echo esc_html__( 'We’ve successfully processed your order, and it’s on its way to you.', 'woocommerce' ) . "\n\n";
 	echo esc_html__( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ) . "\n\n";
-} else {
-	echo esc_html__( 'We have finished processing your order.', 'woocommerce' ) . "\n\n";
 }
 
 /*

--- a/plugins/woocommerce/templates/emails/plain/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -28,7 +28,7 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 /* translators: %s: Customer first name */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 if ( $email_improvements_enabled ) {
-	echo esc_html__( 'We’ve received your order and will let you know when it’s on its way to you!', 'woocommerce' ) . "\n\n";
+	echo esc_html__( 'Just to let you know &mdash; we’ve received your order, and it is now being processed.', 'woocommerce' ) . "\n\n";
 	echo esc_html__( 'Here’s a reminder of what you’ve ordered:', 'woocommerce' ) . "\n\n";
 } else {
 	/* translators: %s: Order number */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/EmailPreview/EmailPreviewTest.php
@@ -60,7 +60,7 @@ class EmailPreviewTest extends WC_Unit_Test_Case {
 	public function test_it_returns_order_email_preview() {
 		$message       = $this->sut->render();
 		$order_title   = 'Thank you for your order';
-		$order_content = 'We’ve received your order and will let you know when it’s on its way to you!';
+		$order_content = 'Just to let you know — we’ve received your order, and it is now being processed.';
 		$order_product = 'Dummy Product';
 		$this->assertStringContainsString( $order_title, $message );
 		$this->assertStringContainsString( $order_content, $message );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

1. Reverts the content of processing and completed order email in `Email improvements` feature not to imply a physical package delivery (which would be confusing for local pickup or digital goods).
2. Fix email preview overlaying with email list when the feature is disabled. 

Closes WOOPLUG-4048, closes #57480.

(For Bug Fixes) Bug introduced in PR #54970.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="637" alt="Screenshot 2025-04-28 at 14 14 34" src="https://github.com/user-attachments/assets/d8a09af3-ec4f-4453-9242-ae69b699cfb3" />    |    <img width="646" alt="Screenshot 2025-04-28 at 14 11 46" src="https://github.com/user-attachments/assets/6c3b28db-5415-4558-a4b3-c0d8cd5ef31d" />   |
|    <img width="635" alt="Screenshot 2025-04-28 at 14 14 30" src="https://github.com/user-attachments/assets/65d10e96-65b3-4c17-9bc7-c56d19ba8aa3" />    |    <img width="627" alt="Screenshot 2025-04-28 at 14 07 03" src="https://github.com/user-attachments/assets/45a8e31a-3fa7-4a1b-944e-429057972ded" />   |
|    <img width="706" alt="Screenshot 2025-04-28 at 14 09 39" src="https://github.com/user-attachments/assets/378cd47a-ebb9-4524-b61f-a85db6372aa5" />    |   <img width="721" alt="Screenshot 2025-04-28 at 14 09 46" src="https://github.com/user-attachments/assets/b5e7c418-396d-4a50-8e2c-53c26cbda257" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the `Email improvements` feature is enabled in **WooCommerce > Settings > Advanced > Features**.
3. Go to **WooCommerce > Settings > Emails**.
4. Review the preview of all order emails sent to the customer to ensure the phrasing in them doesn't imply a physical package will be delivered (which would be confusing for local pickup or digital goods).
5. Note that the email title can imply that, because it's easily changeable when managing an email.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
