### PR TITLE
Legacy Attribute Filter: fix dropdown width

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4082-filter-by-attribute-controls-the-dropdown-display-style-is
+++ b/plugins/woocommerce/changelog/wooplug-4082-filter-by-attribute-controls-the-dropdown-display-style-is
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Legacy Attribute Filter: fix the width of the dropdown style becomes too small when used within Row block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/style.scss
@@ -69,7 +69,6 @@
 	.wc-blocks-components-form-token-field-wrapper {
 		flex-grow: 1;
 		max-width: unset;
-		width: 0;
 		height: max-content;
 
 		&:not(.is-loading) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR fixes the width of the attribute filter block when the dropdown style is used and the container width is narrow, like putting filter blocks inside a Row block.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/57555

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1441" alt="image" src="https://github.com/user-attachments/assets/f61caad7-70e8-4e22-b4e0-4d444c91dabf" />    |    <img width="1441" alt="image" src="https://github.com/user-attachments/assets/40e936d4-5285-4f99-8ff2-103be92ca5b4" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new page with legacy filter blocks. You can use this gist to test: https://gist.github.com/dinhtungdu/3d8a64af2ae37386e0c7813f3e7c1d36.
2. See the dropdown display correctly in the editor, the dropdown properly cover options.
3. Save and verify the same on the front end.

<!-- End testing instructions -->