### PR TITLE
[Checkout] Avoid rounding shipping price when creating shipping line items

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-230-shipping-net-price-is-rounded-to-2-positions-after-the
+++ b/plugins/woocommerce/changelog/wooplug-230-shipping-net-price-is-rounded-to-2-positions-after-the
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid rounding shipping price when creating shipping line items to match products

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -942,7 +942,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected function get_values_for_total( $field ) {
 		$items = array_map(
 			function ( $item ) use ( $field ) {
-				return wc_add_number_precision( $item[ $field ], false );
+				return wc_add_number_precision( (float) $item[ $field ], false );
 			},
 			array_values( $this->get_items() )
 		);

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -301,7 +301,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 					'calc_tax'       => 'per_order', // Calc tax per_order or per_item. Per item needs an array of costs.
 					'meta_data'      => array(), // Array of misc meta data to store along with this rate - key value pairs.
 					'package'        => false, // Package array this rate was generated for @since 2.6.0.
-					'price_decimals' => wc_get_price_decimals(),
+					'price_decimals' => false,
 				)
 			),
 			$this

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -662,15 +662,17 @@ final class WC_Cart_Totals {
 			$item->total_tax = 0;
 
 			if ( has_filter( 'woocommerce_get_discounted_price' ) ) {
-				/**
-				 * Allow plugins to filter this price like in the legacy cart class.
-				 *
-				 * This is legacy and should probably be deprecated in the future.
-				 * $item->object is the cart item object.
-				 * $this->cart is the cart object.
-				 */
 				$item->total = wc_add_number_precision(
-					apply_filters( 'woocommerce_get_discounted_price', wc_remove_number_precision( $item->total ), $item->object, $this->cart )
+					/**
+					 * Allow plugins to filter this price like in the legacy cart class.
+					 *
+					 * This is legacy and should probably be deprecated in the future.
+					 * $item->object is the cart item object.
+					 * $this->cart is the cart object.
+					 *
+					 * @since 3.2.0
+					 */
+					(float) apply_filters( 'woocommerce_get_discounted_price', wc_remove_number_precision( $item->total ), $item->object, $this->cart )
 				);
 			}
 

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -389,7 +389,7 @@ class WC_Discounts {
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
-				$filtered_discount = wc_add_number_precision( (float) apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
+				$filtered_discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 
 				if ( $filtered_discount !== $discount ) {
 					$discount              = $filtered_discount;
@@ -454,7 +454,7 @@ class WC_Discounts {
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
-				$discount = wc_add_number_precision( (float) apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
+				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
 
 			$discount       = min( $discounted_price, $discount );

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -389,7 +389,7 @@ class WC_Discounts {
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
-				$filtered_discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
+				$filtered_discount = wc_add_number_precision( (float) apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 
 				if ( $filtered_discount !== $discount ) {
 					$discount              = $filtered_discount;
@@ -427,7 +427,7 @@ class WC_Discounts {
 	 */
 	protected function apply_coupon_fixed_product( $coupon, $items_to_apply, $amount = null ) {
 		$total_discount  = 0;
-		$amount          = $amount ? $amount : wc_add_number_precision( $coupon->get_amount() );
+		$amount          = $amount ? $amount : wc_add_number_precision( (float) $coupon->get_amount() );
 		$limit_usage_qty = 0;
 		$applied_count   = 0;
 
@@ -454,7 +454,7 @@ class WC_Discounts {
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
-				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
+				$discount = wc_add_number_precision( (float) apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
 
 			$discount       = min( $discounted_price, $discount );
@@ -478,7 +478,7 @@ class WC_Discounts {
 	 */
 	protected function apply_coupon_fixed_cart( $coupon, $items_to_apply, $amount = null ) {
 		$total_discount = 0;
-		$amount         = $amount ? $amount : wc_add_number_precision( $coupon->get_amount() );
+		$amount         = $amount ? $amount : wc_add_number_precision( (float) $coupon->get_amount() );
 		$items_to_apply = array_filter( $items_to_apply, array( $this, 'filter_products_with_price' ) );
 		$item_count     = array_sum( wp_list_pluck( $items_to_apply, 'quantity' ) );
 
@@ -537,7 +537,7 @@ class WC_Discounts {
 			$apply_quantity = max( 0, apply_filters( 'woocommerce_coupon_get_apply_quantity', $apply_quantity, $item, $coupon, $this ) );
 
 			// Run coupon calculations.
-			$discount      = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $apply_quantity;
+			$discount      = wc_add_number_precision( (float) $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $apply_quantity;
 			$discount      = wc_round_discount( min( $discounted_price, $discount ), 0 );
 			$applied_count = $applied_count + $apply_quantity;
 
@@ -565,7 +565,7 @@ class WC_Discounts {
 		$total_discount = 0;
 
 		foreach ( $items_to_apply as $item ) {
-			for ( $i = 0; $i < $item->quantity; $i ++ ) {
+			for ( $i = 0; $i < $item->quantity; $i++ ) {
 				// Find out how much price is available to discount for the item.
 				$price_to_discount = $this->get_discounted_price_in_cents( $item );
 
@@ -1088,9 +1088,9 @@ class WC_Discounts {
 	 */
 	protected function get_object_subtotal() {
 		if ( is_a( $this->object, 'WC_Cart' ) ) {
-			return wc_add_number_precision( $this->object->get_displayed_subtotal() );
+			return wc_add_number_precision( (float) $this->object->get_displayed_subtotal() );
 		} elseif ( is_a( $this->object, 'WC_Order' ) ) {
-			$subtotal = wc_add_number_precision( $this->object->get_subtotal() );
+			$subtotal = wc_add_number_precision( (float) $this->object->get_subtotal() );
 
 			if ( $this->object->get_prices_include_tax() ) {
 				// Add tax to tax-exclusive subtotal.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2064,7 +2064,7 @@ function wc_remove_number_precision( $value ) {
  */
 function wc_add_number_precision_deep( $value, $round = true ) {
 	if ( ! is_array( $value ) ) {
-		return wc_add_number_precision( $value, $round );
+		return wc_add_number_precision( (float) $value, $round );
 	}
 
 	foreach ( $value as $key => $sub_value ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents rounding of shipping costs before line items are created. This matches how products are handled. 

Since the UI does not allow longer decimal values to be input, testing this requires some settings manipulation. The change should not impact existing tests.

Closes #27626

### How to test the changes in this Pull Request:

Regular testers should only check for regressions:

1. Setup a product and flat rate shipping
2. Place order
3. Check order totals match the cart and the shipping line item was created with the correct costs

To check the updated logic is working you need to manipulate the flat rate costs.

1. WC > Settings > General. Set decimal precision to 5
2. WC > Settings > Shipping. Set flat rate shipping cost to 18.12345
3. WC > Settings > General. Set decimal precision to 2
4. Place order using flat rate shipping
5. Edit order in background. Change status to pending, save, and then edit the shipping line item. Check the total is `18.12345` as opposed to `18.12` which would be saved before this patch.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
