### PR TITLE
Update PHP test to match "Password-protected" text changes in WP nightly

### DIFF
--- a/plugins/woocommerce/changelog/fix-password-protected-test
+++ b/plugins/woocommerce/changelog/fix-password-protected-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Changes to test only
+
+

--- a/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
@@ -463,13 +463,7 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		// If the current WP version is greater than 6.9-alpha-60222 the password prompt will be different.
-		// It was changed in https://core.trac.wordpress.org/changeset/60222.
-		$expected = version_compare( get_bloginfo( 'version' ), '6.9-alpha-60222', '>=' )
-			? 'This content is password-protected'
-			: 'This content is password protected';
-
-		$this->assertStringContainsString( $expected, $product_page );
+		$this->assertMatchesRegularExpression( '/This content is password[- ]protected/', $product_page );
 
 		wp_set_current_user( self::$user_contributor );
 
@@ -480,6 +474,6 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertStringContainsString( $expected, $product_page );
+		$this->assertMatchesRegularExpression( '/This content is password[- ]protected/', $product_page );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
@@ -463,7 +463,7 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertStringContainsString( 'This content is password protected', $product_page );
+		$this->assertStringContainsString( 'This content is password-protected', $product_page );
 
 		wp_set_current_user( self::$user_contributor );
 
@@ -474,6 +474,6 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertStringContainsString( 'This content is password protected', $product_page );
+		$this->assertStringContainsString( 'This content is password-protected', $product_page );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-shortcodes-test.php
@@ -463,7 +463,13 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertStringContainsString( 'This content is password-protected', $product_page );
+		// If the current WP version is greater than 6.9-alpha-60222 the password prompt will be different.
+		// It was changed in https://core.trac.wordpress.org/changeset/60222.
+		$expected = version_compare( get_bloginfo( 'version' ), '6.9-alpha-60222', '>=' )
+			? 'This content is password-protected'
+			: 'This content is password protected';
+
+		$this->assertStringContainsString( $expected, $product_page );
 
 		wp_set_current_user( self::$user_contributor );
 
@@ -474,6 +480,6 @@ class WC_Shortcodes_Test extends WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertStringContainsString( 'This content is password-protected', $product_page );
+		$this->assertStringContainsString( $expected, $product_page );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates a PHP test to match text changes made in WP Core.

This commit: https://github.com/WordPress/wordpress-develop/commit/0f5314739c80b9cdf22e13b272b69c7c9ea5df28

changed the wording on password-protected posts from `This content is password protected` to `This content is password-protected` and the test in Woo which looks for that string has been updated.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fixes WOOPLUG-4184

### How to test the changes in this Pull Request:

1. Ensure CI passes

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
