### PR TITLE
Update Cursor rule to require markdown PR descriptions as output

### DIFF
--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -14,12 +14,12 @@ The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/P
 ## Best Practices
 
 - **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
+- **Changelog Section:** The changelog section in the PR description must keep the markdown structure from the PR template exactly as-is, including all checkboxes, comments, and headings. Only the appropriate checkbox may be checked, and the changelog message must be placed under the `#### Comment` heading and before the closing `</details>` tag. Do not add, remove, or reformat any part of the changelog section except for checking the box and adding the message in the correct place.
 - **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
 - **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation.
 - **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
-- **Changelog Section:** If no changelog entry is needed, check the appropriate box and provide a brief comment explaining why.
-- **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change.
+- **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change, following these rules strictly.
 
 ## Example
 
-See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility.
+See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility, and that the changelog message is placed under the `#### Comment` heading as specified above.

--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: When a PR description is asked for.
 globs: 
 alwaysApply: false
 ---
@@ -18,6 +18,7 @@ The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/P
 - **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation.
 - **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
 - **Changelog Section:** If no changelog entry is needed, check the appropriate box and provide a brief comment explaining why.
+- **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change.
 
 ## Example
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the Cursor rule for generating PR descriptions to require that
all PR descriptions are provided in markdown format, using the structure and
sections from the PR template. This ensures that PR descriptions are always
copy-paste ready for GitHub and include all required sections unless specified
otherwise by the user.

### How to test the changes in this Pull Request:

1. Request a PR description from Hal (the AI assistant).
2. Confirm that the output is in markdown format and follows the structure of
   `.github/PULL_REQUEST_TEMPLATE.md`.
3. Verify that all required sections are present and the output is ready to
   copy-paste into GitHub.

### Testing that has already taken place:

- Manual review of the rule file to ensure correct instructions.
- Confirmed that the rule enforces markdown output for PR descriptions.

### Changelog entry

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Dev - Development related task

#### Message

Chore: update PR description Cursor rule to require markdown output. Ensures all
PR descriptions are provided in markdown format using the PR template structure,
ready for GitHub copy-paste.

</details>