### PR TITLE
Fix blueprint package test autoloading and export configuration

### DIFF
--- a/packages/php/blueprint/.gitattributes
+++ b/packages/php/blueprint/.gitattributes
@@ -1,0 +1,9 @@
+/*.md export-ignore
+/changelog export-ignore
+/docs* export-ignore
+/phpcs.* export-ignore
+/phpunit.* export-ignore
+/package.json export-ignore
+/node_modules* export-ignore
+/tests export-ignore
+

--- a/packages/php/blueprint/changelog/fix-blueprint-setup-tests
+++ b/packages/php/blueprint/changelog/fix-blueprint-setup-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix tests and use .gitattributes to prevent dev files from being included
+
+

--- a/packages/php/blueprint/composer.json
+++ b/packages/php/blueprint/composer.json
@@ -3,7 +3,11 @@
 	"version": "0.0.1",
 	"autoload": {
 		"psr-4": {
-			"Automattic\\WooCommerce\\Blueprint\\": "src/",
+			"Automattic\\WooCommerce\\Blueprint\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
 			"Automattic\\WooCommerce\\Blueprint\\Tests\\": "tests/"
 		}
 	},

--- a/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
+++ b/packages/php/blueprint/tests/Unit/ExportSchemaTest.php
@@ -35,7 +35,6 @@ class ExportSchemaTest extends TestCase {
 	 * with the built-in exporters.
 	 */
 	public function test_it_uses_exporters_passed_to_the_constructor() {
-		$this->markTestSkipped( 'Skipping for now as it is failing due to the way the mock is created.' );
 		$empty_exporter     = new EmptySetSiteOptionsExporter();
 		$mock               = Mock( ExportSchema::class, array( array( $empty_exporter ) ) );
 		$built_in_exporters = ( new BuiltInExporters() )->get_all();
@@ -57,7 +56,6 @@ class ExportSchemaTest extends TestCase {
 	 * Test that it correctly sets landingPage value from the filter.
 	 */
 	public function test_wooblueprint_export_landingpage_filter() {
-		$this->markTestSkipped( 'Skipping for now as it is failing due to the way the mock is created.' );
 		$exporter = $this->get_mock( true );
 		$exporter->shouldReceive( 'wp_apply_filters' )
 			->with( 'wooblueprint_exporters', Mockery::any() )
@@ -90,7 +88,6 @@ class ExportSchemaTest extends TestCase {
 	 * @return void
 	 */
 	public function test_it_only_uses_exporters_specified_by_steps_argment() {
-		$this->markTestSkipped( 'Skipping for now as it is failing due to the way the mock is created.' );
 		$mock = Mock(
 			ExportSchema::class,
 			array(
@@ -117,7 +114,6 @@ class ExportSchemaTest extends TestCase {
 	 * @return void
 	 */
 	public function test_it_filters_out_invalid_exporters() {
-		$this->markTestSkipped( 'Skipping for now as it is failing due to the way the mock is created.' );
 		$empty_exporter   = new EmptySetSiteOptionsExporter();
 		$invalid_exporter = new class() {
 			/**

--- a/packages/php/blueprint/tests/bootstrap.php
+++ b/packages/php/blueprint/tests/bootstrap.php
@@ -22,3 +22,6 @@ require "{$_tests_dir}/includes/bootstrap.php";
 
 
 define( 'WOO_BLUEPRINT_TESTS', true );
+
+// Stubs.
+require_once __DIR__ . '/stubs/stubs.php';

--- a/packages/php/blueprint/tests/stubs/stubs.php
+++ b/packages/php/blueprint/tests/stubs/stubs.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Stubs for WooCommerce classes and interfaces.
+ */
+
+if ( ! class_exists( 'WC_Log_Levels', false ) ) {
+	/**
+	 * WC Log Levels Class
+	 */
+	class WC_Log_Levels {
+		const EMERGENCY = 'emergency';
+		const ALERT     = 'alert';
+		const CRITICAL  = 'critical';
+		const ERROR     = 'error';
+		const WARNING   = 'warning';
+		const NOTICE    = 'notice';
+		const INFO      = 'info';
+		const DEBUG     = 'debug';
+	}
+}
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+if ( ! interface_exists( 'WC_Logger_Interface' ) ) {
+	/**
+	 * WC Logger Interface
+	 */
+	interface WC_Logger_Interface {
+		/**
+		 * Log message with level.
+		 *
+		 * @param string $level Log level.
+		 * @param string $message Log message.
+		 * @param array  $context Optional. Additional information for log handlers.
+		 */
+		public function log( $level, $message, $context = array() );
+
+		/**
+		 * Add a log entry.
+		 *
+		 * @param string $handle Log handle.
+		 * @param string $message Log message.
+		 * @param string $level Log level.
+		 */
+		public function add( $handle, $message, $level = 'notice' );
+
+		/**
+		 * Add an emergency level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function emergency( $message, $context = array() );
+
+		/**
+		 * Add an alert level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function alert( $message, $context = array() );
+
+		/**
+		 * Add a critical level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function critical( $message, $context = array() );
+
+		/**
+		 * Add an error level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function error( $message, $context = array() );
+
+		/**
+		 * Add a warning level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function warning( $message, $context = array() );
+
+		/**
+		 * Add a notice level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function notice( $message, $context = array() );
+
+		/**
+		 * Add an info level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function info( $message, $context = array() );
+
+		/**
+		 * Add a debug level message.
+		 *
+		 * @param string $message Log message.
+		 * @param array  $context Log context.
+		 */
+		public function debug( $message, $context = array() );
+	}
+}
+
+if ( ! function_exists( 'wc_get_logger' ) ) {
+	/**
+	 * Mock wc_get_logger function.
+	 *
+	 * @return WC_Logger_Interface
+	 */
+	function wc_get_logger() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+		return Mockery::mock( 'WC_Logger_Interface' )->shouldReceive( 'log' )->getMock();
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Could you describe the changes made to this Pull Request and the reason for these changes? -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR implements a proper fix for the issue with the blueprint package test files' unintentional loading that was temporarily addressed in #57527. 

<details>

```bash
Uncaught Error: Failed opening required '/srv/htdocs/wp-content/plugins/wc_beta_tester_live_branch_9.9.0-dev-14663310349-g771b51e/vendor/woocommerce/blueprint/tests/stubs/stubs.php' (include_path='/:.')
in /srv/htdocs/wp-content/plugins/jetpack/vendor/jetpack-autoloader/class-php-autoloader.php on line 102

Call stack:

Automattic\J\A\jpf11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ14_6_a_7\a\PHP_Autoloader::load_class('WC_Log_Levels')
wp-content/plugins/wc_beta_tester_live_branch_9.9.0-dev-14663310349-g771b51e/includes/class-wc-logger.php:311
WC_Logger::debug('wcadmin_settings_view', array)
wp-content/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php:66
Tracks_Debug_Log::log_event('wcadmin_settings_view', WC_Tracks_Event)
wp-content/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php:92
Tracks_Debug_Log::log_footer_pixels('')
wp-includes/class-wp-hook.php:324
WP_Hook::apply_filters(NULL, array)
wp-includes/class-wp-hook.php:348
WP_Hook::do_action(array)
wp-includes/plugin.php:517
do_action('admin_footer', '')
wp-admin/admin-footer.php:78
require_once('/srv/htdocs/__wp__/wp-admin/admin-footer.php')
wp-admin/admin.php:298```
```

</details>

The issue was because the tests files were included in `plugins/woocommerce/vendor/woocommerce/blueprint` folder and were being scanned and indexed by Jetpack Autoloader for production builds.

This PR ensures test/dev files are only included in blueprint package's development environments and not included in ./plugins/woocommerce.

 The changes include:

- Move test classes autoloading from `autoload` to `autoload-dev` in composer.json
- Add `.gitattributes` to exclude files from production builds
- Restore previously skipped tests now that the loading issue is fixed correctly


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


Before:
<img width="1048" alt="Screenshot 2025-04-29 at 11 53 58" src="https://github.com/user-attachments/assets/bdf97f32-6af8-402b-ba52-a513c9b37e37" />

After:
<img width="964" alt="Screenshot 2025-04-29 at 11 51 26" src="https://github.com/user-attachments/assets/8a194612-0ba2-442a-825f-ff321e4785ba" />




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Run `pnpm install`
2. Check the `plugins/woocommerce/vendor/woocommerce/blueprint/setup` folder and verify that there are no tests, changelog, node_modules, etc.
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard` and continue through the onboarding wizard.
4. Confirm that the onboarding wizard works without any errors


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
