### PR TITLE
Update in app banner link targets

### DIFF
--- a/plugins/woocommerce/changelog/57771-fix-WCCOM-1234-in-app-banner-link-target
+++ b/plugins/woocommerce/changelog/57771-fix-WCCOM-1234-in-app-banner-link-target
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+- Updates the TrackedLink component to support opening external links in a new tab - Adds screen reader text for external links that open in a new tab - Update marketplace banner, footer and vendor links to open in a new tab

--- a/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
+++ b/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
@@ -49,6 +49,7 @@ export const TrackedLink = ( {
 }: TrackedLinkProps ) => {
 	const linkTextMatch = message.match( /{{Link}}(.*?){{\/Link}}/ );
 	const linkText = linkTextMatch ? linkTextMatch[ 1 ] : '';
+	const shouldOpenInNewTab = linkType === 'external' && target === '_blank';
 
 	return (
 		<Text { ...textProps }>
@@ -70,13 +71,9 @@ export const TrackedLink = ( {
 							} }
 							href={ targetUrl }
 							type={ linkType }
-							target={
-								linkType === 'external' && target === '_blank'
-									? '_blank'
-									: undefined
-							}
+							target={ shouldOpenInNewTab ? '_blank' : undefined }
 							aria-label={
-								linkType === 'external' && target === '_blank'
+								shouldOpenInNewTab
 									? `${ linkText } (${ __(
 											'opens in a new tab',
 											'woocommerce'

--- a/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
+++ b/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
@@ -5,6 +5,7 @@ import { Text } from '@woocommerce/experimental';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Link } from '@woocommerce/components';
 import { recordEvent, ExtraProperties } from '@woocommerce/tracks';
+import { __ } from '@wordpress/i18n';
 
 interface TextProps {
 	/**
@@ -45,34 +46,47 @@ export const TrackedLink = ( {
 	linkType = 'wc-admin',
 	target,
 	onClickCallback,
-}: TrackedLinkProps ) => (
-	<Text { ...textProps }>
-		{ interpolateComponents( {
-			mixedString: message,
-			components: {
-				Link: (
-					<Link
-						onClick={ () => {
-							if ( onClickCallback ) {
-								onClickCallback();
-							} else {
-								recordEvent( eventName, eventProperties );
+}: TrackedLinkProps ) => {
+	const linkTextMatch = message.match( /{{Link}}(.*?){{\/Link}}/ );
+	const linkText = linkTextMatch ? linkTextMatch[ 1 ] : '';
+
+	return (
+		<Text { ...textProps }>
+			{ interpolateComponents( {
+				mixedString: message,
+				components: {
+					Link: (
+						<Link
+							onClick={ () => {
+								if ( onClickCallback ) {
+									onClickCallback();
+								} else {
+									recordEvent( eventName, eventProperties );
+								}
+								if ( linkType !== 'external' ) {
+									window.location.href = targetUrl;
+									return false;
+								}
+							} }
+							href={ targetUrl }
+							type={ linkType }
+							target={
+								linkType === 'external' && target === '_blank'
+									? '_blank'
+									: undefined
 							}
-							if ( linkType !== 'external' ) {
-								window.location.href = targetUrl;
-								return false;
+							aria-label={
+								linkType === 'external' && target === '_blank'
+									? `${ linkText } (${ __(
+											'opens in a new tab',
+											'woocommerce'
+									  ) })`
+									: undefined
 							}
-						} }
-						href={ targetUrl }
-						type={ linkType }
-						target={
-							linkType === 'external' && target === '_blank'
-								? '_blank'
-								: undefined
-						}
-					/>
-				),
-			},
-		} ) }
-	</Text>
-);
+						/>
+					),
+				},
+			} ) }
+		</Text>
+	);
+};

--- a/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
+++ b/plugins/woocommerce/client/admin/client/components/tracked-link/tracked-link.tsx
@@ -25,6 +25,7 @@ interface TrackedLinkProps {
 	eventProperties?: ExtraProperties;
 	targetUrl: string;
 	linkType?: 'wc-admin' | 'wp-admin' | 'external';
+	target?: '_blank' | undefined;
 	/**
 	 * Optional callback function to be called when the link is clicked
 	 * If provided, this will be called instead of the default recordEvent behavior
@@ -42,6 +43,7 @@ export const TrackedLink = ( {
 	eventProperties = {},
 	targetUrl,
 	linkType = 'wc-admin',
+	target,
 	onClickCallback,
 }: TrackedLinkProps ) => (
 	<Text { ...textProps }>
@@ -56,11 +58,18 @@ export const TrackedLink = ( {
 							} else {
 								recordEvent( eventName, eventProperties );
 							}
-							window.location.href = targetUrl;
-							return false;
+							if ( linkType !== 'external' ) {
+								window.location.href = targetUrl;
+								return false;
+							}
 						} }
 						href={ targetUrl }
 						type={ linkType }
+						target={
+							linkType === 'external' && target === '_blank'
+								? '_blank'
+								: undefined
+						}
 					/>
 				),
 			},

--- a/plugins/woocommerce/client/admin/client/marketplace/components/footer/footer.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/footer/footer.tsx
@@ -25,6 +25,7 @@ export const refundPolicyTitle = ( location: string ) => {
 				'30-day {{Link}}money-back guarantee{{/Link}}',
 				'woocommerce'
 			) }
+			target="_blank"
 		/>
 	);
 };
@@ -42,6 +43,7 @@ export const supportTitle = ( location: string ) => {
 				'{{Link}}Get help{{/Link}} when you need it',
 				'woocommerce'
 			) }
+			target="_blank"
 		/>
 	);
 };
@@ -59,6 +61,7 @@ export const paymentTitle = ( location: string ) => {
 				'{{Link}}Products{{/Link}} you can trust',
 				'woocommerce'
 			) }
+			target="_blank"
 		/>
 	);
 };

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.tsx
@@ -108,6 +108,12 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 		queueRecordEvent( event, data );
 	}
 
+	const screenReaderText = (
+		<span className="screen-reader-text">
+			{ __( 'Opens in a new tab', 'woocommerce' ) }
+		</span>
+	);
+
 	const isTheme = type === ProductType.theme;
 	const isBusinessService = type === ProductType.businessService;
 	let productVendor: string | JSX.Element | null = product?.vendorName;
@@ -129,6 +135,7 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 				} }
 			>
 				{ product.vendorName }
+				{ screenReaderText }
 			</a>
 		);
 	}
@@ -169,6 +176,7 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 			} }
 		>
 			{ isLoading ? ' ' : product.title }
+			{ screenReaderText }
 		</a>
 	);
 

--- a/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/product-card/product-card.tsx
@@ -115,6 +115,7 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 		productVendor = (
 			<a
 				href={ product.vendorUrl }
+				target="_blank"
 				rel="noopener noreferrer"
 				onClick={ () => {
 					recordTracksEvent(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Clicking on a product card in WooCommerce->Extensions, opens the product page on WooCommerce.com in a new tab.

The vendor, banner and footer links on the page, which also go to WooCommerce.com, open in the current tab. As these are all external links, we want them to open in a new tab as well.

Closes [WCCOM-1234](https://linear.app/a8c/issue/WCCOM-1234/fix-new-in-app-links-to-open-in-new-tab)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch.
2. Navigate to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
3. Visit the [Marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
4. Run `localStorage.setItem( 'debug', 'wc-admin:*' );` to output track events in the console and remember to enable `preserve log` on browser
5. Click on a link in the banner. It should open in a new tab, and in the current tab confirm the tracks are still logged in the console:

![Screenshot 2025-02-19 at 4 18 22 PM](https://github.com/user-attachments/assets/93c1a814-7e8f-4bc0-ac26-05a8e8ba1b3b)
![Screenshot 2025-02-21 at 6 47 39 PM](https://github.com/user-attachments/assets/086f1c59-7b1f-472c-8763-6380e36f32a9)

6. Click on a footer link and confirm that the tracks are fired with the event name "footer" to differentiate it from the banner.
![Screenshot 2025-02-21 at 6 48 59 PM](https://github.com/user-attachments/assets/1664f0ea-18ff-4735-b223-2a9ed654d5be)

7. Click on the vendor name in any product card. It should open the vendor page on WCCOM in a new tab, while firing the `marketplace_product_card_vendor_clicked` event.
![Extensions_‹_WooCommerce_‹](https://github.com/user-attachments/assets/35b049e7-a26b-47ea-be3c-4650b54523e8)

8. Using a screen reader, visit the various links (including product card links) and confirm the link text is being read out along with an announcement that the link will be opened in a new tab.

9. I modified the `<TrackedLink>` component to ensure external links open in a new tab. To confirm this didn't change how internal links using this component works, go to http://localhost:8888/wp-admin/admin.php?page=wc-admin&task=products (assuming you don't have any products yet). Click the official WooCommerce Marketplace link at the bottom. It should navigate back to the Extensions page in the same tab, while firing the `wcadmin_tasklist_add_product_visit_marketplace_click` event.
![Home_‹_WooCommerce_‹_—_WooCommerce](https://github.com/user-attachments/assets/874bb597-c110-466b-b346-6338cab74215)

10. Test around this issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
- Updates the TrackedLink component to support opening external links in a new tab
- Adds screen reader text for external links that open in a new tab
- Update marketplace banner, footer and vendor links to open in a new tab
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
