### PR TITLE
Updating version and changelog for Woo AI

### DIFF
--- a/plugins/woo-ai/CHANGELOG.md
+++ b/plugins/woo-ai/CHANGELOG.md
@@ -1,14 +1,45 @@
 # Changelog
 
+## [0.7](https://github.com/woocommerce/woocommerce/releases/tag/0.7) - 2025-04-30 
+
+-   Minor - Adds deprecation notice for Woo AI interactions
+-   Minor - Bump node version.
+-   Patch - Comment: Fix comment typos across various files.
+-   Patch - Update Woo.com references to WooCommerce.com.
+-   Minor - Use @automattic/tour-kit@1.1.3
+-   Minor - Bump @wordpress/env to 10.14.0 and remove patch for 10.10.0
+-   Patch - Bump @wordpress/env to 10.17.0
+-   Patch - Bump wireit dependency version to latest.
+-   Patch - Fix pnpm version to 9.1.3 to avoid dependency installation issues.
+-   Patch - Minor tooling tweaks (zip compression level, composer invocation)
+-   Patch - Monorepo: bump and patch wp-env to reduce amount of crashes in CI.
+-   Minor - Monorepo: bump pnpm version to 9.15.0
+-   Patch - Monorepo: consolidate @babel/* dependencies versions across the monorepo.
+-   Patch - Monorepo: consolidate syncpack config around React 17/18 usage.
+-   Patch - Monorepo: enable Jest caching.
+-   Patch - Monorepo: ensure monorepo packages are linked via workspace-version of the dependencies.
+-   Patch - Monorepo: minor tweaks in zip building script (use frozen lock file when installing dependecies).
+-   Patch - Monorepo: refresh wireit dependencyOutputs configuration synchronization when installing dependencies.
+-   Patch - Monorepo: review deprecated dev-dependecies (take 2)
+-   Patch - Monorepo: tweak Webpack loaders paths filtering for better build perfromance.
+-   Minor - Remove unused React imports
+-   Patch - Update @wordpress-env package to version 9.0.7
+-   Major [ **BREAKING CHANGE** ] - Updated declared dependencies to React 18 and Wordpress 6.6
+-   Patch - Update pnpm to 9.1.0
+-   Patch - Update wireit to 0.14.10
+-   Minor - Upgraded Typescript in the monorepo to 5.7.2
+-   Minor - Fix typos.
+-   Patch - Request valid JSON from the API when generating AI product names
+
 ## [0.6](https://github.com/woocommerce/woocommerce/releases/tag/0.6) - 2024-03-29 
 
--   Patch - Woo AI - Fix z-index issue with Background Removal Spotlight.
+-   Patch - Woo AI
 -   Patch - Add composer install to changelog script.
 -   Patch - Update references to woocommerce.com to now reference woo.com.
--   Minor - Add React Testing Library and tests to the Woo AI plugin.
 -   Patch - Fix Woo AI webpack build configuration.
 -   Patch - Only initialize background removal when Jetpack connection is present.
 -   Patch - Update / tweak a few more links in docs and comments.
+-   Minor - Add React Testing Library and tests to the Woo AI plugin.
 
 ## [0.5](https://github.com/woocommerce/woocommerce/releases/tag/0.5) - 2023-10-19 
 

--- a/plugins/woo-ai/changelog/45148-poc-request-reviews
+++ b/plugins/woo-ai/changelog/45148-poc-request-reviews
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Bump node version.

--- a/plugins/woo-ai/changelog/47385-dev-update-pnpm9-1
+++ b/plugins/woo-ai/changelog/47385-dev-update-pnpm9-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update pnpm to 9.1.0

--- a/plugins/woo-ai/changelog/49310-dev-pin-block-env-package
+++ b/plugins/woo-ai/changelog/49310-dev-pin-block-env-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: bump wp-env to 9.7.0, include blocks in syncpack
-

--- a/plugins/woo-ai/changelog/50047-fix-typos
+++ b/plugins/woo-ai/changelog/50047-fix-typos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Comment: Fix comment typos across various files.

--- a/plugins/woo-ai/changelog/50568-update-wp-env
+++ b/plugins/woo-ai/changelog/50568-update-wp-env
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: This updates the configuration for the local wp-env development environment so that the mysql database ports remain consistent between sessions.
-

--- a/plugins/woo-ai/changelog/50828-dev-constrain-pnpm-version
+++ b/plugins/woo-ai/changelog/50828-dev-constrain-pnpm-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix pnpm version to 9.1.3 to avoid dependency installation issues.

--- a/plugins/woo-ai/changelog/53165-dev-ts-5-7-2
+++ b/plugins/woo-ai/changelog/53165-dev-ts-5-7-2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Upgraded Typescript in the monorepo to 5.7.2

--- a/plugins/woo-ai/changelog/53531-dev-react-18-ghidorah
+++ b/plugins/woo-ai/changelog/53531-dev-react-18-ghidorah
@@ -1,4 +1,0 @@
-Significance: major
-Type: dev
-
-Updated declared dependencies to React 18 and Wordpress 6.6

--- a/plugins/woo-ai/changelog/53865-dev-pnpm-9-15-0
+++ b/plugins/woo-ai/changelog/53865-dev-pnpm-9-15-0
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Monorepo: bump pnpm version to 9.15.0

--- a/plugins/woo-ai/changelog/54996-chore-update-wireit
+++ b/plugins/woo-ai/changelog/54996-chore-update-wireit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update wireit to 0.14.10

--- a/plugins/woo-ai/changelog/55095-dev-rewrite-wireit-deps-update
+++ b/plugins/woo-ai/changelog/55095-dev-rewrite-wireit-deps-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: refresh wireit dependencyOutputs configuration synchronization when installing dependencies.

--- a/plugins/woo-ai/changelog/56506-remove-wp-components-types
+++ b/plugins/woo-ai/changelog/56506-remove-wp-components-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove deprecated `@types/wordpress__components`
-

--- a/plugins/woo-ai/changelog/56575-dev-bump-babel-deps
+++ b/plugins/woo-ai/changelog/56575-dev-bump-babel-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: consolidate @babel/* dependencies versions across the monorepo.

--- a/plugins/woo-ai/changelog/57299-fix-wireit-in-ci
+++ b/plugins/woo-ai/changelog/57299-fix-wireit-in-ci
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump wireit dependency version to latest.

--- a/plugins/woo-ai/changelog/57567-add-woo-ai-deprecation-notice
+++ b/plugins/woo-ai/changelog/57567-add-woo-ai-deprecation-notice
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Adds deprecation notice for Woo AI interactions

--- a/plugins/woo-ai/changelog/bump-update-wordpress-env-to-9.0.7
+++ b/plugins/woo-ai/changelog/bump-update-wordpress-env-to-9.0.7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update @wordpress-env package to version 9.0.7

--- a/plugins/woo-ai/changelog/dev-babel-loader-jest-caching
+++ b/plugins/woo-ai/changelog/dev-babel-loader-jest-caching
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: enable Jest caching.

--- a/plugins/woo-ai/changelog/dev-bump-wp-env-10.17.0
+++ b/plugins/woo-ai/changelog/dev-bump-wp-env-10.17.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump @wordpress/env to 10.17.0

--- a/plugins/woo-ai/changelog/dev-consolidate-syncpack-config
+++ b/plugins/woo-ai/changelog/dev-consolidate-syncpack-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: consolidate syncpack config around React 17/18 usage.

--- a/plugins/woo-ai/changelog/dev-deps-review-bump-p2
+++ b/plugins/woo-ai/changelog/dev-deps-review-bump-p2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: review deprecated dev-dependecies (take 2)

--- a/plugins/woo-ai/changelog/dev-monorepo-internal-packages-linking-fixes
+++ b/plugins/woo-ai/changelog/dev-monorepo-internal-packages-linking-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: ensure monorepo packages are linked via workspace-version of the dependencies.

--- a/plugins/woo-ai/changelog/dev-solve-wpenv-startup-failures-in-ci-take-2
+++ b/plugins/woo-ai/changelog/dev-solve-wpenv-startup-failures-in-ci-take-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: bump and patch wp-env to reduce amount of crashes in CI.

--- a/plugins/woo-ai/changelog/dev-try-faster-building-zip
+++ b/plugins/woo-ai/changelog/dev-try-faster-building-zip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: minor tweaks in zip building script (use frozen lock file when installing dependecies).

--- a/plugins/woo-ai/changelog/dev-tune-up-zip-generation
+++ b/plugins/woo-ai/changelog/dev-tune-up-zip-generation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Minor tooling tweaks (zip compression level, composer invocation)

--- a/plugins/woo-ai/changelog/dev-update-wp-env-10.14-and-remove-patch
+++ b/plugins/woo-ai/changelog/dev-update-wp-env-10.14-and-remove-patch
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Bump @wordpress/env to 10.14.0 and remove patch for 10.10.0

--- a/plugins/woo-ai/changelog/dev-webpack-loaders-scannig-paths-tweaks
+++ b/plugins/woo-ai/changelog/dev-webpack-loaders-scannig-paths-tweaks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Monorepo: tweak Webpack loaders paths filtering for better build perfromance.

--- a/plugins/woo-ai/changelog/fix-typo-in-woo-ai-plugin-doc
+++ b/plugins/woo-ai/changelog/fix-typo-in-woo-ai-plugin-doc
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Fix typos.

--- a/plugins/woo-ai/changelog/request-json-response-name-suggestions
+++ b/plugins/woo-ai/changelog/request-json-response-name-suggestions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Request valid JSON from the API when generating AI product names

--- a/plugins/woo-ai/changelog/task-update-eslint-config
+++ b/plugins/woo-ai/changelog/task-update-eslint-config
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Remove unused React imports

--- a/plugins/woo-ai/changelog/update-bump-a8c-tour-kit-version
+++ b/plugins/woo-ai/changelog/update-bump-a8c-tour-kit-version
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Use @automattic/tour-kit@1.1.3

--- a/plugins/woo-ai/changelog/update-woo-com-to-woocommerce-com
+++ b/plugins/woo-ai/changelog/update-woo-com-to-woocommerce-com
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update Woo.com references to WooCommerce.com.

--- a/plugins/woo-ai/composer.json
+++ b/plugins/woo-ai/composer.json
@@ -6,7 +6,7 @@
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,
 	"minimum-stability": "dev",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"require": {
 		"composer/installers": "~1.7",
 		"ext-json": "*"

--- a/plugins/woo-ai/package.json
+++ b/plugins/woo-ai/package.json
@@ -8,7 +8,7 @@
 		"url": "git://github.com/woocommerce/woo-ai.git"
 	},
 	"title": "Woo AI",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"homepage": "http://github.com/woocommerce/woo-ai",
 	"devDependencies": {
 		"@babel/preset-react": "7.25.7",

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -3,7 +3,7 @@
  * Plugin Name: Woo AI
  * Plugin URI: https://github.com/woocommerce/woocommerce/
  * Description: Enable AI experiments within the WooCommerce experience. <a href="https://automattic.com/ai-guidelines" target="_blank" rel="noopener noreferrer">Learn more</a>.
- * Version: 0.6.0
+ * Version: 0.7.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Requires at least: 5.8


### PR DESCRIPTION
This PR preps a release of Woo AI that includes a deprecation notice about the features being removed. It follows the instructions from the field guide.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is a version bump and already includes the generated CHANGELOG.

</details>
