### PR TITLE
[Experimental] Add Product Reviews Pagination block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3855-reviews-pagination-block
+++ b/plugins/woocommerce/changelog/wooplug-3855-reviews-pagination-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add experimental Product Reviews Pagination block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-next",
 	"title": "Product Reviews Next Page",
 	"category": "theme",
-	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the next product review's page link.",
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-reviews-pagination-next",
+	"title": "Product Reviews Next Page",
+	"category": "theme",
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"description": "Displays the next product review's page link.",
+	"textdomain": "woocommerce",
+	"attributes": {
+		"label": {
+			"type": "string"
+		}
+	},
+	"usesContext": [ "postId", "reviews/paginationArrow" ],
+	"supports": {
+		"reusable": false,
+		"html": false,
+		"color": {
+			"gradients": true,
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-next",
 	"title": "Product Reviews Next Page",
 	"category": "woocommerce",
-	"parent": [ "woocommerce/product-reviews-pagination" ],
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the next product review's page link.",
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-next",
 	"title": "Product Reviews Next Page",
-	"category": "theme",
+	"category": "woocommerce",
 	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the next product review's page link.",
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/edit.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, PlainText } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+
+const arrowMap = {
+	none: '',
+	arrow: '→',
+	chevron: '»',
+};
+
+type Props = BlockEditProps< { label: string } > & {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	context: { 'reviews/paginationArrow': string };
+};
+
+export default function Edit( {
+	attributes: { label },
+	setAttributes,
+	context: { 'reviews/paginationArrow': paginationArrow },
+}: Props ) {
+	const displayArrow = arrowMap[ paginationArrow as keyof typeof arrowMap ];
+	return (
+		<a
+			href="#reviews-pagination-next-pseudo-link"
+			onClick={ ( event ) => event.preventDefault() }
+			{ ...useBlockProps() }
+		>
+			<PlainText
+				__experimentalVersion={ 2 }
+				tagName="span"
+				aria-label={ __( 'Newer reviews page link', 'woocommerce' ) }
+				placeholder={ __( 'Newer Reviews', 'woocommerce' ) }
+				value={ label }
+				onChange={ ( newLabel ) =>
+					setAttributes( { label: newLabel } )
+				}
+			/>
+			{ displayArrow && (
+				<span
+					className={ `wp-block-woocommerce-product-reviews-pagination-next-arrow is-arrow-${ paginationArrow }` }
+				>
+					{ displayArrow }
+				</span>
+			) }
+		</a>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
@@ -11,8 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 
-const { name } = metadata;
-export { metadata, name };
 
 // @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { queryPaginationNext as icon } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+// @ts-expect-error metadata is not typed.
+registerBlockType( metadata, {
+	icon,
+	edit,
+	example: {
+		attributes: {
+			label: __( 'Newer Reviews', 'woocommerce' ),
+		},
+	},
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/index.tsx
@@ -11,7 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 
-
 // @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {
 	icon,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-numbers",
 	"title": "Product Reviews Page Numbers",
 	"category": "woocommerce",
-	"parent": [ "woocommerce/product-reviews-pagination" ],
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays a list of page numbers for product reviews pagination.",
 	"textdomain": "woocommerce",
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-numbers",
 	"title": "Product Reviews Page Numbers",
 	"category": "theme",
-	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays a list of page numbers for product reviews pagination.",
 	"textdomain": "woocommerce",
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-reviews-pagination-numbers",
+	"title": "Product Reviews Page Numbers",
+	"category": "theme",
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"description": "Displays a list of page numbers for product reviews pagination.",
+	"textdomain": "woocommerce",
+	"usesContext": [ "postId" ],
+	"supports": {
+		"reusable": false,
+		"html": false,
+		"color": {
+			"gradients": true,
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-numbers",
 	"title": "Product Reviews Page Numbers",
-	"category": "theme",
+	"category": "woocommerce",
 	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays a list of page numbers for product reviews pagination.",
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/edit.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import type { ElementType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+const PaginationItem = ( {
+	content,
+	tag: Tag = 'a',
+	extraClass = '',
+}: {
+	content: string;
+	tag?: ElementType;
+	extraClass?: string;
+} ) =>
+	Tag === 'a' ? (
+		<Tag
+			className={ `page-numbers ${ extraClass }` }
+			href="#comments-pagination-numbers-pseudo-link"
+			onClick={ ( event ) => event.preventDefault() }
+		>
+			{ content }
+		</Tag>
+	) : (
+		<Tag className={ `page-numbers ${ extraClass }` }>{ content }</Tag>
+	);
+
+export default function Edit() {
+	return (
+		<div { ...useBlockProps() }>
+			<PaginationItem content="1" />
+			<PaginationItem content="2" />
+			<PaginationItem content="3" tag="span" extraClass="current" />
+			<PaginationItem content="4" />
+			<PaginationItem content="5" />
+			<PaginationItem content="..." tag="span" extraClass="dots" />
+			<PaginationItem content="8" />
+		</div>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/editor.scss
@@ -1,0 +1,12 @@
+.wp-block-woocommerce-product-reviews-pagination-numbers {
+	a {
+		text-decoration: underline;
+	}
+	.page-numbers {
+		margin-right: 2px;
+		&:last-child {
+			/*rtl:ignore*/
+			margin-right: 0;
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { queryPaginationNumbers as icon } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+registerBlockType( metadata, {
+	icon,
+	edit,
+	example: {},
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/index.tsx
@@ -10,9 +10,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 
-const { name } = metadata;
-export { metadata, name };
-
+// @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {
 	icon,
 	edit,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-previous",
 	"title": "Product Reviews Previous Page",
 	"category": "woocommerce",
-	"parent": [ "woocommerce/product-reviews-pagination" ],
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the previous product review's page link.",
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-reviews-pagination-previous",
+	"title": "Product Reviews Previous Page",
+	"category": "theme",
+	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"description": "Displays the previous product review's page link.",
+	"textdomain": "woocommerce",
+	"attributes": {
+		"label": {
+			"type": "string"
+		}
+	},
+	"usesContext": [ "postId", "reviews/paginationArrow" ],
+	"supports": {
+		"reusable": false,
+		"html": false,
+		"color": {
+			"gradients": true,
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -4,7 +4,7 @@
 	"name": "woocommerce/product-reviews-pagination-previous",
 	"title": "Product Reviews Previous Page",
 	"category": "theme",
-	"ancestor": [ "woocommerce/product-reviews-pagination" ],
+	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the previous product review's page link.",
 	"textdomain": "woocommerce",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-previous",
 	"title": "Product Reviews Previous Page",
-	"category": "theme",
+	"category": "woocommerce",
 	"parent": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the previous product review's page link.",
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/edit.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, PlainText } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+
+const arrowMap = {
+	none: '',
+	arrow: '←',
+	chevron: '«',
+};
+
+type Props = BlockEditProps< { label: string } > & {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	context: { 'reviews/paginationArrow': string };
+};
+
+export default function Edit( {
+	attributes: { label },
+	setAttributes,
+	context: { 'reviews/paginationArrow': paginationArrow },
+}: Props ) {
+	const displayArrow = arrowMap[ paginationArrow as keyof typeof arrowMap ];
+	return (
+		<a
+			href="#reviews-pagination-previous-pseudo-link"
+			onClick={ ( event ) => event.preventDefault() }
+			{ ...useBlockProps() }
+		>
+			{ displayArrow && (
+				<span
+					className={ `wp-block-woocommerce-product-reviews-pagination-previous-arrow is-arrow-${ paginationArrow }` }
+				>
+					{ displayArrow }
+				</span>
+			) }
+			<PlainText
+				__experimentalVersion={ 2 }
+				tagName="span"
+				aria-label={ __( 'Older reviews page link', 'woocommerce' ) }
+				placeholder={ __( 'Older Reviews', 'woocommerce' ) }
+				value={ label }
+				onChange={ ( newLabel ) =>
+					setAttributes( { label: newLabel } )
+				}
+			/>
+		</a>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
@@ -11,8 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 
-const { name } = metadata;
-export { metadata, name };
 
 // @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { queryPaginationPrevious as icon } from '@wordpress/icons';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+// @ts-expect-error metadata is not typed.
+registerBlockType( metadata, {
+	icon,
+	edit,
+	example: {
+		attributes: {
+			label: __( 'Older Reviews', 'woocommerce' ),
+		},
+	},
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/index.tsx
@@ -11,7 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import edit from './edit';
 
-
 // @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {
 	icon,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce/product-reviews-pagination",
+	"title": "Product Reviews Pagination",
+	"category": "woocommerce",
+	"ancestor": [ "woocommerce/blockified-product-reviews" ],
+	"allowedBlocks": [
+		"woocommerce/product-reviews-pagination-previous",
+		"woocommerce/product-reviews-pagination-numbers",
+		"woocommerce/product-reviews-pagination-next"
+	],
+	"description": "Displays a paginated navigation to next/previous set of product reviews, when applicable.",
+	"textdomain": "woocommerce",
+	"attributes": {
+		"paginationArrow": {
+			"type": "string",
+			"default": "none"
+		}
+	},
+	"example": {
+		"attributes": {
+			"paginationArrow": "none"
+		}
+	},
+	"providesContext": {
+		"reviews/paginationArrow": "paginationArrow"
+	},
+	"supports": {
+		"align": true,
+		"reusable": false,
+		"html": false,
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true,
+				"link": true
+			}
+		},
+		"layout": {
+			"allowSwitching": false,
+			"allowInheriting": false,
+			"default": {
+				"type": "flex"
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
@@ -43,8 +43,7 @@
 			"allowSwitching": false,
 			"allowInheriting": false,
 			"default": {
-				"type": "flex",
-				"justifyContent": "space-between"
+				"type": "flex"
 			}
 		},
 		"typography": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
@@ -43,7 +43,8 @@
 			"allowSwitching": false,
 			"allowInheriting": false,
 			"default": {
-				"type": "flex"
+				"type": "flex",
+				"justifyContent": "space-between"
 			}
 		},
 		"typography": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
@@ -35,6 +35,8 @@ export default function Edit( {
 }: Props ) {
 	const hasNextPreviousBlocks = useSelect(
 		( select ) => {
+			// TODO: remove the @ts-expect-error comment and typecast for innerBlock once we upgrade @wordpress/block-editor types version.
+			// @ts-expect-error We're using an outdated types of `@wordpress/block-editor`, so the property 'getBlocks' does not exist on type returned by select.
 			const { getBlocks } = select( blockEditorStore );
 			const innerBlocks = getBlocks( clientId );
 			/**
@@ -42,7 +44,7 @@ export default function Edit( {
 			 * Product Reviews Pagination Next or Product Reviews Pagination Previous
 			 * block exists.
 			 */
-			return innerBlocks?.find( ( innerBlock ) => {
+			return innerBlocks?.find( ( innerBlock: { name: string } ) => {
 				return [
 					'woocommerce/product-reviews-pagination-previous',
 					'woocommerce/product-reviews-pagination-next',
@@ -59,6 +61,7 @@ export default function Edit( {
 
 	// Get the Discussion settings
 	const pageComments = useSelect( ( select ) => {
+		// @ts-expect-error We're using an outdated types of `@wordpress/block-editor`, so the property 'getSettings' does not exist on type returned by select.
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
 		return __experimentalDiscussionSettings?.pageComments;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
@@ -71,7 +71,7 @@ export default function Edit( {
 		return (
 			<Warning>
 				{ __(
-					'Product Reviews Pagination block: paging reviews is disabled in the Discussion Settings',
+					'Product Reviews Pagination block: paging comments is disabled in the Discussion Settings',
 					'woocommerce'
 				) }
 			</Warning>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/edit.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { PanelBody } from '@wordpress/components';
+import type { BlockEditProps } from '@wordpress/blocks';
+import {
+	InspectorControls,
+	useBlockProps,
+	// @ts-expect-error useInnerBlocksProps is not exported from @wordpress/block-editor
+	useInnerBlocksProps,
+	store as blockEditorStore,
+	Warning,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ReviewsPaginationArrowControls } from './reviews-pagination-arrow-controls';
+import './editor.scss';
+
+const TEMPLATE = [
+	[ 'woocommerce/product-reviews-pagination-previous' ],
+	[ 'woocommerce/product-reviews-pagination-numbers' ],
+	[ 'woocommerce/product-reviews-pagination-next' ],
+];
+
+type Props = BlockEditProps< { paginationArrow: string | number | undefined } >;
+
+export default function Edit( {
+	attributes: { paginationArrow },
+	setAttributes,
+	clientId,
+}: Props ) {
+	const hasNextPreviousBlocks = useSelect(
+		( select ) => {
+			const { getBlocks } = select( blockEditorStore );
+			const innerBlocks = getBlocks( clientId );
+			/**
+			 * Show the `paginationArrow` control only if a
+			 * Product Reviews Pagination Next or Product Reviews Pagination Previous
+			 * block exists.
+			 */
+			return innerBlocks?.find( ( innerBlock ) => {
+				return [
+					'woocommerce/product-reviews-pagination-previous',
+					'woocommerce/product-reviews-pagination-next',
+				].includes( innerBlock.name );
+			} );
+		},
+		[ clientId ]
+	);
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+	} );
+
+	// Get the Discussion settings
+	const pageComments = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalDiscussionSettings } = getSettings();
+		return __experimentalDiscussionSettings?.pageComments;
+	}, [] );
+
+	// If paging comments is not enabled in the Discussion Settings then hide the pagination
+	// controls. We don't want to remove them from the template so that when the user enables
+	// paging comments, the controls will be visible.
+	if ( ! pageComments ) {
+		return (
+			<Warning>
+				{ __(
+					'Product Reviews Pagination block: paging reviews is disabled in the Discussion Settings',
+					'woocommerce'
+				) }
+			</Warning>
+		);
+	}
+
+	return (
+		<>
+			{ hasNextPreviousBlocks && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+						<ReviewsPaginationArrowControls
+							value={ paginationArrow }
+							onChange={ ( value ) => {
+								setAttributes( {
+									paginationArrow: value,
+								} );
+							} }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
+			<div { ...innerBlocksProps } />
+		</>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
@@ -1,0 +1,35 @@
+$pagination-margin: 0.5em;
+
+// Center flex items. This has an equivalent in style.scss.
+.wp-block[data-align="center"] > .wp-block-reviews-pagination {
+	justify-content: center;
+}
+
+:where(.editor-styles-wrapper) {
+	.wp-block-reviews-pagination {
+		max-width: 100%;
+		&.block-editor-block-list__layout {
+			margin: 0;
+		}
+	}
+}
+
+.wp-block-reviews-pagination {
+	> .wp-block-reviews-pagination-next,
+	> .wp-block-reviews-pagination-previous,
+	> .wp-block-reviews-pagination-numbers {
+		// Override editor auto block margins.
+		margin-left: 0;
+		margin-top: $pagination-margin;
+
+		/*rtl:ignore*/
+		margin-right: $pagination-margin;
+		margin-bottom: $pagination-margin;
+
+		font-size: inherit;
+		&:last-child {
+			/*rtl:ignore*/
+			margin-right: 0;
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
@@ -1,12 +1,13 @@
 $pagination-margin: 0.5em;
 
 // Center flex items. This has an equivalent in style.scss.
-.wp-block[data-align="center"] > .wp-block-reviews-pagination {
+.wp-block[data-align="center"]
+	> .wp-block-woocommerce-product-reviews-pagination {
 	justify-content: center;
 }
 
 :where(.editor-styles-wrapper) {
-	.wp-block-reviews-pagination {
+	.wp-block-woocommerce-product-reviews-pagination {
 		max-width: 100%;
 		&.block-editor-block-list__layout {
 			margin: 0;
@@ -14,10 +15,10 @@ $pagination-margin: 0.5em;
 	}
 }
 
-.wp-block-reviews-pagination {
-	> .wp-block-reviews-pagination-next,
-	> .wp-block-reviews-pagination-previous,
-	> .wp-block-reviews-pagination-numbers {
+.wp-block-woocommerce-product-reviews-pagination {
+	> .wp-block-woocommerce-product-reviews-pagination-next,
+	> .wp-block-woocommerce-product-reviews-pagination-previous,
+	> .wp-block-woocommerce-product-reviews-pagination-numbers {
 		// Override editor auto block margins.
 		margin-left: 0;
 		margin-top: $pagination-margin;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/editor.scss
@@ -1,8 +1,7 @@
 $pagination-margin: 0.5em;
 
 // Center flex items. This has an equivalent in style.scss.
-.wp-block[data-align="center"]
-	> .wp-block-woocommerce-product-reviews-pagination {
+.wp-block[data-align="center"] > .wp-block-woocommerce-product-reviews-pagination {
 	justify-content: center;
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { queryPagination as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+import './style.scss';
+
+// @ts-expect-error metadata is not typed.
+registerBlockType( metadata, {
+	icon,
+	edit,
+	save,
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/reviews-pagination-arrow-controls.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/reviews-pagination-arrow-controls.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+
+export function ReviewsPaginationArrowControls( {
+	value,
+	onChange,
+}: {
+	value: string | number | undefined;
+	onChange: ( value: string | number | undefined ) => void;
+} ) {
+	return (
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Arrow', 'woocommerce' ) }
+			value={ value }
+			onChange={ onChange }
+			help={ __(
+				'A decorative arrow appended to the next and previous product reviews link.',
+				'woocommerce'
+			) }
+			isBlock
+		>
+			<ToggleGroupControlOption
+				value="none"
+				label={ _x(
+					'None',
+					'Arrow option for Product Reviews Pagination Next/Previous blocks',
+					'woocommerce'
+				) }
+			/>
+			<ToggleGroupControlOption
+				value="arrow"
+				label={ _x(
+					'Arrow',
+					'Arrow option for Product Reviews Pagination Next/Previous blocks',
+					'woocommerce'
+				) }
+			/>
+			<ToggleGroupControlOption
+				value="chevron"
+				label={ _x(
+					'Chevron',
+					'Arrow option for Product Reviews Pagination Next/Previous blocks',
+					'woocommerce'
+				) }
+			/>
+		</ToggleGroupControl>
+	);
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/save.tsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save() {
+	return <InnerBlocks.Content />;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/style.scss
@@ -1,0 +1,39 @@
+$pagination-margin: 0.5em;
+.wp-block-woocommerce-product-reviews-pagination {
+	// Increased specificity to override blocks default margin.
+	> .wp-block-woocommerce-product-reviews-pagination-next,
+	> .wp-block-woocommerce-product-reviews-pagination-previous,
+	> .wp-block-woocommerce-product-reviews-pagination-numbers {
+		/*rtl:ignore*/
+		margin-right: $pagination-margin;
+		margin-bottom: $pagination-margin;
+
+		font-size: inherit;
+		&:last-child {
+			/*rtl:ignore*/
+			margin-right: 0;
+		}
+	}
+	.wp-block-woocommerce-product-reviews-pagination-previous-arrow {
+		margin-right: 1ch;
+		display: inline-block; // Needed so that the transform works.
+		// chevron(`»`) symbol doesn't need the mirroring by us.
+		&:not(.is-arrow-chevron) {
+			// Flip for RTL.
+			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
+		}
+	}
+	.wp-block-woocommerce-product-reviews-pagination-next-arrow {
+		margin-left: 1ch;
+		display: inline-block; // Needed so that the transform works.
+		// chevron(`»`) symbol doesn't need the mirroring by us.
+		&:not(.is-arrow-chevron) {
+			// Flip for RTL.
+			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
+		}
+	}
+
+	&.aligncenter {
+		justify-content: center;
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -87,7 +87,7 @@ const TEMPLATE: InnerBlockTemplate[] = [
 			],
 		],
 	],
-	[ 'core/comments-pagination' ],
+	[ 'woocommerce/product-reviews-pagination' ],
 	[ 'woocommerce/product-review-form' ],
 ];
 

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -216,6 +216,9 @@ const blocks = {
 	'product-reviews-pagination': {
 		customDir: 'product-reviews/inner-blocks/reviews-pagination',
 	},
+	'product-reviews-pagination-next': {
+		customDir: 'product-reviews/inner-blocks/reviews-pagination-next',
+	},
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -213,6 +213,9 @@ const blocks = {
 	'product-review-author-name': {
 		customDir: 'product-reviews/inner-blocks/review-author-name',
 	},
+	'product-reviews-pagination': {
+		customDir: 'product-reviews/inner-blocks/reviews-pagination',
+	},
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -222,6 +222,9 @@ const blocks = {
 	'product-reviews-pagination-previous': {
 		customDir: 'product-reviews/inner-blocks/reviews-pagination-previous',
 	},
+	'product-reviews-pagination-numbers': {
+		customDir: 'product-reviews/inner-blocks/reviews-pagination-numbers',
+	},
 };
 
 /**

--- a/plugins/woocommerce/client/blocks/bin/webpack-entries.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-entries.js
@@ -219,6 +219,9 @@ const blocks = {
 	'product-reviews-pagination-next': {
 		customDir: 'product-reviews/inner-blocks/reviews-pagination-next',
 	},
+	'product-reviews-pagination-previous': {
+		customDir: 'product-reviews/inner-blocks/reviews-pagination-previous',
+	},
 };
 
 /**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -103,4 +103,15 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 		return false;
 	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPagination.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPagination.php
@@ -1,0 +1,54 @@
+<?php declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviewsPagination class.
+ */
+class ProductReviewsPagination extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-reviews-pagination';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( empty( trim( $content ) ) ) {
+			return '';
+		}
+
+		if ( post_password_required() ) {
+			return;
+		}
+
+		$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
+			$content
+		);
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
@@ -1,0 +1,75 @@
+<?php declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviewsPaginationNext class.
+ */
+class ProductReviewsPaginationNext extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-reviews-pagination-next';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		// Bail out early if the post ID is not set for some reason.
+		if ( empty( $block->context['postId'] ) ) {
+			return '';
+		}
+
+		$comment_vars     = build_comment_query_vars_from_block( $block );
+		$max_page         = ( new \WP_Comment_Query( $comment_vars ) )->max_num_pages;
+		$default_label    = __( 'Newer Reviews' );
+		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+		$pagination_arrow = get_comments_pagination_arrow( $block, 'next' );
+
+		$filter_link_attributes = static function () {
+			return get_block_wrapper_attributes();
+		};
+		add_filter( 'next_comments_link_attributes', $filter_link_attributes );
+
+		if ( $pagination_arrow ) {
+			$label .= $pagination_arrow;
+		}
+
+		$next_comments_link = get_next_comments_link( $label, $max_page, $comment_vars['paged'] ?? null );
+
+		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
+
+		if ( ! isset( $next_comments_link ) ) {
+			return '';
+		}
+		return $next_comments_link;
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
@@ -32,7 +32,7 @@ class ProductReviewsPaginationNext extends AbstractBlock {
 		$max_page         = ( new \WP_Comment_Query( $comment_vars ) )->max_num_pages;
 		$default_label    = __( 'Newer Reviews' );
 		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-		$pagination_arrow = get_comments_pagination_arrow( $block, 'next' );
+		$pagination_arrow = $this->get_pagination_arrow( $block );
 
 		$filter_link_attributes = static function () {
 			return get_block_wrapper_attributes();
@@ -51,6 +51,27 @@ class ProductReviewsPaginationNext extends AbstractBlock {
 			return '';
 		}
 		return $next_comments_link;
+	}
+
+	/**
+	 * Get the pagination arrow.
+	 *
+	 * @param \WP_Block $block Block instance.
+	 * @return string|null
+	 */
+	protected function get_pagination_arrow( $block ) {
+		$arrow_map = array(
+			'none'    => '',
+			'arrow'   => '→',
+			'chevron' => '»',
+		);
+		if ( ! empty( $block->context['reviews/paginationArrow'] ) && ! empty( $arrow_map[ $block->context['reviews/paginationArrow'] ] ) ) {
+			$arrow_attribute = $block->context['reviews/paginationArrow'];
+			$arrow           = $arrow_map[ $block->context['reviews/paginationArrow'] ];
+			$arrow_classes   = "wp-block-woocommerce-product-reviews-pagination-next-arrow is-arrow-$arrow_attribute";
+			return "<span class='$arrow_classes' aria-hidden='true'>$arrow</span>";
+		}
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNext.php
@@ -30,7 +30,7 @@ class ProductReviewsPaginationNext extends AbstractBlock {
 
 		$comment_vars     = build_comment_query_vars_from_block( $block );
 		$max_page         = ( new \WP_Comment_Query( $comment_vars ) )->max_num_pages;
-		$default_label    = __( 'Newer Reviews' );
+		$default_label    = __( 'Newer Reviews', 'woocommerce' );
 		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 		$pagination_arrow = $this->get_pagination_arrow( $block );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNumbers.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationNumbers.php
@@ -1,0 +1,78 @@
+<?php declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviewsPaginationNumbers class.
+ */
+class ProductReviewsPaginationNumbers extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-reviews-pagination-numbers';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		// Bail out early if the post ID is not set for some reason.
+		if ( empty( $block->context['postId'] ) ) {
+			return '';
+		}
+
+		$comment_vars = build_comment_query_vars_from_block( $block );
+
+		$total   = ( new \WP_Comment_Query( $comment_vars ) )->max_num_pages;
+		$current = ! empty( $comment_vars['paged'] ) ? $comment_vars['paged'] : null;
+
+		// Render links.
+		$content = paginate_comments_links(
+			array(
+				'total'     => $total,
+				'current'   => $current,
+				'prev_next' => false,
+				'echo'      => false,
+			)
+		);
+
+		if ( empty( $content ) ) {
+			return '';
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
+			$content
+		);
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
@@ -26,7 +26,7 @@ class ProductReviewsPaginationPrevious extends AbstractBlock {
 		$default_label    = __( 'Older Reviews', 'woocommerce' );
 		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 		$pagination_arrow = $this->get_pagination_arrow( $block );
-		
+
 		if ( $pagination_arrow ) {
 			$label = $pagination_arrow . $label;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
@@ -25,7 +25,8 @@ class ProductReviewsPaginationPrevious extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		$default_label    = __( 'Older Reviews', 'woocommerce' );
 		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-		$pagination_arrow = get_comments_pagination_arrow( $block, 'previous' );
+		$pagination_arrow = $this->get_pagination_arrow( $block );
+		
 		if ( $pagination_arrow ) {
 			$label = $pagination_arrow . $label;
 		}
@@ -45,6 +46,28 @@ class ProductReviewsPaginationPrevious extends AbstractBlock {
 		}
 
 		return $previous_comments_link;
+	}
+
+	/**
+	 * Get the pagination arrow.
+	 *
+	 * @param \WP_Block $block Block instance.
+	 * @return string|null
+	 */
+	protected function get_pagination_arrow( $block ) {
+		$arrow_map = array(
+			'none'    => '',
+			'arrow'   => '←',
+			'chevron' => '«',
+		);
+
+		if ( ! empty( $block->context['reviews/paginationArrow'] ) && ! empty( $arrow_map[ $block->context['reviews/paginationArrow'] ] ) ) {
+			$arrow_attribute = $block->context['reviews/paginationArrow'];
+			$arrow           = $arrow_map[ $block->context['reviews/paginationArrow'] ];
+			$arrow_classes   = "wp-block-woocommerce-product-reviews-pagination-previous-arrow is-arrow-$arrow_attribute";
+			return "<span class='$arrow_classes' aria-hidden='true'>$arrow</span>";
+		}
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPaginationPrevious.php
@@ -1,0 +1,69 @@
+<?php declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+
+/**
+ * ProductReviewsPaginationPrevious class.
+ */
+class ProductReviewsPaginationPrevious extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-reviews-pagination-previous';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$default_label    = __( 'Older Reviews', 'woocommerce' );
+		$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+		$pagination_arrow = get_comments_pagination_arrow( $block, 'previous' );
+		if ( $pagination_arrow ) {
+			$label = $pagination_arrow . $label;
+		}
+
+		$filter_link_attributes = static function () {
+			return get_block_wrapper_attributes();
+		};
+		add_filter( 'previous_comments_link_attributes', $filter_link_attributes );
+
+		$comment_vars           = build_comment_query_vars_from_block( $block );
+		$previous_comments_link = get_previous_comments_link( $label, $comment_vars['paged'] ?? null );
+
+		remove_filter( 'previous_comments_link_attributes', $filter_link_attributes );
+
+		if ( ! isset( $previous_comments_link ) ) {
+			return '';
+		}
+
+		return $previous_comments_link;
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return string|null
+	 */
+	protected function get_block_type_style() {
+		return null;
+	}
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -537,11 +537,6 @@ final class BlockTypesController {
 				$block_types[] = 'AddToCartWithOptions\GroupedProductSelectorItemTemplate';
 				$block_types[] = 'AddToCartWithOptions\GroupedProductSelectorItemCTA';
 			}
-			// Generic blocks that will be pushed upstream.
-			$block_types[] = 'Accordion\AccordionGroup';
-			$block_types[] = 'Accordion\AccordionItem';
-			$block_types[] = 'Accordion\AccordionPanel';
-			$block_types[] = 'Accordion\AccordionHeader';
 			$block_types[] = 'BlockifiedProductDetails';
 			$block_types[] = 'ProductDescription';
 			$block_types[] = 'ProductSpecifications';
@@ -555,6 +550,12 @@ final class BlockTypesController {
 			$block_types[] = 'Reviews\ProductReviewsPagination';
 			$block_types[] = 'Reviews\ProductReviewsPaginationNext';
 			$block_types[] = 'Reviews\ProductReviewsPaginationPrevious';
+			// Generic blocks that will be pushed upstream.
+			$block_types[] = 'Accordion\AccordionGroup';
+			$block_types[] = 'Accordion\AccordionItem';
+			$block_types[] = 'Accordion\AccordionPanel';
+			$block_types[] = 'Accordion\AccordionHeader';
+			// End: generic blocks that will be pushed upstream.
 		}
 
 		/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -550,6 +550,8 @@ final class BlockTypesController {
 			$block_types[] = 'Reviews\ProductReviewsPagination';
 			$block_types[] = 'Reviews\ProductReviewsPaginationNext';
 			$block_types[] = 'Reviews\ProductReviewsPaginationPrevious';
+			$block_types[] = 'Reviews\ProductReviewsPaginationNumbers';
+
 			// Generic blocks that will be pushed upstream.
 			$block_types[] = 'Accordion\AccordionGroup';
 			$block_types[] = 'Accordion\AccordionItem';

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -537,6 +537,7 @@ final class BlockTypesController {
 				$block_types[] = 'AddToCartWithOptions\GroupedProductSelectorItemTemplate';
 				$block_types[] = 'AddToCartWithOptions\GroupedProductSelectorItemCTA';
 			}
+
 			$block_types[] = 'BlockifiedProductDetails';
 			$block_types[] = 'ProductDescription';
 			$block_types[] = 'ProductSpecifications';

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -553,6 +553,7 @@ final class BlockTypesController {
 			$block_types[] = 'Reviews\ProductReviewContent';
 			$block_types[] = 'Reviews\ProductReviewAuthorName';
 			$block_types[] = 'Reviews\ProductReviewsPagination';
+			$block_types[] = 'Reviews\ProductReviewsPaginationNext';
 		}
 
 		/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -552,6 +552,7 @@ final class BlockTypesController {
 			$block_types[] = 'Reviews\ProductReviewDate';
 			$block_types[] = 'Reviews\ProductReviewContent';
 			$block_types[] = 'Reviews\ProductReviewAuthorName';
+			$block_types[] = 'Reviews\ProductReviewsPagination';
 		}
 
 		/**

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -554,6 +554,7 @@ final class BlockTypesController {
 			$block_types[] = 'Reviews\ProductReviewAuthorName';
 			$block_types[] = 'Reviews\ProductReviewsPagination';
 			$block_types[] = 'Reviews\ProductReviewsPaginationNext';
+			$block_types[] = 'Reviews\ProductReviewsPaginationPrevious';
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds Product Reviews Pagination and its inner blocks. I decided to add them all in a PR for easier testing. New blocks are mimic from Gutenberg with some modification to fit with WooCommerce.

Closes https://github.com/woocommerce/woocommerce/issues/57124

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/54b35f00-a20b-481a-b7a0-03a9a1eaadec" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Comment Pagination in WP Dashboard > Settings > Discussion. Set the `Top level comments per page` setting to a small value if you don't have many reviews on a product.
2. Add the `Blockified Product Details` block to Single Product template.
3. Expand the Reviews item, see new Product Reviews Pagination block.
4. Adjust block settings, see editor preview react accordingly.
5. Save and test on the front end with a product that have multiple reviews, verify the pagination works and customization is applied.
6. Test other product with no review, see block isn't rendered.
<!-- End testing instructions -->