### PR TITLE
[Blueprint] Disable Cancel/X during import and minor UI fixes

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4188-blueprint-cant-cancel-import-process
+++ b/plugins/woocommerce/changelog/wooplug-4188-blueprint-cant-cancel-import-process
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Dsiable blueprint cancel button during import

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/overwrite-confirmation-modal.tsx
@@ -29,6 +29,7 @@ export const OverwriteConfirmationModal = ( {
 			) }
 			onRequestClose={ onClose }
 			className="woocommerce-blueprint-overwrite-modal"
+			isDismissible={ ! isImporting }
 		>
 			<p className="woocommerce-blueprint-overwrite-modal__description">
 				{ overwrittenItems.length
@@ -53,6 +54,7 @@ export const OverwriteConfirmationModal = ( {
 					className="woocommerce-blueprint-overwrite-modal__actions-cancel"
 					variant="tertiary"
 					onClick={ onClose }
+					disabled={ isImporting }
 				>
 					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/slotfill.js
@@ -178,7 +178,7 @@ const Blueprint = () => {
 					<h4>{ __( 'Import', 'woocommerce' ) }</h4>
 					<p>
 						{ __(
-							'Import .json file, max size 50 MB. Only one Blueprint can be imported at a time.',
+							'Import a .json file, max size 50 MB. Only one Blueprint can be imported at a time.',
 							'woocommerce'
 						) }
 					</p>

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -268,6 +268,10 @@
 			width: 132px;
 			justify-content: center;
 			align-items: center;
+
+			svg {
+				margin: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Currently, the import process cannot be cancelled despite having 'Cancel' and 'X' buttons in the UI. While we could close the import modal, the import request would continue processing. Implementing a proper cancellation mechanism would require more complex changes. 

As an interim solution, this PR disables these buttons during active imports to prevent confusion.

Besides, this PR fixes two minor issues:

1. Spinner was not aligned properly in the import button
2. Typo `Import .json file` -> `Import a .json file`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to /wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint
2. Import a blueprint
3. Observe that the 'Cancel' and 'X' buttons are disabled during the import process

<img width="460" alt="Screenshot 2025-05-07 at 16 48 54" src="https://github.com/user-attachments/assets/177bb893-a4b7-45cc-b37b-8d0667123c0f" />

4. Confirm that spinner is aligned properly in the import button

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
