### PR TITLE
[WC Payments NOX in-context flows] Harden backend api logic for greater coherence

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Settings/Exceptions/ApiArgumentException.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Exceptions/ApiArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings\Exceptions;
+
+/**
+ * ApiArgumentException class.
+ */
+class ApiArgumentException extends ApiException {}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/Exceptions/ApiException.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/Exceptions/ApiException.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings\Exceptions;
+
+/**
+ * ApiException class.
+ */
+class ApiException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public string $error_code;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public array $additional_data = array();
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_step_id`.
+	 * @param string $message          User-friendly translated error message, e.g. 'Step ID is invalid'.
+	 * @param int    $http_status_code Optional. Proper HTTP status code to respond with.
+	 *                                 Defaults to 400 (Bad request).
+	 * @param array  $additional_data  Optional. Extra data (key value pairs) to expose in the error response.
+	 *                                 Defaults to empty array.
+	 */
+	public function __construct( string $error_code, string $message, int $http_status_code = 400, array $additional_data = array() ) {
+		$this->error_code      = $error_code;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct( $message, $http_status_code );
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string The machine-readable error code.
+	 */
+	public function getErrorCode(): string {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array Extra data (key value pairs).
+	 */
+	public function getAdditionalData(): array {
+		return $this->additional_data;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments.php
@@ -55,9 +55,11 @@ class WooPayments extends PaymentGateway {
 			)
 		);
 
-		// If the WooPayments installed version is less than 9.3.0, we can't use the in-context onboarding flows
-		// due to our dependency on the newly introduced REST API endpoints.
-		if ( defined( 'WCPAY_VERSION_NUMBER' ) && version_compare( WCPAY_VERSION_NUMBER, '9.3.0', '<' ) ) {
+		// If the WooPayments installed version is less than minimum required version,
+		// we can't use the in-context onboarding flows.
+		if ( defined( 'WCPAY_VERSION_NUMBER' ) &&
+			version_compare( WCPAY_VERSION_NUMBER, PaymentProviders\WooPayments\WooPaymentsService::EXTENSION_MINIMUM_VERSION, '<' ) ) {
+
 			return $details;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -3,11 +3,13 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments;
 
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
 use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\Init as WCPayPromotion;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use Exception;
 use WP_Error;
+use WP_Http;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -332,7 +334,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	/**
 	 * Initialize the class instance.
 	 *
-	 * @param Payments           $payments The general payments settings page service.
+	 * @param Payments           $payments    The general payments settings page service.
 	 * @param WooPaymentsService $woopayments The WooPayments-specific Payments settings page service.
 	 *
 	 * @internal
@@ -346,7 +348,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 * Get the onboarding details for the given location.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_Error|WP_REST_Response
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function get_onboarding_details( WP_REST_Request $request ) {
 		$location = $request->get_param( 'location' );
@@ -357,8 +359,10 @@ class WooPaymentsRestController extends RestApiControllerBase {
 
 		try {
 			$onboarding_details = $this->woopayments->get_onboarding_details( $location, $this->get_rest_url_path( 'onboarding' ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => WP_Http::INTERNAL_SERVER_ERROR ) );
 		}
 
 		return rest_ensure_response( $this->prepare_onboarding_details_response( $onboarding_details ) );
@@ -369,13 +373,10 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_step_start( WP_REST_Request $request ) {
-		$step_id = $request->get_param( 'step' );
-		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
+		$step_id = $request->get_param( 'step' ) ?? '';
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
@@ -383,19 +384,19 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			$location = $this->payments->get_country();
 		}
 
-		$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
-
 		try {
-			$this->woopayments->set_onboarding_step_started( $step_id, $location );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
-		}
+			$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
 
-		$response = array(
-			'success'         => true,
-			'previous_status' => $previous_status,
-			'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
-		);
+			$this->woopayments->set_onboarding_step_started( $step_id, $location );
+
+			$response = array(
+				'success'         => true,
+				'previous_status' => $previous_status,
+				'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+			);
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
 
 		return rest_ensure_response( $response );
 	}
@@ -408,10 +409,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 * @return WP_Error|WP_REST_Response The response.
 	 */
 	protected function handle_onboarding_step_save( WP_REST_Request $request ) {
-		$step_id = $request->get_param( 'step' );
-		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
+		$step_id = $request->get_param( 'step' ) ?? '';
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
@@ -421,8 +419,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 
 		try {
 			$this->woopayments->onboarding_step_save( $step_id, $location, $request->get_params() );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		return rest_ensure_response( array( 'success' => true ) );
@@ -433,13 +431,10 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_step_check( WP_REST_Request $request ) {
-		$step_id = $request->get_param( 'step' );
-		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
+		$step_id = $request->get_param( 'step' ) ?? '';
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
@@ -449,8 +444,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 
 		try {
 			$result = $this->woopayments->onboarding_step_check( $step_id, $location );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		// Merge the result with the success flag.
@@ -464,13 +459,10 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_step_finish( WP_REST_Request $request ) {
-		$step_id = $request->get_param( 'step' );
-		if ( empty( $step_id ) || ! $this->woopayments->is_valid_onboarding_step_id( $step_id ) ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_invalid_step', __( 'Invalid onboarding step ID.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
+		$step_id = $request->get_param( 'step' ) ?? '';
 
 		$location = $request->get_param( 'location' );
 		if ( empty( $location ) ) {
@@ -478,19 +470,19 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			$location = $this->payments->get_country();
 		}
 
-		$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
-
 		try {
-			$this->woopayments->set_onboarding_step_completed( $step_id, $location );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
-		}
+			$previous_status = $this->woopayments->get_onboarding_step_status( $step_id, $location );
 
-		$response = array(
-			'success'         => true,
-			'previous_status' => $previous_status,
-			'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
-		);
+			$this->woopayments->set_onboarding_step_completed( $step_id, $location );
+
+			$response = array(
+				'success'         => true,
+				'previous_status' => $previous_status,
+				'current_status'  => $this->woopayments->get_onboarding_step_status( $step_id, $location ),
+			);
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
 
 		return rest_ensure_response( $response );
 	}
@@ -500,7 +492,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_test_account_init( WP_REST_Request $request ) {
 		$location = $request->get_param( 'location' );
@@ -514,15 +506,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			$this->woopayments->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
 			$result = $this->woopayments->onboarding_test_account_init( $location, $request->get_param( 'source' ) ?? '' );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		return rest_ensure_response(
 			array_merge(
-				array(
-					'success' => true,
-				),
+				array( 'success' => true ),
 				$result
 			)
 		);
@@ -533,7 +523,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_business_verification_kyc_session_init( WP_REST_Request $request ) {
 		// If we receive self assessment data with the request, we will use it.
@@ -547,8 +537,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 
 		try {
 			$account_session = $this->woopayments->get_onboarding_kyc_session( $location, $self_assessment );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		return rest_ensure_response(
@@ -564,7 +554,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_onboarding_business_verification_kyc_session_finish( WP_REST_Request $request ) {
 		$location = $request->get_param( 'location' );
@@ -575,8 +565,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 
 		try {
 			$response = $this->woopayments->finish_onboarding_kyc_session( $location, $request->get_param( 'source' ) ?? '' );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		// If there is no success key in the response, we assume the operation was successful.
@@ -592,13 +582,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function reset_onboarding( WP_REST_Request $request ) {
 		try {
 			$this->woopayments->reset_onboarding( $request->get_param( 'from' ) ?? '', $request->get_param( 'source' ) ?? '' );
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		return rest_ensure_response(
@@ -613,7 +603,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
-	 * @return WP_Error|WP_REST_Response The response.
+	 * @return WP_Error|WP_REST_Response The response or error.
 	 */
 	protected function handle_test_account_disable( WP_REST_Request $request ) {
 		try {
@@ -622,8 +612,8 @@ class WooPaymentsRestController extends RestApiControllerBase {
 				$request->get_param( 'from' ) ?? '',
 				$request->get_param( 'source' ) ?? ''
 			);
-		} catch ( Exception $e ) {
-			return new WP_Error( 'woocommerce_rest_woopayments_onboarding_error', $e->getMessage(), array( 'status' => 500 ) );
+		} catch ( ApiException $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 
 		return rest_ensure_response(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -70,7 +70,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
@@ -92,14 +92,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
 							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
 						),
 						'source'   => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -119,7 +119,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
@@ -140,7 +140,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
@@ -161,14 +161,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
 							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
 						),
 						'source'   => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -189,14 +189,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
 							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
 						),
 						'source'   => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -216,14 +216,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
 							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
 						),
 						'source'   => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -243,14 +243,14 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'location' => array(
-							'description'       => __( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
+							'description'       => esc_html__( 'ISO3166 alpha-2 country code. Defaults to the stored providers business location country code.', 'woocommerce' ),
 							'type'              => 'string',
 							'pattern'           => '[a-zA-Z]{2}', // Two alpha characters.
 							'required'          => false,
 							'validate_callback' => fn( $value, $request ) => $this->check_location_arg( $value, $request ),
 						),
 						'source'   => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -271,13 +271,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'from'   => array(
-							'description'       => __( 'Where from in the onboarding flow this request was triggered.', 'woocommerce' ),
+							'description'       => esc_html__( 'Where from in the onboarding flow this request was triggered.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'source' => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
@@ -311,13 +311,13 @@ class WooPaymentsRestController extends RestApiControllerBase {
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 					'args'                => array(
 						'from'   => array(
-							'description'       => __( 'Where from in the onboarding flow this request was triggered.', 'woocommerce' ),
+							'description'       => esc_html__( 'Where from in the onboarding flow this request was triggered.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'source' => array(
-							'description'       => __( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
+							'description'       => esc_html__( 'The upmost entry point from where the merchant entered the onboarding flow.', 'woocommerce' ),
 							'type'              => 'string',
 							'required'          => false,
 							'sanitize_callback' => 'sanitize_text_field',

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -730,6 +730,9 @@ class WooPaymentsService {
 		// For sanity, make sure the payment methods step is marked as completed.
 		// This is to avoid the user being prompted to set up payment methods again.
 		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_PAYMENT_METHODS, $location );
+		// For sanity, make sure the test account step is marked as completed.
+		// After disabling a test account, the user should be prompted to set up a live account.
+		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
 		return $response;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -4,10 +4,13 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments;
 
 use Automattic\Jetpack\Connection\Manager as WPCOM_Connection_Manager;
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiArgumentException;
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Exception;
+use WP_Http;
 
 defined( 'ABSPATH' ) || exit;
 /**
@@ -89,15 +92,15 @@ class WooPaymentsService {
 	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
 	 *
 	 * @return array The onboarding details.
-	 * @throws Exception If the WooPayments plugin is not active or there was an error.
+	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
+	 * @throws Exception If there were errors when generating the onboarding details.
 	 */
 	public function get_onboarding_details( string $location, string $rest_path ): array {
-		// If the WooPayments plugin is not active, we don't do onboarding.
-		if ( ! $this->is_extension_active() ) {
-			throw new Exception( 'WooPayments is not active.' );
-		}
+		// Since getting the onboarding details is not idempotent, we will check it as an action.
+		$this->check_if_onboarding_action_is_acceptable();
 
 		return array(
+			// This state is high-level data, independent of the type of onboarding flow.
 			'state'   => array(
 				'started'   => $this->provider->is_onboarding_started( $this->get_payment_gateway() ),
 				'completed' => $this->provider->is_onboarding_completed( $this->get_payment_gateway() ),
@@ -136,13 +139,22 @@ class WooPaymentsService {
 	/**
 	 * Get the status of an onboarding step.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return string The status of the onboarding step.
+	 * @throws ApiArgumentException If the given onboarding step ID is invalid.
 	 */
 	public function get_onboarding_step_status( string $step_id, string $location ): string {
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new ApiArgumentException(
+				'woocommerce_woopayments_onboarding_invalid_step_id',
+				esc_html__( 'Invalid onboarding step ID.', 'woocommerce' ),
+				(int) WP_Http::NOT_ACCEPTABLE
+			);
+		}
+
 		$stored_statuses = (array) $this->get_nox_profile_onboarding_step_entry( $step_id, $location, 'statuses' );
 
 		// First, we check the status of the onboarding step based on the current state of the store.
@@ -250,17 +262,11 @@ class WooPaymentsService {
 	 * @param bool   $overwrite Whether to overwrite the step status if it is already started and update the timestamp.
 	 *
 	 * @return bool Whether the onboarding step was marked as started.
-	 * @throws Exception If the given onboarding step ID is invalid or step requirements are not met.
+	 * @throws ApiArgumentException If the given onboarding step ID is invalid.
+	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
 	 */
 	public function set_onboarding_step_started( string $step_id, string $location, bool $overwrite = false ): bool {
-		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
-			throw new Exception( 'Invalid onboarding step ID.' );
-		}
-
-		// Check step requirements.
-		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
-			throw new Exception( 'Onboarding step can no be started because requirements are not met.' );
-		}
+		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
 		$statuses = (array) $this->get_nox_profile_onboarding_step_entry( $step_id, $location, 'statuses' );
 		if ( ! $overwrite && ! empty( $statuses[ self::ONBOARDING_STEP_STATUS_STARTED ] ) ) {
@@ -283,17 +289,11 @@ class WooPaymentsService {
 	 * @param bool   $overwrite Whether to overwrite the step status if it is already completed and update the timestamp.
 	 *
 	 * @return bool Whether the onboarding step was marked as completed.
-	 * @throws Exception If the given onboarding step ID is invalid.
+	 * @throws ApiArgumentException If the given onboarding step ID is invalid.
+	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
 	 */
 	public function set_onboarding_step_completed( string $step_id, string $location, bool $overwrite = false ): bool {
-		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
-			throw new Exception( 'Invalid onboarding step ID.' );
-		}
-
-		// Check step requirements.
-		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
-			throw new Exception( 'Onboarding step can no be completed because requirements are not met.' );
-		}
+		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
 		$statuses = (array) $this->get_nox_profile_onboarding_step_entry( $step_id, $location, 'statuses' );
 		if ( ! $overwrite && ! empty( $statuses[ self::ONBOARDING_STEP_STATUS_COMPLETED ] ) ) {
@@ -316,17 +316,20 @@ class WooPaymentsService {
 	 * @param array  $request_data The entire data received in the request.
 	 *
 	 * @return bool Whether the onboarding step data was saved.
-	 * @throws Exception If the given onboarding step ID or data are invalid.
+	 * @throws ApiArgumentException If the given onboarding step ID or step data is invalid.
+	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
 	 */
 	public function onboarding_step_save( string $step_id, string $location, array $request_data ): bool {
-		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
-			throw new Exception( 'Invalid onboarding step ID.' );
-		}
+		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
 		// Validate the received step data.
 		// If we didn't receive any known data for the step, we consider it an invalid save operation.
 		if ( ! $this->is_valid_onboarding_step_data( $step_id, $request_data ) ) {
-			throw new Exception( 'Invalid onboarding step data.' );
+			throw new ApiArgumentException(
+				'woocommerce_woopayments_onboarding_invalid_step_data',
+				esc_html__( 'Invalid onboarding step data.', 'woocommerce' ),
+				(int) WP_Http::NOT_ACCEPTABLE
+			);
 		}
 
 		$step_details = $this->get_nox_profile_onboarding_step( $step_id, $location );
@@ -350,7 +353,11 @@ class WooPaymentsService {
 				}
 				break;
 			default:
-				throw new Exception( 'Invalid onboarding step ID.' );
+				throw new ApiException(
+					'woocommerce_woopayments_onboarding_step_action_not_supported',
+					esc_html__( 'Save action not supported for the onboarding step ID.', 'woocommerce' ),
+					(int) WP_Http::NOT_ACCEPTABLE
+				);
 		}
 
 		// Store the updated step data.
@@ -411,17 +418,11 @@ class WooPaymentsService {
 	 *                         This is a ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return array The check result.
-	 * @throws Exception If the given onboarding step ID is invalid.
+	 * @throws ApiArgumentException If the given onboarding step ID or step data is invalid.
+	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
 	 */
 	public function onboarding_step_check( string $step_id, string $location ): array {
-		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
-			throw new Exception( 'Invalid onboarding step ID.' );
-		}
-
-		// Check step requirements.
-		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
-			throw new Exception( 'Onboarding step requirements are not met.' );
-		}
+		$this->check_if_onboarding_step_action_is_acceptable( $step_id, $location );
 
 		// Just return the step status, for now.
 		return array( 'status' => $this->get_onboarding_step_status( $step_id, $location ) );
@@ -448,37 +449,29 @@ class WooPaymentsService {
 	 *                         If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
 	 * @return array The result of the test account initialization.
-	 * @throws Exception If there was an error initializing the test account.
+	 * @throws ApiArgumentException|ApiException If the given onboarding step ID or step data is invalid.
+	 *                                           If the onboarding action can not be performed due to the current state
+	 *                                           of the site or there was an error initializing the test account.
 	 */
 	public function onboarding_test_account_init( string $location, string $source = '' ): array {
-		// Nothing to do if we already have a test account.
-		if ( $this->has_account() && $this->has_test_account() ) {
-			return array(
-				'message' => __( 'Test account is already set up.', 'woocommerce' ),
-			);
-		}
+		$this->check_if_onboarding_step_action_is_acceptable( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
-		// Check if the test account creation is already in progress.
-		if ( ! empty( $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'in_progress', false ) ) ) {
+		// Nothing to do if we already have a test account.
+		if ( $this->has_test_account() ) {
 			return array(
-				'message' => __( 'Test account creation is already in progress.', 'woocommerce' ),
+				'message' => esc_html__( 'A test account is already set up.', 'woocommerce' ),
 			);
 		}
 
 		// Nothing to do if there is an account, but it is not a test account.
 		if ( $this->has_account() ) {
 			return array(
-				'message' => __( 'An account is already set up. Reset the onboarding first.', 'woocommerce' ),
+				'message' => esc_html__( 'An account is already set up. Reset the onboarding first.', 'woocommerce' ),
 			);
 		}
 
-		// Check step requirements.
-		if ( ! $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-			throw new Exception( 'Onboarding step requirements are not met.' );
-		}
-
-		// Mark the test account step as in progress.
-		$this->save_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'in_progress', true );
+		// Lock the onboarding to prevent concurrent actions.
+		$this->set_onboarding_lock();
 
 		// Call the WooPayments API to initialize the test account.
 		$response = $this->proxy->call_static(
@@ -493,15 +486,24 @@ class WooPaymentsService {
 			)
 		);
 
-		// Mark the test account step as NOT in progress.
-		$this->save_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, 'in_progress', false );
+		// Unlock the onboarding after the API call finished.
+		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( esc_html( $response->get_error_message() ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html( $response->get_error_message() ),
+				(int) WP_Http::FAILED_DEPENDENCY,
+				map_deep( (array) $response->get_error_data(), 'esc_html' )
+			);
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( esc_html__( 'Failed to initialize the test account.', 'woocommerce' ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html__( 'Failed to initialize the test account.', 'woocommerce' ),
+				(int) WP_Http::FAILED_DEPENDENCY
+			);
 		}
 
 		return $response;
@@ -516,13 +518,19 @@ class WooPaymentsService {
 	 *                                If not provided, the stored data will be used.
 	 *
 	 * @return array The KYC account session data.
-	 * @throws Exception If the KYC session data could not be retrieved or there was an error.
+	 * @throws ApiException If the extension is not active, step requirements are not met, or
+	 *                      the KYC session data could not be retrieved.
 	 */
 	public function get_onboarding_kyc_session( string $location, array $self_assessment = array() ): array {
+		$this->check_if_onboarding_step_action_is_acceptable( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+
 		if ( empty( $self_assessment ) ) {
 			// Get the stored self-assessment data.
 			$self_assessment = (array) $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'self_assessment' );
 		}
+
+		// Lock the onboarding to prevent concurrent actions.
+		$this->set_onboarding_lock();
 
 		// Call the WooPayments API to get the KYC session.
 		$account_session = $this->proxy->call_static(
@@ -534,12 +542,24 @@ class WooPaymentsService {
 			)
 		);
 
+		// Unlock the onboarding after the API call finished.
+		$this->clear_onboarding_lock();
+
 		if ( is_wp_error( $account_session ) ) {
-			throw new Exception( esc_html( $account_session->get_error_message() ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html( $account_session->get_error_message() ),
+				(int) WP_Http::FAILED_DEPENDENCY,
+				map_deep( (array) $account_session->get_error_data(), 'esc_html' )
+			);
 		}
 
 		if ( ! is_array( $account_session ) ) {
-			throw new Exception( esc_html__( 'Failed to get KYC session data.', 'woocommerce' ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html__( 'Failed to get the KYC session data.', 'woocommerce' ),
+				(int) WP_Http::FAILED_DEPENDENCY
+			);
 		}
 
 		// Add the user locale to the account session data to allow for localized KYC sessions.
@@ -557,9 +577,15 @@ class WooPaymentsService {
 	 *                         If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
 	 * @return array The response from the WooPayments API.
-	 * @throws Exception If the KYC session could not be finished or there was an error.
+	 * @throws ApiException If the extension is not active, step requirements are not met, or
+	 *                      the KYC session could not be finished.
 	 */
 	public function finish_onboarding_kyc_session( string $location, string $source = '' ): array {
+		$this->check_if_onboarding_step_action_is_acceptable( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+
+		// Lock the onboarding to prevent concurrent actions.
+		$this->set_onboarding_lock();
+
 		// Call the WooPayments API to finalize the KYC session.
 		$response = $this->proxy->call_static(
 			Utils::class,
@@ -571,12 +597,24 @@ class WooPaymentsService {
 			)
 		);
 
+		// Unlock the onboarding after the API call finished.
+		$this->clear_onboarding_lock();
+
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( esc_html( $response->get_error_message() ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html( $response->get_error_message() ),
+				(int) WP_Http::FAILED_DEPENDENCY,
+				map_deep( (array) $response->get_error_data(), 'esc_html' )
+			);
 		}
 
 		if ( ! is_array( $response ) ) {
-			throw new Exception( esc_html__( 'Failed to finish the KYC session.', 'woocommerce' ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html__( 'Failed to finish the KYC session.', 'woocommerce' ),
+				(int) WP_Http::FAILED_DEPENDENCY
+			);
 		}
 
 		// Mark the business verification step as completed.
@@ -594,9 +632,14 @@ class WooPaymentsService {
 	 *                       If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
 	 * @return array The response from the WooPayments API.
-	 * @throws Exception If the KYC session could not be finished or there was an error.
+	 * @throws ApiException If we could not reset onboarding or there was an error.
 	 */
 	public function reset_onboarding( string $from = '', string $source = '' ): array {
+		$this->check_if_onboarding_action_is_acceptable();
+
+		// Lock the onboarding to prevent concurrent actions.
+		$this->set_onboarding_lock();
+
 		// Call the WooPayments API to reset onboarding.
 		$response = $this->proxy->call_static(
 			Utils::class,
@@ -608,15 +651,27 @@ class WooPaymentsService {
 			)
 		);
 
+		// Unlock the onboarding after the API call finished.
+		$this->clear_onboarding_lock();
+
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( esc_html( $response->get_error_message() ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html( $response->get_error_message() ),
+				(int) WP_Http::FAILED_DEPENDENCY,
+				map_deep( (array) $response->get_error_data(), 'esc_html' )
+			);
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( esc_html__( 'Failed to reset onboarding.', 'woocommerce' ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html__( 'Failed to reset onboarding.', 'woocommerce' ),
+				(int) WP_Http::FAILED_DEPENDENCY
+			);
 		}
 
-		// Remove NOX-specific onboarding data.
+		// Clean up any NOX-specific onboarding data.
 		$this->proxy->call_function( 'delete_option', self::NOX_PROFILE_OPTION_KEY );
 
 		return $response;
@@ -633,10 +688,15 @@ class WooPaymentsService {
 	 *                         If not provided, it will identify the source as the WC Admin Payments settings.
 	 *
 	 * @return array The response from the WooPayments API.
-	 * @throws Exception If the KYC session could not be finished or there was an error.
+	 * @throws ApiException If we could not disable the test account or there was an error.
 	 */
 	public function disable_test_account( string $location, string $from = '', string $source = '' ): array {
-		// Call the WooPayments API to reset onboarding.
+		$this->check_if_onboarding_action_is_acceptable();
+
+		// Lock the onboarding to prevent concurrent actions.
+		$this->set_onboarding_lock();
+
+		// Call the WooPayments API to disable the test account and prepare for the switch to live.
 		$response = $this->proxy->call_static(
 			Utils::class,
 			'rest_endpoint_post_request',
@@ -647,12 +707,24 @@ class WooPaymentsService {
 			)
 		);
 
+		// Unlock the onboarding after the API call finished.
+		$this->clear_onboarding_lock();
+
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( esc_html( $response->get_error_message() ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html( $response->get_error_message() ),
+				(int) WP_Http::FAILED_DEPENDENCY,
+				map_deep( (array) $response->get_error_data(), 'esc_html' )
+			);
 		}
 
 		if ( ! is_array( $response ) || empty( $response['success'] ) ) {
-			throw new Exception( esc_html__( 'Failed to disable test account.', 'woocommerce' ) );
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_client_api_error',
+				esc_html__( 'Failed to disable the test account.', 'woocommerce' ),
+				(int) WP_Http::FAILED_DEPENDENCY
+			);
 		}
 
 		// For sanity, make sure the payment methods step is marked as completed.
@@ -1162,11 +1234,12 @@ class WooPaymentsService {
 	/**
 	 * Check if the requirements for an onboarding step are met.
 	 *
-	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $step_id  The ID of the onboarding step.
 	 * @param string $location The location for which we are onboarding.
 	 *                         This is a ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return bool Whether the onboarding step requirements are met.
+	 * @throws ApiArgumentException If the given onboarding step ID is invalid.
 	 */
 	private function check_onboarding_step_requirements( string $step_id, string $location ): bool {
 		$requirements = $this->get_onboarding_step_required_steps( $step_id );

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -31,7 +31,8 @@ class WooPaymentsService {
 	const ACTION_TYPE_REST     = 'REST';
 	const ACTION_TYPE_REDIRECT = 'REDIRECT';
 
-	const NOX_PROFILE_OPTION_KEY = 'woocommerce_woopayments_nox_profile';
+	const NOX_PROFILE_OPTION_KEY    = 'woocommerce_woopayments_nox_profile';
+	const NOX_ONBOARDING_LOCKED_KEY = 'woocommerce_woopayments_nox_onboarding_locked';
 
 	const FROM_PAYMENT_SETTINGS = 'WCADMIN_PAYMENT_SETTINGS';
 	const FROM_NOX_IN_CONTEXT   = 'WCADMIN_NOX_IN_CONTEXT';
@@ -659,6 +660,98 @@ class WooPaymentsService {
 		$this->set_onboarding_step_completed( self::ONBOARDING_STEP_PAYMENT_METHODS, $location );
 
 		return $response;
+	}
+
+	/**
+	 * Check if an onboarding action should be allowed to be processed.
+	 *
+	 * @return void
+	 * @throws ApiException If the extension is not active or onboarding is locked.
+	 */
+	private function check_if_onboarding_action_is_acceptable() {
+		// If the WooPayments plugin is not active, we can't do anything.
+		if ( ! $this->is_extension_active() ) {
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_extension_not_active',
+				/* translators: %s: WooPayments. */
+				sprintf( esc_html__( 'The %s extension is not active.', 'woocommerce' ), 'WooPayments' ),
+				(int) WP_Http::FORBIDDEN
+			);
+		}
+
+		// If the onboarding is locked, we shouldn't do anything.
+		if ( $this->is_onboarding_locked() ) {
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_locked',
+				esc_html__( 'Another onboarding action is already in progress. Please wait for it to finish.', 'woocommerce' ),
+				(int) WP_Http::CONFLICT
+			);
+		}
+	}
+
+	/**
+	 * Check if an onboarding step action should be allowed to be processed.
+	 *
+	 * @param string $step_id The ID of the onboarding step.
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return void
+	 * @throws ApiArgumentException If the onboarding step ID is invalid.
+	 * @throws ApiException If the extension is not active or step requirements are not met.
+	 */
+	private function check_if_onboarding_step_action_is_acceptable( string $step_id, string $location ): void {
+		// First, check general onboarding actions.
+		$this->check_if_onboarding_action_is_acceptable();
+
+		// Second, do onboarding step specific checks.
+		if ( ! $this->is_valid_onboarding_step_id( $step_id ) ) {
+			throw new ApiArgumentException(
+				'woocommerce_woopayments_onboarding_invalid_step_id',
+				esc_html__( 'Invalid onboarding step ID.', 'woocommerce' ),
+				(int) WP_Http::BAD_REQUEST
+			);
+		}
+		if ( ! $this->check_onboarding_step_requirements( $step_id, $location ) ) {
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_step_requirements_not_met',
+				esc_html__( 'Onboarding step requirements are not met.', 'woocommerce' ),
+				(int) WP_Http::FORBIDDEN
+			);
+		}
+	}
+
+	/**
+	 * Check if the onboarding is locked.
+	 *
+	 * @return bool Whether the onboarding is locked.
+	 */
+	private function is_onboarding_locked(): bool {
+		return 'yes' === $this->proxy->call_function( 'get_option', self::NOX_ONBOARDING_LOCKED_KEY, 'no' );
+	}
+
+	/**
+	 * Lock the onboarding.
+	 *
+	 * This will save a flag in the database to indicate that onboarding is locked.
+	 * This is used to prevent certain onboarding actions to happen while others have not finished.
+	 * This is especially important for actions that modify the account (initializing it, deleting it, etc.)
+	 * These actions tend to be longer-running and we want to have backstops in place to prevent race conditions.
+	 *
+	 * @return void
+	 */
+	private function set_onboarding_lock(): void {
+		$this->proxy->call_function( 'update_option', self::NOX_ONBOARDING_LOCKED_KEY, 'yes' );
+	}
+
+	/**
+	 * Unlock the onboarding.
+	 *
+	 * @return void
+	 */
+	private function clear_onboarding_lock(): void {
+		// We update rather than delete the option for performance reasons.
+		$this->proxy->call_function( 'update_option', self::NOX_ONBOARDING_LOCKED_KEY, 'no' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -21,6 +21,11 @@ class WooPaymentsService {
 
 	const GATEWAY_ID = 'woocommerce_payments';
 
+	/**
+	 * The minimum required version of the WooPayments extension.
+	 */
+	const EXTENSION_MINIMUM_VERSION = '9.3.0';
+
 	const ONBOARDING_PATH_BASE = '/woopayments/onboarding';
 
 	const ONBOARDING_STEP_PAYMENT_METHODS       = 'payment_methods';
@@ -816,6 +821,16 @@ class WooPaymentsService {
 				'woocommerce_woopayments_onboarding_extension_not_active',
 				/* translators: %s: WooPayments. */
 				sprintf( esc_html__( 'The %s extension is not active.', 'woocommerce' ), 'WooPayments' ),
+				(int) WP_Http::FORBIDDEN
+			);
+		}
+
+		// If the WooPayments installed version is less than the minimum required version, we can't do anything.
+		if ( defined( 'WCPAY_VERSION_NUMBER' ) && version_compare( WCPAY_VERSION_NUMBER, self::EXTENSION_MINIMUM_VERSION, '<' ) ) {
+			throw new ApiException(
+				'woocommerce_woopayments_onboarding_extension_version',
+				/* translators: %s: WooPayments. */
+				sprintf( esc_html__( 'The %s extension is not up-to-date. Please update to the latest version and try again.', 'woocommerce' ), 'WooPayments' ),
 				(int) WP_Http::FORBIDDEN
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Exception;
+use WP_Error;
 use WP_Http;
 
 defined( 'ABSPATH' ) || exit;
@@ -473,20 +474,33 @@ class WooPaymentsService {
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
-		// Call the WooPayments API to initialize the test account.
-		$response = $this->proxy->call_static(
-			Utils::class,
-			'rest_endpoint_post_request',
-			'/wc/v3/payments/onboarding/test_drive_account/init',
-			array(
-				'country'      => $location,
-				'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
-				'source'       => ! empty( $source ) ? $source : self::FROM_NOX_IN_CONTEXT,
-				'from'         => self::FROM_NOX_IN_CONTEXT,
-			)
-		);
+		try {
+			// Call the WooPayments API to initialize the test account.
+			$response = $this->proxy->call_static(
+				Utils::class,
+				'rest_endpoint_post_request',
+				'/wc/v3/payments/onboarding/test_drive_account/init',
+				array(
+					'country'      => $location,
+					'capabilities' => ( ! empty( $step_data['payment_methods'] ) && is_array( $step_data['payment_methods'] ) ) ? $step_data['payment_methods'] : array(),
+					'source'       => ! empty( $source ) ? $source : self::FROM_NOX_IN_CONTEXT,
+					'from'         => self::FROM_NOX_IN_CONTEXT,
+				)
+			);
+		} catch ( Exception $e ) {
+			// Catch any exceptions to allow for proper error handling and onboarding unlock.
+			$response = new WP_Error(
+				'woocommerce_woopayments_onboarding_client_api_exception',
+				esc_html__( 'An unexpected error happened while initializing the test account.', 'woocommerce' ),
+				array(
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'trace'   => $e->getTrace(),
+				)
+			);
+		}
 
-		// Unlock the onboarding after the API call finished.
+		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {
@@ -532,17 +546,30 @@ class WooPaymentsService {
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
-		// Call the WooPayments API to get the KYC session.
-		$account_session = $this->proxy->call_static(
-			Utils::class,
-			'rest_endpoint_post_request',
-			'/wc/v3/payments/onboarding/kyc/session',
-			array(
-				'self_assessment' => $self_assessment,
-			)
-		);
+		try {
+			// Call the WooPayments API to get the KYC session.
+			$account_session = $this->proxy->call_static(
+				Utils::class,
+				'rest_endpoint_post_request',
+				'/wc/v3/payments/onboarding/kyc/session',
+				array(
+					'self_assessment' => $self_assessment,
+				)
+			);
+		} catch ( Exception $e ) {
+			// Catch any exceptions to allow for proper error handling and onboarding unlock.
+			$response = new WP_Error(
+				'woocommerce_woopayments_onboarding_client_api_exception',
+				esc_html__( 'An unexpected error happened while creating the KYC session.', 'woocommerce' ),
+				array(
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'trace'   => $e->getTrace(),
+				)
+			);
+		}
 
-		// Unlock the onboarding after the API call finished.
+		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $account_session ) ) {
@@ -586,18 +613,31 @@ class WooPaymentsService {
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
-		// Call the WooPayments API to finalize the KYC session.
-		$response = $this->proxy->call_static(
-			Utils::class,
-			'rest_endpoint_post_request',
-			'/wc/v3/payments/onboarding/kyc/finalize',
-			array(
-				'source' => ! empty( $source ) ? $source : self::FROM_PAYMENT_SETTINGS,
-				'from'   => self::FROM_NOX_IN_CONTEXT,
-			)
-		);
+		try {
+			// Call the WooPayments API to finalize the KYC session.
+			$response = $this->proxy->call_static(
+				Utils::class,
+				'rest_endpoint_post_request',
+				'/wc/v3/payments/onboarding/kyc/finalize',
+				array(
+					'source' => ! empty( $source ) ? $source : self::FROM_PAYMENT_SETTINGS,
+					'from'   => self::FROM_NOX_IN_CONTEXT,
+				)
+			);
+		} catch ( Exception $e ) {
+			// Catch any exceptions to allow for proper error handling and onboarding unlock.
+			$response = new WP_Error(
+				'woocommerce_woopayments_onboarding_client_api_exception',
+				esc_html__( 'An unexpected error happened while finalizing the KYC session.', 'woocommerce' ),
+				array(
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'trace'   => $e->getTrace(),
+				)
+			);
+		}
 
-		// Unlock the onboarding after the API call finished.
+		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {
@@ -640,18 +680,31 @@ class WooPaymentsService {
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
-		// Call the WooPayments API to reset onboarding.
-		$response = $this->proxy->call_static(
-			Utils::class,
-			'rest_endpoint_post_request',
-			'/wc/v3/payments/onboarding/reset',
-			array(
-				'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-				'source' => ! empty( $source ) ? esc_attr( $source ) : self::FROM_PAYMENT_SETTINGS,
-			)
-		);
+		try {
+			// Call the WooPayments API to reset onboarding.
+			$response = $this->proxy->call_static(
+				Utils::class,
+				'rest_endpoint_post_request',
+				'/wc/v3/payments/onboarding/reset',
+				array(
+					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+					'source' => ! empty( $source ) ? esc_attr( $source ) : self::FROM_PAYMENT_SETTINGS,
+				)
+			);
+		} catch ( Exception $e ) {
+			// Catch any exceptions to allow for proper error handling and onboarding unlock.
+			$response = new WP_Error(
+				'woocommerce_woopayments_onboarding_client_api_exception',
+				esc_html__( 'An unexpected error happened while resetting onboarding.', 'woocommerce' ),
+				array(
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'trace'   => $e->getTrace(),
+				)
+			);
+		}
 
-		// Unlock the onboarding after the API call finished.
+		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {
@@ -696,18 +749,31 @@ class WooPaymentsService {
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
-		// Call the WooPayments API to disable the test account and prepare for the switch to live.
-		$response = $this->proxy->call_static(
-			Utils::class,
-			'rest_endpoint_post_request',
-			'/wc/v3/payments/onboarding/test_drive_account/disable',
-			array(
-				'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-				'source' => ! empty( $source ) ? esc_attr( $source ) : self::FROM_PAYMENT_SETTINGS,
-			)
-		);
+		try {
+			// Call the WooPayments API to disable the test account and prepare for the switch to live.
+			$response = $this->proxy->call_static(
+				Utils::class,
+				'rest_endpoint_post_request',
+				'/wc/v3/payments/onboarding/test_drive_account/disable',
+				array(
+					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+					'source' => ! empty( $source ) ? esc_attr( $source ) : self::FROM_PAYMENT_SETTINGS,
+				)
+			);
+		} catch ( Exception $e ) {
+			// Catch any exceptions to allow for proper error handling and onboarding unlock.
+			$response = new WP_Error(
+				'woocommerce_woopayments_onboarding_client_api_exception',
+				esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
+				array(
+					'code'    => $e->getCode(),
+					'message' => $e->getMessage(),
+					'trace'   => $e->getTrace(),
+				)
+			);
+		}
 
-		// Unlock the onboarding after the API call finished.
+		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
 		if ( is_wp_error( $response ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestControllerTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings\PaymentProviders\WooPayments;
 
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsService;
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsRestController;
@@ -246,28 +247,6 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test handling onboarding step start with invalid step ID.
-	 */
-	public function test_onboarding_step_start_with_invalid_step_id() {
-		// Arrange.
-		$step_id      = 'invalid_step';
-		$country_code = 'US';
-		$this->mock_onboarding_details( $country_code );
-
-		$this->mock_woopayments_service
-			->expects( $this->never() )
-			->method( 'set_onboarding_step_started' );
-
-		// Act.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/start' );
-		$request->set_param( 'location', $country_code );
-		$response = $this->server->dispatch( $request );
-
-		// Assert.
-		$this->assertSame( 400, $response->get_status() );
-	}
-
-	/**
 	 * Test handling onboarding step start with invalid location.
 	 *
 	 * @dataProvider provider_invalid_location_provider
@@ -302,10 +281,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'set_onboarding_step_started' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/start' );
@@ -313,8 +295,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -368,28 +351,6 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test handling onboarding step save with invalid step ID.
-	 */
-	public function test_onboarding_step_save_with_invalid_step_id() {
-		// Arrange.
-		$step_id      = 'invalid_step';
-		$country_code = 'US';
-		$this->mock_onboarding_details( $country_code );
-
-		$this->mock_woopayments_service
-			->expects( $this->never() )
-			->method( 'onboarding_step_save' );
-
-		// Act.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/save' );
-		$request->set_param( 'location', $country_code );
-		$response = $this->server->dispatch( $request );
-
-		// Assert.
-		$this->assertSame( 400, $response->get_status() );
-	}
-
-	/**
 	 * Test handling onboarding step save with invalid location.
 	 *
 	 * @dataProvider provider_invalid_location_provider
@@ -424,10 +385,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'onboarding_step_save' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/save' );
@@ -435,8 +399,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -474,28 +439,6 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test handling onboarding step check with invalid step ID.
-	 */
-	public function test_onboarding_step_check_with_invalid_step_id() {
-		// Arrange.
-		$step_id      = 'invalid_step';
-		$country_code = 'US';
-		$this->mock_onboarding_details( $country_code );
-
-		$this->mock_woopayments_service
-			->expects( $this->never() )
-			->method( 'onboarding_step_check' );
-
-		// Act.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/check' );
-		$request->set_param( 'location', $country_code );
-		$response = $this->server->dispatch( $request );
-
-		// Assert.
-		$this->assertSame( 400, $response->get_status() );
-	}
-
-	/**
 	 * Test handling onboarding step check with invalid location.
 	 *
 	 * @dataProvider provider_invalid_location_provider
@@ -530,10 +473,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'onboarding_step_check' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/check' );
@@ -541,8 +487,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -582,28 +529,6 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test handling onboarding step finish with invalid step ID.
-	 */
-	public function test_onboarding_step_finish_with_invalid_step_id() {
-		// Arrange.
-		$step_id      = 'invalid_step';
-		$country_code = 'US';
-		$this->mock_onboarding_details( $country_code );
-
-		$this->mock_woopayments_service
-			->expects( $this->never() )
-			->method( 'set_onboarding_step_completed' );
-
-		// Act.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/finish' );
-		$request->set_param( 'location', $country_code );
-		$response = $this->server->dispatch( $request );
-
-		// Assert.
-		$this->assertSame( 400, $response->get_status() );
-	}
-
-	/**
 	 * Test handling onboarding step finish with invalid location.
 	 *
 	 * @dataProvider provider_invalid_location_provider
@@ -638,10 +563,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'set_onboarding_step_completed' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/finish' );
@@ -649,8 +577,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -730,10 +659,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'onboarding_test_account_init' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/init' );
@@ -741,8 +673,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -817,10 +750,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'get_onboarding_kyc_session' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/kyc_session' );
@@ -828,8 +764,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -903,10 +840,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$country_code = 'US';
 		$this->mock_onboarding_details( $country_code );
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'finish_onboarding_kyc_session' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/step/' . $step_id . '/kyc_session/finish' );
@@ -914,8 +854,9 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**
@@ -954,10 +895,13 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$from   = 'test-from';
 		$source = 'test-source';
 
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
 		$this->mock_woopayments_service
 			->expects( $this->once() )
 			->method( 'reset_onboarding' )
-			->willThrowException( new \Exception( 'Test exception' ) );
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
 
 		// Act.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/reset' );
@@ -966,8 +910,77 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
-		$this->assertSame( 500, $response->get_status() );
-		$this->assertSame( 'Test exception', $response->get_data()['message'] );
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
+	}
+
+	/**
+	 * Test disable test account.
+	 */
+	public function test_disable_test_account() {
+		// Arrange.
+		$location = 'US';
+		$from     = 'test-from';
+		$source   = 'test-source';
+
+		$this->mock_payments_service
+			->expects( $this->once() )
+			->method( 'get_country' )
+			->willReturn( $location );
+		$this->mock_woopayments_service
+			->expects( $this->once() )
+			->method( 'disable_test_account' )
+			->with( $location, $from, $source )
+			->willReturn( array( 'success' => true ) );
+
+		// Act.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/test_account/disable' );
+		$request->set_param( 'from', $from );
+		$request->set_param( 'source', $source );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+	}
+
+	/**
+	 * Test disable test account with exception.
+	 */
+	public function test_disable_test_account_with_exception() {
+		// Arrange.
+		$location = 'US';
+		$from     = 'test-from';
+		$source   = 'test-source';
+
+		$this->mock_payments_service
+			->expects( $this->once() )
+			->method( 'get_country' )
+			->willReturn( $location );
+
+		$expected_code      = 'test_exception';
+		$expected_message   = 'Test exception message.';
+		$expected_http_code = 123;
+		$this->mock_woopayments_service
+			->expects( $this->once() )
+			->method( 'disable_test_account' )
+			->with( $location, $from, $source )
+			->willThrowException( new ApiException( $expected_code, $expected_message, $expected_http_code ) );
+
+		// Act.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding/test_account/disable' );
+		$request->set_param( 'from', $from );
+		$request->set_param( 'source', $source );
+		$response = $this->server->dispatch( $request );
+
+		// Assert.
+		$this->assertSame( $expected_code, $response->get_data()['code'] );
+		$this->assertSame( $expected_message, $response->get_data()['message'] );
+		$this->assertSame( $expected_http_code, $response->get_status() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Settings\PaymentProviders\WooPayments;
 
 use Automattic\Jetpack\Connection\Manager as WPCOM_Connection_Manager;
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\PaymentGateway;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentProviders\WooPayments\WooPaymentsService;
@@ -173,7 +174,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	/**
 	 * Test get onboarding details when the extension is NOT active.
 	 */
-	public function test_get_onboarding_details_extension_not_active_throws(): void {
+	public function test_get_onboarding_details_throws_when_extension_not_active(): void {
 		$location = 'US';
 
 		// Arrange.
@@ -190,11 +191,46 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'WooPayments is not active.' );
+		// Act.
+		try {
+			$this->sut->get_onboarding_details( $location, '/some/path' );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test get onboarding details when the extension is active but the onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception If a request is not mocked.
+	 */
+	public function test_get_onboarding_details_throws_with_onboarding_locked(): void {
+		$location = 'US';
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
 
 		// Act.
-		$this->sut->get_onboarding_details( $location, '/some/path' );
+		try {
+			$this->sut->get_onboarding_details( $location, '/some/path' );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -2782,6 +2818,66 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test set_onboarding_step_started throws exception when extension is not active.
+	 */
+	public function test_set_onboarding_step_started_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test set_onboarding_step_started throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_set_onboarding_step_started_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
 	 * Test that set_onboarding_step_started throws an exception when an invalid step ID is provided.
 	 *
 	 * @return void
@@ -2813,10 +2909,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->method( 'has_connected_owner' )
 			->willReturn( false );
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Onboarding step can no be started because requirements are not met.' );
+		try {
+			$this->sut->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
-		$this->sut->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_requirements_not_met', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -2988,6 +3087,69 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test set_onboarding_step_completed throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_set_onboarding_step_completed_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->set_onboarding_step_started( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test set_onboarding_step_completed throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_set_onboarding_step_completed_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->set_onboarding_step_completed( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
 	 * Test that set_onboarding_step_completed throws an exception when an invalid step ID is provided.
 	 *
 	 * @return void
@@ -3019,10 +3181,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->method( 'has_connected_owner' )
 			->willReturn( false );
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Onboarding step can no be completed because requirements are not met.' );
-
-		$this->sut->set_onboarding_step_completed( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+		try {
+			$this->sut->set_onboarding_step_completed( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_requirements_not_met', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -3194,6 +3357,69 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test onboarding_step_save throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_onboarding_step_save_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->onboarding_step_save( WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS, $location, array() );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test onboarding_step_save throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_onboarding_step_save_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->onboarding_step_save( WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS, $location, array() );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
 	 * Test that onboarding_step_save throws an exception when an invalid step ID is provided.
 	 *
 	 * @return void
@@ -3229,10 +3455,22 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	public function test_onboarding_step_save_throws_on_step_without_support() {
 		$location = 'US';
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Invalid onboarding step ID.' );
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
 
-		$this->sut->onboarding_step_save( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location, array() );
+		try {
+			$this->sut->onboarding_step_save( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location, array() );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_action_not_supported', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -3458,6 +3696,69 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test onboarding_step_check throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_onboarding_step_check_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test onboarding_step_check throws excetion when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_onboarding_step_check_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->onboarding_step_check( WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+
+			$this->fail( 'Expected ApiException not thrown' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
 	 * Test that onboarding_step_check throws an exception when an invalid step ID is provided.
 	 *
 	 * @return void
@@ -3584,6 +3885,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	public function test_onboarding_test_account_init_with_existing_test_account() {
 		$location = 'US';
 
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
 		// Arrange the account.
 		$this->mock_provider
 			->expects( $this->any() )
@@ -3632,7 +3944,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertEquals(
 			array(
-				'message' => __( 'Test account is already set up.', 'woocommerce' ),
+				'message' => __( 'A test account is already set up.', 'woocommerce' ),
 			),
 			$result
 		);
@@ -3647,6 +3959,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 */
 	public function test_onboarding_test_account_init_with_existing_live_account() {
 		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
 
 		// Arrange the account.
 		$this->mock_provider
@@ -3704,12 +4027,44 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test onboarding_test_account_init that is already in progress.
+	 * Test onboarding_test_account_init throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_onboarding_test_account_init_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->onboarding_test_account_init( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test onboarding_test_account_init throws exception when onboarding is locked.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
-	public function test_onboarding_test_account_init_already_in_progress() {
+	public function test_onboarding_test_account_init_throws_with_onboarding_locked() {
 		$location = 'US';
 
 		// Arrange the account.
@@ -3718,26 +4073,12 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->method( 'is_account_connected' )
 			->willReturn( false );
 
-		// Arrange the NOX profile.
-		$step_id        = WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT;
-		$stored_profile = array(
-			'onboarding' => array(
-				$location => array(
-					'steps' => array(
-						$step_id => array(
-							'data' => array(
-								'in_progress' => true,
-							),
-						),
-					),
-				),
-			),
-		);
+		// Arrange the onboarding locked DB option.
 		$this->mockable_proxy->register_function_mocks(
 			array(
-				'get_option' => function ( $option_name, $default_value = null ) use ( $stored_profile ) {
-					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
-						return $stored_profile;
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
 					}
 
 					return $default_value;
@@ -3765,15 +4106,15 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		);
 
 		// Act.
-		$result = $this->sut->onboarding_test_account_init( $location );
+		try {
+			$this->sut->onboarding_test_account_init( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
 
 		// Assert.
-		$this->assertEquals(
-			array(
-				'message' => __( 'Test account creation is already in progress.', 'woocommerce' ),
-			),
-			$result
-		);
 		$this->assertCount( 0, $requests_made );
 	}
 
@@ -3796,10 +4137,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->method( 'has_connected_owner' )
 			->willReturn( false );
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Onboarding step requirements are not met.' );
+		try {
+			$this->sut->onboarding_test_account_init( $location );
 
-		$this->sut->onboarding_test_account_init( $location );
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_requirements_not_met', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -3966,7 +4310,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$location = 'US';
 
 		// Arrange the WPCOM connection.
-		// Make it working.
+		// Make it working since it is a dependency for the step.
 		$this->mock_wpcom_connection_manager
 			->expects( $this->any() )
 			->method( 'is_connected' )
@@ -4046,21 +4390,110 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		// Assert.
 		$this->assertEquals( $expected_response, $result );
 		$this->assertCount( 1, $requests_made );
-		$this->assertCount( 2, $updated_stored_profiles );
-		// The in_progress flag should have been set first to true, then to false.
-		$this->assertEquals(
-			array(
-				'in_progress' => true,
-			),
-			$updated_stored_profiles[0]['onboarding'][ $location ]['steps'][ $step_id ]['data']
-		);
-		$this->assertEquals(
-			array(
-				'in_progress' => false,
-			),
-			$updated_stored_profiles[1]['onboarding'][ $location ]['steps'][ $step_id ]['data']
-		);
+		$this->assertCount( 0, $updated_stored_profiles );
 		// There is no automatic completion of the step due to its async nature.
+	}
+
+	/**
+	 * Test get_onboarding_kyc_session throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_get_onboarding_kyc_session_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->get_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test get_onboarding_kyc_session throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_get_onboarding_kyc_session_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->get_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test get_onboarding_kyc_session throws exception when step requirements are not met.
+	 *
+	 * @return void
+	 */
+	public function test_get_onboarding_kyc_session_throws_on_unmet_requirements() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it NOT working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( false );
+
+		try {
+			$this->sut->get_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_requirements_not_met', $e->getErrorCode() );
+		}
 	}
 
 	/**
@@ -4070,6 +4503,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @throws \Exception On GET request not mocked.
 	 */
 	public function test_get_onboarding_kyc_session_throws_on_error_response() {
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
 		// Arrange the REST API requests.
 		$requests_made  = array();
 		$expected_error = array(
@@ -4096,7 +4540,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->expectExceptionMessage( $expected_error['message'] );
 
 		// Act.
-		$this->sut->get_onboarding_kyc_session( 'US', array(), true );
+		$this->sut->get_onboarding_kyc_session( 'US' );
 	}
 
 	/**
@@ -4106,6 +4550,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @throws \Exception On GET request not mocked.
 	 */
 	public function test_get_onboarding_kyc_session_throws_on_failure() {
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
 		// Arrange the REST API requests.
 		$requests_made = array();
 		// Not an array.
@@ -4125,12 +4580,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Assert.
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( esc_html__( 'Failed to get KYC session data.', 'woocommerce' ) );
-
 		// Act.
-		$this->sut->get_onboarding_kyc_session( 'US', array(), true );
+		try {
+			$this->sut->get_onboarding_kyc_session( 'US' );
+		} catch ( ApiException $exception ) {
+			$this->assertSame( 'woocommerce_woopayments_onboarding_client_api_error', $exception->getErrorCode() );
+			$this->assertSame( 'Failed to get the KYC session data.', $exception->getMessage() );
+		}
 	}
 
 	/**
@@ -4142,6 +4598,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	public function test_get_onboarding_kyc_session_uses_stored_data() {
 		$step_id  = WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION;
 		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
 
 		// Arrange the NOX profile.
 		$self_assessment = array(
@@ -4202,7 +4669,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		);
 
 		// Act.
-		$result = $this->sut->get_onboarding_kyc_session( $location, array() );
+		$result = $this->sut->get_onboarding_kyc_session( $location );
 
 		// Assert.
 		self::assertEquals( $expected_response + array( 'locale' => 'en_US' ), $result );
@@ -4223,6 +4690,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			'business_type' => 'individual',
 			'mcc'           => 4567,
 		);
+
+		// Arrange the WPCOM connection.
+		// Make it working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
 
 		// Arrange the NOX profile.
 		$stored_self_assessment = array(
@@ -4295,12 +4773,125 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test finish_onboarding_kyc_session throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_finish_onboarding_kyc_session_throws_when_extension_not_active() {
+		$location = 'US';
+
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->finish_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			self::assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test finish_onboarding_kyc_session throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_finish_onboarding_kyc_session_throws_with_onboarding_locked() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->finish_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			self::assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test finish_onboarding_kyc_session throws exception when step requirements are not met.
+	 *
+	 * @return void
+	 */
+	public function test_finish_onboarding_kyc_session_throws_on_unmet_requirements() {
+		$location = 'US';
+
+		// Arrange the WPCOM connection.
+		// Make it NOT working.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( false );
+
+		try {
+			$this->sut->finish_onboarding_kyc_session( $location );
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_step_requirements_not_met', $e->getErrorCode() );
+		}
+	}
+
+	/**
 	 * Test that finish_onboarding_kyc_session throws an exception when the REST API call fails.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
 	public function test_finish_onboarding_kyc_session_throws_on_error_response() {
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
 		// Arrange the REST API requests.
 		$requests_made  = array();
 		$expected_error = array(
@@ -4337,6 +4928,17 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @throws \Exception On POST request not mocked.
 	 */
 	public function test_finish_onboarding_kyc_session_throws_on_failure() {
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
 		// Arrange the REST API requests.
 		$requests_made = array();
 		// Not an array.
@@ -4473,6 +5075,76 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			$updated_stored_profiles[0]['onboarding'][ $location ]['steps'][ $step_id ]
 		);
+	}
+
+	/**
+	 * Test reset_onboarding throws exception when extension is not active.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_reset_onboarding_throws_when_extension_not_active() {
+		// Arrange.
+		// Mock the extension as not active.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'class_exists' => function ( $class_to_check ) {
+					if ( '\WC_Payments' === $class_to_check ) {
+						return false;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		try {
+			$this->sut->reset_onboarding();
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			self::assertEquals( 'woocommerce_woopayments_onboarding_extension_not_active', $e->getErrorCode() );
+		}
+	}
+
+	/**
+	 * Test reset_onboarding throws exception when onboarding is locked.
+	 *
+	 * @return void
+	 * @throws \Exception When trying to mock uncallable user functions.
+	 */
+	public function test_reset_onboarding_throws_with_onboarding_locked() {
+		// Arrange the WPCOM connection.
+		// Make it working since it is a dependency for the step.
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+		$this->mock_wpcom_connection_manager
+			->expects( $this->any() )
+			->method( 'has_connected_owner' )
+			->willReturn( true );
+
+		// Arrange the onboarding locked DB option.
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default_value = null ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name ) {
+						return 'yes';
+					}
+
+					return $default_value;
+				},
+			)
+		);
+
+		try {
+			$this->sut->reset_onboarding();
+
+			$this->fail( 'Expected ApiException not thrown.' );
+		} catch ( ApiException $e ) {
+			$this->assertEquals( 'woocommerce_woopayments_onboarding_locked', $e->getErrorCode() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We make the following changes to the backend API:
1. We introduce a global onboarding lock (via a WP option) to prevent concurrent onboarding actions from taking place (including read actions that are not idempotent)
2. We introduce stricter, standardized, and layered onboarding action checks (from the WooPayments extension needing to be active down to an action associated with a certain step requiring that step's requirements to be met).
3. We introduce dedicated exceptions that the business logic layer will use to communicate with the REST API controller layer. These allow for more granular and informative API responses, including more deliberate HTTP status codes.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4102

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. The code changes should make sense and align with the overall API design.
2. The PHPUnit tests should pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
