### PR TITLE
Simplify some queries to improve linting compliance

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOO6-5
+++ b/plugins/woocommerce/changelog/fix-WOO6-5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update some queries for better linter compliance.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1934,6 +1934,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					array_fill( 0, 4, $like )
 				);
 
+				// Variations should also search the parent's meta table for fallback fields.
 				if ( $include_variations ) {
 					$term_query .= $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s )", $like );
 				}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1928,7 +1928,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$term_group_query = array();
 
 			foreach ( $search_terms as $search_term ) {
-				$like       = '%' . $wpdb->esc_like( $search_term ) . '%';
+				$like = '%' . $wpdb->esc_like( $search_term ) . '%';
+
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- an array of placeholders is a valid arg.
 				$term_query = $wpdb->prepare(
 					'( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s )',
 					array_fill( 0, 4, $like )

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1925,25 +1925,24 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				$search_terms = array( $term_group );
 			}
 
-			$term_group_query = '';
-			$searchand        = '';
+			$term_group_query = array();
 
 			foreach ( $search_terms as $search_term ) {
-				$like = '%' . $wpdb->esc_like( $search_term ) . '%';
+				$like       = '%' . $wpdb->esc_like( $search_term ) . '%';
+				$term_query = $wpdb->prepare(
+					"( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s )",
+					array_fill( 0, 4, $like )
+				);
 
-				// Variations should also search the parent's meta table for fallback fields.
-				if ( $include_variations ) {
-					$variation_query = $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s ) ", $like );
-				} else {
-					$variation_query = '';
+				if ( $include_variations )  {
+					$term_query .= $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s )", $like );
 				}
 
-				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) $variation_query)", $like, $like, $like, $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$searchand         = ' AND ';
+				$term_group_query[] = "( {$term_query} )";
 			}
 
 			if ( $term_group_query ) {
-				$search_queries[] = $term_group_query;
+				$search_queries[] = implode( ' AND ', $term_group_query );
 			}
 		}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1930,11 +1930,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			foreach ( $search_terms as $search_term ) {
 				$like       = '%' . $wpdb->esc_like( $search_term ) . '%';
 				$term_query = $wpdb->prepare(
-					"( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s )",
+					'( posts.post_title LIKE %s ) OR ( posts.post_excerpt LIKE %s ) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s )',
 					array_fill( 0, 4, $like )
 				);
 
-				if ( $include_variations )  {
+				if ( $include_variations ) {
 					$term_query .= $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s )", $like );
 				}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -84,8 +84,8 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 			'%' . $wpdb->esc_like( $search ) . '%'
 		);
 
-		$query  =  $base_query;
-		$query .= $wpdb->prepare( " ORDER BY post_metas.meta_key $order LIMIT %d, %d", $offset, $limit );
+		$query  = $base_query;
+		$query .= $wpdb->prepare( " ORDER BY post_metas.meta_key $order LIMIT %d, %d", $offset, $limit ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order is safe.
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already.
 		$total_query = "SELECT COUNT(1) FROM ($base_query) AS total";

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-custom-fields-controller.php
@@ -84,12 +84,8 @@ class WC_REST_Product_Custom_Fields_Controller extends WC_REST_Controller {
 			'%' . $wpdb->esc_like( $search ) . '%'
 		);
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already and $order is a static value.
-		$query = $wpdb->prepare(
-			"$base_query ORDER BY post_metas.meta_key $order LIMIT %d, %d",
-			$offset,
-			$limit
-		);
+		$query  =  $base_query;
+		$query .= $wpdb->prepare( " ORDER BY post_metas.meta_key $order LIMIT %d, %d", $offset, $limit );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $base_query has been prepared already.
 		$total_query = "SELECT COUNT(1) FROM ($base_query) AS total";

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -383,13 +383,13 @@ class Register {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$results = $wpdb->get_results(
-				"
-					SELECT   url_id, url, enabled
-					FROM     {$table}
-					{$where_sql}
-					ORDER BY {$order_by} {$order}
-					{$limit_sql}
-				"
+			"
+				SELECT   url_id, url, enabled
+				FROM     {$table}
+				{$where_sql}
+				ORDER BY {$order_by} {$order}
+				{$limit_sql}
+			"
 		);
 
 		$total_rows = (int) $wpdb->get_var( "SELECT COUNT( * ) FROM {$table} {$where_sql}" );

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -379,19 +379,17 @@ class Register {
 			$where_sql = 'WHERE ' . join( ' AND ', $where );
 		}
 
+		$limit_sql = $wpdb->prepare( 'LIMIT %d, %d', ( $page - 1 ) * $per_page, $per_page );
+
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$results = $wpdb->get_results(
-			$wpdb->prepare(
 				"
 					SELECT   url_id, url, enabled
 					FROM     {$table}
 					{$where_sql}
 					ORDER BY {$order_by} {$order}
-					LIMIT    %d, %d
-				",
-				( $page - 1 ) * $per_page,
-				$per_page
-			)
+					{$limit_sql}
+				"
 		);
 
 		$total_rows = (int) $wpdb->get_var( "SELECT COUNT( * ) FROM {$table} {$where_sql}" );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -581,6 +581,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$orders_table = $this->sut::get_orders_table_name();
 		$this->assertEquals( OrderStatus::TRASH, $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$orders_table} WHERE id = %d", $order_id ) ) );
 		$this->assertEquals( OrderStatus::TRASH, $wpdb->get_var( $wpdb->prepare( "SELECT post_status FROM {$wpdb->posts} WHERE id = %d", $order_id ) ) );
+		$this->assertNotEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key LIKE %s", $order_id, '_wp_trash_meta_%' ) ) );
 
 		$this->sut->read( $order );
 		$this->sut->untrash_order( $order );
@@ -588,7 +589,7 @@ class OrdersTableDataStoreTests extends \HposTestCase {
 		$this->assertEquals( OrderStatus::ON_HOLD, $order->get_status() );
 		$this->assertEquals( OrderInternalStatus::ON_HOLD, get_post_status( $order_id ) );
 
-		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key LIKE '_wp_trash_meta_%'", $order_id ) ) );
+		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$this->sut->get_meta_table_name()} WHERE order_id = %d AND meta_key LIKE %s", $order_id, '_wp_trash_meta_%' ) ) );
 		$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE '_wp_trash_meta_%'", $order_id ) ) );
 		//phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR simplifies some queries to make better use of `$wpdb`'s functionality.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your site has a few orders and products, including variable products. Use [Smooth Generator](https://github.com/woocommerce/wc-smooth-generator/) if necessary to add some.
1. Go to **WC > Products**.
1. Enter a search term that you know has a match for said term in the search box and click **Search products**.
1. Confirm the product you expected to appear is included in the results.
1. Enter a search term that's not likely to return a result, such as `sss foobar`.
1. Confirm no results are returned.
1. Go to **WC > Settings > Products > Approved Download Directories**.
1. Once again, enter some search term that you know has a match and click **Search**.
1. Confirm results are as expected.
1. Repeat the search with a term that won't match anything such as `sss foobar` and confirm no results are indeed returned.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
