### PR TITLE
Remove usage of deprecated showSpinner prop causing warnings in console

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2157-remove-deprecated-showspinner-prop-of-the-blocks-components
+++ b/plugins/woocommerce/changelog/wooplug-2157-remove-deprecated-showspinner-prop-of-the-blocks-components
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Remove usage of showSpinner button prop (deprecated)
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/index.tsx
@@ -6,13 +6,11 @@ import { forwardRef } from '@wordpress/element';
 import clsx from 'clsx';
 import type { ForwardedRef } from 'react';
 import type { ButtonProps as AriakitButtonProps } from '@ariakit/react';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import Spinner from '../../../../../packages/components/spinner';
 
 type WCButtonProps = AriakitButtonProps & { children?: React.ReactNode };
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/index.tsx
@@ -18,14 +18,6 @@ type WCButtonProps = AriakitButtonProps & { children?: React.ReactNode };
 
 export interface ButtonProps extends WCButtonProps {
 	/**
-	 * Deprecated: Show a spinner. Preferably,
-	 * render a spinner in the button children
-	 * instead.
-	 *
-	 * @default false
-	 */
-	showSpinner?: boolean | undefined;
-	/**
 	 * Button variant
 	 *
 	 * @default 'contained'
@@ -54,17 +46,8 @@ interface LinkProps extends ButtonProps {
  */
 const Button = forwardRef< HTMLButtonElement, ButtonProps | LinkProps >(
 	( props, ref ) => {
-		if ( 'showSpinner' in props ) {
-			deprecated( 'showSpinner prop', {
-				version: '8.9.0',
-				alternative: 'Render a spinner in the button children instead.',
-				plugin: 'WooCommerce',
-			} );
-		}
-
 		const {
 			className,
-			showSpinner = false,
 			children,
 			variant = 'contained',
 			// To maintain backward compat we render a wrapper for button text by default,
@@ -77,10 +60,7 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps | LinkProps >(
 			'wc-block-components-button',
 			'wp-element-button',
 			className,
-			variant,
-			{
-				'wc-block-components-button--loading': showSpinner,
-			}
+			variant
 		);
 
 		if ( 'href' in props ) {
@@ -91,10 +71,9 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps | LinkProps >(
 							ref={ ref as ForwardedRef< HTMLAnchorElement > }
 							href={ props.href }
 						>
-							{ showSpinner && <Spinner /> }
-							<span className="wc-block-components-button__text">
+							<div className="wc-block-components-button__text">
 								{ children }
-							</span>
+							</div>
 						</a>
 					}
 					className={ buttonClassName }
@@ -106,9 +85,9 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps | LinkProps >(
 		const buttonChildren = removeTextWrap ? (
 			props.children
 		) : (
-			<span className="wc-block-components-button__text">
+			<div className="wc-block-components-button__text">
 				{ props.children }
-			</span>
+			</div>
 		);
 
 		return (
@@ -117,7 +96,6 @@ const Button = forwardRef< HTMLButtonElement, ButtonProps | LinkProps >(
 				className={ buttonClassName }
 				{ ...rest }
 			>
-				{ showSpinner && <Spinner /> }
 				{ buttonChildren }
 			</AriakitButton>
 		);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/stories/index.stories.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/stories/index.stories.tsx
@@ -31,7 +31,6 @@ export const Default = Template.bind( {} );
 Default.args = {
 	children: 'Buy Now',
 	disabled: false,
-	showSpinner: false,
 	type: 'button',
 };
 
@@ -45,5 +44,4 @@ export const Loading = Template.bind( {} );
 Loading.args = {
 	...Default.args,
 	disabled: true,
-	showSpinner: true,
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
@@ -16,12 +16,13 @@
 	.wc-block-components-button__text {
 		display: block;
 
+		// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
+		text-wrap: balance;
+		text-wrap: pretty;
+
 		> svg {
 			fill: currentColor;
 		}
-	}
-	.wc-block-components-spinner + .wc-block-components-button__text {
-		visibility: hidden;
 	}
 
 	&.text {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -92,7 +92,6 @@ const PlaceOrderButton = ( {
 				waitingForProcessing ||
 				waitingForRedirect
 			}
-			showSpinner={ waitingForProcessing }
 		>
 			{ waitingForProcessing && <Spinner /> }
 			{ waitingForRedirect && <Icon icon={ check } /> }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -40,16 +40,9 @@ const PlaceOrderButton = ( {
 
 	const buttonLabel = (
 		<div
-			// Hide this from screen readers while the checkout is processing. The text will not be removed from the
-			// DOM, it will just be hidden with CSS to maintain the button's size while the spinner appears.
-			aria-hidden={ waitingForProcessing || waitingForRedirect }
-			className={ clsx(
-				'wc-block-components-checkout-place-order-button__text',
-				{
-					'wc-block-components-checkout-place-order-button__text--visually-hidden':
-						waitingForProcessing || waitingForRedirect,
-				}
-			) }
+			className={
+				'wc-block-components-checkout-place-order-button__text'
+			}
 		>
 			{ label }
 			{ showPrice && (
@@ -83,7 +76,10 @@ const PlaceOrderButton = ( {
 					'wc-block-components-checkout-place-order-button--full-width':
 						fullWidth,
 				},
-				{ 'wc-blocks-components-button--loading': waitingForProcessing }
+				{
+					'wc-block-components-checkout-place-order-button--loading':
+						waitingForProcessing || waitingForRedirect,
+				}
 			) }
 			onClick={ onSubmit }
 			disabled={
@@ -94,7 +90,12 @@ const PlaceOrderButton = ( {
 			}
 		>
 			{ waitingForProcessing && <Spinner /> }
-			{ waitingForRedirect && <Icon icon={ check } /> }
+			{ waitingForRedirect && (
+				<Icon
+					className="wc-block-components-checkout-place-order-button__icon"
+					icon={ check }
+				/>
+			) }
 			{ buttonLabel }
 		</Button>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { useState, useRef } from '@wordpress/element';
 import Button from '@woocommerce/base-components/button';
@@ -10,6 +11,7 @@ import {
 	ValidationInputError,
 	ValidatedTextInputHandle,
 	Panel,
+	Spinner,
 } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
 import { validationStore } from '@woocommerce/block-data';
@@ -49,12 +51,15 @@ export const TotalsCoupon = ( {
 	const [ isCouponFormVisible, setIsCouponFormVisible ] =
 		useState( displayCouponForm );
 	const textInputId = `wc-block-components-totals-coupon__input-${ instanceId }`;
-	const { validationErrorId } = useSelect( ( select ) => {
-		const store = select( validationStore );
-		return {
-			validationErrorId: store.getValidationErrorId( instanceId ),
-		};
-	} );
+	const { validationErrorId } = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				validationErrorId: store.getValidationErrorId( instanceId ),
+			};
+		},
+		[ instanceId ]
+	);
 	const inputRef = useRef< ValidatedTextInputHandle >( null );
 
 	const handleCouponSubmit: MouseEventHandler< HTMLButtonElement > = (
@@ -75,6 +80,23 @@ export const TotalsCoupon = ( {
 			setIsCouponFormVisible( true );
 		}
 	};
+
+	const buttonLabel = (
+		<div
+			// Hide this from screen readers while showing the spinner. The text will not be removed from the
+			// DOM, it will just be hidden with CSS to maintain the button's size while the spinner appears.
+			aria-hidden={ isLoading }
+			className={ clsx(
+				'wc-block-components-totals-coupon__button__text',
+				{
+					'wc-block-components-totals-coupon__button__text--visually-hidden':
+						isLoading,
+				}
+			) }
+		>
+			{ __( 'Apply', 'woocommerce' ) }
+		</div>
+	);
 
 	return (
 		<Panel
@@ -111,13 +133,19 @@ export const TotalsCoupon = ( {
 							ref={ inputRef }
 						/>
 						<Button
-							className="wc-block-components-totals-coupon__button"
+							className={ clsx(
+								'wc-block-components-totals-coupon__button',
+								{
+									'wc-block-components-totals-coupon__button--loading':
+										isLoading,
+								}
+							) }
 							disabled={ isLoading || ! couponValue }
-							showSpinner={ isLoading }
 							onClick={ handleCouponSubmit }
 							type="submit"
 						>
-							{ __( 'Apply', 'woocommerce' ) }
+							{ isLoading && <Spinner /> }
+							{ buttonLabel }
 						</Button>
 					</form>
 					<ValidationInputError

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -81,23 +81,6 @@ export const TotalsCoupon = ( {
 		}
 	};
 
-	const buttonLabel = (
-		<div
-			// Hide this from screen readers while showing the spinner. The text will not be removed from the
-			// DOM, it will just be hidden with CSS to maintain the button's size while the spinner appears.
-			aria-hidden={ isLoading }
-			className={ clsx(
-				'wc-block-components-totals-coupon__button__text',
-				{
-					'wc-block-components-totals-coupon__button__text--visually-hidden':
-						isLoading,
-				}
-			) }
-		>
-			{ __( 'Apply', 'woocommerce' ) }
-		</div>
-	);
-
 	return (
 		<Panel
 			className="wc-block-components-totals-coupon"
@@ -145,7 +128,7 @@ export const TotalsCoupon = ( {
 							type="submit"
 						>
 							{ isLoading && <Spinner /> }
-							{ buttonLabel }
+							{ __( 'Apply', 'woocommerce' ) }
 						</Button>
 					</form>
 					<ValidationInputError

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -35,6 +35,19 @@
 		white-space: nowrap;
 		flex: 1 1 auto;
 	}
+
+	.wc-block-components-totals-coupon__button__text {
+		display: flex;
+		align-items: center;
+
+		// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
+		text-wrap: balance;
+		text-wrap: pretty;
+
+		&--visually-hidden {
+			visibility: hidden;
+		}
+	}
 }
 
 .wc-block-components-totals-coupon__content {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -34,18 +34,15 @@
 		padding-right: $gap;
 		white-space: nowrap;
 		flex: 1 1 auto;
-	}
 
-	.wc-block-components-totals-coupon__button__text {
-		display: flex;
-		align-items: center;
-
-		// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
-		text-wrap: balance;
-		text-wrap: pretty;
-
-		&--visually-hidden {
-			visibility: hidden;
+		// Hides labels when the spinner is shown.
+		&--loading {
+			.wc-block-components-button__text {
+				visibility: hidden;
+			}
+			.wc-block-components-spinner {
+				visibility: visible;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
@@ -36,8 +36,6 @@ describe( 'TotalsCoupon', () => {
 		} );
 		rerender( <TotalsCoupon instanceId={ 'coupon' } /> );
 
-		// TODO: Fix a recent deprecation of showSpinner prop of Button called in this component.
-		expect( console ).toHaveWarned();
 		expect( screen.getByText( 'Invalid coupon code' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -37,9 +37,6 @@ describe( 'CartEventsProvider', () => {
 			</CartEventsProvider>
 		);
 
-		// TODO: Fix a recent deprecation of showSpinner prop of Button called in this component.
-		expect( console ).toHaveWarned();
-
 		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
 		const button = screen.getByText( 'Proceed to Checkout' );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -41,7 +41,7 @@ describe( 'CartEventsProvider', () => {
 		const button = screen.getByText( 'Proceed to Checkout' );
 
 		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
-		button.parentElement?.removeAttribute( 'href' );
+		button.closest( 'a' )?.removeAttribute( 'href' );
 
 		await act( async () => {
 			await user.click( button );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -12,6 +12,7 @@ import { cartStore, checkoutStore } from '@woocommerce/block-data';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import { isErrorResponse } from '@woocommerce/types';
 import { useCartEventsContext } from '@woocommerce/base-context/providers';
+import { Spinner } from '@woocommerce/blocks-components';
 
 /**
  * Internal dependencies
@@ -24,15 +25,16 @@ import { defaultButtonLabel } from './constants';
 const Block = ( {
 	checkoutPageId,
 	className,
-	buttonLabel,
+	buttonLabel: buttonLabelProp,
 }: {
 	checkoutPageId: number;
 	className: string;
 	buttonLabel: string;
 } ): JSX.Element => {
 	const link = getSetting< string >( 'page-' + checkoutPageId, false );
-	const isCalculating = useSelect( ( select ) =>
-		select( checkoutStore ).isCalculating()
+	const isCalculating = useSelect(
+		( select ) => select( checkoutStore ).isCalculating(),
+		[]
 	);
 
 	const [ positionReferenceElement, positionRelativeToViewport ] =
@@ -62,10 +64,11 @@ const Block = ( {
 	}, [] );
 	const cart = useSelect( ( select ) => {
 		return select( cartStore ).getCartData();
-	} );
+	}, [] );
+
 	const label = applyCheckoutFilter< string >( {
 		filterName: 'proceedToCheckoutButtonLabel',
-		defaultValue: buttonLabel || defaultButtonLabel,
+		defaultValue: buttonLabelProp || defaultButtonLabel,
 		arg: { cart },
 	} );
 
@@ -77,9 +80,25 @@ const Block = ( {
 
 	const { dispatchOnProceedToCheckout } = useCartEventsContext();
 
+	const buttonLabel = (
+		<div
+			// Hide this from screen readers while showing the spinner. The text will not be removed from the
+			// DOM, it will just be hidden with CSS to maintain the button's size while the spinner appears.
+			aria-hidden={ showSpinner }
+			className={ clsx( 'wc-block-cart__submit-button__text', {
+				'wc-block-cart__submit-button__text--visually-hidden':
+					showSpinner,
+			} ) }
+		>
+			{ label }
+		</div>
+	);
+
 	const submitContainerContents = (
 		<Button
-			className="wc-block-cart__submit-button"
+			className={ clsx( 'wc-block-cart__submit-button', {
+				'wc-block-cart__submit-button--loading': showSpinner,
+			} ) }
 			href={ filteredLink }
 			disabled={ isCalculating }
 			onClick={ ( e ) => {
@@ -91,9 +110,9 @@ const Block = ( {
 					setShowSpinner( true );
 				} );
 			} }
-			showSpinner={ showSpinner }
 		>
-			{ label }
+			{ showSpinner && <Spinner /> }
+			{ buttonLabel }
 		</Button>
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -25,7 +25,7 @@ import { defaultButtonLabel } from './constants';
 const Block = ( {
 	checkoutPageId,
 	className,
-	buttonLabel: buttonLabel,
+	buttonLabel,
 }: {
 	checkoutPageId: number;
 	className: string;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -25,7 +25,7 @@ import { defaultButtonLabel } from './constants';
 const Block = ( {
 	checkoutPageId,
 	className,
-	buttonLabel: buttonLabelProp,
+	buttonLabel: buttonLabel,
 }: {
 	checkoutPageId: number;
 	className: string;
@@ -68,7 +68,7 @@ const Block = ( {
 
 	const label = applyCheckoutFilter< string >( {
 		filterName: 'proceedToCheckoutButtonLabel',
-		defaultValue: buttonLabelProp || defaultButtonLabel,
+		defaultValue: buttonLabel || defaultButtonLabel,
 		arg: { cart },
 	} );
 
@@ -79,20 +79,6 @@ const Block = ( {
 	} );
 
 	const { dispatchOnProceedToCheckout } = useCartEventsContext();
-
-	const buttonLabel = (
-		<div
-			// Hide this from screen readers while showing the spinner. The text will not be removed from the
-			// DOM, it will just be hidden with CSS to maintain the button's size while the spinner appears.
-			aria-hidden={ showSpinner }
-			className={ clsx( 'wc-block-cart__submit-button__text', {
-				'wc-block-cart__submit-button__text--visually-hidden':
-					showSpinner,
-			} ) }
-		>
-			{ label }
-		</div>
-	);
 
 	const submitContainerContents = (
 		<Button
@@ -112,7 +98,7 @@ const Block = ( {
 			} }
 		>
 			{ showSpinner && <Spinner /> }
-			{ buttonLabel }
+			{ label }
 		</Button>
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -7,18 +7,15 @@
 	width: 100%;
 	margin: 0;
 	box-sizing: border-box;
-}
 
-.wc-block-cart__submit-button__text {
-	display: flex;
-	align-items: center;
-
-	// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
-	text-wrap: balance;
-	text-wrap: pretty;
-
-	&--visually-hidden {
-		visibility: hidden;
+	// Hides labels when the spinner is shown.
+	&--loading {
+		.wc-block-components-button__text {
+			visibility: hidden;
+		}
+		.wc-block-components-spinner {
+			visibility: visible;
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -9,6 +9,19 @@
 	box-sizing: border-box;
 }
 
+.wc-block-cart__submit-button__text {
+	display: flex;
+	align-items: center;
+
+	// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
+	text-wrap: balance;
+	text-wrap: pretty;
+
+	&--visually-hidden {
+		visibility: hidden;
+	}
+}
+
 .wc-block-cart {
 	.wc-block-cart__submit-container {
 		padding: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -24,9 +24,6 @@ describe( 'Proceed to checkout block', () => {
 			<Block checkoutPageId={ 0 } buttonLabel={ '' } className={ '' } />
 		);
 
-		// TODO: Fix a recent deprecation of showSpinner prop of Button called in this component.
-		expect( console ).toHaveWarned();
-
 		expect( screen.getByText( 'Proceed to step two' ) ).toBeInTheDocument();
 	} );
 	it( 'allows the link to be filtered', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -80,7 +80,7 @@ describe( 'Proceed to checkout block', () => {
 		const button = screen.getByText( 'Proceed to Checkout' );
 
 		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
-		button.parentElement?.removeAttribute( 'href' );
+		button.closest( 'a' )?.removeAttribute( 'href' );
 
 		button.click();
 		await waitFor( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/block.js
@@ -93,9 +93,6 @@ describe( 'Testing cart', () => {
 	it( 'renders cart if there are items in the cart', async () => {
 		render( <CartBlock /> );
 
-		// TODO: Fix a recent deprecation of showSpinner prop of Button called in this component.
-		expect( console ).toHaveWarned();
-
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 
 		expect(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/editor.scss
@@ -1,7 +1,7 @@
 // Shows the text, separator, and price alongside each other in the editor.
 .wp-block-woocommerce-checkout-actions-block {
 	.wc-block-components-checkout-place-order-button {
-		span.wc-block-components-button__text {
+		.wc-block-components-button__text {
 			display: flex;
 			align-items: center;
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -14,18 +14,20 @@
 					width: 100%;
 				}
 
-				// Keeps the text in the DOM but not visible, so it doesn't cause the button to resize while showing the spinner.
-				.wc-block-components-checkout-place-order-button__text--visually-hidden {
-					visibility: hidden;
+				// Hides labels when the spinner is shown.
+				&--loading {
+					.wc-block-components-button__text {
+						visibility: hidden;
+					}
+					.wc-block-components-spinner,
+					.wc-block-components-checkout-place-order-button__icon {
+						visibility: visible;
+					}
 				}
 
 				.wc-block-components-checkout-place-order-button__text {
 					display: flex;
 					align-items: center;
-
-					// Prevent runts/widows. Overwrite `balance` with `pretty`, as `pretty` is not supported in all browsers.
-					text-wrap: balance;
-					text-wrap: pretty;
 				}
 
 				.wc-block-components-checkout-place-order-button__separator {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -150,9 +150,6 @@ describe( 'Testing Checkout', () => {
 	it( 'Renders checkout if there are items in the cart', async () => {
 		render( <CheckoutBlock /> );
 
-		// TODO: Fix a recent deprecation of showSpinner prop of Button called in this component.
-		expect( console ).toHaveWarned();
-
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 
 		expect( screen.getByText( /Place Order/i ) ).toBeInTheDocument();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -39,7 +39,7 @@ describe( 'Mini Cart Checkout Button Block', () => {
 		const button = screen.getByText( 'Proceed to Checkout' );
 
 		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
-		button.parentElement?.removeAttribute( 'href' );
+		button.closest( 'a' )?.removeAttribute( 'href' );
 		button.click();
 		await waitFor( () => {
 			expect( mockObserver ).toHaveBeenCalled();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/form.tsx
@@ -148,16 +148,15 @@ const Form = ( {
 				className={ clsx(
 					'wc-block-order-confirmation-create-account-button',
 					{
-						'is-loading': isLoading,
+						'wc-block-order-confirmation-create-account-button--loading':
+							isLoading,
 					}
 				) }
 				type="submit"
 				disabled={ !! hasValidationError || needsPassword || isLoading }
 			>
 				{ !! isLoading && <Spinner /> }
-				<span className="wc-block-order-confirmation-create-account-button-text">
-					{ __( 'Create account', 'woocommerce' ) }
-				</span>
+				{ __( 'Create account', 'woocommerce' ) }
 			</Button>
 			<input type="hidden" name="email" value={ customerEmail } />
 			<input type="hidden" name="password" value={ password } />

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/create-account/style.scss
@@ -94,14 +94,13 @@
 	}
 
 	.wc-block-order-confirmation-create-account-button {
-		.wc-block-components-button__text {
-			position: relative;
-		}
-		&.is-loading {
-			pointer-events: none;
-
-			.wc-block-components-spinner + .wc-block-order-confirmation-create-account-button-text {
+		// Hides labels when the spinner is shown.
+		&--loading {
+			.wc-block-components-button__text {
 				visibility: hidden;
+			}
+			.wc-block-components-spinner {
+				visibility: visible;
 			}
 		}
 	}

--- a/plugins/woocommerce/client/blocks/packages/components/spinner/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/spinner/style.scss
@@ -6,6 +6,8 @@
 	box-sizing: content-box;
 	text-align: center;
 	font-size: 1.25em;
+	left: 0;
+	top: 0;
 	&::after {
 		content: " ";
 		position: absolute;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`showSpinner` for buttons was deprecated but we never migrated usage. This PR fixes this and prevents deprecation warnings showing on the console when using cart and checkout blocks.

All buttons implementing a spinner have been updated for a consistent approach with similar classnames. As such, each button should be tested to confirm there are no regressions.

Closes #46812

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open console and go to the cart/checkout pages. Confirm there are no deprecation warnings for showSpinner.
2. Enable guest checkout, delayed account creation. Perform the following as as guest.
3. Visually check that the buttons previously consuming `showSpinner` are functional. In all cases, the spinner should appear centred in the button, and the original button text should be hidden:
- On the cart page, proceed to checkout. See spinner.
- On the cart page, apply a coupon. See spinner.
- On the checkout page, place order. See spinner followed by check mark when the order has been placed.
- On the confirmation page, create account. See spinner.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
