### PR TITLE
Removed filter to add display_name column in user search as it's alre…

### DIFF
--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -1003,19 +1003,6 @@ function wc_get_customer_last_order( $customer_id ) {
 }
 
 /**
- * Add support for searching by display_name.
- *
- * @since 3.2.0
- * @param array $search_columns Column names.
- * @return array
- */
-function wc_user_search_columns( $search_columns ) {
-	$search_columns[] = 'display_name';
-	return $search_columns;
-}
-add_filter( 'user_search_columns', 'wc_user_search_columns' );
-
-/**
  * When a user is deleted in WordPress, delete corresponding WooCommerce data.
  *
  * @param int $user_id User ID being deleted.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Removed unnecessary `wc_user_search_columns` function which adds `display_name` column in user search as it's already included by WordPress core.

Closes #57676 .

#### Significance

-   [ ] Patch

#### Type

-   [ ] Tweak - A minor adjustment to the codebase
