### PR TITLE
Add comprehensive unit tests for WC_Email::format_string covering legacy and new placeholder handling

### DIFF
--- a/plugins/woocommerce/changelog/57701-fix-wooplug-4089-blogname-placeholder-isnt-replaced-in-emails-when-using
+++ b/plugins/woocommerce/changelog/57701-fix-wooplug-4089-blogname-placeholder-isnt-replaced-in-emails-when-using
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Adds test coverage for WC_Email::format_string
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\Features\FeaturesController;
  */
 class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 
+
 	/**
 	 * Setup tests.
 	 */
@@ -56,11 +57,11 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 	 * Test that we remove elements with style display none from html mails.
 	 */
 	public function test_remove_display_none_elements() {
-		$email = new WC_Email();
+		$email             = new WC_Email();
 		$email->email_type = 'html';
-		$str_present = 'Should be present!';
-		$str_removed = 'Should be removed!';
-		$result = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
+		$str_present       = 'Should be present!';
+		$str_removed       = 'Should be removed!';
+		$result            = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
 		$this->assertTrue( false !== strpos( $result, $str_present ) );
 		$this->assertTrue( false === strpos( $result, $str_removed ) );
 	}
@@ -101,4 +102,203 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}
 
+	/**
+	 * Test basic placeholder replacement in format_string.
+	 */
+	public function test_format_string_basic_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{site_title}'   => 'Test Store',
+			'{site_address}' => 'teststore.com',
+		);
+		$this->assertEquals(
+			'Welcome to Test Store at teststore.com!',
+			$email->format_string( 'Welcome to {site_title} at {site_address}!' )
+		);
+	}
+
+	/**
+	 * Test legacy blogname placeholder in format_string.
+	 */
+	public function test_format_string_legacy_blogname() {
+		$email = new WC_Email();
+		$this->assertEquals(
+			'Welcome to ' . $email->get_blogname(),
+			$email->format_string( 'Welcome to {blogname}' )
+		);
+	}
+
+	/**
+	 * Test legacy find/replace arrays in format_string.
+	 */
+	public function test_format_string_legacy_find_replace() {
+		$email          = new WC_Email();
+		$email->find    = array( '{order_number}' );
+		$email->replace = array( '12345' );
+		$this->assertEquals(
+			'Order: 12345',
+			$email->format_string( 'Order: {order_number}' )
+		);
+	}
+
+	/**
+	 * Test mixed legacy and new placeholders in format_string.
+	 */
+	public function test_format_string_mixed_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{customer_name}' => 'John Doe',
+		);
+		$email->find         = array( '{order_date}' );
+		$email->replace      = array( '2024-01-01' );
+		$this->assertEquals(
+			'Dear John Doe, your order from 2024-01-01 has been received',
+			$email->format_string( 'Dear {customer_name}, your order from {order_date} has been received' )
+		);
+	}
+
+	/**
+	 * Test filter modification in format_string.
+	 */
+	public function test_format_string_filter_modification() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string_replace',
+			function ( $replace ) {
+				$replace['customer-name'] = 'Jane Smith';
+				return $replace;
+			},
+			10
+		);
+		add_filter(
+			'woocommerce_email_format_string_find',
+			function ( $find ) {
+				$find['customer-name'] = '{customer_name}';
+				return $find;
+			},
+			10
+		);
+
+		$result = $email->format_string( 'Hello {customer_name}' );
+		$this->assertEquals( 'Hello Jane Smith', $result );
+
+		// Clean up filters.
+		remove_all_filters( 'woocommerce_email_format_string_replace' );
+		remove_all_filters( 'woocommerce_email_format_string_find' );
+	}
+
+	/**
+	 * Test legacy blogname placeholder with filter override in format_string.
+	 * Note: blogname is a special case in that it is not a placeholder, but a string when in the scope of the filters.
+	 * So for users wanting to support this replacement string, they need to use both filters.
+	 */
+	public function test_format_string_legacy_blogname_filter_override() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string_replace',
+			function ( $replace ) {
+				$replace['blogname'] = 'My Custom Shop Name';
+				return $replace;
+			},
+			10
+		);
+		add_filter(
+			'woocommerce_email_format_string_find',
+			function ( $find ) {
+				$find['blogname'] = '{blogname}';
+				return $find;
+			},
+			10
+		);
+
+		$this->assertEquals(
+			'Welcome to My Custom Shop Name!',
+			$email->format_string( 'Welcome to {blogname}!' ),
+			'Legacy filters should be able to override the default blogname replacement but cannot due to a bug'
+		);
+
+		// Clean up filters.
+		remove_all_filters( 'woocommerce_email_format_string_replace' );
+		remove_all_filters( 'woocommerce_email_format_string_find' );
+	}
+
+	/**
+	 * Test main filter override in format_string.
+	 */
+	public function test_format_string_main_filter_override() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string',
+			function () {
+				return 'Completely overridden';
+			},
+			10
+		);
+
+		$this->assertEquals(
+			'Completely overridden',
+			$email->format_string( 'Original text with {customer_name}' )
+		);
+
+		// Clean up.
+		remove_all_filters( 'woocommerce_email_format_string' );
+	}
+
+	/**
+	 * Test empty string handling in format_string.
+	 */
+	public function test_format_string_empty_string() {
+		$email = new WC_Email();
+		$this->assertEquals( '', $email->format_string( '' ) );
+	}
+
+	/**
+	 * Test string without placeholders in format_string.
+	 */
+	public function test_format_string_no_placeholders() {
+		$email = new WC_Email();
+		$this->assertEquals(
+			'Just a regular string',
+			$email->format_string( 'Just a regular string' )
+		);
+	}
+
+	/**
+	 * Test partial/invalid placeholders in format_string.
+	 */
+	public function test_format_string_partial_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{test}' => 'TEST',
+		);
+		$this->assertEquals(
+			'Partial {test TEST {test_invalid}',
+			$email->format_string( 'Partial {test TEST {test_invalid}' )
+		);
+	}
+
+	/**
+	 * Test multiple occurrences of same placeholder in format_string.
+	 */
+	public function test_format_string_repeated_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{repeat}' => 'REPLACED',
+		);
+		$this->assertEquals(
+			'REPLACED REPLACED REPLACED',
+			$email->format_string( '{repeat} {repeat} {repeat}' )
+		);
+	}
+
+	/**
+	 * Test null input handling in format_string.
+	 */
+	public function test_format_string_null_input() {
+		$email = new WC_Email();
+		$this->assertEquals( '', $email->format_string( null ) );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
@@ -276,7 +276,7 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals(
 			'Partial {test TEST {test_invalid}',
-			$email->format_string( 'Partial {test TEST {test_invalid}' )
+			$email->format_string( 'Partial {test {test} {test_invalid}' )
 		);
 	}
 


### PR DESCRIPTION
While looking into whether #57574 should be addressed, I concluded that the reported bug is actually intended behavior because the relevant code is deprecated anyway, and it's still possible to achieve what the user was trying to do using the existing legacy filters.

However, while in this file, I figured it'd be good to get some test coverage on it anyway (which also helps demonstrated intended behavior). 

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This doesn't add any new user facing changes and is only adding additional automated tests for existing functionality. The tests should pass.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Adds test coverage for WC_Email::format_string

</details>
