### PR TITLE
Show all validation errors in Checkout even if email is invalid

### DIFF
--- a/plugins/woocommerce/changelog/57693-fix-show-all-errors-on-checkout
+++ b/plugins/woocommerce/changelog/57693-fix-show-all-errors-on-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Validate all fields and don't bail early on email.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -953,7 +953,7 @@ class WC_Checkout {
 		if ( WC()->cart->needs_shipping() ) {
 			$shipping_country = isset( $data['shipping_country'] ) ? $data['shipping_country'] : WC()->customer->get_shipping_country();
 
-			if ( empty( $shipping_country ) ) {
+			if ( empty( $shipping_country ) && ! $errors->get_error_data( 'billing_country_required' ) ) {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
 			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				if ( WC()->countries->country_exists( $shipping_country ) ) {
@@ -1305,8 +1305,15 @@ class WC_Checkout {
 			$errors      = new WP_Error();
 			$posted_data = $this->get_posted_data();
 
-			// Update session for customer and totals.
-			$this->update_session( $posted_data );
+			try {
+				// Update session for customer and totals.
+				$this->update_session( $posted_data );
+			} catch ( WC_Data_Exception $e ) {
+				// Billing email will be validated later down in validate_posted_data. Skip it, throw other errors.
+				if ( 'customer_invalid_billing_email' !== $e->getErrorCode() ) {
+					throw $e;
+				}
+			}
 
 			wc_log_order_step( '[Shortcode #2] Session updated with checkout data and totals calculated' );
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1311,7 +1311,7 @@ class WC_Checkout {
 			} catch ( WC_Data_Exception $e ) {
 				// Billing email will be validated later down in validate_posted_data. Skip it, throw other errors.
 				if ( 'customer_invalid_billing_email' !== $e->getErrorCode() ) {
-					throw $e;
+					throw new Exception( $e->getMessage(), $e->getCode(), $e->getPrevious() );
 				}
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

in 9.5, we added inline errors that are read from the notice returned in Checkout (https://github.com/woocommerce/woocommerce/pull/49094). However, in Checkout, if you submit an invalid email, validation will get shortcut early and only one error is shown. In this PR, I allow validation to continue and ignore that error, this is because the same field and value will get validated in the next function call.

I also skip a redundant error of "Please enter an address" when other errors are present. 

Closes WOOPLUG-4086

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1063" alt="image" src="https://github.com/user-attachments/assets/01135c15-ff47-4ee5-933a-4dd30e15a38a" /> |   <img width="1060" alt="image" src="https://github.com/user-attachments/assets/b13f4811-bea0-40f1-b621-16f18812aa5a" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In shortcode Checkout, with all fields empty (including email and country), submit the order.
2. You should see inline errors for all fields.
3. Insert an invalid value for email like "invalid.com" and submit
4. Notice that all fields still have errors with inline error.
5. Enable shipping, but don't have a country selected, submit the order.
6. Notice there is no "Please enter an address to continue".
7. Provide a country, you should not see that error still.
8. Fill all fields, make sure you can submit the order.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Validate all fields and don't bail early on email.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
