### PR TITLE
Update styles of Download section in order email

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4179-downloadable-products-look-dates-in-new-email-design
+++ b/plugins/woocommerce/changelog/wooplug-4179-downloadable-products-look-dates-in-new-email-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update styles of Download section in order email

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -12,18 +12,30 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.7.0
+ * @version 9.9.0
  */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-?><h2 class="woocommerce-order-downloads__title"><?php esc_html_e( 'Downloads', 'woocommerce' ); ?></h2>
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-<table class="td font-family" cellspacing="0" cellpadding="6" style="width: 100%; margin-bottom: 40px;" border="1">
+?><h2 class="woocommerce-order-downloads__title<?php echo $email_improvements_enabled ? ' email-order-detail-heading' : ''; ?>"><?php esc_html_e( 'Downloads', 'woocommerce' ); ?></h2>
+
+<table
+	class="td font-family<?php echo $email_improvements_enabled ? ' email-order-details' : ''; ?>"
+	cellspacing="0"
+	cellpadding="<?php echo $email_improvements_enabled ? '0' : '6'; ?>"
+	style="width: 100%; margin-bottom: 40px;"
+	border="<?php echo $email_improvements_enabled ? '0' : '1'; ?>"
+>
 	<thead>
 		<tr>
 			<?php foreach ( $columns as $column_id => $column_name ) : ?>
-				<th class="td text-align-left" scope="col"><?php echo esc_html( $column_name ); ?></th>
+				<th class="td <?php echo $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left'; ?>" scope="col">
+					<?php echo esc_html( $column_name ); ?>
+				</th>
 			<?php endforeach; ?>
 		</tr>
 	</thead>
@@ -31,7 +43,7 @@ defined( 'ABSPATH' ) || exit;
 	<?php foreach ( $downloads as $download ) : ?>
 		<tr>
 			<?php foreach ( $columns as $column_id => $column_name ) : ?>
-				<td class="td text-align-left">
+				<td class="td <?php echo $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left'; ?>">
 					<?php
 					if ( has_action( 'woocommerce_email_downloads_column_' . $column_id ) ) {
 						do_action( 'woocommerce_email_downloads_column_' . $column_id, $download, $plain_text );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

A slight visual improvements for Download in order completed email:
1. Unify padding with the rest of the email (smaller top and bottom padding, no padding on the left and right side of the table).
2. Align the last column to the right.
3. Unify `Downloads` heading - specifically on <600px windows the heading should be smaller.

Closes WOOPLUG-4179, closes #57777.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="509" alt="Screenshot 2025-05-06 at 18 56 54" src="https://github.com/user-attachments/assets/f379a860-9056-40ef-aa85-7a519db43024" />     |   <img width="517" alt="Screenshot 2025-05-06 at 18 57 35" src="https://github.com/user-attachments/assets/ac4b31dc-54ca-4000-b8d1-8518c8bfb31c" />   |
|   <img width="534" alt="Screenshot 2025-05-06 at 18 56 40" src="https://github.com/user-attachments/assets/cfa72e52-7a30-4a0d-94a0-924c48045434" />     |   <img width="552" alt="Screenshot 2025-05-06 at 18 57 23" src="https://github.com/user-attachments/assets/35d4e738-f54b-42e7-befd-06aba8ffb4bc" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure **Email improvements** feature is enabled in **WooCommerce > Settings > Advanced > Features**.
2. Create a downloadable product.
3. Order this product and change the order status to completed. 
4. Send an order detail email that includes the downloadable links.
5. Verify that the styling of the Downloads sections aligns with the rest of the email - no side padding, last column aligned to the right, `Downloads` heading is smaller on <600px displays. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
