### PR TITLE
Don't validate hidden postcodes in Checkout block

### DIFF
--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -148,7 +148,8 @@ export const useFormValidation = (
 		if (
 			hasSchemaRules( field, 'validation' ) && // Schema validation only run for fields with validation rules.
 			! field.hidden && // And visible
-			( field.required || field.key in values ) // And is required or has a optional with a value (or both).
+			// @ts-expect-error
+			( field.required || values[ field.key ] ) // And is required or has a optional with a value (or both).
 		) {
 			acc[ field.key ] = field.rules.validation;
 		}
@@ -219,8 +220,13 @@ export const useFormValidation = (
 				return [ field.key, schemaErrorsMap[ field.key ] ];
 			}
 
-			// Pass validation if the field is not required and is empty.
-			if ( ! field.required && ! ( field.key in values ) ) {
+			if (
+				// Skip validation if
+				field.hidden || // the field is hidden
+				// @ts-expect-error
+				! ( field.required || values[ field.key ] ) // the field is not required and doesn't have a value
+				// the field is not in the values
+			) {
 				return null;
 			}
 

--- a/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
+++ b/plugins/woocommerce-blocks/assets/js/base/components/cart-checkout/form/use-form-validation.ts
@@ -148,7 +148,7 @@ export const useFormValidation = (
 		if (
 			hasSchemaRules( field, 'validation' ) && // Schema validation only run for fields with validation rules.
 			! field.hidden && // And visible
-			// @ts-expect-error
+			// @ts-expect-error field.key is part of values but TS can't seem to figure that out.
 			( field.required || values[ field.key ] ) // And is required or has a optional with a value (or both).
 		) {
 			acc[ field.key ] = field.rules.validation;
@@ -223,7 +223,7 @@ export const useFormValidation = (
 			if (
 				// Skip validation if
 				field.hidden || // the field is hidden
-				// @ts-expect-error
+				// @ts-expect-error field.key is part of values but TS can't seem to figure that out.
 				! ( field.required || values[ field.key ] ) // the field is not required and doesn't have a value
 				// the field is not in the values
 			) {

--- a/plugins/woocommerce/changelog/57594-fix-dont-validate-hidden-postcode
+++ b/plugins/woocommerce/changelog/57594-fix-dont-validate-hidden-postcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't run postcode validation for hidden postcodes.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug in which hidden (but previously required) postcode would prevent Checkout from being placed. By default, this bug doesn't affect any country, only via modifying Checkout via `woocommerce_get_country_locale` would a site be affected.

Closes WOOPLUG-4095

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/55254 but made visible in https://github.com/woocommerce/woocommerce/pull/57128


### How to test the changes in this Pull Request:
0. Add the following snippet:
```php
add_filter(
	'woocommerce_get_country_locale',
	function ( array $locale ): array {
		$locale['RO']['postcode'] = array(
			'required' => false,
			'hidden'   => true,
		);
		return $locale;
	}
);

```
2. On Checkout, select Romania.
3. Fill out your address, make sure you can place an address.
4. Select a country with a postcode visible and required.
5. Make sure you can't place an order without filling a correct postcode.
6. Select a country with no postcode (e.g UAE), make sure you can place an order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Don't run postcode validation for hidden postcodes.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
