### PR TITLE
Add/cursor woocommerce phpunit test command and pull request description rules

### DIFF
--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -1,0 +1,24 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Generating a Pull Request Description
+
+This rule provides guidance for generating a pull request (PR) description in this repository.
+
+## Where to Find the Template
+
+The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/PULL_REQUEST_TEMPLATE.md). Always use this template as the basis for your PR descriptions.
+
+## Best Practices
+
+- **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
+- **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
+- **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation.
+- **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
+- **Changelog Section:** If no changelog entry is needed, check the appropriate box and provide a brief comment explaining why.
+
+## Example
+
+See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility.

--- a/.cursor/rules/woo-phpunit.mdc
+++ b/.cursor/rules/woo-phpunit.mdc
@@ -1,0 +1,22 @@
+---
+description: 
+globs: plugins/woocommerce/tests/**/*.php
+alwaysApply: false
+---
+# WooCommerce PHPUnit Tests
+
+Rules for running WooCommerce PHPUnit tests.
+
+## Run PHPUnit Tests
+
+Run WooCommerce PHPUnit tests for specific files or directories.
+
+The command to run is
+
+```
+pnpm run test:php:env {relative_path} --verbose
+```
+
+And the command must be run in the `plugins/woocommerce` directory.
+
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\Features\FeaturesController;
  */
 class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 
+
 	/**
 	 * Setup tests.
 	 */
@@ -56,11 +57,11 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 	 * Test that we remove elements with style display none from html mails.
 	 */
 	public function test_remove_display_none_elements() {
-		$email = new WC_Email();
+		$email             = new WC_Email();
 		$email->email_type = 'html';
-		$str_present = 'Should be present!';
-		$str_removed = 'Should be removed!';
-		$result = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
+		$str_present       = 'Should be present!';
+		$str_removed       = 'Should be removed!';
+		$result            = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
 		$this->assertTrue( false !== strpos( $result, $str_present ) );
 		$this->assertTrue( false === strpos( $result, $str_removed ) );
 	}
@@ -101,4 +102,203 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}
 
+	/**
+	 * Test basic placeholder replacement in format_string.
+	 */
+	public function test_format_string_basic_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{site_title}'   => 'Test Store',
+			'{site_address}' => 'teststore.com',
+		);
+		$this->assertEquals(
+			'Welcome to Test Store at teststore.com!',
+			$email->format_string( 'Welcome to {site_title} at {site_address}!' )
+		);
+	}
+
+	/**
+	 * Test legacy blogname placeholder in format_string.
+	 */
+	public function test_format_string_legacy_blogname() {
+		$email = new WC_Email();
+		$this->assertEquals(
+			'Welcome to ' . $email->get_blogname(),
+			$email->format_string( 'Welcome to {blogname}' )
+		);
+	}
+
+	/**
+	 * Test legacy find/replace arrays in format_string.
+	 */
+	public function test_format_string_legacy_find_replace() {
+		$email          = new WC_Email();
+		$email->find    = array( '{order_number}' );
+		$email->replace = array( '12345' );
+		$this->assertEquals(
+			'Order: 12345',
+			$email->format_string( 'Order: {order_number}' )
+		);
+	}
+
+	/**
+	 * Test mixed legacy and new placeholders in format_string.
+	 */
+	public function test_format_string_mixed_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{customer_name}' => 'John Doe',
+		);
+		$email->find         = array( '{order_date}' );
+		$email->replace      = array( '2024-01-01' );
+		$this->assertEquals(
+			'Dear John Doe, your order from 2024-01-01 has been received',
+			$email->format_string( 'Dear {customer_name}, your order from {order_date} has been received' )
+		);
+	}
+
+	/**
+	 * Test filter modification in format_string.
+	 */
+	public function test_format_string_filter_modification() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string_replace',
+			function ( $replace ) {
+				$replace['customer-name'] = 'Jane Smith';
+				return $replace;
+			},
+			10
+		);
+		add_filter(
+			'woocommerce_email_format_string_find',
+			function ( $find ) {
+				$find['customer-name'] = '{customer_name}';
+				return $find;
+			},
+			10
+		);
+
+		$result = $email->format_string( 'Hello {customer_name}' );
+		$this->assertEquals( 'Hello Jane Smith', $result );
+
+		// Clean up filters.
+		remove_all_filters( 'woocommerce_email_format_string_replace' );
+		remove_all_filters( 'woocommerce_email_format_string_find' );
+	}
+
+	/**
+	 * Test legacy blogname placeholder with filter override in format_string.
+	 * Note: blogname is a special case in that it is not a placeholder, but a string when in the scope of the filters.
+	 * So for users wanting to support this replacement string, they need to use both filters.
+	 */
+	public function test_format_string_legacy_blogname_filter_override() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string_replace',
+			function ( $replace ) {
+				$replace['blogname'] = 'My Custom Shop Name';
+				return $replace;
+			},
+			10
+		);
+		add_filter(
+			'woocommerce_email_format_string_find',
+			function ( $find ) {
+				$find['blogname'] = '{blogname}';
+				return $find;
+			},
+			10
+		);
+
+		$this->assertEquals(
+			'Welcome to My Custom Shop Name!',
+			$email->format_string( 'Welcome to {blogname}!' ),
+			'Legacy filters should be able to override the default blogname replacement but cannot due to a bug'
+		);
+
+		// Clean up filters.
+		remove_all_filters( 'woocommerce_email_format_string_replace' );
+		remove_all_filters( 'woocommerce_email_format_string_find' );
+	}
+
+	/**
+	 * Test main filter override in format_string.
+	 */
+	public function test_format_string_main_filter_override() {
+		$email = new WC_Email();
+
+		add_filter(
+			'woocommerce_email_format_string',
+			function () {
+				return 'Completely overridden';
+			},
+			10
+		);
+
+		$this->assertEquals(
+			'Completely overridden',
+			$email->format_string( 'Original text with {customer_name}' )
+		);
+
+		// Clean up.
+		remove_all_filters( 'woocommerce_email_format_string' );
+	}
+
+	/**
+	 * Test empty string handling in format_string.
+	 */
+	public function test_format_string_empty_string() {
+		$email = new WC_Email();
+		$this->assertEquals( '', $email->format_string( '' ) );
+	}
+
+	/**
+	 * Test string without placeholders in format_string.
+	 */
+	public function test_format_string_no_placeholders() {
+		$email = new WC_Email();
+		$this->assertEquals(
+			'Just a regular string',
+			$email->format_string( 'Just a regular string' )
+		);
+	}
+
+	/**
+	 * Test partial/invalid placeholders in format_string.
+	 */
+	public function test_format_string_partial_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{test}' => 'TEST',
+		);
+		$this->assertEquals(
+			'Partial {test TEST {test_invalid}',
+			$email->format_string( 'Partial {test TEST {test_invalid}' )
+		);
+	}
+
+	/**
+	 * Test multiple occurrences of same placeholder in format_string.
+	 */
+	public function test_format_string_repeated_placeholders() {
+		$email               = new WC_Email();
+		$email->placeholders = array(
+			'{repeat}' => 'REPLACED',
+		);
+		$this->assertEquals(
+			'REPLACED REPLACED REPLACED',
+			$email->format_string( '{repeat} {repeat} {repeat}' )
+		);
+	}
+
+	/**
+	 * Test null input handling in format_string.
+	 */
+	public function test_format_string_null_input() {
+		$email = new WC_Email();
+		$this->assertEquals( '', $email->format_string( null ) );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/email/emails.php
@@ -13,7 +13,6 @@ use Automattic\WooCommerce\Internal\Features\FeaturesController;
  */
 class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 
-
 	/**
 	 * Setup tests.
 	 */
@@ -57,11 +56,11 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 	 * Test that we remove elements with style display none from html mails.
 	 */
 	public function test_remove_display_none_elements() {
-		$email             = new WC_Email();
+		$email = new WC_Email();
 		$email->email_type = 'html';
-		$str_present       = 'Should be present!';
-		$str_removed       = 'Should be removed!';
-		$result            = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
+		$str_present = 'Should be present!';
+		$str_removed = 'Should be removed!';
+		$result = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
 		$this->assertTrue( false !== strpos( $result, $str_present ) );
 		$this->assertTrue( false === strpos( $result, $str_removed ) );
 	}
@@ -102,203 +101,4 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		$features_controller->change_feature_enable( 'email_improvements', $original_value );
 	}
 
-	/**
-	 * Test basic placeholder replacement in format_string.
-	 */
-	public function test_format_string_basic_placeholders() {
-		$email               = new WC_Email();
-		$email->placeholders = array(
-			'{site_title}'   => 'Test Store',
-			'{site_address}' => 'teststore.com',
-		);
-		$this->assertEquals(
-			'Welcome to Test Store at teststore.com!',
-			$email->format_string( 'Welcome to {site_title} at {site_address}!' )
-		);
-	}
-
-	/**
-	 * Test legacy blogname placeholder in format_string.
-	 */
-	public function test_format_string_legacy_blogname() {
-		$email = new WC_Email();
-		$this->assertEquals(
-			'Welcome to ' . $email->get_blogname(),
-			$email->format_string( 'Welcome to {blogname}' )
-		);
-	}
-
-	/**
-	 * Test legacy find/replace arrays in format_string.
-	 */
-	public function test_format_string_legacy_find_replace() {
-		$email          = new WC_Email();
-		$email->find    = array( '{order_number}' );
-		$email->replace = array( '12345' );
-		$this->assertEquals(
-			'Order: 12345',
-			$email->format_string( 'Order: {order_number}' )
-		);
-	}
-
-	/**
-	 * Test mixed legacy and new placeholders in format_string.
-	 */
-	public function test_format_string_mixed_placeholders() {
-		$email               = new WC_Email();
-		$email->placeholders = array(
-			'{customer_name}' => 'John Doe',
-		);
-		$email->find         = array( '{order_date}' );
-		$email->replace      = array( '2024-01-01' );
-		$this->assertEquals(
-			'Dear John Doe, your order from 2024-01-01 has been received',
-			$email->format_string( 'Dear {customer_name}, your order from {order_date} has been received' )
-		);
-	}
-
-	/**
-	 * Test filter modification in format_string.
-	 */
-	public function test_format_string_filter_modification() {
-		$email = new WC_Email();
-
-		add_filter(
-			'woocommerce_email_format_string_replace',
-			function ( $replace ) {
-				$replace['customer-name'] = 'Jane Smith';
-				return $replace;
-			},
-			10
-		);
-		add_filter(
-			'woocommerce_email_format_string_find',
-			function ( $find ) {
-				$find['customer-name'] = '{customer_name}';
-				return $find;
-			},
-			10
-		);
-
-		$result = $email->format_string( 'Hello {customer_name}' );
-		$this->assertEquals( 'Hello Jane Smith', $result );
-
-		// Clean up filters.
-		remove_all_filters( 'woocommerce_email_format_string_replace' );
-		remove_all_filters( 'woocommerce_email_format_string_find' );
-	}
-
-	/**
-	 * Test legacy blogname placeholder with filter override in format_string.
-	 * Note: blogname is a special case in that it is not a placeholder, but a string when in the scope of the filters.
-	 * So for users wanting to support this replacement string, they need to use both filters.
-	 */
-	public function test_format_string_legacy_blogname_filter_override() {
-		$email = new WC_Email();
-
-		add_filter(
-			'woocommerce_email_format_string_replace',
-			function ( $replace ) {
-				$replace['blogname'] = 'My Custom Shop Name';
-				return $replace;
-			},
-			10
-		);
-		add_filter(
-			'woocommerce_email_format_string_find',
-			function ( $find ) {
-				$find['blogname'] = '{blogname}';
-				return $find;
-			},
-			10
-		);
-
-		$this->assertEquals(
-			'Welcome to My Custom Shop Name!',
-			$email->format_string( 'Welcome to {blogname}!' ),
-			'Legacy filters should be able to override the default blogname replacement but cannot due to a bug'
-		);
-
-		// Clean up filters.
-		remove_all_filters( 'woocommerce_email_format_string_replace' );
-		remove_all_filters( 'woocommerce_email_format_string_find' );
-	}
-
-	/**
-	 * Test main filter override in format_string.
-	 */
-	public function test_format_string_main_filter_override() {
-		$email = new WC_Email();
-
-		add_filter(
-			'woocommerce_email_format_string',
-			function () {
-				return 'Completely overridden';
-			},
-			10
-		);
-
-		$this->assertEquals(
-			'Completely overridden',
-			$email->format_string( 'Original text with {customer_name}' )
-		);
-
-		// Clean up.
-		remove_all_filters( 'woocommerce_email_format_string' );
-	}
-
-	/**
-	 * Test empty string handling in format_string.
-	 */
-	public function test_format_string_empty_string() {
-		$email = new WC_Email();
-		$this->assertEquals( '', $email->format_string( '' ) );
-	}
-
-	/**
-	 * Test string without placeholders in format_string.
-	 */
-	public function test_format_string_no_placeholders() {
-		$email = new WC_Email();
-		$this->assertEquals(
-			'Just a regular string',
-			$email->format_string( 'Just a regular string' )
-		);
-	}
-
-	/**
-	 * Test partial/invalid placeholders in format_string.
-	 */
-	public function test_format_string_partial_placeholders() {
-		$email               = new WC_Email();
-		$email->placeholders = array(
-			'{test}' => 'TEST',
-		);
-		$this->assertEquals(
-			'Partial {test TEST {test_invalid}',
-			$email->format_string( 'Partial {test TEST {test_invalid}' )
-		);
-	}
-
-	/**
-	 * Test multiple occurrences of same placeholder in format_string.
-	 */
-	public function test_format_string_repeated_placeholders() {
-		$email               = new WC_Email();
-		$email->placeholders = array(
-			'{repeat}' => 'REPLACED',
-		);
-		$this->assertEquals(
-			'REPLACED REPLACED REPLACED',
-			$email->format_string( '{repeat} {repeat} {repeat}' )
-		);
-	}
-
-	/**
-	 * Test null input handling in format_string.
-	 */
-	public function test_format_string_null_input() {
-		$email = new WC_Email();
-		$this->assertEquals( '', $email->format_string( null ) );
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add a new cursor rule for running WooCommerce PHPUnit tests.
- Add a new cursor rule providing guidance on generating pull request descriptions, referencing the PR template and best practices for clarity and automation compatibility.

### How to test the changes in this Pull Request:

1. Review the new rules in `.cursor/rules/woo-phpunit.mdc` and `.cursor/rules/generate-pr-description.mdc`.
2. Confirm the instructions in each rule are accurate and helpful.
3. Optionally, follow the documented command in the PHPUnit rule to ensure it works as described.

### Testing that has already taken place:

- Manual review of both rule files for accuracy and clarity.

### Changelog entry

- [ ] Automatically create a changelog entry from the details below.

- [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This change only adds documentation for contributors and does not affect runtime code.

</details>