### PR TITLE
[WC Payments NOX] Enable the feature for all stores - change target release from 9.8.4 to 9.8.5

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -277,8 +277,8 @@ class WC_Install {
 		'9.8.0' => array(
 			'wc_update_980_remove_order_attribution_install_banner_dismissed_option',
 		),
-		'9.8.4' => array(
-			'wc_update_984_enable_new_payments_settings_page_feature',
+		'9.8.5' => array(
+			'wc_update_985_enable_new_payments_settings_page_feature',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2957,6 +2957,6 @@ function wc_update_980_remove_order_attribution_install_banner_dismissed_option(
 /**
  * One-time force enable the new Payments Settings page feature for all stores.
  */
-function wc_update_984_enable_new_payments_settings_page_feature() {
+function wc_update_985_enable_new_payments_settings_page_feature() {
 	update_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled', 'yes' );
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With the recent 9.8.4 release we change our target version for one-time enablement of the new Payments Settings page feature flag (`reactify-classic-payments-settings`) from 9.8.4 to 9.8.5.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related to WOOPLUG-4100

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

These testing instructions are an updated version of [the original PR](https://github.com/woocommerce/woocommerce/pull/57614). The screenshots are not updated, so please squint a little and "mentally replace" 9.8.4 with 9.8.5.

#### Testing brand new stores

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dashboard and install and activate WooCommerce using this PR's branch build ([use this file](https://github.com/user-attachments/files/20078603/woocommerce-9-8-5.zip) to get a zip with the proper version - 9.8.5, and directory name)
1. Skip the core profiler and select an EU store country ("Austria," for example).
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is enabled:
![Screenshot 2025-04-14 at 13 26 46](https://github.com/user-attachments/assets/a55708f2-812b-468e-bde6-bd98abd64034)
1. Click on the "Payments" main menu item, and you should see the new Payments Settings page:
![Screenshot 2025-04-14 at 13 28 26](https://github.com/user-attachments/assets/686ca408-77d1-4437-b8d5-14ca15883f7b)
1. Go to WooCommerce > Settings > Advanced > Features and _disable_ the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item, and you should be presented with the WooPayments-flavored Payments task page:
![Screenshot 2025-04-14 at 13 31 26](https://github.com/user-attachments/assets/760d5efb-1776-4e6e-835d-5a699a54eb48)
1. Go to WooCommerce > Settings > Payments, and you should see the legacy page:
![Screenshot 2025-04-14 at 13 32 25](https://github.com/user-attachments/assets/7e7dc3e9-e5d8-401d-a067-f8819e373bcd)
1. Go to WooCommerce > Settings > Advanced > Features and _enable_ the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item, and you should see the new Payments Settings page.

#### Testing (new) stores upgrading from WC 9.7.x

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dashboard and install and activate **WooCommerce 9.7.1** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.7.1.zip))
1. Go through the core profiler, skip it, and select any EU country ("Austria," for example).
1. Go to Plugins > Add plugin and install and activate the WooCommerce Beta Tester plugin (either [from WCCOM](https://woocommerce.com/products/woocommerce-beta-tester/) or directly from [here](https://github.com/user-attachments/files/19734140/woocommerce-beta-tester.1.zip))
1. Go to Tools > WCA Test Helper > Features and make sure the `reactify-classic-payments-settings` feature is enabled. If it is already enabled when you visit the page, disable it and enable it back (to make it interacted with and stored):
![Screenshot 2025-04-14 at 13 46 13](https://github.com/user-attachments/assets/1c1d3dd3-0dc9-4836-abcf-5337e3cc1653)
1. Click on the "Payments" main menu item and confirm you see the new Payments Settings page: 
![Screenshot 2025-04-14 at 13 49 08](https://github.com/user-attachments/assets/56930ce5-efd6-4f20-8e66-5448fc97ff31)
1. Go to Plugins > Add plugin and upload WooCommerce using this PR's branch build ([use this file](https://github.com/user-attachments/files/20078603/woocommerce-9-8-5.zip) to get a zip with the proper version - 9.8.5, and directory name). When asked, replace the current version (9.7.1) with the new one.
1. Go to WooCommerce > Home and run the WooCommerce database updates when prompted in the notice:
![Screenshot 2025-04-30 at 12 46 19](https://github.com/user-attachments/assets/6f9508de-00f8-4ff1-90e4-c105351f3a4b)
1. Wait for the database updates to finish (or you can manually run them from WooCommerce > Status > Scheduled Actions:
![Screenshot 2025-04-30 at 12 49 09](https://github.com/user-attachments/assets/00ea5b1d-b7ee-4da9-946b-00ad8aa6a05a)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is enabled:
![Screenshot 2025-04-14 at 13 26 46](https://github.com/user-attachments/assets/a55708f2-812b-468e-bde6-bd98abd64034)
1. Click on the "Payments" main menu item, and you should see the new Payments Settings page:
![Screenshot 2025-04-14 at 13 28 26](https://github.com/user-attachments/assets/686ca408-77d1-4437-b8d5-14ca15883f7b)
1. Go to WooCommerce > Settings > Advanced > Features and disable the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item, and you should be presented with the WooPayments-flavored Payments task page:
![Screenshot 2025-04-14 at 13 31 26](https://github.com/user-attachments/assets/760d5efb-1776-4e6e-835d-5a699a54eb48)
1. Go to WooCommerce > Settings > Payments and you should see the legacy page:
![Screenshot 2025-04-14 at 13 32 25](https://github.com/user-attachments/assets/7e7dc3e9-e5d8-401d-a067-f8819e373bcd)
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin (this will run WC Install again):
![Screenshot 2025-04-14 at 13 57 50](https://github.com/user-attachments/assets/1cbdf12a-236b-4679-b241-2348c1f72ece)
1. Go to WooCommerce > Settings > Payments, and you should still see the legacy page.
1. Go to WooCommerce > Settings > Advanced > Features and enable the "Payments Settings (beta)" feature. Refresh the page again.
1. Click on the "Payments" main menu item, and you should see the new page.

#### Test (new) stores upgrading from WC 9.8.x

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dashboard and install and activate **WooCommerce 9.8.0** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.8.0.zip))
1. Go through the core profiler, skip it, and select any EU country ("Austria," for example).
1. Go to WooCommerce > Settings > Advanced > Features and make sure you _disable_ the "Payments Settings (beta)" feature.
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to Plugins > Add plugin and upload WooCommerce using this PR's branch build ([use this file](https://github.com/user-attachments/files/20078603/woocommerce-9-8-5.zip) to get a zip with the proper version - 9.8.5, and directory name). When asked, replace the current version (9.8.0) with the new one.
1. Go to WooCommerce > Home and run the WooCommerce database updates when prompted in the notice:
![Screenshot 2025-04-30 at 12 46 19](https://github.com/user-attachments/assets/6f9508de-00f8-4ff1-90e4-c105351f3a4b)
1. Wait for the database updates to finish (or you can manually run them from WooCommerce > Status > Scheduled Actions:
![Screenshot 2025-04-30 at 12 49 09](https://github.com/user-attachments/assets/00ea5b1d-b7ee-4da9-946b-00ad8aa6a05a)
1. Go to WooCommerce > Settings > Advanced > Features and the "Payments Settings (beta)" feature should be enabled.
1. Click on the "Payments" main menu item and should see the new Payments Settings page.
1. Go to WooCommerce > Settings > Advanced > Features and _disable_ the "Payments Settings (beta)" feature.
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin.
1. Go to WooCommerce > Settings > Payments and you should see the legacy Payments Settings page.

#### Testing existing stores upgrading from WC pre-9.7

1. Create a blank Jurassic Ninja site (here is [a direct link](https://jurassic.ninja/create/?shortlived&nojetpack)).
1. Go to the new site's WP dashboard and install and activate **WooCommerce 9.6.2** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.6.2.zip))
1. Go through the core profiler, skip it, and select any EU country ("Austria," for example).
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to WooCommerce > Settings > Payments and enable an offline payment method.
1. Go to Plugins > Add plugin and upload WooCommerce using this PR's branch build ([use this file](https://github.com/user-attachments/files/20078603/woocommerce-9-8-5.zip) to get a zip with the proper version - 9.8.5, and directory name). When asked, replace the current version (9.6.2) with the new one.
1. Go to WooCommerce > Home and run the WooCommerce database updates when prompted in the notice:
![Screenshot 2025-04-30 at 12 46 19](https://github.com/user-attachments/assets/6f9508de-00f8-4ff1-90e4-c105351f3a4b)
1. Wait for the database updates to finish (or you can manually run them from WooCommerce > Status > Scheduled Actions:
![Screenshot 2025-04-30 at 12 49 09](https://github.com/user-attachments/assets/00ea5b1d-b7ee-4da9-946b-00ad8aa6a05a)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is **enabled.**
1. Go to WooCommerce > Settings > Payments, and you should see the new Payments Settings page.

#### Testing existing stores (created pre-9.7) that upgraded to 9.7.x

1. Create a blank Jurassic Ninja site _without_ the drop-in cache plugin.
1. Go to the new site's WP dashboard and install and activate **WooCommerce 9.6.2** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.6.2.zip))
1. Go through the core profiler, skip it, and select any EU country ("Austria," for example).
1. Go to WooCommerce > Home, click on the "Add your products" task, click on the "View more product types" link and then click on "Load sample products":
![Screenshot 2025-04-14 at 14 02 35](https://github.com/user-attachments/assets/6fa0f7ce-89cf-4c93-8138-6fcfc671e996)
1. Go to WooCommerce > Settings > Payments and enable an offline payment method.
1. Go to Plugins > Add plugin and upload **WooCommerce 9.7.1** (available [from WPORG](https://wordpress.org/plugins/woocommerce/advanced/) or [directly from here](https://downloads.wordpress.org/plugin/woocommerce.9.7.1.zip)). When asked, replace the current version (9.6.2) with the new one (9.7.1).
1. Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page. If you don't, it means you landed in the 50% that get the control experience in the experiment. Do the following:
    - Go to Plugins > Add new and install and activate the [Transients Manger](https://wordpress.org/plugins/transients-manager/) plugin
    - Go to Tools > Transients and search for `abtest_variation_woocommerce_payment_settings_2025_v1`. You should have an entry with the `control` value. Edit it to have the `treatment` value.
    - Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page.
1. Go to Plugins > Add plugin and upload WooCommerce using this PR's branch build ([use this file](https://github.com/user-attachments/files/20078603/woocommerce-9-8-5.zip) to get a zip with the proper version - 9.8.5, and directory name). When asked, replace the current version (9.7.1) with the new one.
1. Go to WooCommerce > Home and run the WooCommerce database updates when prompted in the notice:
![Screenshot 2025-04-30 at 12 46 19](https://github.com/user-attachments/assets/6f9508de-00f8-4ff1-90e4-c105351f3a4b)
1. Wait for the database updates to finish (or you can manually run them from WooCommerce > Status > Scheduled Actions:
![Screenshot 2025-04-30 at 12 49 09](https://github.com/user-attachments/assets/00ea5b1d-b7ee-4da9-946b-00ad8aa6a05a)
1. Go to WooCommerce > Settings > Advanced > Features, and confirm that "Payments Settings (beta)" is **enabled.**
1. Go to WooCommerce > Settings > Payments and you should see the new Payments Settings page.
1. Go to Plugins and deactivate and reactivate the WooCommerce plugin (this will run WC Install again).
1. Go to WooCommerce > Settings > Payments and you should still see the new Payments Settings page.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
