### PR TITLE
[Experimental] Product Reviews: remove `Product` prefix from inner blocks

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4130-remove-product-prefix-from-review-blocks
+++ b/plugins/woocommerce/changelog/wooplug-4130-remove-product-prefix-from-review-blocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Product Reviews block: remove Product prefix for review inner blocks.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-author-name/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-author-name/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-author-name",
-	"title": "Product Review Author Name",
+	"title": "Review Author Name",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays the name of the author of the review.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-content/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-content/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-content",
-	"title": "Product Review Content",
+	"title": "Review Content",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays the contents of a product review.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-date/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-date/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-date",
-	"title": "Product Review Date",
+	"title": "Review Date",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays the date on which the review was posted.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-form",
-	"title": "Product Reviews Form",
+	"title": "Reviews Form",
 	"category": "woocommerce",
 	"description": "Display a product's reviews form.",
 	"textdomain": "woocommerce",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-rating/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-rating",
-	"title": "Product Review Rating",
+	"title": "Review Rating",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays the rating of a product review.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-review-template",
-	"title": "Product Reviews Template",
+	"title": "Reviews Template",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"attributes": {},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-next/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-next",
-	"title": "Product Reviews Next Page",
+	"title": "Reviews Next Page",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the next product review's page link.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-numbers/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-numbers",
-	"title": "Product Reviews Page Numbers",
+	"title": "Reviews Page Numbers",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays a list of page numbers for product reviews pagination.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination-previous/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination-previous",
-	"title": "Product Reviews Previous Page",
+	"title": "Reviews Previous Page",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/product-reviews-pagination" ],
 	"description": "Displays the previous product review's page link.",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-pagination/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-pagination",
-	"title": "Product Reviews Pagination",
+	"title": "Reviews Pagination",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"allowedBlocks": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "woocommerce/product-reviews-title",
-	"title": "Product Reviews Title",
+	"title": "Reviews Title",
 	"category": "woocommerce",
 	"ancestor": [ "woocommerce/blockified-product-reviews" ],
 	"description": "Displays a title with the number of reviews.",


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

- This PR removes the `Product` prefix from the review **inner blocks**. Only the title is updated, the slug is unchanged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the `Blockified Product Details` block to the Single Product template.
2. See the Reviews block inside the last accordion item.
3. See `Product Reviews` inner blocks title doesn't include `Product` prefix.
4. See the block and its inner blocks work as `trunk`, both in editor and on the front end.
5. Try submitting a review on the front end, see the review is submitted successfully.