### PR TITLE
[Blueprint] Prevent import interruption when site state changes from Coming Soon to Live

### DIFF
--- a/plugins/woocommerce/changelog/57797-fix-blueprint-import-live
+++ b/plugins/woocommerce/changelog/57797-fix-blueprint-import-live
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Blueprint imports interrupted if the site state changed from Coming Soon to Live

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -114,7 +114,7 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 				} );
 				continue; // Skip this step
 			}
-			const response = await apiFetch< BlueprintImportStepResponse >( {
+			const response = await apiFetch< Response >( {
 				path: 'wc-admin/blueprint/import-step',
 				method: 'POST',
 				headers: {
@@ -122,20 +122,21 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 					'X-Blueprint-Import-Session': sessionToken,
 				},
 				body: stepJson,
+				parse: false,
 			} );
 
-			if ( ! response.success ) {
+			const data: BlueprintImportStepResponse = await response.json();
+
+			if ( ! data.success ) {
 				errors.push( {
 					step: step.step,
-					messages: response.messages,
+					messages: data.messages,
 				} );
 			}
 
-			if (
-				response.sessionToken &&
-				response.sessionToken !== sessionToken
-			) {
-				sessionToken = response.sessionToken;
+			if ( ! sessionToken ) {
+				sessionToken =
+					response.headers.get( 'X-Blueprint-Import-Session' ) ?? '';
 			}
 		}
 

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -84,6 +84,7 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 			window?.wcSettings?.admin?.blueprint_max_step_size_bytes ||
 			50 * 1024 * 1024; // defaults to 50MB
 
+		let sessionToken = '';
 		// Loop through each step and send it to the endpoint
 		for ( const step of steps ) {
 			const stepJson = JSON.stringify( {
@@ -118,6 +119,7 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
+					'X-Blueprint-Import-Session': sessionToken,
 				},
 				body: stepJson,
 			} );
@@ -127,6 +129,13 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 					step: step.step,
 					messages: response.messages,
 				} );
+			}
+
+			if (
+				response.sessionToken &&
+				response.sessionToken !== sessionToken
+			) {
+				sessionToken = response.sessionToken;
 			}
 		}
 

--- a/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
@@ -32,4 +32,5 @@ export type BlueprintImportStepResponse = {
 		type: string;
 		message: string;
 	}[];
+	sessionToken?: string;
 };

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -262,7 +262,7 @@ class RestApi {
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 *
-	 * @return array
+	 * @return \WP_REST_Response|array
 	 */
 	public function import_step( \WP_REST_Request $request ) {
 		$session_token = $request->get_header( 'X-Blueprint-Import-Session' );
@@ -311,11 +311,14 @@ class RestApi {
 		$step_importer   = new ImportStep( $step_definition );
 		$result          = $step_importer->import();
 
-		return array(
-			'success'      => $result->is_success(),
-			'messages'     => $result->get_messages(),
-			'sessionToken' => $session_token,
+		$response = new \WP_REST_Response(
+			array(
+				'success'  => $result->is_success(),
+				'messages' => $result->get_messages(),
+			)
 		);
+		$response->header( 'X-Blueprint-Import-Session', $session_token );
+		return $response;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -267,7 +267,7 @@ class RestApi {
 	public function import_step( \WP_REST_Request $request ) {
 		$session_token = $request->get_header( 'X-Blueprint-Import-Session' );
 
-		// If no session token, this is the first step: generate and store a new token
+		// If no session token, this is the first step: generate and store a new token.
 		if ( ! $session_token ) {
 			$session_token = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'bp_', true );
 		}

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -265,7 +265,14 @@ class RestApi {
 	 * @return array
 	 */
 	public function import_step( \WP_REST_Request $request ) {
-		if ( ! $this->can_import_blueprint() ) {
+		$session_token = $request->get_header( 'X-Blueprint-Import-Session' );
+
+		// If no session token, this is the first step: generate and store a new token
+		if ( ! $session_token ) {
+			$session_token = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'bp_', true );
+		}
+
+		if ( ! $this->can_import_blueprint( $session_token ) ) {
 			return array(
 				'success'  => false,
 				'messages' => array(
@@ -276,6 +283,11 @@ class RestApi {
 				),
 			);
 		}
+
+		if ( false === get_transient( 'blueprint_import_session_' . $session_token ) ) {
+			set_transient( 'blueprint_import_session_' . $session_token, true, 10 * MINUTE_IN_SECONDS );
+		}
+
 		// Get the raw body size.
 		$body_size = strlen( $request->get_body() );
 		if ( $body_size > $this->get_max_file_size() ) {
@@ -300,18 +312,24 @@ class RestApi {
 		$result          = $step_importer->import();
 
 		return array(
-			'success'  => $result->is_success(),
-			'messages' => $result->get_messages(),
+			'success'      => $result->is_success(),
+			'messages'     => $result->get_messages(),
+			'sessionToken' => $session_token,
 		);
 	}
 
-
 	/**
-	 * Check if blueprint imports are allowed based on site status and configuration.
+	 * Check if blueprint imports are allowed based on site status, configuration, and session token.
 	 *
+	 * @param string|null $session_token Optional session token for import session.
 	 * @return bool Returns true if imports are allowed, false otherwise.
 	 */
-	private function can_import_blueprint() {
+	private function can_import_blueprint( $session_token = null ) {
+		// Allow import if a valid session token is present so when a site is turned into live during the import process, the import can continue.
+		if ( $session_token && get_transient( 'blueprint_import_session_' . $session_token ) ) {
+			return true;
+		}
+
 		// Check if override constant is defined and true.
 		if ( defined( 'ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE' ) && ALLOW_BLUEPRINT_IMPORT_IN_LIVE_MODE ) {
 			return true;

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/RestApiTest.php
@@ -183,10 +183,10 @@ class RestApiTest extends WP_Test_REST_TestCase {
 		);
 		$request->set_header( 'Content-Type', 'application/json' );
 
-		$response = $this->rest_api->import_step( $request );
-
-		$this->assertTrue( $response['success'], $response['messages'][0]['message'] );
-		$this->assertCount( 1, $response['messages'] );
-		$this->assertStringContainsString( 'woocommerce_store_address has been updated', $response['messages'][0]['message'] );
+		$response      = $this->rest_api->import_step( $request );
+		$response_data = $response->get_data();
+		$this->assertTrue( $response_data['success'], $response_data['messages'][0]['message'] );
+		$this->assertCount( 1, $response_data['messages'] );
+		$this->assertStringContainsString( 'woocommerce_store_address has been updated', $response_data['messages'][0]['message'] );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Previously, if a Blueprint import was started while the site was in Coming Soon mode, but the import process itself changed the site to Live (as part of the imported settings), subsequent import steps would fail due to the site state change ([Add security restriction to only allow blueprint imports in Coming Soon mode #57382](https://github.com/woocommerce/woocommerce/pull/57382)). This resulted in incomplete imports.

This PR fixes the issue by introducing a session token mechanism: when an import starts, a session token is generated and returned to the client. All subsequent import step requests must include this session token, allowing the import to continue even if the site becomes Live mid-process. (New imports are still blocked on live sites, but ongoing sessions are allowed to complete.)


### Screenshots or screen recordings:


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Set the site to Coming Soon mode.
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
3. Import  [woo-blueprint.json](https://github.com/user-attachments/files/20077369/woo-blueprint.json)
4. Confirm the import is successful.
5. Reload the page and confirm the import is disabled.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix Blueprint imports interrupted if the site state changed from Coming Soon to Live

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>