### PR TITLE
Fix various console warnings from useSelect usage on cart/checkout

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-checkout-block-console-warnings
+++ b/plugins/woocommerce/changelog/fix-cart-checkout-block-console-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix various cart/checkout useSelect warnings in console
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -28,22 +28,15 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { setValidationErrors } = useDispatch( validationStore );
 
-	const {
-		isApplyingCoupon,
-		isRemovingCoupon,
-	}: Pick< StoreCartCoupon, 'isApplyingCoupon' | 'isRemovingCoupon' > =
-		useSelect( ( select ) => {
-			const store = select( cartStore );
-
-			return {
-				isApplyingCoupon: store.isApplyingCoupon(),
-				isRemovingCoupon: store.isRemovingCoupon(),
-			};
-		} );
+	const [ isApplyingCoupon, isRemovingCoupon ] = useSelect( ( select ) => {
+		const store = select( cartStore );
+		return [ store.isApplyingCoupon(), store.isRemovingCoupon() ];
+	}, [] );
 
 	const { applyCoupon, removeCoupon } = useDispatch( cartStore );
-	const orderId = useSelect( ( select ) =>
-		select( checkoutStore ).getOrderId()
+	const orderId = useSelect(
+		( select ) => select( checkoutStore ).getOrderId(),
+		[]
 	);
 
 	// Return cart, checkout or generic error message.

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import {
 	cartStore,
 	validationStore,
 	checkoutStore,
 } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import type { StoreCartCoupon, ApiErrorResponse } from '@woocommerce/types';
+import type {
+	StoreCartCoupon,
+	CouponApiErrorResponse,
+} from '@woocommerce/types';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
@@ -24,109 +28,122 @@ import { useStoreCart } from './use-store-cart';
  */
 export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 	const { cartCoupons, cartIsLoading } = useStoreCart();
-	const { createErrorNotice } = useDispatch( 'core/notices' );
-	const { createNotice } = useDispatch( 'core/notices' );
-	const { setValidationErrors } = useDispatch( validationStore );
-
-	const [ isApplyingCoupon, isRemovingCoupon ] = useSelect( ( select ) => {
-		const store = select( cartStore );
-		return [ store.isApplyingCoupon(), store.isRemovingCoupon() ];
-	}, [] );
-
 	const { applyCoupon, removeCoupon } = useDispatch( cartStore );
+
+	const isApplyingCoupon = useSelect(
+		( select ) => select( cartStore ).isApplyingCoupon(),
+		[]
+	);
+	const isRemovingCoupon = useSelect(
+		( select ) => select( cartStore ).isRemovingCoupon(),
+		[]
+	);
 	const orderId = useSelect(
 		( select ) => select( checkoutStore ).getOrderId(),
 		[]
 	);
 
 	// Return cart, checkout or generic error message.
-	const getCouponErrorMessage = ( error: ApiErrorResponse ) => {
-		if ( orderId && orderId > 0 && error?.data?.details?.checkout ) {
-			return error.data.details.checkout;
-		} else if ( error?.data?.details?.cart ) {
-			return error.data.details.cart;
-		}
-		return error.message;
-	};
+	const getCouponErrorMessage = useCallback(
+		( error: CouponApiErrorResponse ) => {
+			if ( orderId && orderId > 0 && error?.data?.details?.checkout ) {
+				return error.data.details.checkout;
+			} else if ( error?.data?.details?.cart ) {
+				return error.data.details.cart;
+			}
+			return error.message;
+		},
+		[ orderId ]
+	);
 
-	const applyCouponWithNotices = ( couponCode: string ) => {
-		return applyCoupon( couponCode )
-			.then( () => {
-				if (
-					applyCheckoutFilter( {
-						filterName: 'showApplyCouponNotice',
-						defaultValue: true,
-						arg: { couponCode, context },
-					} )
-				) {
-					createNotice(
-						'info',
-						sprintf(
-							/* translators: %s coupon code. */
-							__(
-								'Coupon code "%s" has been applied to your cart.',
-								'woocommerce'
+	const applyCouponWithNotices = useCallback(
+		( couponCode: string ) => {
+			return applyCoupon( couponCode )
+				.then( () => {
+					if (
+						applyCheckoutFilter( {
+							filterName: 'showApplyCouponNotice',
+							defaultValue: true,
+							arg: { couponCode, context },
+						} )
+					) {
+						dispatch( 'core/notices' ).createNotice(
+							'info',
+							sprintf(
+								/* translators: %s coupon code. */
+								__(
+									'Coupon code "%s" has been applied to your cart.',
+									'woocommerce'
+								),
+								couponCode
 							),
-							couponCode
-						),
+							{
+								id: 'coupon-form',
+								type: 'snackbar',
+								context,
+							}
+						);
+					}
+					return Promise.resolve( true );
+				} )
+				.catch( ( error ) => {
+					const errorMessage = getCouponErrorMessage( error );
+					dispatch( validationStore ).setValidationErrors( {
+						coupon: {
+							message: decodeEntities( errorMessage ),
+							hidden: false,
+						},
+					} );
+					return Promise.resolve( false );
+				} );
+		},
+		[ applyCoupon, getCouponErrorMessage, context ]
+	);
+
+	const removeCouponWithNotices = useCallback(
+		( couponCode: string ) => {
+			return removeCoupon( couponCode )
+				.then( () => {
+					if (
+						applyCheckoutFilter( {
+							filterName: 'showRemoveCouponNotice',
+							defaultValue: true,
+							arg: { couponCode, context },
+						} )
+					) {
+						dispatch( 'core/notices' ).createNotice(
+							'info',
+							sprintf(
+								/* translators: %s coupon code. */
+								__(
+									'Coupon code "%s" has been removed from your cart.',
+									'woocommerce'
+								),
+								couponCode
+							),
+							{
+								id: 'coupon-form',
+								type: 'snackbar',
+								context,
+							}
+						);
+					}
+					return Promise.resolve( true );
+				} )
+				.catch( ( error ) => {
+					dispatch( 'core/notices' ).createErrorNotice(
+						error.message,
 						{
 							id: 'coupon-form',
 							type: 'snackbar',
 							context,
 						}
 					);
-				}
-				return Promise.resolve( true );
-			} )
-			.catch( ( error ) => {
-				const errorMessage = getCouponErrorMessage( error );
-				setValidationErrors( {
-					coupon: {
-						message: decodeEntities( errorMessage ), // TODO fix the circular loop with ApiErrorResponseData and ApiErrorResponseDataDetails
-						hidden: false,
-					},
+					return Promise.resolve( false );
 				} );
-				return Promise.resolve( false );
-			} );
-	};
-
-	const removeCouponWithNotices = ( couponCode: string ) => {
-		return removeCoupon( couponCode )
-			.then( () => {
-				if (
-					applyCheckoutFilter( {
-						filterName: 'showRemoveCouponNotice',
-						defaultValue: true,
-						arg: { couponCode, context },
-					} )
-				) {
-					createNotice(
-						'info',
-						sprintf(
-							/* translators: %s coupon code. */
-							__(
-								'Coupon code "%s" has been removed from your cart.',
-								'woocommerce'
-							),
-							couponCode
-						),
-						{
-							id: 'coupon-form',
-							type: 'snackbar',
-							context,
-						}
-					);
-				}
-				return Promise.resolve( true );
-			} )
-			.catch( ( error ) => {
-				createErrorNotice( error.message, {
-					id: 'coupon-form',
-					context,
-				} );
-				return Promise.resolve( false );
-			} );
-	};
+		},
+		[ removeCoupon, context ]
+	);
 
 	return {
 		appliedCoupons: cartCoupons,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -29,17 +29,12 @@ import { useStoreCart } from './use-store-cart';
 export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 	const { cartCoupons, cartIsLoading } = useStoreCart();
 	const { applyCoupon, removeCoupon } = useDispatch( cartStore );
-
-	const isApplyingCoupon = useSelect(
-		( select ) => select( cartStore ).isApplyingCoupon(),
-		[]
-	);
-	const isRemovingCoupon = useSelect(
-		( select ) => select( cartStore ).isRemovingCoupon(),
-		[]
-	);
-	const orderId = useSelect(
-		( select ) => select( checkoutStore ).getOrderId(),
+	const { isApplyingCoupon, isRemovingCoupon, orderId } = useSelect(
+		( select ) => ( {
+			isApplyingCoupon: select( cartStore ).isApplyingCoupon(),
+			isRemovingCoupon: select( cartStore ).isRemovingCoupon(),
+			orderId: select( checkoutStore ).getOrderId(),
+		} ),
 		[]
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -187,22 +187,25 @@ export const useStoreCart = (
 			: EMPTY_CART_COUPONS;
 	}, [ JSON.stringify( cartData.coupons ) ] );
 
-	const billingAddress = useMemo( () => {
-		return emptyHiddenAddressFields(
-			decodeValues( cartData.billingAddress )
-		);
-	}, [ JSON.stringify( cartData.billingAddress ) ] );
+	const nextBillingAddress = emptyHiddenAddressFields(
+		decodeValues( cartData.billingAddress )
+	);
 
-	const shippingAddress = useMemo( () => {
-		return cartData.needsShipping
-			? emptyHiddenAddressFields(
-					decodeValues( cartData.shippingAddress )
-			  )
-			: billingAddress;
-	}, [
-		JSON.stringify( cartData.shippingAddress ),
-		JSON.stringify( billingAddress ),
-	] );
+	if ( ! fastDeepEqual( billingAddressRef.current, nextBillingAddress ) ) {
+		billingAddressRef.current = nextBillingAddress;
+	}
+
+	const billingAddress = billingAddressRef.current;
+
+	const nextShippingAddress = cartData.needsShipping
+		? emptyHiddenAddressFields( decodeValues( cartData.shippingAddress ) )
+		: billingAddress;
+
+	if ( ! fastDeepEqual( shippingAddressRef.current, nextShippingAddress ) ) {
+		shippingAddressRef.current = nextShippingAddress;
+	}
+
+	const shippingAddress = shippingAddressRef.current;
 
 	const storeCart: StoreCart = {
 		cartCoupons,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -149,26 +149,6 @@ export const useStoreCart = (
 			};
 		}, [] );
 
-	const cartFees = useMemo( () => {
-		return cartData.fees.length > 0
-			? cartData.fees.map( ( fee: CartResponseFeeItem ) =>
-					decodeValues( fee )
-			  )
-			: EMPTY_CART_FEES;
-	}, [ JSON.stringify( cartData.fees ) ] );
-
-	// Add a text property to the coupon to allow extensions to modify
-	// the text used to display the coupon, without affecting the
-	// functionality when it comes to removing the coupon.
-	const cartCoupons: CartResponseCoupons = useMemo( () => {
-		return cartData.coupons.length > 0
-			? cartData.coupons.map( ( coupon: CartResponseCouponItem ) => ( {
-					...coupon,
-					label: coupon.code,
-			  } ) )
-			: EMPTY_CART_COUPONS;
-	}, [ JSON.stringify( cartData.coupons ) ] );
-
 	if ( ! shouldSelect ) {
 		return defaultCartData;
 	}
@@ -194,10 +174,23 @@ export const useStoreCart = (
 	const shippingAddress = shippingAddressRef.current;
 
 	const storeCart: StoreCart = {
-		cartCoupons,
+		cartCoupons:
+			cartData.coupons.length > 0
+				? cartData.coupons.map(
+						( coupon: CartResponseCouponItem ) => ( {
+							...coupon,
+							label: coupon.code,
+						} )
+				  )
+				: EMPTY_CART_COUPONS,
 		cartItems: cartData.items,
 		crossSellsProducts: cartData.crossSells,
-		cartFees,
+		cartFees:
+			cartData.fees.length > 0
+				? cartData.fees.map( ( fee: CartResponseFeeItem ) =>
+						decodeValues( fee )
+				  )
+				: EMPTY_CART_FEES,
 		cartItemsCount: cartData.itemsCount,
 		cartItemsWeight: cartData.itemsWeight,
 		cartNeedsPayment: cartData.needsPayment,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { useRef } from '@wordpress/element';
+import { useRef, useMemo } from '@wordpress/element';
 import {
 	cartStore,
 	EMPTY_CART_COUPONS,
@@ -19,7 +19,7 @@ import {
 	EMPTY_PAYMENT_REQUIREMENTS,
 	EMPTY_EXTENSIONS,
 } from '@woocommerce/block-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type {
 	StoreCart,
@@ -80,7 +80,12 @@ const defaultCartTotals: CartResponseTotals = {
 	currency_suffix: '',
 };
 
-const decodeValues = < T extends Record< string, unknown > >(
+const decodeValues = <
+	T extends
+		| Record< string, unknown >
+		| CartResponseBillingAddress
+		| CartResponseShippingAddress
+>(
 	object: T
 ): T => {
 	return Object.fromEntries(
@@ -122,122 +127,115 @@ export const defaultCartData: StoreCart = {
 };
 
 /**
- * This is a custom hook that is wired up to the `wc/store/cart` data
- * store.
- *
- * @param {Object}  options              An object declaring the various
- *                                       collection arguments.
- * @param {boolean} options.shouldSelect If false, the previous results will be
- *                                       returned and internal selects will not
- *                                       fire.
- *
- * @return {StoreCart} Object containing cart data.
+ * This is a custom hook that is wired up to the `wc/store/cart` data store.
  */
-
 export const useStoreCart = (
 	options: { shouldSelect: boolean } = { shouldSelect: true }
 ): StoreCart => {
 	const { shouldSelect } = options;
-	const currentResults = useRef();
+	const currentStoreCart = useRef< StoreCart >();
 	const billingAddressRef = useRef( defaultBillingAddress );
 	const shippingAddressRef = useRef( defaultShippingAddress );
 
 	// This will keep track of jQuery and DOM events that invalidate the store resolution.
 	useStoreCartEventListeners();
 
-	const results: StoreCart = useSelect(
-		( select, { dispatch } ) => {
-			if ( ! shouldSelect ) {
-				return defaultCartData;
-			}
+	const { receiveCart, receiveCartContents } = useDispatch( cartStore );
+	const { cartData, cartErrors, cartTotals, cartIsLoading, isLoadingRates } =
+		useSelect(
+			( select ) => {
+				const store = select( cartStore );
+				const cartData = store.getCartData();
+				const cartErrors = store.getCartErrors();
+				const cartTotals = store.getCartTotals();
+				const cartIsLoading =
+					// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
+					! store.hasFinishedResolution( 'getCartData' );
+				const isLoadingRates = store.isCustomerDataUpdating();
+				return {
+					cartData,
+					cartErrors,
+					cartTotals,
+					cartIsLoading,
+					isLoadingRates,
+				};
+			},
+			[ shouldSelect ]
+		);
 
-			const store = select( cartStore );
-			const cartData = store.getCartData();
-			const cartErrors = store.getCartErrors();
-			const cartTotals = store.getCartTotals();
-			const cartIsLoading =
-				// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
-				! store.hasFinishedResolution( 'getCartData' );
-
-			const isLoadingRates = store.isCustomerDataUpdating();
-			const { receiveCart, receiveCartContents } = dispatch( cartStore );
-
-			const cartFees =
-				cartData.fees.length > 0
-					? cartData.fees.map( ( fee: CartResponseFeeItem ) =>
-							decodeValues( fee )
-					  )
-					: EMPTY_CART_FEES;
-
-			// Add a text property to the coupon to allow extensions to modify
-			// the text used to display the coupon, without affecting the
-			// functionality when it comes to removing the coupon.
-			const cartCoupons: CartResponseCoupons =
-				cartData.coupons.length > 0
-					? cartData.coupons.map(
-							( coupon: CartResponseCouponItem ) => ( {
-								...coupon,
-								label: coupon.code,
-							} )
-					  )
-					: EMPTY_CART_COUPONS;
-
-			// Update refs to keep the hook stable.
-			const billingAddress = emptyHiddenAddressFields(
-				decodeValues( cartData.billingAddress )
-			);
-			const shippingAddress = cartData.needsShipping
-				? emptyHiddenAddressFields(
-						decodeValues( cartData.shippingAddress )
-				  )
-				: billingAddress;
-
-			if (
-				! fastDeepEqual( billingAddress, billingAddressRef.current )
-			) {
-				billingAddressRef.current = billingAddress;
-			}
-
-			if (
-				! fastDeepEqual( shippingAddress, shippingAddressRef.current )
-			) {
-				shippingAddressRef.current = shippingAddress;
-			}
-
-			return {
-				cartCoupons,
-				cartItems: cartData.items,
-				crossSellsProducts: cartData.crossSells,
-				cartFees,
-				cartItemsCount: cartData.itemsCount,
-				cartItemsWeight: cartData.itemsWeight,
-				cartNeedsPayment: cartData.needsPayment,
-				cartNeedsShipping: cartData.needsShipping,
-				cartItemErrors: cartData.errors,
-				cartTotals,
-				cartIsLoading,
-				cartErrors,
-				billingData: billingAddressRef.current,
-				billingAddress: billingAddressRef.current,
-				shippingAddress: shippingAddressRef.current,
-				extensions: cartData.extensions,
-				shippingRates: cartData.shippingRates,
-				isLoadingRates,
-				cartHasCalculatedShipping: cartData.hasCalculatedShipping,
-				paymentRequirements: cartData.paymentRequirements,
-				receiveCart,
-				receiveCartContents,
-			};
-		},
-		[ shouldSelect ]
-	);
-
-	if (
-		! currentResults.current ||
-		! fastDeepEqual( currentResults.current, results )
-	) {
-		currentResults.current = results;
+	if ( ! shouldSelect ) {
+		return defaultCartData;
 	}
 
-	return currentResults.current;
+	const cartFees = useMemo( () => {
+		return cartData.fees.length > 0
+			? cartData.fees.map( ( fee: CartResponseFeeItem ) =>
+					decodeValues( fee )
+			  )
+			: EMPTY_CART_FEES;
+	}, [ JSON.stringify( cartData.fees ) ] );
+
+	// Add a text property to the coupon to allow extensions to modify
+	// the text used to display the coupon, without affecting the
+	// functionality when it comes to removing the coupon.
+	const cartCoupons: CartResponseCoupons = useMemo( () => {
+		return cartData.coupons.length > 0
+			? cartData.coupons.map( ( coupon: CartResponseCouponItem ) => ( {
+					...coupon,
+					label: coupon.code,
+			  } ) )
+			: EMPTY_CART_COUPONS;
+	}, [ JSON.stringify( cartData.coupons ) ] );
+
+	const billingAddress = useMemo( () => {
+		return emptyHiddenAddressFields(
+			decodeValues( cartData.billingAddress )
+		);
+	}, [ JSON.stringify( cartData.billingAddress ) ] );
+
+	const shippingAddress = useMemo( () => {
+		return cartData.needsShipping
+			? emptyHiddenAddressFields(
+					decodeValues( cartData.shippingAddress )
+			  )
+			: billingAddress;
+	}, [
+		JSON.stringify( cartData.shippingAddress ),
+		JSON.stringify( billingAddress ),
+	] );
+
+	const storeCart: StoreCart = {
+		cartCoupons,
+		cartItems: cartData.items,
+		crossSellsProducts: cartData.crossSells,
+		cartFees,
+		cartItemsCount: cartData.itemsCount,
+		cartItemsWeight: cartData.itemsWeight,
+		cartNeedsPayment: cartData.needsPayment,
+		cartNeedsShipping: cartData.needsShipping,
+		cartItemErrors: cartData.errors,
+		cartTotals,
+		cartIsLoading,
+		cartErrors,
+		billingData: billingAddress,
+		billingAddress: billingAddress,
+		shippingAddress: shippingAddress,
+		extensions: cartData.extensions,
+		shippingRates: cartData.shippingRates,
+		isLoadingRates,
+		cartHasCalculatedShipping: cartData.hasCalculatedShipping,
+		paymentRequirements: cartData.paymentRequirements,
+		paymentMethods: cartData.paymentMethods,
+		receiveCart,
+		receiveCartContents,
+	};
+
+	if (
+		! currentStoreCart.current ||
+		! fastDeepEqual( currentStoreCart.current, storeCart )
+	) {
+		currentStoreCart.current = storeCart;
+	}
+
+	return currentStoreCart.current;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import fastDeepEqual from 'fast-deep-equal/es6';
-import { useRef, useMemo } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import {
 	cartStore,
 	EMPTY_CART_COUPONS,
@@ -26,7 +26,6 @@ import type {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
 	CartResponseCouponItem,
-	CartResponseCoupons,
 } from '@woocommerce/types';
 import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -136,21 +136,18 @@ export const useStoreCart = (
 
 	const { receiveCart, receiveCartContents } = useDispatch( cartStore );
 	const { cartData, cartErrors, cartTotals, cartIsLoading, isLoadingRates } =
-		useSelect(
-			( select ) => {
-				const store = select( cartStore );
-				return {
-					cartData: store.getCartData(),
-					cartErrors: store.getCartErrors(),
-					cartTotals: store.getCartTotals(),
-					cartIsLoading:
-						// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
-						! store.hasFinishedResolution( 'getCartData' ),
-					isLoadingRates: store.isCustomerDataUpdating(),
-				};
-			},
-			[ shouldSelect ]
-		);
+		useSelect( ( select ) => {
+			const store = select( cartStore );
+			return {
+				cartData: store.getCartData(),
+				cartErrors: store.getCartErrors(),
+				cartTotals: store.getCartTotals(),
+				cartIsLoading:
+					// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
+					! store.hasFinishedResolution( 'getCartData' ),
+				isLoadingRates: store.isCustomerDataUpdating(),
+			};
+		}, [] );
 
 	const cartFees = useMemo( () => {
 		return cartData.fees.length > 0

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -1,5 +1,3 @@
-/** @typedef { import('@woocommerce/type-defs/hooks').StoreCart } StoreCart */
-
 /**
  * External dependencies
  */
@@ -96,10 +94,6 @@ const decodeValues = <
 	) as T;
 };
 
-/**
- * @constant
- * @type  {StoreCart} Object containing cart data.
- */
 export const defaultCartData: StoreCart = {
 	cartCoupons: EMPTY_CART_COUPONS,
 	cartItems: EMPTY_CART_ITEMS,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -152,10 +152,6 @@ export const useStoreCart = (
 			[ shouldSelect ]
 		);
 
-	if ( ! shouldSelect ) {
-		return defaultCartData;
-	}
-
 	const cartFees = useMemo( () => {
 		return cartData.fees.length > 0
 			? cartData.fees.map( ( fee: CartResponseFeeItem ) =>
@@ -175,6 +171,10 @@ export const useStoreCart = (
 			  } ) )
 			: EMPTY_CART_COUPONS;
 	}, [ JSON.stringify( cartData.coupons ) ] );
+
+	if ( ! shouldSelect ) {
+		return defaultCartData;
+	}
 
 	const nextBillingAddress = emptyHiddenAddressFields(
 		decodeValues( cartData.billingAddress )
@@ -210,8 +210,8 @@ export const useStoreCart = (
 		cartIsLoading,
 		cartErrors,
 		billingData: billingAddress,
-		billingAddress: billingAddress,
-		shippingAddress: shippingAddress,
+		billingAddress,
+		shippingAddress,
 		extensions: cartData.extensions,
 		shippingRates: cartData.shippingRates,
 		isLoadingRates,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -139,19 +139,14 @@ export const useStoreCart = (
 		useSelect(
 			( select ) => {
 				const store = select( cartStore );
-				const cartData = store.getCartData();
-				const cartErrors = store.getCartErrors();
-				const cartTotals = store.getCartTotals();
-				const cartIsLoading =
-					// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
-					! store.hasFinishedResolution( 'getCartData' );
-				const isLoadingRates = store.isCustomerDataUpdating();
 				return {
-					cartData,
-					cartErrors,
-					cartTotals,
-					cartIsLoading,
-					isLoadingRates,
+					cartData: store.getCartData(),
+					cartErrors: store.getCartErrors(),
+					cartTotals: store.getCartTotals(),
+					cartIsLoading:
+						// @ts-expect-error `hasFinishedResolution` is not typed in @wordpress/data yet.
+						! store.hasFinishedResolution( 'getCartData' ),
+					isLoadingRates: store.isCustomerDataUpdating(),
 				};
 			},
 			[ shouldSelect ]

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -56,61 +56,74 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 				customerId: store.getCustomerId(),
 				isCalculating: store.isCalculating(),
 			};
-		} );
-	const { paymentStatus, activePaymentMethod, shouldSavePayment } = useSelect(
-		( select ) => {
-			const store = select( paymentStore );
+		}, [] );
 
-			return {
-				// The paymentStatus is exposed to third parties via the payment method interface so the API must not be changed
-				paymentStatus: {
-					get isPristine() {
-						deprecated( 'isPristine', {
-							since: '9.6.0',
-							alternative: 'isIdle',
-							plugin: 'WooCommerce Blocks',
-							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
-						} );
-						return store.isPaymentIdle();
-					}, // isPristine is the same as isIdle
-					isIdle: store.isPaymentIdle(),
-					isStarted: store.isExpressPaymentStarted(),
-					isProcessing: store.isPaymentProcessing(),
-					get isFinished() {
-						deprecated( 'isFinished', {
-							since: '9.6.0',
-							plugin: 'WooCommerce Blocks',
-							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
-						} );
-						return (
-							store.hasPaymentError() || store.isPaymentReady()
-						);
-					},
-					hasError: store.hasPaymentError(),
-					get hasFailed() {
-						deprecated( 'hasFailed', {
-							since: '9.6.0',
-							plugin: 'WooCommerce Blocks',
-							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
-						} );
-						return store.hasPaymentError();
-					},
-					get isSuccessful() {
-						deprecated( 'isSuccessful', {
-							since: '9.6.0',
-							plugin: 'WooCommerce Blocks',
-							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
-						} );
-						return store.isPaymentReady();
-					},
-					isReady: store.isPaymentReady(),
-					isDoingExpressPayment: store.isExpressPaymentMethodActive(),
-				},
-				activePaymentMethod: store.getActivePaymentMethod(),
-				shouldSavePayment: store.getShouldSavePaymentMethod(),
-			};
-		}
-	);
+	const {
+		paymentIsIdle,
+		paymentIsStarted,
+		paymentIsProcessing,
+		paymentHasError,
+		paymentIsReady,
+		paymentIsDoingExpressPayment,
+		activePaymentMethod,
+		shouldSavePayment,
+	} = useSelect( ( select ) => {
+		const store = select( paymentStore );
+
+		return {
+			paymentIsIdle: store.isPaymentIdle(),
+			paymentIsStarted: store.isExpressPaymentStarted(),
+			paymentIsProcessing: store.isPaymentProcessing(),
+			paymentHasError: store.hasPaymentError(),
+			paymentIsReady: store.isPaymentReady(),
+			paymentIsDoingExpressPayment: store.isExpressPaymentMethodActive(),
+			activePaymentMethod: store.getActivePaymentMethod(),
+			shouldSavePayment: store.getShouldSavePaymentMethod(),
+		};
+	}, [] );
+
+	// The paymentStatus is exposed to third parties via the payment method interface so the API must not be changed.
+	const paymentStatus = {
+		isIdle: paymentIsIdle,
+		isStarted: paymentIsStarted,
+		isProcessing: paymentIsProcessing,
+		hasError: paymentHasError,
+		isReady: paymentIsReady,
+		isDoingExpressPayment: paymentIsDoingExpressPayment,
+		get isPristine() {
+			deprecated( 'isPristine', {
+				since: '9.6.0',
+				alternative: 'isIdle',
+				plugin: 'WooCommerce Blocks',
+				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
+			} );
+			return paymentIsIdle;
+		},
+		get isFinished() {
+			deprecated( 'isFinished', {
+				since: '9.6.0',
+				plugin: 'WooCommerce Blocks',
+				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
+			} );
+			return paymentHasError || paymentIsReady;
+		},
+		get hasFailed() {
+			deprecated( 'hasFailed', {
+				since: '9.6.0',
+				plugin: 'WooCommerce Blocks',
+				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
+			} );
+			return paymentHasError;
+		},
+		get isSuccessful() {
+			deprecated( 'isSuccessful', {
+				since: '9.6.0',
+				plugin: 'WooCommerce Blocks',
+				link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8110',
+			} );
+			return paymentIsReady;
+		},
+	};
 
 	const { __internalSetExpressPaymentError } = useDispatch( paymentStore );
 
@@ -132,8 +145,9 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 		needsShipping,
 	} = useShippingData();
 
-	const { billingAddress, shippingAddress } = useSelect( ( select ) =>
-		select( cartStore ).getCustomerData()
+	const { billingAddress, shippingAddress } = useSelect(
+		( select ) => select( cartStore ).getCustomerData(),
+		[]
 	);
 	const { setShippingAddress } = useDispatch( cartStore );
 	const { cartItems, cartFees, cartTotals, extensions } = useStoreCart();

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import type {
 	ValidationData,
 	ValidationContextError,
@@ -18,34 +18,32 @@ export const useValidation = (): ValidationData => {
 
 	const prefix = 'extensions-errors';
 
-	const { hasValidationErrors, getValidationError } = useSelect(
+	const { hasValidationErrors, getValidationErrorFromStore } = useSelect(
 		( mapSelect ) => {
 			const store = mapSelect( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
-				getValidationError: ( validationErrorId: string ) =>
-					store.getValidationError(
-						`${ prefix }-${ validationErrorId }`
-					),
+				getValidationErrorFromStore: store.getValidationError,
 			};
-		}
+		},
+		[]
 	);
 
-	return {
-		hasValidationErrors,
-		getValidationError,
-		clearValidationError: useCallback(
-			( validationErrorId: string ) =>
+	const getValidationError = useCallback(
+		( validationErrorId: string ) =>
+			getValidationErrorFromStore( `${ prefix }-${ validationErrorId }` ),
+		[ getValidationErrorFromStore ]
+	);
+
+	const memoizedCallbacks = useMemo(
+		() => ( {
+			clearValidationError: ( validationErrorId: string ) =>
 				clearValidationError( `${ prefix }-${ validationErrorId }` ),
-			[ clearValidationError ]
-		),
-		hideValidationError: useCallback(
-			( validationErrorId: string ) =>
+			hideValidationError: ( validationErrorId: string ) =>
 				hideValidationError( `${ prefix }-${ validationErrorId }` ),
-			[ hideValidationError ]
-		),
-		setValidationErrors: useCallback(
-			( errorsObject: Record< string, ValidationContextError > ) =>
+			setValidationErrors: (
+				errorsObject: Record< string, ValidationContextError >
+			) =>
 				setValidationErrors(
 					Object.fromEntries(
 						Object.entries( errorsObject ).map(
@@ -56,7 +54,13 @@ export const useValidation = (): ValidationData => {
 						)
 					)
 				),
-			[ setValidationErrors ]
-		),
+		} ),
+		[ clearValidationError, hideValidationError, setValidationErrors ]
+	);
+
+	return {
+		hasValidationErrors,
+		getValidationError,
+		...memoizedCallbacks,
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import type {
 	ValidationData,
 	ValidationContextError,
@@ -18,12 +18,12 @@ export const useValidation = (): ValidationData => {
 
 	const prefix = 'extensions-errors';
 
-	const { hasValidationErrors, getValidationErrorFromStore } = useSelect(
+	const { hasValidationErrors, getValidationErrorSelector } = useSelect(
 		( mapSelect ) => {
 			const store = mapSelect( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
-				getValidationErrorFromStore: store.getValidationError,
+				getValidationErrorSelector: store.getValidationError,
 			};
 		},
 		[]
@@ -31,19 +31,25 @@ export const useValidation = (): ValidationData => {
 
 	const getValidationError = useCallback(
 		( validationErrorId: string ) =>
-			getValidationErrorFromStore( `${ prefix }-${ validationErrorId }` ),
-		[ getValidationErrorFromStore ]
+			getValidationErrorSelector( `${ prefix }-${ validationErrorId }` ),
+		[ getValidationErrorSelector, prefix ]
 	);
 
-	const memoizedCallbacks = useMemo(
-		() => ( {
-			clearValidationError: ( validationErrorId: string ) =>
+	return {
+		hasValidationErrors,
+		getValidationError,
+		clearValidationError: useCallback(
+			( validationErrorId: string ) =>
 				clearValidationError( `${ prefix }-${ validationErrorId }` ),
-			hideValidationError: ( validationErrorId: string ) =>
+			[ clearValidationError ]
+		),
+		hideValidationError: useCallback(
+			( validationErrorId: string ) =>
 				hideValidationError( `${ prefix }-${ validationErrorId }` ),
-			setValidationErrors: (
-				errorsObject: Record< string, ValidationContextError >
-			) =>
+			[ hideValidationError ]
+		),
+		setValidationErrors: useCallback(
+			( errorsObject: Record< string, ValidationContextError > ) =>
 				setValidationErrors(
 					Object.fromEntries(
 						Object.entries( errorsObject ).map(
@@ -54,13 +60,7 @@ export const useValidation = (): ValidationData => {
 						)
 					)
 				),
-		} ),
-		[ clearValidationError, hideValidationError, setValidationErrors ]
-	);
-
-	return {
-		hasValidationErrors,
-		getValidationError,
-		...memoizedCallbacks,
+			[ setValidationErrors ]
+		),
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/__mocks__/express-payment-props.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/__mocks__/express-payment-props.ts
@@ -140,11 +140,15 @@ export const getExpectedExpressPaymentProps = ( name: string ) => ( {
 	onSubmit: expect.any( Function ),
 	paymentStatus: {
 		hasError: false,
+		hasFailed: false,
 		isDoingExpressPayment: false,
+		isFinished: false,
 		isIdle: true,
+		isPristine: true,
 		isProcessing: false,
 		isReady: false,
 		isStarted: false,
+		isSuccessful: false,
 	},
 	setExpressPaymentError: expect.any( Function ),
 	shippingData: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/__mocks__/express-payment-props.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/test/__mocks__/express-payment-props.ts
@@ -140,15 +140,11 @@ export const getExpectedExpressPaymentProps = ( name: string ) => ( {
 	onSubmit: expect.any( Function ),
 	paymentStatus: {
 		hasError: false,
-		hasFailed: false,
 		isDoingExpressPayment: false,
-		isFinished: false,
 		isIdle: true,
-		isPristine: true,
 		isProcessing: false,
 		isReady: false,
 		isStarted: false,
-		isSuccessful: false,
 	},
 	setExpressPaymentError: expect.any( Function ),
 	shippingData: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/edit.tsx
@@ -64,39 +64,42 @@ export const Edit = ( {
 		hasDarkControls = false,
 	} = attributes;
 
-	const defaultFields = useSelect( ( select ) => {
-		const settings = select(
+	const fieldSettings = useSelect( ( select ) => {
+		return select(
 			coreStore as unknown as string
+			// @ts-expect-error getEditedEntityRecord is not typed in @wordpress/core-data yet.
 		).getEditedEntityRecord( 'root', 'site' ) as Record< string, string >;
+	}, [] );
 
-		const fieldsWithDefaults = {
-			phone: 'optional',
-			company: 'hidden',
-			address_2: 'optional',
-		} as const;
+	const fieldsWithDefaults = {
+		phone: 'optional',
+		company: 'hidden',
+		address_2: 'optional',
+	} as const;
 
-		return {
-			...defaultFieldsSetting,
-			...Object.fromEntries(
-				Object.entries( fieldsWithDefaults ).map(
-					( [ field, defaultValue ] ) => {
-						const value =
-							settings[
-								`woocommerce_checkout_${ field }_field`
-							] || defaultValue;
-						return [
-							field,
-							{
-								...defaultFieldsSetting[ field ],
-								required: value === 'required',
-								hidden: value === 'hidden',
-							},
-						];
-					}
-				)
-			),
-		};
-	} );
+	const defaultFields = {
+		...defaultFieldsSetting,
+		...Object.fromEntries(
+			Object.entries( fieldsWithDefaults ).map(
+				( [ field, defaultValue ] ) => {
+					const value =
+						fieldSettings[
+							`woocommerce_checkout_${ field }_field`
+						] || defaultValue;
+					return [
+						field,
+						{
+							...defaultFieldsSetting[
+								field as keyof typeof defaultFieldsSetting
+							],
+							required: value === 'required',
+							hidden: value === 'hidden',
+						},
+					];
+				}
+			)
+		),
+	};
 
 	// This focuses on the block when a certain query param is found. This is used on the link from the task list.
 	const focus = useRef( getQueryArg( window.location.href, 'focus' ) );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
 import type { AddressFormValues } from '@woocommerce/settings';
@@ -27,24 +27,27 @@ const CustomerAddress = () => {
 	const { dispatchCheckoutEvent } = useStoreEvents();
 
 	// Forces editing state if store has errors.
-	const { hasValidationErrors, invalidProps } = useSelect(
+	const { hasValidationErrors, getValidationErrorSelector } = useSelect(
 		( select ) => {
 			const store = select( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
-				invalidProps: Object.keys( billingAddress )
-					.filter( ( key ) => {
-						return (
-							key !== 'email' &&
-							store.getValidationError( 'billing_' + key ) !==
-								undefined
-						);
-					} )
-					.filter( Boolean ),
+				getValidationErrorSelector: store.getValidationError,
 			};
 		},
-		[ billingAddress ]
+		[]
 	);
+
+	const invalidProps = useMemo( () => {
+		return Object.keys( billingAddress )
+			.filter( ( key ) => {
+				return (
+					key !== 'email' &&
+					getValidationErrorSelector( 'billing_' + key ) !== undefined
+				);
+			} )
+			.filter( Boolean );
+	}, [ JSON.stringify( billingAddress ), getValidationErrorSelector ] );
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -47,7 +47,7 @@ const CustomerAddress = () => {
 				);
 			} )
 			.filter( Boolean );
-	}, [ JSON.stringify( billingAddress ), getValidationErrorSelector ] );
+	}, [ billingAddress, getValidationErrorSelector ] );
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { Form } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
 import type { ShippingAddress } from '@woocommerce/settings';
@@ -27,23 +27,27 @@ const CustomerAddress = () => {
 	const { dispatchCheckoutEvent } = useStoreEvents();
 
 	// Forces editing state if store has errors.
-	const { hasValidationErrors, invalidProps } = useSelect(
+	const { hasValidationErrors, getValidationErrorSelector } = useSelect(
 		( select ) => {
 			const store = select( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
-				invalidProps: Object.keys( shippingAddress )
-					.filter( ( key ) => {
-						return (
-							store.getValidationError( 'shipping_' + key ) !==
-							undefined
-						);
-					} )
-					.filter( Boolean ),
+				getValidationErrorSelector: store.getValidationError,
 			};
 		},
-		[ shippingAddress ]
+		[]
 	);
+
+	const invalidProps = useMemo( () => {
+		return Object.keys( shippingAddress )
+			.filter( ( key ) => {
+				return (
+					getValidationErrorSelector( 'shipping_' + key ) !==
+					undefined
+				);
+			} )
+			.filter( Boolean );
+	}, [ JSON.stringify( shippingAddress ), getValidationErrorSelector ] );
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -47,7 +47,7 @@ const CustomerAddress = () => {
 				);
 			} )
 			.filter( Boolean );
-	}, [ JSON.stringify( shippingAddress ), getValidationErrorSelector ] );
+	}, [ shippingAddress, getValidationErrorSelector ] );
 
 	useEffect( () => {
 		if ( invalidProps.length > 0 && editing === false ) {

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/selectors.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/selectors.ts
@@ -10,6 +10,7 @@ import type {
 	ApiErrorResponse,
 } from '@woocommerce/types';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -26,17 +27,21 @@ export const getCartData = ( state: CartState ): Cart => {
 	return state.cartData;
 };
 
-export const getCustomerData = (
-	state: CartState
-): {
-	shippingAddress: ShippingAddress;
-	billingAddress: BillingAddress;
-} => {
-	return {
-		shippingAddress: state.cartData.shippingAddress,
-		billingAddress: state.cartData.billingAddress,
-	};
-};
+export const getCustomerData = createSelector(
+	(
+		state: CartState
+	): {
+		shippingAddress: ShippingAddress;
+		billingAddress: BillingAddress;
+	} => {
+		return {
+			shippingAddress: state.cartData
+				.shippingAddress as unknown as ShippingAddress,
+			billingAddress: state.cartData
+				.billingAddress as unknown as BillingAddress,
+		};
+	}
+);
 
 /**
  * Retrieves shipping rates from state.

--- a/plugins/woocommerce/client/blocks/assets/js/data/payment/selectors.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/payment/selectors.ts
@@ -5,6 +5,7 @@ import { objectHasProp } from '@woocommerce/types';
 import deprecated from '@wordpress/deprecated';
 import { getSetting } from '@woocommerce/settings';
 import type { GlobalPaymentMethod } from '@woocommerce/types';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -110,30 +111,41 @@ export const getPaymentMethodData = ( state: PaymentState ) => {
 	return state.paymentMethodData;
 };
 
-export const getIncompatiblePaymentMethods = ( state: PaymentState ) => {
-	const {
-		availablePaymentMethods,
-		availableExpressPaymentMethods,
-		paymentMethodsInitialized,
-		expressPaymentMethodsInitialized,
-	} = state;
+export const getIncompatiblePaymentMethods = createSelector(
+	( state: PaymentState ) => {
+		const {
+			availablePaymentMethods,
+			availableExpressPaymentMethods,
+			paymentMethodsInitialized,
+			expressPaymentMethodsInitialized,
+		} = state;
 
-	if ( ! paymentMethodsInitialized || ! expressPaymentMethodsInitialized ) {
-		return {};
-	}
+		if (
+			! paymentMethodsInitialized ||
+			! expressPaymentMethodsInitialized
+		) {
+			return {};
+		}
 
-	return Object.fromEntries(
-		Object.entries( globalPaymentMethods ).filter( ( [ k ] ) => {
-			return ! (
-				k in
-				{
-					...availablePaymentMethods,
-					...availableExpressPaymentMethods,
-				}
-			);
-		} )
-	);
-};
+		return Object.fromEntries(
+			Object.entries( globalPaymentMethods ).filter( ( [ k ] ) => {
+				return ! (
+					k in
+					{
+						...availablePaymentMethods,
+						...availableExpressPaymentMethods,
+					}
+				);
+			} )
+		);
+	},
+	( state: PaymentState ) => [
+		state.availablePaymentMethods,
+		state.availableExpressPaymentMethods,
+		state.paymentMethodsInitialized,
+		state.expressPaymentMethodsInitialized,
+	]
+);
 
 export const getSavedPaymentMethods = ( state: PaymentState ) => {
 	return state.savedPaymentMethods;

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/api-error-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/api-error-response.ts
@@ -10,6 +10,12 @@ export type ApiErrorResponse = {
 	data?: ApiErrorResponseData | undefined;
 };
 
+export type CouponApiErrorResponse = ApiErrorResponse & {
+	data: ApiErrorResponseData & {
+		details: Record< 'cart' | 'checkout', string >;
+	};
+};
+
 // API errors contain data with the status, and more in-depth error details. This may be null.
 export type ApiErrorResponseData = {
 	status: number;

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/currency.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/currency.ts
@@ -34,7 +34,7 @@ export interface Currency {
 }
 
 export interface CurrencyResponse {
-	currency_code: CurrencyCode;
+	currency_code: CurrencyCode | '';
 	currency_symbol: string;
 	currency_minor_unit: number;
 	currency_decimal_separator: string;

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/payment-method-interface.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/payment-method-interface.ts
@@ -173,14 +173,11 @@ export type PaymentMethodInterface = {
 	onSubmit: () => void;
 	// Various payment status helpers.
 	paymentStatus: {
-		isPristine: boolean;
 		isIdle: boolean;
 		isStarted: boolean;
 		isProcessing: boolean;
-		isFinished: boolean;
 		hasError: boolean;
-		hasFailed: boolean;
-		isSuccessful: boolean;
+		isReady: boolean;
 		isDoingExpressPayment: boolean;
 	};
 	// Deprecated. For setting an error (error message string) for express payment methods. Does not change payment status.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes warnings in our useSelect usage. Context: https://make.wordpress.org/core/2025/03/12/data-a-helpful-performance-warning-for-developers-in-the-useselect-hook/

Should be covered by existing CI, touches validation, addresses, and payment statuses.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI should pass.
2. Smoke test cart/checkout to place order and validate fields.
3. Keep console open and ensure there are no warnings relating to useSelect.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
