### PR TITLE
Fix race conditions when quickly switching between delivery options

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4075-incorrect-rate-when-toggling-between-shipping-and-local
+++ b/plugins/woocommerce/changelog/wooplug-4075-incorrect-rate-when-toggling-between-shipping-and-local
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix race conditions when quickly switching between delivery options

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -10,27 +10,25 @@ import { useShippingData } from '@woocommerce/base-context';
 
 interface LocalPickupSelectProps {
 	title?: string | undefined;
-	setSelectedOption: ( value: string ) => void;
 	selectedOption: string;
 	pickupLocations: CartShippingPackageShippingRate[];
-	onSelectRate: ( value: string ) => void;
 	renderPickupLocation: (
 		location: CartShippingPackageShippingRate,
 		pickupLocationsCount: number
 	) => RadioControlOptionType;
 	packageCount: number;
+	onChange: ( value: string ) => void;
 }
 /**
  * Local pickup select component, used to render a package title and local pickup options.
  */
 export const LocalPickupSelect = ( {
 	title,
-	setSelectedOption,
 	selectedOption,
 	pickupLocations,
-	onSelectRate,
 	renderPickupLocation,
 	packageCount,
+	onChange,
 }: LocalPickupSelectProps ) => {
 	const { shippingRates } = useShippingData();
 	const internalPackageCount = shippingRates?.length || 1;
@@ -45,10 +43,7 @@ export const LocalPickupSelect = ( {
 		<div className="wc-block-components-local-pickup-select">
 			{ multiplePackages && title ? <div>{ title }</div> : false }
 			<RadioControl
-				onChange={ ( value ) => {
-					setSelectedOption( value );
-					onSelectRate( value );
-				} }
+				onChange={ onChange }
 				highlightChecked={ true }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -3,64 +3,37 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 /**
  * Internal dependencies
  */
 import LocalPickupSelect from '..';
+import { generateShippingRate } from '../../../../../mocks/shipping-package';
 
 describe( 'LocalPickupSelect', () => {
 	const TestComponent = ( {
-		selectedOptionOverride = null,
-		onSelectRateOverride = null,
+		onChange,
 	}: {
-		selectedOptionOverride?: null | ( ( value: string ) => void );
-		onSelectRateOverride?: null | ( ( value: string ) => void );
+		onChange?: ( value: string ) => void;
 	} ) => (
 		<LocalPickupSelect
 			title="Package 1"
-			setSelectedOption={ selectedOptionOverride || jest.fn() }
+			onChange={ onChange ?? jest.fn() }
 			selectedOption=""
 			pickupLocations={ [
-				{
-					rate_id: '1',
-					currency_code: 'USD',
-					currency_decimal_separator: '.',
-					currency_minor_unit: 2,
-					currency_prefix: '$',
-					currency_suffix: '',
-					currency_thousand_separator: ',',
-					currency_symbol: '$',
+				generateShippingRate( {
+					rateId: '1',
 					name: 'Store 1',
-					description: 'Store 1 description',
-					delivery_time: '1 day',
+					instanceID: 1,
 					price: '0',
-					taxes: '0',
-					instance_id: 1,
-					method_id: 'test_shipping:0',
-					meta_data: [],
-					selected: false,
-				},
-				{
-					rate_id: '2',
-					currency_code: 'USD',
-					currency_decimal_separator: '.',
-					currency_minor_unit: 2,
-					currency_prefix: '$',
-					currency_suffix: '',
-					currency_thousand_separator: ',',
-					currency_symbol: '$',
+				} ),
+				generateShippingRate( {
+					rateId: '2',
 					name: 'Store 2',
-					description: 'Store 2 description',
-					delivery_time: '2 days',
+					instanceID: 1,
 					price: '0',
-					taxes: '0',
-					instance_id: 1,
-					method_id: 'test_shipping:1',
-					meta_data: [],
-					selected: false,
-				},
+				} ),
 			] }
-			onSelectRate={ onSelectRateOverride || jest.fn() }
 			packageCount={ 1 }
 			renderPickupLocation={ ( location ) => {
 				return {
@@ -103,19 +76,14 @@ describe( 'LocalPickupSelect', () => {
 		expect( screen.getByText( 'Package 1' ) ).toBeInTheDocument();
 	} );
 	it( 'Calls the correct functions when changing selected option', async () => {
-		const setSelectedOption = jest.fn();
-		const onSelectRate = jest.fn();
-		render(
-			<TestComponent
-				selectedOptionOverride={ setSelectedOption }
-				onSelectRateOverride={ onSelectRate }
-			/>
-		);
-		await userEvent.click( screen.getByText( 'Store 2' ) );
-		expect( setSelectedOption ).toHaveBeenLastCalledWith( '2' );
-		expect( onSelectRate ).toHaveBeenLastCalledWith( '2' );
-		await userEvent.click( screen.getByText( 'Store 1' ) );
-		expect( setSelectedOption ).toHaveBeenLastCalledWith( '1' );
-		expect( onSelectRate ).toHaveBeenLastCalledWith( '1' );
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+		render( <TestComponent onChange={ onChange } /> );
+
+		await user.click( screen.getByText( 'Store 2' ) );
+		expect( onChange ).toHaveBeenLastCalledWith( '2' );
+
+		await user.click( screen.getByText( 'Store 1' ) );
+		expect( onChange ).toHaveBeenLastCalledWith( '1' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useShippingData } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingRatesControlPackage } from './index';
+import {
+	generateShippingPackage,
+	generateShippingRate,
+} from '../../../../mocks/shipping-package';
+
+jest.mock( '@woocommerce/base-context/hooks' );
+
+test( 'renders available shipping rates', async () => {
+	const packageData = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+			} ),
+			generateShippingRate( {
+				rateId: 'flat_rate:2',
+				name: 'Flat rate (premium)',
+				price: '1500',
+				instanceID: 5,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: packageData,
+		};
+	} );
+
+	render(
+		<ShippingRatesControlPackage
+			packageData={ packageData }
+			packageId={ packageData.package_id }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Flat rate $10.00',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	// even though it's not selected we mark first one as checked by default
+	expect( firstRate ).toBeChecked();
+
+	expect(
+		screen.getByRole( 'radio', { name: 'Flat rate (premium) $15.00' } )
+	).toBeInTheDocument();
+} );
+
+test( 'changes rate selection locally and informs API about it', async () => {
+	const selectShippingRate = jest.fn();
+
+	const packageData = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+			} ),
+			generateShippingRate( {
+				rateId: 'flat_rate:2',
+				name: 'Flat rate (premium)',
+				price: '1500',
+				instanceID: 5,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate,
+			isSelectingRate: false,
+			shippingRates: packageData,
+		};
+	} );
+
+	render(
+		<ShippingRatesControlPackage
+			packageData={ packageData }
+			packageId={ packageData.package_id }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Flat rate $10.00',
+	} );
+	const secondRate = screen.getByRole( 'radio', {
+		name: 'Flat rate (premium) $15.00',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( firstRate ).toBeChecked();
+
+	await act( async () => {
+		await userEvent.click( secondRate );
+	} );
+
+	expect( secondRate ).toBeChecked();
+	expect( selectShippingRate ).toHaveBeenLastCalledWith( 'flat_rate:2', 0 );
+} );
+
+test( 'upstream rate selection updates are properly reflected in local state', async () => {
+	const packageData = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+				selected: false,
+			} ),
+			generateShippingRate( {
+				rateId: 'flat_rate:2',
+				name: 'Flat rate (premium)',
+				price: '1500',
+				instanceID: 5,
+				selected: true,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: packageData,
+		};
+	} );
+
+	const { rerender } = render(
+		<ShippingRatesControlPackage
+			packageData={ packageData }
+			packageId={ packageData.package_id }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Flat rate $10.00',
+	} );
+	const secondRate = screen.getByRole( 'radio', {
+		name: 'Flat rate (premium) $15.00',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( secondRate ).toBeInTheDocument();
+	expect( firstRate ).not.toBeChecked();
+	expect( secondRate ).toBeChecked();
+
+	const packageDataWithFlippedSelection = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '1000',
+				instanceID: 1,
+				selected: true,
+			} ),
+			generateShippingRate( {
+				rateId: 'flat_rate:2',
+				name: 'Flat rate (premium)',
+				price: '1500',
+				instanceID: 5,
+				selected: false,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: packageDataWithFlippedSelection,
+		};
+	} );
+
+	rerender(
+		<ShippingRatesControlPackage
+			packageData={ packageDataWithFlippedSelection }
+			packageId={ packageDataWithFlippedSelection.package_id }
+			noResultsMessage={
+				<span>No shipping rates available at the moment</span>
+			}
+		/>
+	);
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( secondRate ).toBeInTheDocument();
+	expect( firstRate ).toBeChecked();
+	expect( secondRate ).not.toBeChecked();
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -44,7 +44,6 @@ export const ShippingRatesControlPackage = ( {
 				document.querySelectorAll( `.${ packageClass }` ).length
 			);
 		};
-
 		updateCount();
 
 		const observer = new MutationObserver( updateCount );

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -34,13 +34,13 @@ const PackageRates = ( {
 	disabled = false,
 	highlightChecked = false,
 }: PackageRates ): JSX.Element => {
-	const selectedRateId = selectedRate?.rate_id || '';
+	const selectedRateId = selectedRate?.rate_id;
 	const previousSelectedRateId = usePrevious( selectedRateId );
 
 	// Store selected rate ID in local state so shipping rates changes are shown in the UI instantly.
-	const [ selectedOption, setSelectedOption ] = useState(
-		selectedRateId ?? ''
-	);
+	const [ selectedOption, setSelectedOption ] = useState<
+		string | undefined
+	>( selectedRateId ?? rates[ 0 ]?.rate_id );
 
 	// Update the selected option if cart state changes in the data store.
 	useEffect( () => {
@@ -54,14 +54,13 @@ const PackageRates = ( {
 	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
 
 	// Update on mount, we do it every time to:
-	// - set the initial value if selectedOption not set
+	// - sync the initial value with the server
 	// - or reset pending request to change shipping rate that might be coming
 	//   from other components (e.g. local pickup), selectShippingRate thunk in
 	//   the cart store properly handles aborting the previous request if needed
 	useEffect( () => {
-		if ( rates.length > 0 ) {
-			setSelectedOption( selectedOption || rates[ 0 ].rate_id );
-			onSelectRate( selectedOption || rates[ 0 ].rate_id );
+		if ( selectedOption ) {
+			onSelectRate( selectedOption );
 		}
 		// We want this to run on mount only, beware of updating it as it may cause
 		// shipping rate selection to end up in inifite loop
@@ -81,7 +80,7 @@ const PackageRates = ( {
 			} }
 			highlightChecked={ highlightChecked }
 			disabled={ disabled }
-			selected={ selectedOption }
+			selected={ selectedOption ?? '' }
 			options={ rates.map( renderOption ) }
 			descriptionStackingDirection="column"
 		/>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -42,17 +42,6 @@ const PackageRates = ( {
 		string | undefined
 	>( selectedRateId ?? rates[ 0 ]?.rate_id );
 
-	// Update the selected option if cart state changes in the data store.
-	useEffect( () => {
-		if (
-			selectedRateId &&
-			selectedRateId !== previousSelectedRateId &&
-			selectedRateId !== selectedOption
-		) {
-			setSelectedOption( selectedRateId );
-		}
-	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
-
 	// Update on mount, we do it every time to:
 	// - sync the initial value with the server
 	// - or reset pending request to change shipping rate that might be coming
@@ -66,6 +55,17 @@ const PackageRates = ( {
 		// shipping rate selection to end up in inifite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+
+	// Update the selected option if cart state changes in the data store.
+	useEffect( () => {
+		if (
+			selectedRateId &&
+			selectedRateId !== previousSelectedRateId &&
+			selectedRateId !== selectedOption
+		) {
+			setSelectedOption( selectedRateId );
+		}
+	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
 
 	if ( rates.length === 0 ) {
 		return noResultsMessage;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -53,13 +53,20 @@ const PackageRates = ( {
 		}
 	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
 
-	// Update the selected option if there is no rate selected on mount.
+	// Update on mount, we do it every time to:
+	// - set the initial value if selectedOption not set
+	// - or reset pending request to change shipping rate that might be coming
+	//   from other components (e.g. local pickup), selectShippingRate thunk in
+	//   the cart store properly handles aborting the previous request if needed
 	useEffect( () => {
-		if ( ! selectedOption && rates.length > 0 ) {
-			setSelectedOption( rates[ 0 ].rate_id );
-			onSelectRate( rates[ 0 ].rate_id );
+		if ( rates.length > 0 ) {
+			setSelectedOption( selectedOption || rates[ 0 ].rate_id );
+			onSelectRate( selectedOption || rates[ 0 ].rate_id );
 		}
-	}, [ onSelectRate, rates, selectedOption ] );
+		// We want this to run on mount only, beware of updating it as it may cause
+		// shipping rate selection to end up in inifite loop
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	if ( rates.length === 0 ) {
 		return noResultsMessage;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/test/index.tsx
@@ -8,45 +8,45 @@ import { useShippingData } from '@woocommerce/base-context/hooks';
 /**
  * Internal dependencies
  */
-import { ShippingRatesControlPackage } from './index';
+import { ShippingRatesControlPackage } from '../index';
 import {
 	generateShippingPackage,
 	generateShippingRate,
-} from '../../../../mocks/shipping-package';
+} from '../../../../../mocks/shipping-package';
 
 jest.mock( '@woocommerce/base-context/hooks' );
 
-test( 'renders available shipping rates', async () => {
-	const packageData = generateShippingPackage( {
-		packageId: 0,
-		shippingRates: [
-			generateShippingRate( {
-				rateId: 'flat_rate:1',
-				name: 'Flat rate',
-				price: '1000',
-				instanceID: 1,
-			} ),
-			generateShippingRate( {
-				rateId: 'flat_rate:2',
-				name: 'Flat rate (premium)',
-				price: '1500',
-				instanceID: 5,
-			} ),
-		],
-	} );
+const testPackageData = generateShippingPackage( {
+	packageId: 0,
+	shippingRates: [
+		generateShippingRate( {
+			rateId: 'flat_rate:1',
+			name: 'Flat rate',
+			price: '1000',
+			instanceID: 1,
+		} ),
+		generateShippingRate( {
+			rateId: 'flat_rate:2',
+			name: 'Flat rate (premium)',
+			price: '1500',
+			instanceID: 5,
+		} ),
+	],
+} );
 
+test( 'renders available shipping rates', async () => {
 	( useShippingData as jest.Mock ).mockImplementation( () => {
 		return {
 			selectShippingRate: jest.fn(),
 			isSelectingRate: false,
-			shippingRates: packageData,
+			shippingRates: [ testPackageData ],
 		};
 	} );
 
 	render(
 		<ShippingRatesControlPackage
-			packageData={ packageData }
-			packageId={ packageData.package_id }
+			packageData={ testPackageData }
+			packageId={ testPackageData.package_id }
 			noResultsMessage={
 				<span>No shipping rates available at the moment</span>
 			}
@@ -69,36 +69,18 @@ test( 'renders available shipping rates', async () => {
 test( 'changes rate selection locally and informs API about it', async () => {
 	const selectShippingRate = jest.fn();
 
-	const packageData = generateShippingPackage( {
-		packageId: 0,
-		shippingRates: [
-			generateShippingRate( {
-				rateId: 'flat_rate:1',
-				name: 'Flat rate',
-				price: '1000',
-				instanceID: 1,
-			} ),
-			generateShippingRate( {
-				rateId: 'flat_rate:2',
-				name: 'Flat rate (premium)',
-				price: '1500',
-				instanceID: 5,
-			} ),
-		],
-	} );
-
 	( useShippingData as jest.Mock ).mockImplementation( () => {
 		return {
 			selectShippingRate,
 			isSelectingRate: false,
-			shippingRates: packageData,
+			shippingRates: [ testPackageData ],
 		};
 	} );
 
 	render(
 		<ShippingRatesControlPackage
-			packageData={ packageData }
-			packageId={ packageData.package_id }
+			packageData={ testPackageData }
+			packageId={ testPackageData.package_id }
 			noResultsMessage={
 				<span>No shipping rates available at the moment</span>
 			}
@@ -148,7 +130,7 @@ test( 'upstream rate selection updates are properly reflected in local state', a
 		return {
 			selectShippingRate: jest.fn(),
 			isSelectingRate: false,
-			shippingRates: packageData,
+			shippingRates: [ packageData ],
 		};
 	} );
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/test/shipping-rates.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/test/shipping-rates.ts
@@ -17,6 +17,7 @@ import {
 	getLocalPickupPrices,
 	getShippingPrices,
 } from '../../../blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/helpers';
+import { generateShippingRate } from '../../../mocks/shipping-package';
 
 jest.mock( '@woocommerce/settings', () => {
 	return {
@@ -39,35 +40,6 @@ jest.mock( '@woocommerce/block-settings', () => ( {
 } ) );
 const blockSettingsMock = jest.requireMock( '@woocommerce/block-settings' );
 
-// Returns a rate object with the given values
-const generateRate = (
-	rateId: string,
-	name: string,
-	price: string,
-	instanceID: number,
-	selected = false
-): ( typeof testPackage.shipping_rates )[ 0 ] => {
-	return {
-		rate_id: rateId,
-		name,
-		description: '',
-		delivery_time: '',
-		price,
-		taxes: '0',
-		instance_id: instanceID,
-		method_id: name.toLowerCase().split( ' ' ).join( '_' ),
-		meta_data: [],
-		selected,
-		currency_code: 'USD',
-		currency_symbol: '$',
-		currency_minor_unit: 2,
-		currency_decimal_separator: '.',
-		currency_thousand_separator: ',',
-		currency_prefix: '$',
-		currency_suffix: '',
-	};
-};
-
 // A test package with 5 shipping rates
 const testPackage: CartShippingRate = {
 	package_id: 0,
@@ -82,25 +54,69 @@ const testPackage: CartShippingRate = {
 	},
 	items: [],
 	shipping_rates: [
-		generateRate( 'flat_rate:1', 'Flat rate', '10', 1 ),
-		generateRate( 'local_pickup:1', 'Local pickup', '0', 2 ),
-		generateRate( 'local_pickup:2', 'Local pickup', '10', 3 ),
-		generateRate( 'local_pickup:3', 'Local pickup', '50', 4 ),
-		generateRate( 'flat_rate:2', 'Flat rate', '50', 5 ),
+		generateShippingRate( {
+			rateId: 'flat_rate:1',
+			name: 'Flat rate',
+			price: '10',
+			instanceID: 1,
+		} ),
+		generateShippingRate( {
+			rateId: 'local_pickup:1',
+			name: 'Local pickup',
+			price: '0',
+			instanceID: 2,
+		} ),
+		generateShippingRate( {
+			rateId: 'local_pickup:2',
+			name: 'Local pickup',
+			price: '10',
+			instanceID: 3,
+		} ),
+		generateShippingRate( {
+			rateId: 'local_pickup:3',
+			name: 'Local pickup',
+			price: '50',
+			instanceID: 4,
+		} ),
+		generateShippingRate( {
+			rateId: 'flat_rate:2',
+			name: 'Flat rate',
+			price: '50',
+			instanceID: 5,
+		} ),
 	],
 };
 describe( 'Test Min and Max rates', () => {
 	it( 'returns the lowest and highest rates when local pickup method is used', () => {
 		expect( getLocalPickupPrices( testPackage.shipping_rates ) ).toEqual( {
-			min: generateRate( 'local_pickup:1', 'Local pickup', '0', 2 ),
-
-			max: generateRate( 'local_pickup:3', 'Local pickup', '50', 4 ),
+			min: generateShippingRate( {
+				rateId: 'local_pickup:1',
+				name: 'Local pickup',
+				price: '0',
+				instanceID: 2,
+			} ),
+			max: generateShippingRate( {
+				rateId: 'local_pickup:3',
+				name: 'Local pickup',
+				price: '50',
+				instanceID: 4,
+			} ),
 		} );
 	} );
 	it( 'returns the lowest and highest rates when flat rate shipping method is used', () => {
 		expect( getShippingPrices( testPackage.shipping_rates ) ).toEqual( {
-			min: generateRate( 'flat_rate:1', 'Flat rate', '10', 1 ),
-			max: generateRate( 'flat_rate:2', 'Flat rate', '50', 5 ),
+			min: generateShippingRate( {
+				rateId: 'flat_rate:1',
+				name: 'Flat rate',
+				price: '10',
+				instanceID: 1,
+			} ),
+			max: generateShippingRate( {
+				rateId: 'flat_rate:2',
+				name: 'Flat rate',
+				price: '50',
+				instanceID: 5,
+			} ),
 		} );
 	} );
 	it( 'returns undefined as lowest and highest rates when shipping rates are not available', () => {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -145,8 +145,12 @@ const Block = () => {
 		);
 	}, [ shippingRates ] );
 
-	const [ selectedOption, setSelectedOption ] = useState< string >(
-		() => pickupLocations.find( ( rate ) => rate.selected )?.rate_id || ''
+	const [ selectedOption, setSelectedOption ] = useState<
+		string | undefined
+	>(
+		() =>
+			pickupLocations.find( ( rate ) => rate.selected )?.rate_id ??
+			pickupLocations[ 0 ]?.rate_id
 	);
 
 	const handleShippingRateChange = useCallback(
@@ -158,15 +162,13 @@ const Block = () => {
 	);
 
 	// Update on mount, we do it every time to:
-	// - set the initial value if selectedOption not set
+	// - sync the initial value with the server
 	// - or reset pending request to change shipping rate that might be coming
 	//   from other components (e.g. shipping options), selectShippingRate thunk
 	//   in the cart store properly handles aborting the previous request if needed
 	useEffect( () => {
-		if ( pickupLocations.length > 0 ) {
-			handleShippingRateChange(
-				selectedOption || pickupLocations[ 0 ].rate_id
-			);
+		if ( selectedOption ) {
+			selectShippingRate( selectedOption );
 		}
 		// We want this to run on mount only, beware of updating it as it may cause
 		// shipping rate selection to end up in inifite loop
@@ -193,7 +195,7 @@ const Block = () => {
 			<ExperimentalOrderLocalPickupPackages>
 				<LocalPickupSelect
 					title={ shippingRates[ 0 ].name }
-					selectedOption={ selectedOption }
+					selectedOption={ selectedOption ?? '' }
 					renderPickupLocation={ renderPickupLocation }
 					pickupLocations={ pickupLocations }
 					packageCount={ getShippingRatesPackageCount(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -175,6 +175,16 @@ const Block = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	// Update the selected option if cart state changes in the data store.
+	useEffect( () => {
+		const selectedRate = pickupLocations.find( ( rate ) => rate.selected );
+		const selectedRateId = selectedRate?.rate_id;
+
+		if ( selectedRateId && selectedRateId !== selectedOption ) {
+			setSelectedOption( selectedRateId );
+		}
+	}, [ pickupLocations, selectedOption ] );
+
 	// Prepare props to pass to the ExperimentalOrderLocalPickupPackages slot fill.
 	// We need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -135,7 +135,7 @@ const renderPickupLocation = (
 	};
 };
 
-const Block = (): JSX.Element | null => {
+const Block = () => {
 	const { shippingRates, selectShippingRate } = useShippingData();
 
 	// Memoize pickup locations to prevent re-rendering when the shipping rates change.
@@ -149,12 +149,29 @@ const Block = (): JSX.Element | null => {
 		() => pickupLocations.find( ( rate ) => rate.selected )?.rate_id || ''
 	);
 
-	const onSelectRate = useCallback(
+	const handleShippingRateChange = useCallback(
 		( rateId: string ) => {
+			setSelectedOption( rateId );
 			selectShippingRate( rateId );
 		},
-		[ selectShippingRate ]
+		[ setSelectedOption, selectShippingRate ]
 	);
+
+	// Update on mount, we do it every time to:
+	// - set the initial value if selectedOption not set
+	// - or reset pending request to change shipping rate that might be coming
+	//   from other components (e.g. shipping options), selectShippingRate thunk
+	//   in the cart store properly handles aborting the previous request if needed
+	useEffect( () => {
+		if ( pickupLocations.length > 0 ) {
+			handleShippingRateChange(
+				selectedOption || pickupLocations[ 0 ].rate_id
+			);
+		}
+		// We want this to run on mount only, beware of updating it as it may cause
+		// shipping rate selection to end up in inifite loop
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	// Prepare props to pass to the ExperimentalOrderLocalPickupPackages slot fill.
 	// We need to pluck out receiveCart.
@@ -170,32 +187,19 @@ const Block = (): JSX.Element | null => {
 		renderPickupLocation,
 	};
 
-	useEffect( () => {
-		if (
-			! selectedOption &&
-			pickupLocations[ 0 ] &&
-			selectedOption !== pickupLocations[ 0 ].rate_id
-		) {
-			setSelectedOption( pickupLocations[ 0 ].rate_id );
-			onSelectRate( pickupLocations[ 0 ].rate_id );
-		}
-		// Removing onSelectRate as it lead to an infinite loop when only one pickup location is available.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ pickupLocations, selectedOption ] );
-
-	const packageCount = getShippingRatesPackageCount( shippingRates );
 	return (
 		<>
 			<ExperimentalOrderLocalPickupPackages.Slot { ...slotFillProps } />
 			<ExperimentalOrderLocalPickupPackages>
 				<LocalPickupSelect
 					title={ shippingRates[ 0 ].name }
-					setSelectedOption={ setSelectedOption }
-					onSelectRate={ onSelectRate }
 					selectedOption={ selectedOption }
 					renderPickupLocation={ renderPickupLocation }
 					pickupLocations={ pickupLocations }
-					packageCount={ packageCount }
+					packageCount={ getShippingRatesPackageCount(
+						shippingRates
+					) }
+					onChange={ ( value ) => handleShippingRateChange( value ) }
 				/>
 			</ExperimentalOrderLocalPickupPackages>
 		</>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
@@ -84,8 +84,6 @@ test( 'renders available shipping rates', async () => {
 
 	render( <CheckoutPickupOptionsBlock /> );
 
-	// Find the radio buttons directly using screen queries
-	// The baseElement option allows us to search within portals
 	const firstRate = await screen.findByRole( 'radio', {
 		name: 'Pickup New York City free',
 	} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
@@ -1,0 +1,216 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useShippingData, useStoreCart } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import CheckoutPickupOptionsBlock from '../block';
+import {
+	generateShippingPackage,
+	generateShippingRate,
+} from '../../../../../mocks/shipping-package';
+
+jest.mock( '@woocommerce/base-context/hooks' );
+
+// getting rid of the slot fill
+jest.mock( '@woocommerce/blocks-checkout', () => {
+	const PassthroughComponent = ( {
+		children,
+	}: {
+		children: React.ReactNode;
+	} ) => <>{ children }</>;
+
+	PassthroughComponent.Slot = PassthroughComponent;
+
+	return {
+		ExperimentalOrderLocalPickupPackages: PassthroughComponent,
+	};
+} );
+
+// Setting needed to treat shipping rate as a local pickup.
+// Can't rely on setting it through allSettings.collectableMethodIds = [...]
+// as getSettings is used when the module is initialized (so before attempts
+// to overwrite setting in beforeEach/All)
+jest.mock( '@woocommerce/settings', () => {
+	const actualModule = jest.requireActual( '@woocommerce/settings' );
+	return {
+		...actualModule,
+		getSetting: ( name: string, ...rest: unknown[] ) => {
+			if ( name === 'collectableMethodIds' ) {
+				return [ 'pickup_nyc', 'pickup_la' ];
+			}
+
+			return actualModule.getSetting( name, ...rest );
+		},
+	};
+} );
+
+( useStoreCart as jest.Mock ).mockImplementation( () =>
+	jest.requireActual( '@woocommerce/base-context/hooks' ).useStoreCart()
+);
+
+const testPackageData = generateShippingPackage( {
+	packageId: 0,
+	shippingRates: [
+		generateShippingRate( {
+			rateId: 'pickup_location:1',
+			name: 'Pickup New York City',
+			methodID: 'pickup_nyc',
+			price: '0',
+			instanceID: 0,
+		} ),
+		generateShippingRate( {
+			rateId: 'pickup_location:2',
+			name: 'Pickup Los Angeles',
+			methodID: 'pickup_la',
+			price: '0',
+			instanceID: 1,
+		} ),
+	],
+} );
+
+test( 'renders available shipping rates', async () => {
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ testPackageData ],
+		};
+	} );
+
+	render( <CheckoutPickupOptionsBlock /> );
+
+	// Find the radio buttons directly using screen queries
+	// The baseElement option allows us to search within portals
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Pickup New York City free',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	// even though it's not selected we mark first one as checked by default
+	expect( firstRate ).toBeChecked();
+
+	expect(
+		screen.getByRole( 'radio', { name: 'Pickup Los Angeles free' } )
+	).toBeInTheDocument();
+} );
+
+test( 'changes rate selection locally and informs API about it', async () => {
+	const selectShippingRate = jest.fn();
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate,
+			isSelectingRate: false,
+			shippingRates: [ testPackageData ],
+		};
+	} );
+
+	render( <CheckoutPickupOptionsBlock /> );
+
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Pickup New York City free',
+	} );
+	const secondRate = screen.getByRole( 'radio', {
+		name: 'Pickup Los Angeles free',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( firstRate ).toBeChecked();
+
+	await act( async () => {
+		await userEvent.click( secondRate );
+	} );
+
+	expect( secondRate ).toBeChecked();
+	expect( selectShippingRate ).toHaveBeenLastCalledWith(
+		'pickup_location:2'
+	);
+} );
+
+test( 'upstream rate selection updates are properly reflected in local state', async () => {
+	const packageData = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'pickup_location:1',
+				name: 'Pickup New York City',
+				methodID: 'pickup_nyc',
+				price: '0',
+				instanceID: 0,
+				selected: false,
+			} ),
+			generateShippingRate( {
+				rateId: 'pickup_location:2',
+				name: 'Pickup Los Angeles',
+				methodID: 'pickup_la',
+				price: '0',
+				instanceID: 1,
+				selected: true,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ packageData ],
+		};
+	} );
+
+	const { rerender } = render( <CheckoutPickupOptionsBlock /> );
+
+	const firstRate = await screen.findByRole( 'radio', {
+		name: 'Pickup New York City free',
+	} );
+	const secondRate = screen.getByRole( 'radio', {
+		name: 'Pickup Los Angeles free',
+	} );
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( secondRate ).toBeInTheDocument();
+	expect( firstRate ).not.toBeChecked();
+	expect( secondRate ).toBeChecked();
+
+	const packageDataWithFlippedSelection = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'pickup_location:1',
+				name: 'Pickup New York City',
+				methodID: 'pickup_nyc',
+				price: '0',
+				instanceID: 0,
+				selected: true,
+			} ),
+			generateShippingRate( {
+				rateId: 'pickup_location:2',
+				name: 'Pickup Los Angeles',
+				methodID: 'pickup_la',
+				price: '0',
+				instanceID: 1,
+				selected: false,
+			} ),
+		],
+	} );
+
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ packageDataWithFlippedSelection ],
+		};
+	} );
+
+	rerender( <CheckoutPickupOptionsBlock /> );
+
+	expect( firstRate ).toBeInTheDocument();
+	expect( secondRate ).toBeInTheDocument();
+	expect( firstRate ).toBeChecked();
+	expect( secondRate ).not.toBeChecked();
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -438,6 +438,12 @@ export const selectShippingRate =
 			);
 
 		if ( selectedShippingRate?.rate_id === rateId ) {
+			// Early return here signifies that the rate is correctly selected.
+			// We might have some pending requests that will be trying to set it, so
+			// let's abort them just in case.
+			if ( abortController ) {
+				abortController.abort();
+			}
 			return;
 		}
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -478,12 +478,13 @@ export const selectShippingRate =
 
 			dispatch.receiveCart( rest );
 			dispatch.shippingRatesBeingSelected( false );
-
 			return response as CartResponse;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			dispatch.shippingRatesBeingSelected( false );
 			return Promise.reject( error );
+		} finally {
+			abortController = null;
 		}
 	};
 

--- a/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
@@ -11,12 +11,14 @@ export const generateShippingRate = ( {
 	name,
 	price,
 	instanceID,
+	methodID = name.toLowerCase().split( ' ' ).join( '_' ),
 	selected = false,
 }: {
 	rateId: string;
 	name: string;
 	price: string;
 	instanceID: number;
+	methodID?: string;
 	selected?: boolean;
 } ): CartShippingPackageShippingRate => {
 	return {
@@ -27,7 +29,7 @@ export const generateShippingRate = ( {
 		price,
 		taxes: '0',
 		instance_id: instanceID,
-		method_id: name.toLowerCase().split( ' ' ).join( '_' ),
+		method_id: methodID,
 		meta_data: [],
 		selected,
 		currency_code: 'USD',

--- a/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import {
+	CartShippingRate,
+	CartShippingPackageShippingRate,
+} from '@woocommerce/type-defs/cart';
+
+export const generateShippingRate = ( {
+	rateId,
+	name,
+	price,
+	instanceID,
+	selected = false,
+}: {
+	rateId: string;
+	name: string;
+	price: string;
+	instanceID: number;
+	selected?: boolean;
+} ): CartShippingPackageShippingRate => {
+	return {
+		rate_id: rateId,
+		name,
+		description: '',
+		delivery_time: '',
+		price,
+		taxes: '0',
+		instance_id: instanceID,
+		method_id: name.toLowerCase().split( ' ' ).join( '_' ),
+		meta_data: [],
+		selected,
+		currency_code: 'USD',
+		currency_symbol: '$',
+		currency_minor_unit: 2,
+		currency_decimal_separator: '.',
+		currency_thousand_separator: ',',
+		currency_prefix: '$',
+		currency_suffix: '',
+	};
+};
+
+export const generateShippingPackage = ( {
+	packageId,
+	shippingRates,
+}: {
+	packageId: number;
+	shippingRates: CartShippingPackageShippingRate[];
+} ): CartShippingRate => {
+	return {
+		package_id: packageId,
+		name: 'Shipping',
+		destination: {
+			address_1: '',
+			address_2: '',
+			city: '',
+			state: '',
+			postcode: '',
+			country: '',
+		},
+		items: [],
+		shipping_rates: shippingRates,
+	};
+};

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -164,9 +164,7 @@ test.describe( 'Shopper → Local pickup', () => {
 		await checkoutPageObject.verifyBillingDetails();
 	} );
 
-	// Skipping temporarily as we work on a proper fix for underlying issue
-	// Tracked in https://github.com/woocommerce/woocommerce/issues/57542
-	test.skip( 'Switching between local pickup and shipping does not affect the address and is used for the order', async ( {
+	test( 'Switching between local pickup and shipping does not affect the address and is used for the order', async ( {
 		page,
 		frontendUtils,
 		checkoutPageObject,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #57542

Every time the new delivery option is selected, we're doing a server call through `selectShippingRate` thunk present in the cart data store. The problem is, even though we properly abort the async operation within `selectShippingRate` thunk (see [this abort controller](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L418)), we don't call it consistently every time we switch the tab between delivery and pickup options. 

My fix resolves around:
- calling it consistently on component mount and letting thunk handle conflicts with the mentioned abort controller
- make sure it is consistently called every time a new delivery option is picked from the list (not changing tabs, but picking some specific option from the list)

I also simplified the `LocalPickupSelect` component API slightly to make it easier to follow. Instead of passing functions that are leaking implementation details (`setSelectedOption`, `onSelectRate`) I've opted it to a generic `onChange` handler.

### How to test the changes in this Pull Request:

1. Go to WC → Settings → Shipping → Local pickup.
2. Enable Local Pickup and set up a location.
3. Ensure you have valid shipping methods set up.
4. Add an item to your cart and go to the Checkout block.
5. Switch between Local Pickup and Shipping quickly and notice that sometimes the incorrect rate is chosen. Some additional notes here:
    - suggest watching the video attached to the issue before proceeding with testing
    - what you need to do essentially is be on the "ship" tab and then quickly switch to "pickup" and back to "ship" again (or pickup → ship → pickup), without the fix this would cause the pickup rate being selected even though you are on the ship tab after performing these steps
    - with "Slow 4G" network throttling it was easier to reproduce the bug, so you might opt it for testing with some throttling as well
    - you can inspect the network tab and verify whether the API calls for selecting shipping rate are properly cancelled

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
