### PR TITLE
Cast string to float when calculating refund totals within `WC_Order::get_total_refunded_for_item()`

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2660-fatal-error-unsupported-operand-types-in-wc_order
+++ b/plugins/woocommerce/changelog/wooplug-2660-fatal-error-unsupported-operand-types-in-wc_order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Defensive typecast of string to integer when calculating refund totals
+
+

--- a/plugins/woocommerce/changelog/wooplug-2660-fatal-error-unsupported-operand-types-in-wc_order
+++ b/plugins/woocommerce/changelog/wooplug-2660-fatal-error-unsupported-operand-types-in-wc_order
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: Defensive typecast of string to integer when calculating refund totals
+Comment: Defensive typecast of string to float when calculating refund totals
 
 

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -9,6 +9,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
+use Automattic\WooCommerce\Utilities\NumberUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -2300,18 +2301,18 @@ class WC_Order extends WC_Abstract_Order {
 	 *
 	 * @param  int    $item_id   ID of the item we're checking.
 	 * @param  string $item_type Type of the item we're checking, if not a line_item.
-	 * @return int
+	 * @return float
 	 */
 	public function get_total_refunded_for_item( $item_id, $item_type = 'line_item' ) {
 		$total = 0;
 		foreach ( $this->get_refunds() as $refund ) {
 			foreach ( $refund->get_items( $item_type ) as $refunded_item ) {
 				if ( absint( $refunded_item->get_meta( '_refunded_item_id' ) ) === $item_id ) {
-					$total += (int) $refunded_item->get_total();
+					$total += (float) $refunded_item->get_total();
 				}
 			}
 		}
-		return $total * -1;
+		return NumberUtil::round( $total * -1, wc_get_price_decimals() );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2307,7 +2307,7 @@ class WC_Order extends WC_Abstract_Order {
 		foreach ( $this->get_refunds() as $refund ) {
 			foreach ( $refund->get_items( $item_type ) as $refunded_item ) {
 				if ( absint( $refunded_item->get_meta( '_refunded_item_id' ) ) === $item_id ) {
-					$total += $refunded_item->get_total();
+					$total += (int) $refunded_item->get_total();
 				}
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -191,7 +191,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	public function test_get_total_refunded_for_item() {
 		// Create a product.
 		$product = WC_Helper_Product::create_simple_product();
-		$product->set_regular_price( 100 );
+		$product->set_regular_price( 99.99 );
 		$product->save();
 
 		// Create an order with the product.
@@ -201,7 +201,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			array(
 				'product'  => $product,
 				'quantity' => 2,
-				'total'    => 200,
+				'total'    => 199.98,
 			)
 		);
 		$order->add_item( $item );
@@ -219,34 +219,34 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => 50,
+				'amount'     => 49.99,
 				'line_items' => array(
 					$item_id => array(
 						'qty'          => 0.5,
-						'refund_total' => 50,
+						'refund_total' => 49.99,
 					),
 				),
 			)
 		);
 
 		// Verify the refunded amount for the item after first refund.
-		$this->assertEquals( 50, $order->get_total_refunded_for_item( $item_id ) );
+		$this->assertEquals( 49.99, $order->get_total_refunded_for_item( $item_id ) );
 
 		// Create second partial refund for remaining amount.
 		wc_create_refund(
 			array(
 				'order_id'   => $order->get_id(),
-				'amount'     => 150,
+				'amount'     => 149.99,
 				'line_items' => array(
 					$item_id => array(
 						'qty'          => 1.5,
-						'refund_total' => 150,
+						'refund_total' => 149.99,
 					),
 				),
 			)
 		);
 
 		// Verify the total refunded amount for the item after both refunds.
-		$this->assertEquals( 200, $order->get_total_refunded_for_item( $item_id ) );
+		$this->assertEquals( 199.98, $order->get_total_refunded_for_item( $item_id ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -184,4 +184,69 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 1, $order->get_data_store()->get_recorded_coupon_usage_counts( $order ) );
 		$this->assertEquals( 1, ( new WC_Coupon( $coupon ) )->get_usage_count() );
 	}
+
+	/**
+	 * Test getting total refunded for an item with and without refunds.
+	 */
+	public function test_get_total_refunded_for_item() {
+		// Create a product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create an order with the product.
+		$order = new WC_Order();
+		$item  = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 2,
+				'total'    => 200,
+			)
+		);
+		$order->add_item( $item );
+		$order->calculate_totals();
+		$order->save();
+
+		// Get the item ID.
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Test that by default there is no refund.
+		$this->assertEquals( 0, $order->get_total_refunded_for_item( $item_id ) );
+
+		// Create first partial refund for 1 item.
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 50,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 0.5,
+						'refund_total' => 50,
+					),
+				),
+			)
+		);
+
+		// Verify the refunded amount for the item after first refund.
+		$this->assertEquals( 50, $order->get_total_refunded_for_item( $item_id ) );
+
+		// Create second partial refund for remaining amount.
+		wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => 150,
+				'line_items' => array(
+					$item_id => array(
+						'qty'          => 1.5,
+						'refund_total' => 150,
+					),
+				),
+			)
+		);
+
+		// Verify the total refunded amount for the item after both refunds.
+		$this->assertEquals( 200, $order->get_total_refunded_for_item( $item_id ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While I could not replicate this issue on PHP 8.2, we can be more defensive when calculating totals. We're working with floats stored as strings, so they should be typecasted back to float. This includes a round on the final total, and I've added some new tests to cover this logic.

Closes #52180

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product, give it a decimal price such as `10.49` (avoid ints)
2. Add product to cart and place order.
3. View order in backend. Refund the line item.
4. Check the refunded total matches the line item total.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
