### PR TITLE
WOOPLUG-4108: Strengthen the test account creation step

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -64,87 +64,188 @@ type Status = 'idle' | 'initializing' | 'polling' | 'success' | 'error';
 const TestAccountStep = () => {
 	const { currentStep, navigateToNextStep, closeModal } =
 		useOnboardingContext();
-	const [ testDriveLoaderProgress, setTestDriveLoaderProgress ] =
-		useState( 5 );
+
+	// Component State
+	const [ status, setStatus ] = useState< Status >( 'idle' );
+	const [ progress, setProgress ] = useState( 0 );
 	const [ errorMessage, setErrorMessage ] = useState< string | undefined >();
+	const [ pollingPhase, setPollingPhase ] = useState( 0 ); // 0: initial, 1: extended 1, 2: extended 2
 	const [ retryCounter, setRetryCounter ] = useState( 0 );
-	const [ testAccountCreationSuccess, setTestAccountCreationSuccess ] =
-		useState( false );
 
-	// Create a reference object.
-	const loaderProgressRef = useRef( testDriveLoaderProgress );
-	loaderProgressRef.current = testDriveLoaderProgress;
+	// Refs for timers and phase tracking
+	const pollingTimeoutRef = useRef< number | null >( null );
+	const phase1StartTimeRef = useRef< number | null >( null );
 
-	const updateLoaderProgress = ( maxPercent: number, progressBy: number ) => {
-		if ( loaderProgressRef.current < maxPercent ) {
-			const newProgress = loaderProgressRef.current + progressBy;
-			setTestDriveLoaderProgress( newProgress );
+	// Helper to clear timers
+	const clearTimers = () => {
+		if ( pollingTimeoutRef.current !== null ) {
+			clearTimeout( pollingTimeoutRef.current );
+			pollingTimeoutRef.current = null;
 		}
 	};
 
+	// Reset state function
+	const resetState = useCallback( () => {
+		setStatus( 'idle' );
+		setProgress( 0 );
+		setErrorMessage( undefined );
+		setPollingPhase( 0 );
+		phase1StartTimeRef.current = null;
+		clearTimers();
+	}, [ setStatus, setProgress, setErrorMessage, setPollingPhase ] );
+
+	// Main effect for handling initialization and polling loop
 	useEffect( () => {
-		// Create a polling function to check the status of the test account setup.
-		const checkTestAccountStatus = () => {
-			// Add progress
-			updateLoaderProgress( 100, 5 );
+		// -- Initialization Phase --
+		if ( status === 'idle' ) {
+			const stepHasError = currentStep?.errors?.[ 0 ];
+			if ( stepHasError ) {
+				setErrorMessage( stepHasError );
+				setStatus( 'error' );
+				return;
+			}
 
-			apiFetch( {
-				url: currentStep?.actions?.check?.href,
-				method: 'POST',
-			} ).then( ( response ) => {
-				if (
-					( response as StepCheckResponse )?.status === 'completed'
-				) {
-					// Set the progress to 100%.
-					setTestDriveLoaderProgress( 100 );
+			if ( currentStep?.status === 'completed' ) {
+				setStatus( 'success' );
+				setProgress( 100 ); // Show success state immediately
+				return;
+			}
 
-					// Set the test account creation success to true after some time to avoid UI re-rendering rapidly.
-					setTimeout( () => {
-						setTestAccountCreationSuccess( true );
-					}, 1000 );
-				}
-			} );
+			if ( currentStep?.status === 'not_started' ) {
+				setStatus( 'initializing' );
+				apiFetch< { success: boolean; message?: string } >( {
+					url: currentStep?.actions?.init?.href,
+					method: 'POST',
+				} )
+					.then( ( response ) => {
+						if ( response?.success ) {
+							// Start polling immediately after successful init
+							setStatus( 'polling' );
+						} else {
+							setErrorMessage(
+								response?.message ||
+									__(
+										'Creating test account failed. Please try again.',
+										'woocommerce'
+									)
+							);
+							setStatus( 'error' );
+						}
+					} )
+					.catch( ( error ) => {
+						setErrorMessage( error.message );
+						setStatus( 'error' );
+					} );
+			} else {
+				// If status is neither 'not_started' nor 'completed', assume we can start polling
+				setStatus( 'polling' );
+			}
+		}
+
+		// -- Polling Phase --
+		if ( status === 'polling' ) {
+			const poll = () => {
+				apiFetch< StepCheckResponse >( {
+					url: currentStep?.actions?.check?.href,
+					method: 'POST',
+				} )
+					.then( ( response ) => {
+						if ( response?.status === 'completed' ) {
+							// Use timeout for smoother transition to success UI
+							pollingTimeoutRef.current = window.setTimeout(
+								() => {
+									setStatus( 'success' );
+									setProgress( 100 ); // Visually complete
+								},
+								1000
+							);
+							return; // Stop polling loop
+						}
+
+						// Still pending, update progress and determine next poll
+						let nextPhase = pollingPhase;
+						let nextInterval = POLLING_INTERVAL_INITIAL;
+
+						// Use functional update to ensure we always increment from the latest progress
+						setProgress( ( currentProgress ) => {
+							const newProgress = Math.min(
+								currentProgress + 5,
+								MAX_PROGRESS
+							);
+
+							if ( newProgress >= MAX_PROGRESS ) {
+								if ( pollingPhase === 0 ) {
+									// Transition to phase 1
+									nextPhase = 1;
+									nextInterval = POLLING_INTERVAL_EXTENDED_1;
+									phase1StartTimeRef.current = Date.now();
+								} else if ( pollingPhase === 1 ) {
+									// Check if phase 1 duration exceeded
+									if (
+										phase1StartTimeRef.current &&
+										Date.now() -
+											phase1StartTimeRef.current >
+											EXTENDED_POLLING_PHASE_1_DURATION
+									) {
+										// Transition to phase 2
+										nextPhase = 2;
+										nextInterval =
+											POLLING_INTERVAL_EXTENDED_2;
+									} else {
+										// Stay in phase 1
+										nextPhase = 1;
+										nextInterval =
+											POLLING_INTERVAL_EXTENDED_1;
+									}
+								} else {
+									// Stay in phase 2
+									nextPhase = 2;
+									nextInterval = POLLING_INTERVAL_EXTENDED_2;
+								}
+							} else {
+								// Still in phase 0
+								nextPhase = 0;
+								nextInterval = POLLING_INTERVAL_INITIAL;
+							}
+
+							setPollingPhase( nextPhase ); // Update phase based on newProgress
+							return newProgress; // Return the calculated new progress for setProgress
+						} );
+
+						// Schedule the next poll using the interval determined above
+						// Note: setPollingPhase happens *after* this render, but the interval
+						// for the *next* timeout is correctly determined based on the logic above.
+						pollingTimeoutRef.current = window.setTimeout(
+							poll,
+							nextInterval
+						);
+					} )
+					.catch( ( error ) => {
+						setErrorMessage( error.message );
+						setStatus( 'error' );
+						clearTimers();
+					} );
+			};
+
+			// Start the first poll
+			poll();
+		}
+
+		// Cleanup function for the effect
+		return () => {
+			clearTimers();
 		};
+	}, [ status, currentStep, retryCounter, pollingPhase ] );
 
-		const stepHasError = currentStep?.errors?.[ 0 ];
-
-		if (
-			currentStep?.status === 'not_started' &&
-			! testAccountCreationSuccess
-		) {
-			// Send a request to the server to initialize the test account setup.
-			// We don't wait for the response here, as we want to start the polling immediately.
-			apiFetch( {
-				url: currentStep?.actions?.init?.href,
-				method: 'POST',
-			} ).catch( ( response ) => {
-				setErrorMessage( response.message );
-			} );
+	// Effect to reset state on retry
+	useEffect( () => {
+		if ( retryCounter > 0 ) {
+			resetState();
 		}
+	}, [ retryCounter, resetState ] );
 
-		if (
-			currentStep?.status !== 'completed' &&
-			! stepHasError &&
-			! testAccountCreationSuccess
-		) {
-			// Check the status of the test account setup every 3 seconds.
-			const interval = setInterval( checkTestAccountStatus, 3000 );
-			return () => clearInterval( interval );
-		}
-
-		if ( stepHasError ) {
-			setErrorMessage( stepHasError );
-		}
-	}, [
-		currentStep?.status,
-		currentStep?.errors,
-		currentStep?.actions?.init?.href,
-		currentStep?.actions?.check?.href,
-		retryCounter,
-		testAccountCreationSuccess,
-	] );
-
-	if ( testAccountCreationSuccess ) {
+	if ( status === 'success' ) {
+		// Render success state
 		return (
 			<>
 				<WooPaymentsStepHeader onClose={ closeModal } />
@@ -153,7 +254,7 @@ const TestAccountStep = () => {
 						<div className="woocommerce-woopayments-modal__content woocommerce-payments-test-account-step__success_content">
 							<h1 className="woocommerce-payments-test-account-step__success_content_title">
 								{ __(
-									'You’re ready to test payments!',
+									"You're ready to test payments!",
 									'woocommerce'
 								) }
 							</h1>
@@ -285,10 +386,13 @@ const TestAccountStep = () => {
 		);
 	}
 
+	// Render loading/error state
 	return (
 		<div className="woocommerce-payments-test-account-step">
 			<WooPaymentsStepHeader onClose={ closeModal } />
-			{ errorMessage && (
+
+			{ /* Error Notice */ }
+			{ status === 'error' && errorMessage && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
@@ -297,9 +401,7 @@ const TestAccountStep = () => {
 							label: __( 'Try Again', 'woocommerce' ),
 							variant: 'primary',
 							onClick: () => {
-								// Increment the retry counter to trigger the test account setup again.
-								setRetryCounter( ( prev ) => prev + 1 );
-								setErrorMessage( undefined );
+								setRetryCounter( ( c ) => c + 1 );
 							},
 						},
 						{
@@ -317,7 +419,49 @@ const TestAccountStep = () => {
 					</p>
 				</Notice>
 			) }
-			<TestDriveLoader progress={ testDriveLoaderProgress } />
+
+			{ /* Informational notice for phase 1 */ }
+			{ status === 'polling' && pollingPhase === 1 && (
+				<Notice
+					status="info"
+					isDismissible={ false }
+					className="woocommerce-payments-test-account-step__info-notice"
+				>
+					<p>
+						{ __(
+							"The test account creation is taking a bit longer than expected, but don't worry—we're on it! Please bear with us for a few seconds more as we set everything up for your store.",
+							'woocommerce'
+						) }
+					</p>
+				</Notice>
+			) }
+
+			{ /* Informational notice for phase 2 */ }
+			{ status === 'polling' && pollingPhase === 2 && (
+				<Notice
+					status="info"
+					isDismissible={ false }
+					className="woocommerce-payments-test-account-step__info-notice"
+				>
+					<p>
+						{ __(
+							"Thank you for your patience! Unfortunately, the test account creation is taking a bit longer than we anticipated. But don't worry—we won't give up!",
+							'woocommerce'
+						) }
+					</p>
+					<p>
+						{ __(
+							'Feel free to close this modal and check back later. We appreciate your understanding!',
+							'woocommerce'
+						) }
+					</p>
+				</Notice>
+			) }
+
+			{ /* Loader - shown during initializing and polling */ }
+			{ ( status === 'initializing' || status === 'polling' ) && (
+				<TestDriveLoader progress={ progress } />
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -96,6 +96,8 @@ const TestAccountStep = () => {
 			} );
 		};
 
+		const stepHasError = currentStep?.errors?.[ 0 ];
+
 		if (
 			currentStep?.status === 'not_started' &&
 			! testAccountCreationSuccess
@@ -138,8 +140,8 @@ const TestAccountStep = () => {
 			return () => clearInterval( interval );
 		}
 
-		if ( currentStep?.errors?.[ 0 ] ) {
-			setErrorMessage( currentStep.errors[ 0 ] );
+		if ( stepHasError ) {
+			setErrorMessage( stepHasError );
 		}
 	}, [
 		currentStep?.status,

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -56,7 +56,10 @@ const POLLING_INTERVAL_INITIAL = 3000; // 3 seconds is the initial polling inter
 const POLLING_INTERVAL_EXTENDED_1 = 5000; // 5 seconds is the extended polling interval for phase 1
 const POLLING_INTERVAL_EXTENDED_2 = 7000; // 7 seconds is the extended polling interval for phase 2
 const EXTENDED_POLLING_PHASE_1_DURATION = 30000; // 30 seconds is the duration of phase 1
-const MAX_INITIAL_PROGRESS = 90; // Cap progress at 90%
+const MAX_INITIAL_PROGRESS = 90; // Cap progress at 90% for the initial phase
+const MAX_EXTENDED_PHASE_1_PROGRESS = 96; // Cap progress at 96% for the extended phase 1
+const INITIAL_PHASE_INCREMENT = 5; // Increment progress by 20% for the initial phase
+const EXTENDED_PHASE_1_INCREMENT = 1; // Increment progress by 1% for the extended phase 1
 
 // Status types for the component
 type Status = 'idle' | 'initializing' | 'polling' | 'success' | 'error';

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Loader } from '@woocommerce/onboarding';
 import { __ } from '@wordpress/i18n';

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -267,13 +267,13 @@ const TestAccountStep = () => {
 	const getPhaseMessage = ( phase: number ) => {
 		if ( phase === 1 ) {
 			return __(
-				"The test account creation is taking a bit longer than expected, but don't worry—we're on it! Please bear with us for a few seconds more as we set everything up for your store.",
+				"The test account creation is taking a bit longer than expected, but don't worry — we're on it! Please bear with us for a few seconds more as we set everything up for your store.",
 				'woocommerce'
 			);
 		}
 		if ( phase === 2 ) {
 			return __(
-				"Thank you for your patience! Unfortunately, the test account creation is taking a bit longer than we anticipated. But don't worry—we won't give up! Feel free to close this modal and check back later. We appreciate your understanding!",
+				"Thank you for your patience! Unfortunately, the test account creation is taking a bit longer than we anticipated. But don't worry — we won't give up! Feel free to close this modal and check back later. We appreciate your understanding!",
 				'woocommerce'
 			);
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -73,6 +73,29 @@ const TestAccountStep = () => {
 	};
 
 	useEffect( () => {
+		// Create a polling function to check the status of the test account setup.
+		const checkTestAccountStatus = () => {
+			// Add progress
+			updateLoaderProgress( 100, 5 );
+
+			apiFetch( {
+				url: currentStep?.actions?.check?.href,
+				method: 'POST',
+			} ).then( ( response ) => {
+				if (
+					( response as StepCheckResponse )?.status === 'completed'
+				) {
+					// Set the progress to 100%.
+					setTestDriveLoaderProgress( 100 );
+
+					// Set the test account creation success to true after some time to avoid UI re-rendering rapidly.
+					setTimeout( () => {
+						setTestAccountCreationSuccess( true );
+					}, 1000 );
+				}
+			} );
+		};
+
 		if (
 			currentStep?.status === 'not_started' &&
 			! testAccountCreationSuccess

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -72,7 +72,7 @@ const TestAccountStep = () => {
 
 	// Component State
 	const [ status, setStatus ] = useState< Status >( 'idle' );
-	const [ progress, setProgress ] = useState( 0 );
+	const [ progress, setProgress ] = useState( 20 );
 	const [ errorMessage, setErrorMessage ] = useState< string | undefined >();
 	const [ pollingPhase, setPollingPhase ] = useState( 0 ); // 0: initial, 1: extended 1, 2: extended 2
 	const [ retryCounter, setRetryCounter ] = useState( 0 );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -110,31 +110,13 @@ const TestAccountStep = () => {
 			} ).catch( ( response ) => {
 				setErrorMessage( response.message );
 			} );
+		}
 
-			// Create a polling function to check the status of the test account setup.
-			const checkTestAccountStatus = () => {
-				// Add progress
-				updateLoaderProgress( 100, 5 );
-
-				apiFetch( {
-					url: currentStep?.actions?.check?.href,
-					method: 'POST',
-				} ).then( ( response ) => {
-					if (
-						( response as StepCheckResponse )?.status ===
-						'completed'
-					) {
-						// Set the progress to 100%.
-						setTestDriveLoaderProgress( 100 );
-
-						// Set the test account creation success to true after some time to avoid UI re-rendering rapidly.
-						setTimeout( () => {
-							setTestAccountCreationSuccess( true );
-						}, 1000 );
-					}
-				} );
-			};
-
+		if (
+			currentStep?.status !== 'completed' &&
+			! stepHasError &&
+			! testAccountCreationSuccess
+		) {
 			// Check the status of the test account setup every 3 seconds.
 			const interval = setInterval( checkTestAccountStatus, 3000 );
 			return () => clearInterval( interval );

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -171,56 +171,69 @@ const TestAccountStep = () => {
 						// Still pending, update progress and determine next poll
 						let nextPhase = pollingPhase;
 						let nextInterval = POLLING_INTERVAL_INITIAL;
+						let newProgress = 0;
 
 						// Use functional update to ensure we always increment from the latest progress
 						setProgress( ( currentProgress ) => {
-							const newProgress = Math.min(
-								currentProgress + 5,
-								MAX_PROGRESS
-							);
-
-							if ( newProgress >= MAX_PROGRESS ) {
-								if ( pollingPhase === 0 ) {
-									// Transition to phase 1
-									nextPhase = 1;
-									nextInterval = POLLING_INTERVAL_EXTENDED_1;
-									phase1StartTimeRef.current = Date.now();
-								} else if ( pollingPhase === 1 ) {
-									// Check if phase 1 duration exceeded
-									if (
-										phase1StartTimeRef.current &&
-										Date.now() -
-											phase1StartTimeRef.current >
-											EXTENDED_POLLING_PHASE_1_DURATION
-									) {
-										// Transition to phase 2
-										nextPhase = 2;
-										nextInterval =
-											POLLING_INTERVAL_EXTENDED_2;
-									} else {
-										// Stay in phase 1
-										nextPhase = 1;
-										nextInterval =
-											POLLING_INTERVAL_EXTENDED_1;
-									}
-								} else {
-									// Stay in phase 2
-									nextPhase = 2;
-									nextInterval = POLLING_INTERVAL_EXTENDED_2;
-								}
+							// Apply different increment logic based on phase
+							if ( pollingPhase === 0 ) {
+								// Phase 0: increment by INITIAL_PHASE_INCREMENT until MAX_INITIAL_PROGRESS
+								newProgress = Math.min(
+									currentProgress + INITIAL_PHASE_INCREMENT,
+									MAX_INITIAL_PROGRESS
+								);
+							} else if ( pollingPhase === 1 ) {
+								// Phase 1: increment by EXTENDED_PHASE_1_INCREMENT until 96%
+								newProgress = Math.min(
+									currentProgress +
+										EXTENDED_PHASE_1_INCREMENT,
+									MAX_EXTENDED_PHASE_1_PROGRESS
+								);
 							} else {
-								// Still in phase 0
-								nextPhase = 0;
-								nextInterval = POLLING_INTERVAL_INITIAL;
+								newProgress = currentProgress;
 							}
-
-							setPollingPhase( nextPhase ); // Update phase based on newProgress
-							return newProgress; // Return the calculated new progress for setProgress
+							return newProgress;
 						} );
 
-						// Schedule the next poll using the interval determined above
-						// Note: setPollingPhase happens *after* this render, but the interval
-						// for the *next* timeout is correctly determined based on the logic above.
+						// Update next phase and interval based on current phase and progress
+						if (
+							pollingPhase === 0 &&
+							newProgress >= MAX_INITIAL_PROGRESS
+						) {
+							// Transition to phase 1 when first reaching MAX_INITIAL_PROGRESS while in phase 0
+							nextPhase = 1;
+							nextInterval = POLLING_INTERVAL_EXTENDED_1;
+							phase1StartTimeRef.current = Date.now();
+						} else if ( pollingPhase === 1 ) {
+							// Already in phase 1, check if duration exceeded
+							if (
+								phase1StartTimeRef.current &&
+								Date.now() - phase1StartTimeRef.current >
+									EXTENDED_POLLING_PHASE_1_DURATION
+							) {
+								// Transition to phase 2
+								nextPhase = 2;
+								nextInterval = POLLING_INTERVAL_EXTENDED_2;
+							} else {
+								// Stay in phase 1
+								nextPhase = 1;
+								nextInterval = POLLING_INTERVAL_EXTENDED_1;
+							}
+						} else if ( pollingPhase === 2 ) {
+							// Stay in phase 2
+							nextPhase = 2;
+							nextInterval = POLLING_INTERVAL_EXTENDED_2;
+						} else {
+							// Stay in phase 0
+							nextPhase = 0;
+							nextInterval = POLLING_INTERVAL_INITIAL;
+						}
+
+						setPollingPhase( nextPhase ); // Update phase state
+
+						console.log( 'nextInterval', nextInterval );
+
+						// Schedule the next poll
 						pollingTimeoutRef.current = window.setTimeout(
 							poll,
 							nextInterval
@@ -239,7 +252,7 @@ const TestAccountStep = () => {
 
 		// Cleanup function for the effect
 		return () => {
-			clearTimers();
+			clearTimers(); // Clear any pending timeouts
 		};
 	}, [ status, currentStep, retryCounter, pollingPhase ] );
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -148,6 +148,9 @@ const TestAccountStep = () => {
 		// -- Polling Phase --
 		if ( status === 'polling' ) {
 			const poll = () => {
+				// Clear any existing timeout before starting a new one
+				clearTimers();
+
 				apiFetch< StepCheckResponse >( {
 					url: currentStep?.actions?.check?.href,
 					method: 'POST',

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -56,7 +56,7 @@ const POLLING_INTERVAL_INITIAL = 3000; // 3 seconds is the initial polling inter
 const POLLING_INTERVAL_EXTENDED_1 = 5000; // 5 seconds is the extended polling interval for phase 1
 const POLLING_INTERVAL_EXTENDED_2 = 7000; // 7 seconds is the extended polling interval for phase 2
 const EXTENDED_POLLING_PHASE_1_DURATION = 30000; // 30 seconds is the duration of phase 1
-const MAX_PROGRESS = 95; // Cap progress at 95%
+const MAX_INITIAL_PROGRESS = 90; // Cap progress at 90%
 
 // Status types for the component
 type Status = 'idle' | 'initializing' | 'polling' | 'success' | 'error';

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -51,6 +51,16 @@ const TestDriveLoader: React.FunctionComponent< {
 	</Loader>
 );
 
+// Constants for polling intervals and phase durations
+const POLLING_INTERVAL_INITIAL = 3000; // 3 seconds is the initial polling interval
+const POLLING_INTERVAL_EXTENDED_1 = 5000; // 5 seconds is the extended polling interval for phase 1
+const POLLING_INTERVAL_EXTENDED_2 = 7000; // 7 seconds is the extended polling interval for phase 2
+const EXTENDED_POLLING_PHASE_1_DURATION = 30000; // 30 seconds is the duration of phase 1
+const MAX_PROGRESS = 95; // Cap progress at 95%
+
+// Status types for the component
+type Status = 'idle' | 'initializing' | 'polling' | 'success' | 'error';
+
 const TestAccountStep = () => {
 	const { currentStep, navigateToNextStep, closeModal } =
 		useOnboardingContext();

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -26,7 +26,8 @@ interface StepCheckResponse {
 
 const TestDriveLoader: React.FunctionComponent< {
 	progress: number;
-} > = ( { progress } ) => (
+	message?: string;
+} > = ( { progress, message } ) => (
 	<Loader className="woocommerce-payments-test-account-step__preloader">
 		<Loader.Layout className="woocommerce-payments-test-account-step__preloader-layout">
 			<Loader.Illustration>
@@ -42,10 +43,11 @@ const TestDriveLoader: React.FunctionComponent< {
 			</Loader.Title>
 			<Loader.ProgressBar progress={ progress ?? 0 } />
 			<Loader.Sequence interval={ 0 }>
-				{ __(
-					"In just a few moments, you'll be ready to test payments on your store.",
-					'woocommerce'
-				) }
+				{ message ||
+					__(
+						"In just a few moments, you'll be ready to test payments on your store.",
+						'woocommerce'
+					) }
 			</Loader.Sequence>
 		</Loader.Layout>
 	</Loader>
@@ -262,6 +264,22 @@ const TestAccountStep = () => {
 		}
 	}, [ retryCounter, resetState ] );
 
+	const getPhaseMessage = ( phase: number ) => {
+		if ( phase === 1 ) {
+			return __(
+				"The test account creation is taking a bit longer than expected, but don't worry—we're on it! Please bear with us for a few seconds more as we set everything up for your store.",
+				'woocommerce'
+			);
+		}
+		if ( phase === 2 ) {
+			return __(
+				"Thank you for your patience! Unfortunately, the test account creation is taking a bit longer than we anticipated. But don't worry—we won't give up! Feel free to close this modal and check back later. We appreciate your understanding!",
+				'woocommerce'
+			);
+		}
+		return undefined;
+	};
+
 	if ( status === 'success' ) {
 		// Render success state
 		return (
@@ -438,47 +456,12 @@ const TestAccountStep = () => {
 				</Notice>
 			) }
 
-			{ /* Informational notice for phase 1 */ }
-			{ status === 'polling' && pollingPhase === 1 && (
-				<Notice
-					status="info"
-					isDismissible={ false }
-					className="woocommerce-payments-test-account-step__info-notice"
-				>
-					<p>
-						{ __(
-							"The test account creation is taking a bit longer than expected, but don't worry—we're on it! Please bear with us for a few seconds more as we set everything up for your store.",
-							'woocommerce'
-						) }
-					</p>
-				</Notice>
-			) }
-
-			{ /* Informational notice for phase 2 */ }
-			{ status === 'polling' && pollingPhase === 2 && (
-				<Notice
-					status="info"
-					isDismissible={ false }
-					className="woocommerce-payments-test-account-step__info-notice"
-				>
-					<p>
-						{ __(
-							"Thank you for your patience! Unfortunately, the test account creation is taking a bit longer than we anticipated. But don't worry—we won't give up!",
-							'woocommerce'
-						) }
-					</p>
-					<p>
-						{ __(
-							'Feel free to close this modal and check back later. We appreciate your understanding!',
-							'woocommerce'
-						) }
-					</p>
-				</Notice>
-			) }
-
 			{ /* Loader - shown during initializing and polling */ }
 			{ ( status === 'initializing' || status === 'polling' ) && (
-				<TestDriveLoader progress={ progress } />
+				<TestDriveLoader
+					progress={ progress }
+					message={ getPhaseMessage( pollingPhase ) }
+				/>
 			) }
 		</div>
 	);

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -190,6 +190,7 @@ const TestAccountStep = () => {
 									MAX_EXTENDED_PHASE_1_PROGRESS
 								);
 							} else {
+								// Phase 2: Do not increment progress
 								newProgress = currentProgress;
 							}
 							return newProgress;
@@ -230,8 +231,6 @@ const TestAccountStep = () => {
 						}
 
 						setPollingPhase( nextPhase ); // Update phase state
-
-						console.log( 'nextInterval', nextInterval );
 
 						// Schedule the next poll
 						pollingTimeoutRef.current = window.setTimeout(

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
@@ -37,6 +37,12 @@
 		}
 	}
 
+	&__info-notice {
+		margin: $gap-small auto;
+		width: 90%;
+		max-width: 648px;
+	}
+
 	&__error {
 		margin: $gap-small auto;
 		width: 90%;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
@@ -37,12 +37,6 @@
 		}
 	}
 
-	&__info-notice {
-		margin: $gap-small auto;
-		width: 90%;
-		max-width: 648px;
-	}
-
 	&__error {
 		margin: $gap-small auto;
 		width: 90%;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR strengthens the test account creation step by supporting multiple internal step statuses for initialization, polling, error, and more. The goal is to implement the following logic:

1. In a happy path, account creation will be quick. We will increase the loader step by 5% and poll every 3 seconds. If the progress reaches 90% and the account is still not created, then we have reached "Polling phase 1".
2. In "Polling phase 1", we will: display an information message, increase the polling interval to 5 seconds, and reduce the loader step to 1%. If we stay in this phase for more than 30 seconds, we have reached phase 2 of the polling.
3. In "Polling phase 2", we will: display another information message, increase the polling interval to 7 seconds, and stop increasing the loader.
4. Finally, in all phases, when account creation results in either an error or success, polling should stop, and an error or success screen should be displayed accordingly.

Closes WOOPLUG-4108
Closes #57617

### How to test the changes in this Pull Request:

See a video of how this should look:

<!-- Error downloading from cln.sh/wnyBWllBS6bDHJ5RFpNC. Please attach media directly to GitHub. See console log for more info. -->


https://github.com/user-attachments/assets/d92d2c2f-55aa-4716-b4d2-45186cf2a73f



**Testing this PR is only possible locally (so we can delay the account creation)**

Set up the local env:
1. Get this PR locally and build it
5. Make sure to remove the NOX option `woocommerce_woopayments_nox_profile` from `wp_options`
6. Make sure you are **not listening** to Stripe's webhooks (we want to sync the account manually)

Testing:
1. Go to `WooCommerce > Settings > Payments` and open the `Network` tab from the browser's dev tools
1. Click on "Complete setup" button.
2. Click "Continue" on the first step
3. When you reach the account creation step, make sure the following phases are respected:
- Initial phase: Polling should happen every 3 seconds, and the loader should move by +5 after every update.
- Phase 1 (When reaching 90% of progress): An information message should be displayed, polling should happen every 5 seconds, and the loader should move by +1 after every update.
- Phase 2 (When reaching 96% of progress): Another information message should be displayed, polling should happen every 7 seconds, and the loader **should not move**.
5. After confirming, go to WooPayments Dev Tools and refresh the account data
5. Go back to the modal, and it should automatically update with a success screen
6. Once the success screen is displayed, make sure no other API call is made

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR isn't merged to trunk, no need for a changelog entry

</details>