### PR TITLE
[NOX In-Context] Mark the WPCOM connect button as busy and disabled when clicked

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-add-loading-state-to-wccom-connect-button
+++ b/plugins/woocommerce/changelog/enhancement-add-loading-state-to-wccom-connect-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Mark the WPCOM connect button as busy and disabled when clicked.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/wpcom-connection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/wpcom-connection/index.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,6 +15,8 @@ import './style.scss';
 
 export const JetpackStep: React.FC = () => {
 	const { currentStep, closeModal } = useOnboardingContext();
+	const [ isConnectButtonLoading, setIsConnectButtonLoading ] =
+		useState( false );
 
 	return (
 		<>
@@ -32,7 +35,10 @@ export const JetpackStep: React.FC = () => {
 					<Button
 						variant="primary"
 						className="settings-payments-onboarding-modal__step--content-jetpack-button"
+						isBusy={ isConnectButtonLoading }
+						disabled={ isConnectButtonLoading }
 						onClick={ () => {
+							setIsConnectButtonLoading( true );
 							window.location.href =
 								currentStep?.actions?.auth?.href ?? '';
 						} }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR updates the Jetpack connection screen in the NOX flow to improve the user experience and prevent duplicate actions. When the Continue button is clicked, it is now marked as loading and disabled while waiting for the redirect to complete. 

### Screenshots or screen recordings:
[<img width="1100" alt="Screenshot 2025-05-02 at 16 15 43" src="https://github.com/user-attachments/assets/66d1d38c-1dfc-444f-bd14-275b787116d2" />](https://www.loom.com/share/6384dd66cbd04957983c6613c0b67f92)

### How to test the changes in this Pull Request:
**Prerequisites**
1. Check out this PR locally.
2. Check out WooPayments `develop` branch locally.
3. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
4. If you have a WooPayments account connected, please disconnect it.
5. If you have Jetpack connected, please disconnect it.

**Testing instructions**
1. Go to WooCommerce > Settings > Payments in the admin dashboard.
2. Click the Enable or Complete setup button for the WooPayments payment method.
3. Confirm that the Onboarding Modal opens and displays the Select payment methods screen.
4. Select any PMs from the list and click Continue.
5. Click the Connect button on the next step and ensure the button is entering a loading state and is disabled.
6. Ensure you are redirected to the Jetpack connection screen.

### Testing that has already taken place:
- See above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
