### PR TITLE
Update email descriptions to use 'customers' instead of 'shoppers' for consistency across various order notification emails.

### DIFF
--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-completed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-completed-order.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Let shoppers know once their order is complete and is being shipped.', 'woocommerce' )
+				? __( 'Let customers know once their order is complete and is being shipped.', 'woocommerce' )
 				: __( 'Order complete emails are sent to customers when their orders are marked completed and usually indicate that their orders have been shipped.', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-failed-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-failed-order.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Email_Customer_Failed_Order', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Let shoppers know when their order has failed and what to do next.', 'woocommerce' )
+				? __( 'Let customers know when their order has failed and what to do next.', 'woocommerce' )
 				: __( 'Order failed emails are sent to customers when their orders are marked as failed.', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Manually send an email to your shoppers containing their order information and payment links.', 'woocommerce' )
+				? __( 'Manually send an email to your customers containing their order information and payment links.', 'woocommerce' )
 				: __( 'Order detail emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
 
 			$this->manual = true;

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-note.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-note.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Let your shoppers know when you’ve added a note to their order.', 'woocommerce' )
+				? __( 'Let your customers know when you’ve added a note to their order.', 'woocommerce' )
 				: __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'This order notification will be sent to shoppers after an order is placed on-hold from a Pending, Cancelled, or Failed order status.', 'woocommerce' )
+				? __( 'This order notification will be sent to customers after an order is placed on-hold from a Pending, Cancelled, or Failed order status.', 'woocommerce' )
 				: __( 'This is an order notification sent to customers containing order details after an order is placed on-hold from Pending, Cancelled or Failed order status.', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-processing-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-processing-order.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Let your shoppers know that you’re processing their order following successful payment.', 'woocommerce' )
+				? __( 'Let your customers know that you’re processing their order following successful payment.', 'woocommerce' )
 				: __( 'This is an order notification sent to customers containing order details after payment.', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-refunded-order.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 
 			// Must be after parent's constructor which sets `email_improvements_enabled` property.
 			$this->description = $this->email_improvements_enabled
-				? __( 'Let shoppers know when a full or partial refund is on its way to them.', 'woocommerce' )
+				? __( 'Let customers know when a full or partial refund is on its way to them.', 'woocommerce' )
 				: __( 'Order refunded emails are sent to customers when their orders are refunded.', 'woocommerce' );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the descriptions in various WooCommerce order notification emails to use the term **"customers"** instead of **"shoppers"** for improved consistency and clarity across the platform. The affected emails include:

- Completed Order
- Failed Order
- Invoice
- Customer Note
- On-Hold Order
- Processing Order
- Refunded Order

**Reason for change:**  
Standardizing terminology improves user experience and aligns with WooCommerce's preferred language.
More details here: p1745843835365269-slack-C0316THTWTX

Closes #57563 WOOPLUG-4083


(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    ![Screenshot 2025-04-28 at 1 31 02 PM](https://github.com/user-attachments/assets/c63aa0ce-da02-406c-8c5f-dc4a388da751)   |   ![Screenshot 2025-04-29 at 11 05 25 AM](https://github.com/user-attachments/assets/530c280a-993d-48a6-94c8-047497f23c89)  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha).
2. Open the email listing page WooCommerce → Settings → Emails.
3. Review the email descriptions in the WooCommerce admin and in the emails sent to customers.
4. Confirm that all instances of "shoppers" have been replaced with "customers" in the email descriptions.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Minor text update.
</details>