### PR TITLE
Add tracking for email preview usage

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3923-add-email-preview-tracking
+++ b/plugins/woocommerce/changelog/wooplug-3923-add-email-preview-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add email preview usage tracking

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-device-type.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-device-type.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -25,8 +26,22 @@ export const EmailPreviewDeviceType = ( {
 }: EmailPreviewDeviceTypeProps ) => {
 	const isDesktop = deviceType === DEVICE_TYPE_DESKTOP;
 	const isMobile = deviceType === DEVICE_TYPE_MOBILE;
-	const setDesktop = () => setDeviceType( DEVICE_TYPE_DESKTOP );
-	const setMobile = () => setDeviceType( DEVICE_TYPE_MOBILE );
+	const setDesktop = () => {
+		if ( ! isDesktop ) {
+			recordEvent( 'settings_emails_preview_device_type_toggle', {
+				device_type: DEVICE_TYPE_DESKTOP,
+			} );
+			setDeviceType( DEVICE_TYPE_DESKTOP );
+		}
+	};
+	const setMobile = () => {
+		if ( ! isMobile ) {
+			recordEvent( 'settings_emails_preview_device_type_toggle', {
+				device_type: DEVICE_TYPE_MOBILE,
+			} );
+			setDeviceType( DEVICE_TYPE_MOBILE );
+		}
+	};
 
 	return (
 		<div className="wc-settings-email-preview-device-type">

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-preview-send.tsx
@@ -6,6 +6,7 @@ import { Icon, check, warning } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 import { isValidEmail } from '@woocommerce/product-editor/build/utils/validate-email'; // Import from the build directory so we don't load the entire product editor since we only need this one function.
 
 /**
@@ -48,10 +49,17 @@ export const EmailPreviewSend = ( { type }: EmailPreviewSendProps ) => {
 			} );
 			setNotice( response.message );
 			setNoticeType( 'success' );
+			recordEvent( 'settings_emails_preview_test_sent_successful', {
+				email_type: type,
+			} );
 		} catch ( e ) {
 			const wpError = e as WPError;
 			setNotice( wpError.message );
 			setNoticeType( 'error' );
+			recordEvent( 'settings_emails_preview_test_sent_failed', {
+				email_type: type,
+				error: wpError.message,
+			} );
 		}
 		setIsSending( false );
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Add usage tracking when toggling email preview device type (desktop/mobile) or when a test email is sent.

Closes WOOPLUG-3923, closes #57243.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that `Enable tracking` is checked in **WooCommerce > Settings > Advanced > WooCommerce.com**.
2. Go to **WooCommerce > Settings > Emails**.
3. Toggle device type (desktop/mobile) and check that the event is tracked
    - This should fire a request for `pixel.wp.com/t.gif` or you can check after ~5 minutes in the Tracks admin).
4. Send a test email preview and check that the event is tracked (there are different events for when the preview is successfully sent or when it fails, e.g. when the website can't send emails).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I tested that the events are visible in Tracks:
<img width="752" alt="Screenshot 2025-04-30 at 13 55 24" src="https://github.com/user-attachments/assets/5cfdb836-57e7-40e6-b288-430dea22a514" />

