### PR TITLE
Pevent unsaved changes popup after successful blueprint import

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-unsaved-changes-popup-after-import
+++ b/plugins/woocommerce/changelog/fix-remove-unsaved-changes-popup-after-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unsaved changes popup after successful import for blueprint

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -479,7 +479,7 @@ export const BlueprintUploadDropzone = () => {
 				( state.matches( 'idle' ) ||
 					state.matches( 'error' ) ||
 					state.matches( 'parsingSteps' ) ) && (
-					<div className="blueprint-upload-form">
+					<div className="blueprint-upload-form wc-settings-prevent-change-event">
 						<FormFileUpload
 							className="blueprint-upload-field"
 							accept="application/json, application/zip"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related: pfwcF5-1Cm-p2#comment-1481

This PR fixes an issue where users saw an unsaved changes popup when navigating away from the blueprint import page after a successful import. This was confusing, as there were no actual changes to save at this point.

The issue stems from WooCommerce's `settings.js` which implements a form change detection mechanism to prevent users from accidentally navigating away from forms with unsaved changes. The relevant code is:

https://github.com/woocommerce/woocommerce/blob/efca148bb2120711e64e725a6e08d9f56e5e531b/plugins/woocommerce/client/legacy/js/admin/settings.js#L106-L145

Any input change event triggers the form change detection, and once triggered, it sets up a `beforeunload` event handler that shows the "unsaved changes" warning. However, in the blueprint import flow, even after a successful import, the form state wasn't being properly reset, causing this warning to appear unnecessarily.

This PR adds the `wc-settings-prevent-change-event` class to the blueprint import form elements after a successful import.



### Screenshots or screen recordings:

Before:

![image](https://github.com/user-attachments/assets/322aeeb1-5486-43de-824a-7d8b2c0cc817)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Advanced > Blueprints (beta)
2. Upload and complete a blueprint import successfully 
[woo-blueprint.json](https://github.com/user-attachments/files/19996220/woo-blueprint.json)
3. Navigate to any other section in the WP Admin dashboard
4. Verify that no unsaved changes popup appears

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>