### PR TITLE
[dev] Monorepo: fix pre-push validation.

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -50,8 +50,9 @@ if [ -n "$changedFiles" ]; then
 		echo -n "-> Executing '$command' ($iteration of $iterations) "
 		start=$SECONDS
 		result=$($command 2>&1)
+		code=$?
 		duration=$(( SECONDS - start ))
-		if [ $? -ne 0 ]; then
+		if [ $code -ne 0 ]; then
 			echo "[ERR] (aborting, please run manually to troubleshoot)"
 			exit 1
 		fi


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Related to: https://github.com/woocommerce/woocommerce/pull/57338
Context: p1746099994162199/1746098500.417509-slack-C03CPM3UXDJ

Fix pre-push linting, which passes even if linting itself has failed.