### PR TITLE
Move recipient settings to the email editor sidebar

### DIFF
--- a/plugins/woocommerce/changelog/add-recipient-fields-to-email-editor-sidebar
+++ b/plugins/woocommerce/changelog/add-recipient-fields-to-email-editor-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add recipient fields to the email editor sidebar.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -3,9 +3,16 @@
  */
 import { select, dispatch } from '@wordpress/data';
 import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
+import {
+	BaseControl,
+	PanelRow,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,7 +31,13 @@ const SidebarSettings = ( { RichTextWithButton } ) => {
 		'woocommerce_data'
 	);
 
-	const updateWooMailProperty = ( name: string, value: string ) => {
+	// Initialize toggle control state
+	const [ addBCC, setAddBCC ] = useState(
+		woocommerce_email_data?.bcc || false
+	);
+	const [ addCC, setAddCC ] = useState( woocommerce_email_data?.cc || false );
+
+	const updateWooMailProperty = ( name: string, value: string | boolean ) => {
 		const editedPost = select( coreDataStore ).getEditedEntityRecord(
 			'postType',
 			'woo_email',
@@ -109,6 +122,104 @@ const SidebarSettings = ( { RichTextWithButton } ) => {
 					'woocommerce'
 				) }
 			/>
+			<PanelRow>
+				<BaseControl
+					__nextHasNoMarginBottom
+					label={ __( 'Recipients', 'woocommerce' ) }
+					id="woocommerce-email-editor-recipients"
+				>
+					{ woocommerce_email_data.recipient === null ? (
+						<p className="woocommerce-email-editor-recipients-help">
+							{ __(
+								'This email is sent to Customer.',
+								'woocommerce'
+							) }
+						</p>
+					) : (
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							name="recipient"
+							value={ woocommerce_email_data.recipient }
+							onChange={ ( value ) => {
+								updateWooMailProperty( 'recipient', value );
+							} }
+							help={ __(
+								'Separate with commas to add multiple email addresses.',
+								'woocommerce'
+							) }
+						/>
+					) }
+				</BaseControl>
+			</PanelRow>
+			<PanelRow>
+				<BaseControl __nextHasNoMarginBottom>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						name="add_cc"
+						checked={ addCC }
+						label={ __( 'Add CC', 'woocommerce' ) }
+						onChange={ ( value ) => {
+							setAddCC( value );
+							if ( ! value ) {
+								updateWooMailProperty( 'cc', '' );
+							}
+						} }
+					/>
+				</BaseControl>
+			</PanelRow>
+			{ addCC && (
+				<PanelRow>
+					<BaseControl __nextHasNoMarginBottom>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							value={ woocommerce_email_data?.cc || '' }
+							onChange={ ( value ) => {
+								updateWooMailProperty( 'cc', value );
+							} }
+							help={ __(
+								'Separate with commas to add multiple email addresses.',
+								'woocommerce'
+							) }
+						/>
+					</BaseControl>
+				</PanelRow>
+			) }
+			<PanelRow>
+				<BaseControl __nextHasNoMarginBottom>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						name="add_bcc"
+						checked={ addBCC }
+						label={ __( 'Add BCC', 'woocommerce' ) }
+						onChange={ ( value ) => {
+							setAddBCC( value );
+							if ( ! value ) {
+								updateWooMailProperty( 'bcc', '' );
+							}
+						} }
+					/>
+				</BaseControl>
+			</PanelRow>
+			{ addBCC && (
+				<PanelRow>
+					<BaseControl __nextHasNoMarginBottom>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							value={ woocommerce_email_data?.bcc || '' }
+							onChange={ ( value ) => {
+								updateWooMailProperty( 'bcc', value );
+							} }
+							help={ __(
+								'Separate with commas to add multiple email addresses.',
+								'woocommerce'
+							) }
+						/>
+					</BaseControl>
+				</PanelRow>
+			) }
 		</>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/sidebar_settings.tsx
@@ -32,10 +32,8 @@ const SidebarSettings = ( { RichTextWithButton } ) => {
 	);
 
 	// Initialize toggle control state
-	const [ addBCC, setAddBCC ] = useState(
-		woocommerce_email_data?.bcc || false
-	);
-	const [ addCC, setAddCC ] = useState( woocommerce_email_data?.cc || false );
+	const [ addBCC, setAddBCC ] = useState( !! woocommerce_email_data?.bcc );
+	const [ addCC, setAddCC ] = useState( !! woocommerce_email_data?.cc );
 
 	const updateWooMailProperty = ( name: string, value: string | boolean ) => {
 		const editedPost = select( coreDataStore ).getEditedEntityRecord(
@@ -179,7 +177,7 @@ const SidebarSettings = ( { RichTextWithButton } ) => {
 								updateWooMailProperty( 'cc', value );
 							} }
 							help={ __(
-								'Separate with commas to add multiple email addresses.',
+								'Add recipients who will receive a copy of the email. Separate multiple addresses with commas.',
 								'woocommerce'
 							) }
 						/>
@@ -213,7 +211,7 @@ const SidebarSettings = ( { RichTextWithButton } ) => {
 								updateWooMailProperty( 'bcc', value );
 							} }
 							help={ __(
-								'Separate with commas to add multiple email addresses.',
+								'Add recipients who will receive a hidden copy of the email. Separate multiple addresses with commas.',
 								'woocommerce'
 							) }
 						/>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/style.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/style.scss
@@ -19,4 +19,11 @@
 	.woocommerce-settings-panel__preview-text-length-error {
 		color: #cc1818;
 	}
+	.woocommerce-email-editor-recipients-help {
+		color: $gray-700;
+		font-size: 12px;
+		font-style: normal;
+		margin-bottom: 0;
+		margin-top: calc(8px);
+	}
 }

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/style.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/style.scss
@@ -4,6 +4,9 @@
 			text-align: right;
 		}
 	}
+	.woocommerce-settings-panel-preheader-text .components-base-control__help {
+		text-align: right;
+	}
 	.woocommerce-settings-panel__preview-text-length {
 		color: #000;
 		display: inline-block;

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -51,15 +51,35 @@ class EmailApiController {
 		$post_option = get_option( "woocommerce_{$email_type}_settings" );
 		$email       = $this->get_email_by_type( $email_type ?? '' );
 
+		// When the email type is not found, it means that the email type is not supported.
+		if ( ! $email ) {
+			return array(
+				'subject'         => null,
+				'subject_full'    => null,
+				'subject_partial' => null,
+				'preheader'       => null,
+				'default_subject' => null,
+				'email_type'      => null,
+				'recipient'       => null,
+				'cc'              => null,
+				'bcc'             => null,
+			);
+		}
+
+		$form_fields = $email->get_form_fields();
 		return array(
 			'enabled'         => $email->is_enabled(),
 			'is_manual'       => $email->is_manual(),
-			'subject'         => $post_option['subject'] ?? null,
-			'subject_full'    => $post_option['subject_full'] ?? null, // For customer_refunded_order email type because it has two different subjects.
-			'subject_partial' => $post_option['subject_partial'] ?? null,
-			'preheader'       => $post_option['preheader'] ?? null,
-			'default_subject' => $email ? $email->get_default_subject() : null,
+			'subject'         => $email->get_option( 'subject' ),
+			'subject_full'    => $email->get_option( 'subject_full' ), // For customer_refunded_order email type because it has two different subjects.
+			'subject_partial' => $email->get_option( 'subject_partial' ),
+			'preheader'       => $email->get_option( 'preheader' ),
+			'default_subject' => $email->get_default_subject(),
 			'email_type'      => $email_type,
+			// Recipient is possible to set only for the specific type of emails. When the field `recipient` is set in the form fields, it means that the email type has a recipient field.
+			'recipient'       => array_key_exists( 'recipient', $form_fields ) ? $email->get_option( 'recipient', get_option( 'admin_email' ) ) : null,
+			'cc'              => $email->get_option( 'cc' ),
+			'bcc'             => $email->get_option( 'bcc' ),
 		);
 	}
 
@@ -96,6 +116,15 @@ class EmailApiController {
 		if ( array_key_exists( 'enabled', $data ) ) {
 			$post_option['enabled'] = $data['enabled'] ? 'yes' : 'no';
 		}
+		if ( array_key_exists( 'recipient', $data ) ) {
+			$post_option['recipient'] = $data['recipient'];
+		}
+		if ( array_key_exists( 'cc', $data ) ) {
+			$post_option['cc'] = $data['cc'];
+		}
+		if ( array_key_exists( 'bcc', $data ) ) {
+			$post_option['bcc'] = $data['bcc'];
+		}
 		update_option( $option_name, $post_option );
 	}
 
@@ -111,8 +140,11 @@ class EmailApiController {
 				'subject_full'    => Builder::string()->nullable(), // For customer_refunded_order email type because it has two different subjects.
 				'subject_partial' => Builder::string()->nullable(),
 				'preheader'       => Builder::string()->nullable(),
-				'default_subject' => Builder::string(),
-				'email_type'      => Builder::string(),
+				'default_subject' => Builder::string()->nullable(),
+				'email_type'      => Builder::string()->nullable(),
+				'recipient'       => Builder::string()->nullable(),
+				'cc'              => Builder::string()->nullable(),
+				'bcc'             => Builder::string()->nullable(),
 			)
 		)->to_array();
 	}

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -155,7 +155,7 @@ class EmailApiController {
 	 * @param string $id - The email ID.
 	 * @return \WC_Email|null - The email object or null if not found.
 	 */
-	private function get_email_by_type( string $id ): ?WC_Email {
+	private function get_email_by_type( ?string $id ): ?WC_Email {
 		foreach ( $this->emails as $email ) {
 			if ( $email->id === $id ) {
 				return $email;

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailApiControllerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
+
+use Automattic\WooCommerce\Internal\EmailEditor\EmailApiController;
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
+use Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager;
+
+/**
+ * Tests for the EmailApiController class.
+ */
+class EmailApiControllerTest extends \WC_Unit_Test_Case {
+	/**
+	 * @var EmailApiController
+	 */
+	private EmailApiController $email_api_controller;
+
+	/**
+	 * @var \WP_Post
+	 */
+	private \WP_Post $email_post;
+
+	/**
+	 * @var string
+	 */
+	private string $email_type = 'test_email';
+
+	/**
+	 * Setup test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		add_option( 'woocommerce_feature_block_email_editor_enabled', 'yes' );
+		// Create a test email post.
+		$this->email_post = $this->factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Test Email',
+				'post_name'    => $this->email_type,
+				'post_type'    => Integration::EMAIL_POST_TYPE,
+				'post_content' => 'Test content',
+				'post_status'  => 'draft',
+			)
+		);
+		// Associate the post with the email type.
+		WCTransactionalEmailPostsManager::get_instance()->save_email_template_post_id(
+			$this->email_type,
+			$this->email_post->ID
+		);
+		// Initialize the controller.
+		$this->email_api_controller = new EmailApiController();
+		$this->email_api_controller->init();
+	}
+
+	/**
+	 * Cleanup after test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( 'woocommerce_feature_block_email_editor_enabled' );
+		delete_option( 'woocommerce_' . $this->email_type . '_settings' );
+	}
+
+	/**
+	 * Test that the email data is returned correctly for an unsupported email type.
+	 */
+	public function test_get_email_data_returns_nulls_for_unsupported_email_type(): void {
+		// Use a post ID not associated with any email type.
+		$unassociated_post = $this->factory()->post->create_and_get(
+			array(
+				'post_title'   => 'Unassociated Email',
+				'post_name'    => 'unassociated_email',
+				'post_type'    => Integration::EMAIL_POST_TYPE,
+				'post_content' => 'Test content',
+				'post_status'  => 'draft',
+			)
+		);
+		$post_data         = array( 'id' => $unassociated_post->ID );
+		$result            = $this->email_api_controller->get_email_data( $post_data );
+		$this->assertNull( $result['subject'] );
+		$this->assertNull( $result['email_type'] );
+	}
+
+	/**
+	 * Test that the email data is returned correctly for a supported email type.
+	 */
+	public function test_get_email_data_returns_email_data_for_supported_type(): void {
+		// Set up a WC_Email mock and inject it into the controller's emails array.
+		$mock_email     = $this->createMock( \WC_Email::class );
+		$mock_email->id = $this->email_type;
+		$mock_email->method( 'get_option' )->willReturnMap(
+			array(
+				array( 'subject', null, 'Test Subject' ),
+				array( 'subject_full', null, null ),
+				array( 'subject_partial', null, null ),
+				array( 'preheader', null, 'Test Preheader' ),
+				array( 'recipient', get_option( 'admin_email' ), 'admin@example.com' ),
+				array( 'cc', null, null ),
+				array( 'bcc', null, null ),
+			)
+		);
+		$mock_email->method( 'get_default_subject' )->willReturn( 'Default Subject' );
+		$mock_email->method( 'get_form_fields' )->willReturn(
+			array(
+				'recipient' => array(),
+			)
+		);
+		// Inject the mock into the controller.
+		$reflection  = new \ReflectionClass( $this->email_api_controller );
+		$emails_prop = $reflection->getProperty( 'emails' );
+		$emails_prop->setAccessible( true );
+		$emails_prop->setValue( $this->email_api_controller, array( $mock_email ) );
+
+		$post_data = array( 'id' => $this->email_post->ID );
+		$result    = $this->email_api_controller->get_email_data( $post_data );
+		$this->assertEquals( 'Test Subject', $result['subject'] );
+		$this->assertEquals( 'Default Subject', $result['default_subject'] );
+		$this->assertEquals( 'Test Preheader', $result['preheader'] );
+		$this->assertEquals( $this->email_type, $result['email_type'] );
+		$this->assertEquals( 'admin@example.com', $result['recipient'] );
+	}
+
+	/**
+	 * Test that the email data is saved correctly.
+	 */
+	public function test_save_email_data_updates_options(): void {
+		$data = array(
+			'subject'   => 'Updated Subject',
+			'preheader' => 'Updated Preheader',
+			'recipient' => 'recipient@example.com',
+			'cc'        => 'cc@example.com',
+			'bcc'       => 'bcc@example.com',
+		);
+		$this->email_api_controller->save_email_data( $data, $this->email_post );
+		$option = get_option( 'woocommerce_' . $this->email_type . '_settings' );
+		$this->assertEquals( 'Updated Subject', $option['subject'] );
+		$this->assertEquals( 'Updated Preheader', $option['preheader'] );
+		$this->assertEquals( 'recipient@example.com', $option['recipient'] );
+		$this->assertEquals( 'cc@example.com', $option['cc'] );
+		$this->assertEquals( 'bcc@example.com', $option['bcc'] );
+	}
+
+	/**
+	 * Test that the email data schema returns the expected schema.
+	 */
+	public function test_get_email_data_schema_returns_expected_schema(): void {
+		$schema = $this->email_api_controller->get_email_data_schema();
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'subject', $schema['properties'] );
+		$this->assertArrayHasKey( 'preheader', $schema['properties'] );
+		$this->assertArrayHasKey( 'recipient', $schema['properties'] );
+	}
+
+	/**
+	 * Test that the recipient is null when not in form fields.
+	 */
+	public function test_get_email_data_recipient_is_null_when_not_in_form_fields(): void {
+		$mock_email     = $this->createMock( \WC_Email::class );
+		$mock_email->id = $this->email_type;
+		$mock_email->method( 'get_option' )->willReturnMap(
+			array(
+				array( 'subject', null, 'Test Subject' ),
+				array( 'subject_full', null, null ),
+				array( 'subject_partial', null, null ),
+				array( 'preheader', null, 'Test Preheader' ),
+				array( 'cc', null, null ),
+				array( 'bcc', null, null ),
+			)
+		);
+		$mock_email->method( 'get_default_subject' )->willReturn( 'Default Subject' );
+		$mock_email->method( 'get_form_fields' )->willReturn(
+			array(
+			// No 'recipient' key here.
+			)
+		);
+		$reflection  = new \ReflectionClass( $this->email_api_controller );
+		$emails_prop = $reflection->getProperty( 'emails' );
+		$emails_prop->setAccessible( true );
+		$emails_prop->setValue( $this->email_api_controller, array( $mock_email ) );
+
+		$post_data = array( 'id' => $this->email_post->ID );
+		$result    = $this->email_api_controller->get_email_data( $post_data );
+		$this->assertNull( $result['recipient'] );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-3527.

This PR adds new input fields to the email settings panel that could already be set in the old email settings.
Those fields are:
- Recipient - displayed only when the recipient can be set. If not, a text mentions that the email is sent to the customer.
- CC - displayed when the toggle is enabled
- BCC - displayed when the toggle is enabled

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="347" alt="Screenshot 2025-05-07 at 9 14 40" src="https://github.com/user-attachments/assets/33749532-e131-4c84-ac9f-bef16cdf545a" />|<img width="350" alt="Screenshot 2025-05-07 at 9 11 29" src="https://github.com/user-attachments/assets/2c4949a2-7e59-4931-8586-c52f487335be" />|
||<img width="348" alt="Screenshot 2025-05-07 at 9 12 00" src="https://github.com/user-attachments/assets/d91457a9-6961-4988-80a9-cd8f149352bc" />|



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the Block Email Editor feature is enabled in WooCommerce > Settings > Advanced > Features.
2. Go to WooCommerce > Settings > Emails.
3. Edit one of the emails and update values in the recipient fields in the settings sidebar.
4. Make sure that changes are stored.
5. Sent email and verify that the new values are used.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
