### PR TITLE
Fix Add to Cart with Options Stepper style having missing styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-stepper-add-to-cart-with-options-missing-styles
+++ b/plugins/woocommerce/changelog/fix-stepper-add-to-cart-with-options-missing-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Add to Cart with Options Stepper style having missing styles
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -11,5 +11,6 @@
 	"supports": {
 		"interactivity": true
 	},
-	"$schema": "https://schemas.wp.org/trunk/block.json"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"style": "file:../woocommerce/add-to-cart-with-options-quantity-selector-style.css"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/style.scss
@@ -1,0 +1,1 @@
+@import "../../../base/components/quantity-selector/style";

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -1,4 +1,5 @@
 @import "../../../base/components/skeleton/style";
+@import "../../../base/components/quantity-selector/style";
 
 .wc-block-add-to-cart-form {
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes an issue that caused _Stepper_ styles not to be loaded in the _Add to Cart with Options_ block.

Kudos to @AhmarZaidi for finding this issue (https://github.com/woocommerce/woocommerce/pull/57570#issuecomment-2841346423).

### How to test the changes in this Pull Request:

1. In a classic theme (ie: Storefront).
2. Create a post or page and add the _Single Product_ block.
3. Select any product and change the _Add to Cart with Options_ block display style to _Stepper_.
4. In the frontend, verify the buttons look correct:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/5bfee3b5-2d54-4cb1-890c-bb82eeb28f9a) | ![imatge](https://github.com/user-attachments/assets/ed01bd0e-7709-438c-9805-1f5b52411b52)

5. Switch to a block theme (ie: Twenty-Twenty Five). Remove the _Mini-Cart_ block from the header if it's there.
6. Reload the same post and verify the buttons look correct as well:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/a247342d-5197-43b4-bb77-f1ad6c4a0641) | ![imatge](https://github.com/user-attachments/assets/5f9ac0f7-1b9e-44e0-8d71-40cd8c69d28a)

7. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
8. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
9. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
10. Click on the _Add to Cart with Options_ block and update to the blockified version.
11. Visit a product template in the frontend and verify the styles are also loaded correctly:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/ad697a45-0c76-459f-9b54-54d64e08648e) | ![imatge](https://github.com/user-attachments/assets/d4bbfc6e-e0da-457f-a292-88c3dfa6e997)
