### PR TITLE
Enhance Blueprint Import UI with Persistent Notifications and Improved Styling

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4104-blueprint-persist-success-notifications
+++ b/plugins/woocommerce/changelog/wooplug-4104-blueprint-persist-success-notifications
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Enhance Blueprint import notifications

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -9,7 +9,7 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
-import { closeSmall, upload } from '@wordpress/icons';
+import { closeSmall, upload, check, warning } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMachine } from '@xstate5/react';
 import {
@@ -130,19 +130,26 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 			}
 		}
 
-		let errorMessage;
 		if ( errors.length > 0 ) {
-			errorMessage = `${ __(
-				'Your Blueprint has been imported, but there were some errors. Please check the messages.',
-				'woocommerce'
-			) }`;
+			dispatch( 'core/notices' ).createWarningNotice(
+				`${ __(
+					'Your Blueprint has been imported, but there were some errors. Please check the messages.',
+					'woocommerce'
+				) }`,
+				{
+					icon: <Icon icon={ warning } size={ 24 } fill="#d63638" />,
+					explicitDismiss: true,
+				}
+			);
 		} else {
-			errorMessage = `${ __(
-				'Your Blueprint has been imported!',
-				'woocommerce'
-			) }`;
+			dispatch( 'core/notices' ).createSuccessNotice(
+				`${ __( 'Your Blueprint has been imported!', 'woocommerce' ) }`,
+				{
+					icon: <Icon icon={ check } size={ 24 } fill="#1ed15A" />,
+					explicitDismiss: true,
+				}
+			);
 		}
-		dispatch( 'core/notices' ).createSuccessNotice( errorMessage );
 		return errors;
 	} catch ( e ) {
 		throw e;

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -2,6 +2,19 @@
 	.blueprint-settings-slotfill {
 		min-height: 650px;
 	}
+
+	.components-snackbar .components-snackbar__content-with-icon {
+		padding-left: 0;
+	}
+
+	.components-snackbar .components-snackbar__icon {
+		display: flex;
+		margin-right: $gap-smaller;
+	}
+
+	.components-snackbar__content {
+		align-items: center;
+	}
 }
 
 .blueprint-settings-slotfill {
@@ -178,6 +191,7 @@
 			color: $gray-900;
 			line-height: 24px; /* 184.615% */
 			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			text-wrap: auto;
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4104

This PR improves the Blueprint import notifications by:

- Adding explicit dismiss buttons to notifications, making them persist until user action
- Implementing distinct visual indicators for different notification types:
  - Success notifications with green checkmark icon
  - Warning notifications with warning icon for partial imports
- Improving notification styling:
  - Better icon alignment and spacing
  - Proper text wrapping for longer messages
  - Consistent padding and visual hierarchy
  - Centered content alignment


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


<img width="1003" alt="Screenshot 2025-04-30 at 13 21 13" src="https://github.com/user-attachments/assets/dc4d9540-9f88-4fff-a106-84272517934d" />

<img width="1011" alt="Screenshot 2025-04-30 at 13 20 58" src="https://github.com/user-attachments/assets/20751379-c592-4c04-a000-267546f1ebf9" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `Navigate to WooCommerce > Settings > Advanced > Blueprint (beta)`
2. Import a valid Blueprint file  [woo-blueprint.json](https://github.com/user-attachments/files/19971530/woo-blueprint.json)
3. Wait a few seconds to verify the notice persists
4. Import a blueprint with partial errors [woo-blueprint-error.json](https://github.com/user-attachments/files/19971554/woo-blueprint-error.json)
5. Confirm that a warning notification is displayed with the warning icon
   - Text is properly wrapped and aligned
   - Icons are properly aligned with text
   - Dismiss button is clearly visible and functional
  

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
