### PR TITLE
Fix Add to Cart Form block quantity input size in some extensions

### DIFF
--- a/plugins/woocommerce/changelog/fix-57721-small-inputs-in-extensions
+++ b/plugins/woocommerce/changelog/fix-57721-small-inputs-in-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Add to Cart Form block quantity input size in some extensions

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss
@@ -60,6 +60,7 @@
 		margin-right: 4px;
 		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
 		.qty {
+			box-sizing: content-box;
 			width: 3.631em;
 			text-align: center;
 		}
@@ -138,10 +139,6 @@ div.wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 		.wc-block-components-quantity-selector {
 			width: 107px;
 		}
-	}
-	.input-text.qty.text {
-		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
-		width: 3.631em;
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/57721.
Closes WOOPLUG-4150.

### Screenshots or screen recordings:

Simple product

Storefront (before) | Storefront (after)
--- | ---
![Image](https://github.com/user-attachments/assets/e94fca13-ea98-4abe-adee-ad26134b010f) | ![Image](https://github.com/user-attachments/assets/4d5a16d8-ec7b-4239-9285-5551056e86f0)

TT5 (before) | TT5 (after)
--- | ---
![Image](https://github.com/user-attachments/assets/b39483b7-c139-4132-94f4-59be8971f394) | ![Image](https://github.com/user-attachments/assets/7a147337-8b08-46bc-92d9-6c3f7a698aef)

Simple product in Single Product block

Storefront (before) | Storefront (after)
--- | ---
![Image](https://github.com/user-attachments/assets/43149fae-7b74-40b9-b27a-f12a05b0e057) | ![Image](https://github.com/user-attachments/assets/c9e7ef65-9159-44c8-81be-2c3edc7c6325)

TT5 (before) | TT5 (after)
--- | ---
![Image](https://github.com/user-attachments/assets/c2136841-8c2b-4ece-ac40-49ea72852539) | ![Image](https://github.com/user-attachments/assets/a9e43037-dcd9-4808-b54b-d1215180451e)

Product Bundle

Storefront (before) | Storefront (after)
--- | ---
![Image](https://github.com/user-attachments/assets/696b7aac-ce8d-484e-bfcf-8f1e35a431f6) | ![Image](https://github.com/user-attachments/assets/554311e0-3d15-4418-9d07-b8f32dea9959)

TT5 (before) | TT5 (after)
--- | ---
![Image](https://github.com/user-attachments/assets/dc29075f-4a7c-4a34-8817-daa7900290bb) | ![Image](https://github.com/user-attachments/assets/c19a5d56-3aed-478c-8f7f-839d2f7db557)

Product Bundle in Single Product block

Storefront (before) | Storefront (after)
--- | ---
![Image](https://github.com/user-attachments/assets/c5f62b72-7dd5-465e-8557-19f3c7150511) | ![Image](https://github.com/user-attachments/assets/b18edc86-33ee-4471-88fe-d8b9b59cdbaf)

TT5 (before) | TT5 (after)
--- | ---
![Image](https://github.com/user-attachments/assets/1aac7eff-e720-4f3f-9f82-6bb10dc7b167) | ![Image](https://github.com/user-attachments/assets/5e9a09b9-d325-43d7-9958-3c20e862facb)

### How to test the changes in this Pull Request:

1. Create a Composite Product and Product Bundle in your store.
2. In a classic theme, visit their template. Verify the quantity inputs are visible and have enough width.
3. Create a post, add two _Single Product_ blocks and select the products you created in step 1.
4. Visit the post in the frontend and verify the quantity inputs are visible and have enough width.
5. Switch to a block theme and visit the post and templates again. Verify the sizing of the input looks good and there are no regressions.