### PR TITLE
Fix order statuses array check in OrderAwareControllerTrait

### DIFF
--- a/plugins/woocommerce/changelog/57705-fix-WOOPLUG-4124-order-statuses-array-check
+++ b/plugins/woocommerce/changelog/57705-fix-WOOPLUG-4124-order-statuses-array-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix: Ensure `woocommerce_actionable_order_statuses` is always an array to prevent errors in analytics endpoints.
+

--- a/plugins/woocommerce/src/Admin/API/Reports/OrderAwareControllerTrait.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/OrderAwareControllerTrait.php
@@ -95,6 +95,11 @@ trait OrderAwareControllerTrait {
 		// See: https://github.com/woocommerce/woocommerce-admin/issues/5592.
 		$actionable_statuses = get_option( 'woocommerce_actionable_order_statuses', array() );
 
+		// Prevent errors if the database entry is not the expected type (array).
+		if ( ! is_array( $actionable_statuses ) ) {
+			$actionable_statuses = array();
+		}
+
 		// See WC_REST_Orders_V2_Controller::get_collection_params() re: any/trash statuses.
 		$registered_statuses = array_merge( array( 'any', 'trash' ), array_keys( self::get_order_status_labels() ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue where the `woocommerce_actionable_order_statuses` option
could be set to a non-array value, causing errors in analytics endpoints that
rely on actionable order statuses. The change ensures the value is always an
array, preventing such issues.

Closes #WOOPLUG-4124

### How to test the changes in this Pull Request:

1. Set the `woocommerce_actionable_order_statuses` option in the database to a
   non-array value (e.g., a string or integer).
2. Access any analytics endpoint or feature that uses order statuses.
3. Confirm that no errors occur and that the feature works as expected.
4. Restore the option to a valid array and confirm normal operation.

### Testing that has already taken place:

- Manual testing with both valid and invalid option values.
- Verified analytics endpoints do not throw errors with non-array values.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fix: Ensure `woocommerce_actionable_order_statuses` is always an array to
prevent errors in analytics endpoints.

</details>