### PR TITLE
Add product filter rating block to the ancestors list of checkbox list block

### DIFF
--- a/plugins/woocommerce/changelog/57680-wooplug-3921-add-the-rating-block-to-the-ancestors-list-of-the-checkbox
+++ b/plugins/woocommerce/changelog/57680-wooplug-3921-add-the-rating-block-to-the-ancestors-list-of-the-checkbox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add product filter rating block to the ancestors list of checkbox list block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/block.json
@@ -9,7 +9,8 @@
 	"apiVersion": 3,
 	"ancestor": [
 		"woocommerce/product-filter-attribute",
-		"woocommerce/product-filter-status"
+		"woocommerce/product-filter-status",
+		"woocommerce/product-filter-rating"
 	],
 	"supports": {
 		"color": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Add product filter rating block to the ancestors list of checkbox list block

Closes #57237

### Screenshots or screen recordings:

N/A
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a page or post and add product collection / product filters
2. Go to the ratings filter in the block list and delete / remove the "List" block
3. Now confirm that you can re-add that block. Note that it's easy to confuse with the existing list block, the icon is this one:

<img width="324" alt="Screenshot 2025-05-02 at 3 54 05 PM" src="https://github.com/user-attachments/assets/bef72493-89a9-43e7-bfb3-fac19d0b49a3" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add product filter rating block to the ancestors list of checkbox list block

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
