### PR TITLE
[Experimental] Reviews Pagination Client Navigation

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4162-add-client-side-navigation-to-reviews-pagination-block
+++ b/plugins/woocommerce/changelog/wooplug-4162-add-client-side-navigation-to-reviews-pagination-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Experiment Product Reviews: add client side navigation to reviews pagination.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/block.json
@@ -14,9 +14,7 @@
 		}
 	},
 	"supports": {
-		"interactivity": {
-			"clientNavigation": true
-		},
+		"interactivity": true,
 		"align": [ "wide", "full" ],
 		"html": false,
 		"color": {
@@ -64,5 +62,6 @@
 		"woocommerce/single-product",
 		"woocommerce/product-template",
 		"core/post-template"
-	]
+	],
+	"viewScriptModule": "woocommerce/blockified-product-reviews"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/frontend.ts
@@ -23,13 +23,18 @@ const productReviewsStore = {
 				return;
 			}
 
-			console.log( ref, ref.href );
-
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);
 
 			yield actions.navigate( ref.href );
+
+			ref.closest(
+				'.wp-block-woocommerce-blockified-product-reviews'
+			)?.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'start',
+			} );
 		},
 	},
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/frontend.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { getElement, store } from '@wordpress/interactivity';
+
+function isValidLink( ref: HTMLElement | null ): ref is HTMLAnchorElement {
+	return (
+		ref !== null &&
+		ref instanceof window.HTMLAnchorElement &&
+		!! ref.href &&
+		( ! ref.target || ref.target === '_self' ) &&
+		ref.origin === window.location.origin
+	);
+}
+
+const productReviewsStore = {
+	actions: {
+		*navigate( event: MouseEvent ) {
+			event.preventDefault();
+			const { ref } = getElement();
+
+			if ( ! isValidLink( ref ) ) {
+				return;
+			}
+
+			console.log( ref, ref.href );
+
+			const { actions } = yield import(
+				'@wordpress/interactivity-router'
+			);
+
+			yield actions.navigate( ref.href );
+		},
+	},
+};
+
+store< typeof productReviewsStore >(
+	'woocommerce/blockified-product-reviews',
+	productReviewsStore,
+	{
+		lock: true,
+	}
+);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -33,7 +33,7 @@ class ProductReviews extends AbstractBlock {
 		}
 
 		$p = new \WP_HTML_Tag_Processor( $content );
-		$p->next_tag( 'div' );
+		$p->next_tag();
 		$p->set_attribute( 'data-wp-interactive', $this->get_full_block_name() );
 		$p->set_attribute( 'data-wp-router-region', $this->get_full_block_name() );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviews.php
@@ -3,37 +3,20 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
 
 /**
  * ProductReviews class.
  */
 class ProductReviews extends AbstractBlock {
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'blockified-product-reviews';
-
-	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return string[]|null
-	 */
-	protected function get_block_type_style() {
-		return null;
-	}
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @see $this->register_block_type()
-	 * @param string $key Data to get, or default to everything.
-	 * @return array|string|null
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
 
 	/**
 	 * Render the block.
@@ -48,6 +31,12 @@ class ProductReviews extends AbstractBlock {
 		if ( ! comments_open() ) {
 			return '';
 		}
-		return $content;
+
+		$p = new \WP_HTML_Tag_Processor( $content );
+		$p->next_tag( 'div' );
+		$p->set_attribute( 'data-wp-interactive', $this->get_full_block_name() );
+		$p->set_attribute( 'data-wp-router-region', $this->get_full_block_name() );
+
+		return $p->get_updated_html();
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPagination.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsPagination.php
@@ -32,12 +32,22 @@ class ProductReviewsPagination extends AbstractBlock {
 		}
 
 		$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'               => $classes,
+				'data-wp-interactive' => 'woocommerce/blockified-product-reviews',
+			)
+		);
+
+		$p = new \WP_HTML_Tag_Processor( $content );
+		while ( $p->next_tag( 'a' ) ) {
+			$p->set_attribute( 'data-wp-on--click', 'actions.navigate' );
+		}
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',
 			$wrapper_attributes,
-			$content
+			$p->get_updated_html()
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds client-side navigation to the reviews pagination block. Clicking on pagination links will no longer trigger a full page reload.

Changes include:
- Added a new frontend script to handle client-side navigation
- Updated block.json to support interactivity and register the view script
- Modified PHP block classes to enable interactive attributes
- Added interactive data attributes to pagination links

https://github.com/user-attachments/assets/4f074b3a-440f-48c2-bcef-2b4bfbd87d81

### How to test the changes in this Pull Request:

1. Add the `Blockified Product Details` block to the Single Product template.
2. Enable paginated reviews in Settings > Discussion > Break comments into pages.
3. Go to a product with multiple reviews (or create enough reviews to trigger pagination). You can also reduce the `Top level comments per page` setting to avoid creating too many reviews.
4. Open the reviews section.
5. Click on the pagination links (next page, previous page, or page numbers).
6. Verify that the page transitions smoothly without a full page reload.
7. Verify that the reviews content updates correctly.
8. Verify that browser back/forward buttons work as expected.
9. Verify that the page scrolls back to the top of the comment list.
