### PR TITLE
[WC Payments NOX In-context]  Invalidate the onboarding data store when opening the onboarding modal

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -248,11 +248,9 @@ export const OnboardingProvider: React.FC< {
 				closeModal: () => {
 					closeModal();
 
-					// Reset the onboarding data both in the store and local state.
-					// This is important to ensure that the onboarding data is cleared when the modal is closed.
-					// This is to avoid stale data when the modal is opened again.
+					// Reset the onboarding data in the local state.
+					// The onboarding data store is invalidated on modal open to ensure the latest data is fetched.
 					resetLocalState();
-					invalidateWooPaymentsOnboarding( 'getOnboardingData' );
 
 					// Invalidate the getPaymentProviders store selector to ensure the latest data is fetched.
 					// This is important to ensure that the payment providers buttons are up to date.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -248,9 +248,11 @@ export const OnboardingProvider: React.FC< {
 				closeModal: () => {
 					closeModal();
 
-					// Reset the onboarding data in the local state.
-					// The onboarding data store is invalidated on modal open to ensure the latest data is fetched.
+					// Reset the onboarding data both in the store and local state.
+					// This is important to ensure that the onboarding data is cleared when the modal is closed.
+					// This is to avoid stale data when the modal is opened again.
 					resetLocalState();
+					invalidateWooPaymentsOnboarding( 'getOnboardingData' );
 
 					// Invalidate the getPaymentProviders store selector to ensure the latest data is fetched.
 					// This is important to ensure that the payment providers buttons are up to date.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -160,9 +160,16 @@ export const OnboardingProvider: React.FC< {
 		areStepDependenciesCompleted,
 	] );
 
+	const resetLocalState = () => {
+		setStateStoreSteps( [] );
+		setIsStateStoreLoading( true );
+		setAllSteps( [] );
+	};
+
 	/**
 	 * useEffect functions
 	 */
+
 	// Update local state when store data changes
 	useEffect( () => {
 		if ( ! isStoreLoading && storeData.steps.length > 0 ) {
@@ -229,19 +236,13 @@ export const OnboardingProvider: React.FC< {
 		);
 	}, [ stateStoreSteps, areStepDependenciesCompleted ] );
 
-	useEffect(() => {
-		// Reset the onboarding data both in the store and local state when context mounts
+	useEffect( () => {
+		// Reset the onboarding data both in the store and local state when the onboardingcontext mounts.
 		// This is important to ensure that the onboarding data is cleared when the modal is closed.
 		// This is to avoid stale data when the modal is opened again.
 		resetLocalState();
 		invalidateWooPaymentsOnboarding( 'getOnboardingData' );
-	}, []);
-
-	const resetLocalState = () => {
-		setStateStoreSteps( [] );
-		setIsStateStoreLoading( true );
-		setAllSteps( [] );
-	};
+	}, [] );
 
 	return (
 		<OnboardingContext.Provider

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -229,6 +229,14 @@ export const OnboardingProvider: React.FC< {
 		);
 	}, [ stateStoreSteps, areStepDependenciesCompleted ] );
 
+	useEffect(() => {
+		// Reset the onboarding data both in the store and local state when context mounts
+		// This is important to ensure that the onboarding data is cleared when the modal is closed.
+		// This is to avoid stale data when the modal is opened again.
+		resetLocalState();
+		invalidateWooPaymentsOnboarding( 'getOnboardingData' );
+	}, []);
+
 	const resetLocalState = () => {
 		setStateStoreSteps( [] );
 		setIsStateStoreLoading( true );
@@ -247,12 +255,6 @@ export const OnboardingProvider: React.FC< {
 				getStepByKey,
 				closeModal: () => {
 					closeModal();
-
-					// Reset the onboarding data both in the store and local state.
-					// This is important to ensure that the onboarding data is cleared when the modal is closed.
-					// This is to avoid stale data when the modal is opened again.
-					resetLocalState();
-					invalidateWooPaymentsOnboarding( 'getOnboardingData' );
 
 					// Invalidate the getPaymentProviders store selector to ensure the latest data is fetched.
 					// This is important to ensure that the payment providers buttons are up to date.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/index.tsx
@@ -6,7 +6,9 @@ import { __ } from '@wordpress/i18n';
 import { useLocation } from 'react-router-dom';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getQueryArg } from '@wordpress/url';
-import { dispatch } from '@wordpress/data';
+import { dispatch, useDispatch } from '@wordpress/data';
+import { woopaymentsOnboardingStore } from '@woocommerce/data';
+
 /**
  * Internal dependencies
  */
@@ -31,6 +33,9 @@ export default function WooPaymentsModal( {
 		getQueryArg( window.location.href, 'wpcom_connection_return' ) || false;
 	const hasWPComConnection =
 		providerData?.onboarding?.state?.wpcom_has_working_connection || false;
+	const {
+		invalidateResolutionForStoreSelector: invalidateWooPaymentsOnboarding,
+	} = useDispatch( woopaymentsOnboardingStore );
 
 	// Open modal when on an onboarding route
 	React.useEffect( () => {
@@ -69,6 +74,13 @@ export default function WooPaymentsModal( {
 			history.push( newPath );
 		}
 	}, [ isOpen, location.pathname, history ] );
+
+	// If the modal is open, invalidate the context store to ensure the latest data is fetched
+	React.useEffect( () => {
+		if ( isOpen ) {
+			invalidateWooPaymentsOnboarding( 'getOnboardingData' );
+		}
+	}, [ isOpen ] );
 
 	// Handle modal close by navigating away from onboarding routes
 	const handleClose = () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/index.tsx
@@ -6,8 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useLocation } from 'react-router-dom';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getQueryArg } from '@wordpress/url';
-import { dispatch, useDispatch } from '@wordpress/data';
-import { woopaymentsOnboardingStore } from '@woocommerce/data';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -33,9 +32,6 @@ export default function WooPaymentsModal( {
 		getQueryArg( window.location.href, 'wpcom_connection_return' ) || false;
 	const hasWPComConnection =
 		providerData?.onboarding?.state?.wpcom_has_working_connection || false;
-	const {
-		invalidateResolutionForStoreSelector: invalidateWooPaymentsOnboarding,
-	} = useDispatch( woopaymentsOnboardingStore );
 
 	// Open modal when on an onboarding route
 	React.useEffect( () => {
@@ -74,13 +70,6 @@ export default function WooPaymentsModal( {
 			history.push( newPath );
 		}
 	}, [ isOpen, location.pathname, history ] );
-
-	// If the modal is open, invalidate the context store to ensure the latest data is fetched
-	React.useEffect( () => {
-		if ( isOpen ) {
-			invalidateWooPaymentsOnboarding( 'getOnboardingData' );
-		}
-	}, [ isOpen ] );
 
 	// Handle modal close by navigating away from onboarding routes
 	const handleClose = () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR implements invalidation of the onboarding data store on opening the onboarding modal to ensure the latest data is fetched.

Closes WOOPLUG-4109

### How to test the changes in this Pull Request:
**Prerequisites**
1. Check out this PR locally.
2. Check out WooPayments `develop` branch locally.
3. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
4. If you have a WooPayments account connected, please disconnect it.

**Testing instructions**
1. Go to WooCommerce > Settings > Payments in the admin dashboard.
2. Click the Enable or Complete setup button for the WooPayments payment method.
3. Confirm that the Onboarding Modal opens and displays the Select payment methods screen.
4. Interact with the PMs list (turn things on/off) without clicking Continue.
5. Close the modal
6. Open browser Dev Tools on the Network tab.
7. Open the modal again.
8. Verify the API call `/settings/payments/woopayments/onboarding` is fetched.
9. Ensure the changes you made on the Select PMs screen are preserved.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
