### PR TITLE
Allow links in order item meta in new emails templates

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4110-links-from-order-meta-removed-from-emails-when-email
+++ b/plugins/woocommerce/changelog/wooplug-4110-links-from-order-meta-removed-from-emails-when-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow links in order item meta in new emails templates

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 9.9.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -98,11 +98,18 @@ foreach ( $items as $item_id => $item ) :
 								)
 							);
 							echo '<div class="email-order-item-meta">';
+							// Using wp_kses instead of wp_kses_post to remove all block elements.
 							echo wp_kses(
 								$item_meta,
 								array(
 									'br'   => array(),
 									'span' => array(),
+									'a'    => array(
+										'href'   => true,
+										'target' => true,
+										'rel'    => true,
+										'title'  => true,
+									),
 								)
 							);
 							echo '</div>';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In new email templates, we use `wp_kses` instead of `wp_kses_post` (which is already part of `wc_display_item_meta()`) because we want to remove all block elements (`<p>`, `<ul>`...) from the rendered HTML, because they often break rendering in different email clients. This PR allows `<a>` in addition to already allowed `<br>` and `<span>`.

Closes WOOPLUG-4110, closes #57622.

(For Bug Fixes) Bug introduced in PR #55599.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="549" alt="Screenshot 2025-04-30 at 14 54 18" src="https://github.com/user-attachments/assets/6b96075d-ecf6-46a3-88cd-ebe36bc1f3d9" />    |  <img width="553" alt="Screenshot 2025-04-30 at 14 53 58" src="https://github.com/user-attachments/assets/dc94d7ad-fe1f-48ec-b6af-fa2ee179da98" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a Variable product and use a URL in one of the attributes so it's used in variants.
    <img width="837" alt="Screenshot 2025-04-30 at 14 52 02" src="https://github.com/user-attachments/assets/dfe60806-db98-4557-9bc9-c36d58d9bdd2" />
2. Install WP Mail Logging unless you already have emails set up locally or you want to send an actual email.
3. Create an order with the product from step 1, and send the order details by email.
    <img width="279" alt="Screenshot 2025-04-30 at 14 53 10" src="https://github.com/user-attachments/assets/ab3f98ec-481f-4f75-96ae-cbb62d607415" />
4. Observe that the order item attribute has a clickable URL (**the URL in the title shouldn't be clickable**).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
