### PR TITLE
[Experimental] Product Details: mark the Description accordion item open by default

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4161-open-the-first-accordion-item-by-default
+++ b/plugins/woocommerce/changelog/wooplug-4161-open-the-first-accordion-item-by-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Experimental Product Details: mark the Description opened by default.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -16,41 +16,66 @@ import {
  */
 import { ProductDetailsEditProps } from './types';
 
-const createAccordionItem = (
-	title: string,
-	content: InnerBlockTemplate[]
-): InnerBlockTemplate => {
-	return [
-		'woocommerce/accordion-item',
-		{},
-		[
-			[ 'woocommerce/accordion-header', { title }, [] ],
-			[ 'woocommerce/accordion-panel', {}, content ],
-		],
-	];
-};
-
-const descriptionAccordion = createAccordionItem( 'Description', [
-	[ 'woocommerce/product-description', {}, [] ],
-] );
-
-const additionalInformationAccordion = createAccordionItem(
-	'Additional Information',
-	[ [ 'woocommerce/product-specifications', {} ] ]
-);
-
-const reviewsAccordion = createAccordionItem( 'Reviews', [
-	[ 'woocommerce/blockified-product-reviews', {} ],
-] );
-
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
 		'woocommerce/accordion-group',
 		{},
 		[
-			descriptionAccordion,
-			additionalInformationAccordion,
-			reviewsAccordion,
+			[
+				'woocommerce/accordion-item',
+				{
+					openByDefault: true,
+				},
+				[
+					[
+						'woocommerce/accordion-header',
+						{ title: __( 'Description', 'woocommerce' ) },
+						[],
+					],
+					[
+						'woocommerce/accordion-panel',
+						{},
+						[ [ 'woocommerce/product-description', {}, [] ] ],
+					],
+				],
+			],
+			[
+				'woocommerce/accordion-item',
+				{},
+				[
+					[
+						'woocommerce/accordion-header',
+						{
+							title: __(
+								'Additional Information',
+								'woocommerce'
+							),
+						},
+						[],
+					],
+					[
+						'woocommerce/accordion-panel',
+						{},
+						[ [ 'woocommerce/product-specifications', {} ] ],
+					],
+				],
+			],
+			[
+				'woocommerce/accordion-item',
+				{},
+				[
+					[
+						'woocommerce/accordion-header',
+						{ title: __( 'Reviews', 'woocommerce' ) },
+						[],
+					],
+					[
+						'woocommerce/accordion-panel',
+						{},
+						[ [ 'woocommerce/blockified-product-reviews', {} ] ],
+					],
+				],
+			],
 		],
 	],
 ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR modifies the Product Details block to mark the Description item to open by default. This PR removes the immediate function and use the plain block template for simplicity.

### How to test the changes in this Pull Request:

1. Add the `Blockified Product Details` block to the Single Product template.
2. Observe that the first accordion item is open by default
3. Save the template and view a product on the front end, see the description tab is opened by default too.
