### PR TITLE
Show refunds in the order preview popup in admin

### DIFF
--- a/plugins/woocommerce/changelog/pr-57709
+++ b/plugins/woocommerce/changelog/pr-57709
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show refunds in the order preview popup in admin

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2247,6 +2247,25 @@ ul.wc_coupon_list_block {
 	}
 }
 
+#woocommerce-order-items .woocommerce_order_items_wrapper, .wc-order-preview-table-wrapper {
+	small.refunded {
+		display: block;
+		color: red;
+		white-space: nowrap;
+		margin-top: 0.5em;
+
+		&::before {
+			@include icon_dashicons("\f171");
+			position: relative;
+			top: auto;
+			left: auto;
+			margin: -1px 4px 0 0;
+			vertical-align: middle;
+			line-height: 1em;
+		}
+	}
+}
+
 #woocommerce-order-items {
 	.inside {
 		display: block !important;
@@ -2674,23 +2693,6 @@ ul.wc_coupon_list_block {
 
 				&:hover .delete-order-tax {
 					visibility: visible;
-				}
-			}
-
-			small.refunded {
-				display: block;
-				color: $red;
-				white-space: nowrap;
-				margin-top: 0.5em;
-
-				&::before {
-					@include icon_dashicons("\f171");
-					position: relative;
-					top: auto;
-					left: auto;
-					margin: -1px 4px 0 0;
-					vertical-align: middle;
-					line-height: 1em;
 				}
 			}
 		}

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -443,7 +443,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$billing_address  = $order->get_formatted_billing_address();
 		$shipping_address = $order->get_formatted_shipping_address();
 
-		return apply_filters(
+		$order_details = apply_filters(
 			'woocommerce_admin_order_preview_get_order_details',
 			array(
 				'data'                       => $order->get_data(),
@@ -462,6 +462,9 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			),
 			$order
 		);
+
+		$order_details['data'] = array_intersect_key( $order_details['data'], array_flip( array( 'id', 'billing', 'shipping', 'customer_note' ) ) );
+		return $order_details;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -284,10 +284,28 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				</thead>
 				<tbody>';
 
+		$refunds = array();
+		foreach ( $order->get_refunds() as $refund ) {
+			foreach ( $refund->get_items() as $item ) {
+				$product_id = $item->get_product_id();
+				if ( array_key_exists( $product_id, $refunds ) ) {
+					$refunds[ $product_id ]['quantity'] += absint( $item->get_quantity() );
+					$refunds[ $product_id ]['total']    += abs( (float) $item->get_total() );
+				} else {
+					$refunds[ $product_id ] = array(
+						'quantity' => absint( $item->get_quantity() ),
+						'total'    => abs( (float) $item->get_total() ),
+					);
+				}
+			}
+		}
+
+		$price_args = array( 'currency' => $order->get_currency() );
 		foreach ( $line_items as $item_id => $item ) {
 
 			$product_object = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
 			$row_class      = apply_filters( 'woocommerce_admin_html_order_preview_item_class', '', $item, $order );
+			$refund         = $refunds[ $item->get_product_id() ] ?? null;
 
 			$html .= '<tr class="wc-order-preview-table__item wc-order-preview-table__item--' . esc_attr( $item_id ) . ( $row_class ? ' ' . esc_attr( $row_class ) : '' ) . '">';
 
@@ -317,12 +335,18 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 						break;
 					case 'quantity':
 						$html .= esc_html( $item->get_quantity() );
+						if ( $refund ) {
+							$html .= "<div><small class='refunded'>-" . $refund['quantity'] . '</small></div><br/>';
+						}
 						break;
 					case 'tax':
-						$html .= wc_price( $item->get_total_tax(), array( 'currency' => $order->get_currency() ) );
+						$html .= wc_price( $item->get_total_tax(), $price_args );
 						break;
 					case 'total':
-						$html .= wc_price( $item->get_total(), array( 'currency' => $order->get_currency() ) );
+						$html .= wc_price( $item->get_total(), $price_args );
+						if ( $refund ) {
+							$html .= "<div><small class='refunded'>-" . wc_price( $refund['total'], $price_args ) . '</small></div><br/>';
+						}
 						break;
 					default:
 						$html .= apply_filters( 'woocommerce_admin_order_preview_line_item_column_' . sanitize_key( $column ), '', $item, $item_id, $order );

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -443,6 +443,12 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$billing_address  = $order->get_formatted_billing_address();
 		$shipping_address = $order->get_formatted_shipping_address();
 
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		/**
+		 * Filter to customize the order details data that the woocommerce_get_order_details action will send.
+		 *
+		 * @param array $order_details Order details.
+		 */
 		$order_details = apply_filters(
 			'woocommerce_admin_order_preview_get_order_details',
 			array(
@@ -462,6 +468,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			),
 			$order
 		);
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		$order_details['data'] = array_intersect_key( $order_details['data'], array_flip( array( 'id', 'billing', 'shipping', 'customer_note' ) ) );
 		return $order_details;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The order details page in admin shows refunds as the quantity and amount refunded in red under each item of the order. This pull request implements the display of the same information with the same format in the order details preview that appears when clicking the eye icon in the orders list.

Additionally, the amount of data returned in the `data` key of the response to the `woocommerce_get_order_details` action is reduced so that it now includes only the data required by the fronted, instead of the entire set returned by the order's `get_data` method.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/d159f17f-c53e-48a3-b371-d3e1af131080)    |     ![image](https://github.com/user-attachments/assets/30a9d0d5-7980-4d12-85ec-41343c8edfbb)    |


### How to test the changes in this Pull Request:

1. Create an order containing three products and a quantity of e.g. five for each.
2. Do a partial refund for one of the items and a total refund for another one.
3. Do another partial refund for the same item you have already partially refunded.
4. Verify that the correct refund data (quantity and amount) is still displayed under each item in red, with a "turn back" arrow, in the order details page (as it was the case before).
5. Click the eye icon for the order in the orders list page, next to the order number, and check that the same refund information (quantity and total) is now displayed in the preview popup that opens.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
