### PR TITLE
[Blueprint] Only show WordPress.org plugins 

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4187-blueprint-only-show-wordpressorg-plugins-plugins
+++ b/plugins/woocommerce/changelog/wooplug-4187-blueprint-only-show-wordpressorg-plugins-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update blueprint feature to only display WordPress.org plugins

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -306,7 +306,7 @@ class Init {
 			$all_plugins,
 			function ( $plugin ) use ( $api_response ) {
 				$slug = $plugin['slug'];
-				return isset( $api_response->$slug ) && ! isset( $api_response->{$slug}['error'] );
+				return isset( $api_response->{$slug} ) && ! isset( $api_response->{$slug}['error'] );
 			}
 		);
 

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -27,6 +27,7 @@ use Automattic\WooCommerce\Blueprint\UseWPFunctions;
 class Init {
 	use UseWPFunctions;
 
+	const INSTALLED_WP_ORG_PLUGINS_TRANSIENT = 'woocommerce_blueprint_installed_wp_org_plugins';
 	/**
 	 * Array of initialized exporters.
 	 *
@@ -49,6 +50,9 @@ class Init {
 		);
 
 		add_filter( 'wooblueprint_exporters', array( $this, 'add_woo_exporters' ) );
+
+		add_action( 'upgrader_process_complete', array( $this, 'clear_installed_wp_org_plugins_transient' ), 10, 2 );
+		add_action( 'deleted_plugin', array( $this, 'clear_installed_wp_org_plugins_transient' ), 10, 2 );
 	}
 
 	/**
@@ -108,7 +112,9 @@ class Init {
 	 * @return array|array[] $plugins
 	 */
 	public function get_plugins_for_export_group() {
-		$plugins        = $this->wp_get_plugins();
+		$plugins = $this->get_installed_wp_org_plugins();
+
+		// Get active plugins from WordPress options and transform plugins array into export format.
 		$active_plugins = $this->wp_get_option( 'active_plugins', array() );
 		$plugins        = array_map(
 			function ( $key, $plugin ) use ( $active_plugins ) {
@@ -128,8 +134,14 @@ class Init {
 				return $b['checked'] <=> $a['checked'];
 			}
 		);
-
 		return $plugins;
+	}
+
+	/**
+	 * Clear the installed WordPress.org plugins transient.
+	 */
+	public function clear_installed_wp_org_plugins_transient() {
+		delete_transient( self::INSTALLED_WP_ORG_PLUGINS_TRANSIENT );
 	}
 
 	/**
@@ -225,5 +237,80 @@ class Init {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Get all installed WordPress.org plugins.
+	 *
+	 * @return array
+	 */
+	private function get_installed_wp_org_plugins() {
+		// Try to get cached plugin list.
+		$wp_org_plugins = get_transient( self::INSTALLED_WP_ORG_PLUGINS_TRANSIENT );
+		if ( is_array( $wp_org_plugins ) ) {
+			return $wp_org_plugins;
+		}
+
+		// Get all installed plugins.
+		$all_plugins  = $this->wp_get_plugins();
+		$plugin_slugs = array();
+
+		// Build a map of plugin file => slug.
+		foreach ( $all_plugins as $key => $plugin ) {
+			$slug = dirname( $key );
+			/**
+			 * Apply the WP Core "wp_plugin_dependencies_slug" filter to get the correct plugin slug.
+			 */
+			$slug = apply_filters( 'wp_plugin_dependencies_slug', $slug ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+
+			$plugin_slugs[]              = $slug;
+			$all_plugins[ $key ]['slug'] = $slug;
+		}
+
+		$api_response = $this->wp_plugins_api(
+			'plugin_information',
+			array(
+				'fields' => array(
+					'short_description' => false,
+					'sections'          => false,
+					'description'       => false,
+					'tested'            => false,
+					'requires'          => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'downloadlink'      => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'versions'          => false,
+					'donate_link'       => false,
+					'reviews'           => false,
+					'banners'           => false,
+					'icons'             => false,
+					'active_installs'   => false,
+				),
+				'slugs'  => $plugin_slugs,
+			)
+		);
+
+		// If API fails, return all plugins.
+		if ( is_wp_error( $api_response ) ) {
+			return $all_plugins;
+		}
+
+		// Filter plugins: only keep those with a valid API response (no 'error' for their slug).
+		$wp_org_plugins = array_filter(
+			$all_plugins,
+			function ( $plugin ) use ( $api_response ) {
+				$slug = $plugin['slug'];
+				return isset( $api_response->$slug ) && ! isset( $api_response->{$slug}['error'] );
+			}
+		);
+
+		set_transient( self::INSTALLED_WP_ORG_PLUGINS_TRANSIENT, $wp_org_plugins );
+		return $wp_org_plugins;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Automattic\WooCommerce\Tests\Admin\Features\Blueprint;
 
 use Automattic\WooCommerce\Admin\Features\Blueprint\Init;

--- a/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/Features/Blueprint/InitTest.php
@@ -7,18 +7,34 @@ use Automattic\WooCommerce\Tests\Admin\Features\Blueprint\stubs\DummyExporter;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
+/**
+ * Class InitTest
+ *
+ * @package Automattic\WooCommerce\Tests\Admin\Features\Blueprint
+ */
 class InitTest extends MockeryTestCase {
+	/**
+	 * The Init instance.
+	 *
+	 * @var Mockery\MockInterface
+	 */
 	protected $init;
 
+	/**
+	 * Set up the test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		// Create a Mockery mock of Init class
+		// Create a Mockery mock of Init class.
 		$this->init = Mockery::mock( Init::class )->makePartial();
 	}
 
+	/**
+	 * Test the get_plugins_for_export_group method.
+	 */
 	public function test_get_plugins_for_export_group() {
-		// Fake plugins list
+		// Fake plugins list.
 		$mock_plugins = array(
 			'plugin-1/plugin.php' => array( 'Name' => 'Plugin One' ),
 			'plugin-2/plugin.php' => array( 'Name' => 'Plugin Two' ),
@@ -26,11 +42,17 @@ class InitTest extends MockeryTestCase {
 
 		$active_plugins = array( 'plugin-1/plugin.php' );
 
-		// Mock methods
+		$plugins_api = (object) array(
+			'plugin-1' => array( 'Name' => 'Plugin One' ),
+			'plugin-2' => array( 'Name' => 'Plugin Two' ),
+		);
+
+		// Mock methods.
 		$this->init->shouldReceive( 'wp_get_plugins' )->andReturn( $mock_plugins );
 		$this->init->shouldReceive( 'wp_get_option' )->andReturn( $active_plugins );
+		$this->init->shouldReceive( 'wp_plugins_api' )->andReturn( $plugins_api );
 
-		// Run the function
+		// Run the function.
 		$result = $this->init->get_plugins_for_export_group();
 
 		$expected = array(
@@ -49,17 +71,20 @@ class InitTest extends MockeryTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	/**
+	 * Test the get_themes_for_export_group method.
+	 */
 	public function test_get_themes_for_export_group() {
-		// Create mock themes that mimic WP_Theme
+		// Create mock themes that mimic WP_Theme.
 		$mock_theme_1      = $this->createMockTheme( 'theme-one', 'Theme One' );
 		$mock_theme_2      = $this->createMockTheme( 'theme-two', 'Theme Two' );
 		$mock_active_theme = $this->createMockTheme( 'theme-one', 'Theme One' );
 
-		// Mock methods
+		// Mock methods.
 		$this->init->shouldReceive( 'wp_get_themes' )->andReturn( array( $mock_theme_1, $mock_theme_2 ) );
 		$this->init->shouldReceive( 'wp_get_theme' )->andReturn( $mock_active_theme );
 
-		// Run the function
+		// Run the function.
 		$result = $this->init->get_themes_for_export_group();
 
 		$expected = array(
@@ -78,6 +103,9 @@ class InitTest extends MockeryTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
+	/**
+	 * Test the get_step_groups_for_js method.
+	 */
 	public function test_get_step_groups_for_js() {
 		$this->init->shouldReceive( 'get_woo_exporters' )->andReturn( array( new DummyExporter() ) );
 
@@ -137,6 +165,11 @@ class InitTest extends MockeryTestCase {
 
 	/**
 	 * Helper method to create a mock WP_Theme-like object.
+	 *
+	 * @param string $stylesheet The stylesheet of the theme.
+	 * @param string $name The name of the theme.
+	 *
+	 * @return Mockery\MockInterface The mock WP_Theme object.
 	 */
 	private function createMockTheme( string $stylesheet, string $name ) {
 		$mock_theme = Mockery::mock( 'stdClass' );
@@ -146,8 +179,13 @@ class InitTest extends MockeryTestCase {
 		return $mock_theme;
 	}
 
+	/**
+	 * Tear down the test.
+	 */
 	protected function tearDown(): void {
 		Mockery::close();
 		parent::tearDown();
+
+		delete_transient( $this->init::INSTALLED_WP_ORG_PLUGINS_TRANSIENT );
 	}
 }


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The blueprint feature only supports exporting plugins that are available in the WordPress.org. Previously, we showed all plugin for user to select from. Now, we only show the plugins that are available in the WordPress.org so users don't get confused when they selected all plugins but only some of them are exported.

I use the `plugins_api` to check if the plugin is available in the WordPress.org. If it is not, we will not show it in the list. To improve the performance, I cache the result in a transient and clear the transient when a plugin is installed or deleted.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install a plugin that is not available in the WordPress.org such as AutomateWoo
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
3. Observe that the plugin is not shown in the plugins section
4. Delete or add a WordPress.org plugin
5. Observe that the plugin is shown/removed in the plugins section

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
