### PR TITLE
Fix Filter by Price slider color to use current in RTL languages instead of hardcoded purple

### DIFF
--- a/plugins/woocommerce/changelog/57687-fix-price-slider-rtl-color
+++ b/plugins/woocommerce/changelog/57687-fix-price-slider-rtl-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Filter by Price slider to use the current color in RTL languages instead of a hardcoded purple value.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/price-slider/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/price-slider/style.scss
@@ -260,7 +260,7 @@
 .rtl {
 	.wc-block-components-price-slider__range-input-progress {
 		--track-background: linear-gradient(to left, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
-		--range-color: #{$studio-woocommerce-purple-30};
+		--range-color: currentColor;
 		background: var(--track-background);
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/price-slider/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/price-slider/style.scss
@@ -260,7 +260,6 @@
 .rtl {
 	.wc-block-components-price-slider__range-input-progress {
 		--track-background: linear-gradient(to left, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
-		--range-color: currentColor;
 		background: var(--track-background);
 	}
 }
@@ -271,9 +270,6 @@
 		background: transparent;
 		border: $border-width solid currentColor;
 		box-sizing: border-box;
-	}
-	.wc-block-components-price-slider__range-input-progress {
-		--range-color: currentColor;
 	}
 	.wc-block-price-filter__range-input {
 		background: transparent;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the `Filter by Price Controls` block's slider color is hardcoded to purple in RTL languages, instead of inheriting the current font color as it does in LTR languages.

Closes #54148 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| ![filter-by-price-rtl-before](https://github.com/user-attachments/assets/91331dae-20f7-4b48-a10f-28441ee2fa15) | ![filter-by-price-rtl-after](https://github.com/user-attachments/assets/bbd0a084-db5a-4d34-9a95-51db6ae7cf32) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a page and add the `Product Collection` blocks.
2. Switch to **Code editor** mode.
3. Copy and paste the following code to add the `Filter by Price Controls` block, then return to **Visual editor** mode.

    <details>
    <summary>Filter by Price Controls Block</summary>

    ```html
    <!-- wp:woocommerce/filter-wrapper {"filterType":"price-filter","heading":"Filter by price"} -->
    <div class="wp-block-woocommerce-filter-wrapper"><!-- wp:heading {"level":3} -->
    <h3 class="wp-block-heading">Filter by price</h3>
    <!-- /wp:heading -->

    <!-- wp:woocommerce/price-filter {"heading":"","lock":{"remove":true}} -->
    <div class="wp-block-woocommerce-price-filter is-loading"><span aria-hidden="true" class="wc-block-product-categories__placeholder"></span></div>
    <!-- /wp:woocommerce/price-filter --></div>
    <!-- /wp:woocommerce/filter-wrapper -->
    ```

</details>

4. Save the page.
5. Go to _Settings > General > Site Language_ and change language to a RTL language (ie: Arabic).
6. Verify on frontend by viewing the page that now the slider color is picking the theme's the font color.
7. Verify by changing the global color of site from _Appearance > Editor > Styles > Color > Palletes_
 and choosing any other color
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
