### PR TITLE
[NOX In-Context] Tweak NOX Settings → Payments layout by adjusting navigation and button borders

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPLUG-4195-settings-payments-navigation-borders
+++ b/plugins/woocommerce/changelog/update-WOOPLUG-4195-settings-payments-navigation-borders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak NOX Settings > Payments layout by adjusting navigation and button borders

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/header/header.scss
@@ -23,7 +23,6 @@
 
 	&:has(.woocommerce-settings-payments-header__title) {
 		padding: $gap-large 2 * $gap-large;
-		border-bottom: 1px solid #ebebeb;
 
 		.woocommerce-layout__header-heading {
 			height: initial;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -4,9 +4,10 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { RecommendedPaymentMethod } from '@woocommerce/data';
-import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useState, useEffect, useMemo, useRef } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { close } from '@wordpress/icons';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -45,6 +46,9 @@ export default function PaymentMethodsSelection() {
 			? combineRequestMethods( contextPaymentMethods )
 			: [];
 	}, [ contextPaymentMethods ] );
+
+	const scrollRef = useRef< HTMLDivElement | null >( null );
+	const [ hasOverflow, setHasOverflow ] = useState( false );
 
 	// Update the local payment methods state when the context changes
 	useEffect( () => {
@@ -125,6 +129,35 @@ export default function PaymentMethodsSelection() {
 		}
 	};
 
+	// Check if overflow exists for Payment Methods list container.
+	const checkHasOverflow = () => {
+		const pmsContainer = scrollRef.current;
+
+		if ( pmsContainer ) {
+			// Compare scrollHeight and clientHeight to determine overflow.
+			setHasOverflow(
+				pmsContainer.scrollHeight > pmsContainer.clientHeight
+			);
+		}
+	};
+
+	// Check for overflow on initial render and on window resize.
+	useEffect( () => {
+		// Use setTimeout to ensure the DOM is updated before checking for overflow.
+		const timeout = setTimeout( () => {
+			checkHasOverflow();
+		}, 0 ); // Runs after paint
+
+		// Check for overflow on window resize.
+		window.addEventListener( 'resize', checkHasOverflow );
+
+		return () => {
+			// Cleanup the timeout and event listener on unmount.
+			clearTimeout( timeout );
+			window.removeEventListener( 'resize', checkHasOverflow );
+		};
+	}, [] );
+
 	return (
 		<div className="settings-payments-onboarding-modal__step--content">
 			<div className="woocommerce-layout__header woocommerce-recommended-payment-methods">
@@ -152,7 +185,10 @@ export default function PaymentMethodsSelection() {
 					</div>
 				</div>
 				<div className="woocommerce-recommended-payment-methods__list">
-					<div className="settings-payments-methods__container">
+					<div
+						className="settings-payments-methods__container"
+						ref={ scrollRef }
+					>
 						<div className="woocommerce-list">
 							{ recommendedPaymentMethods?.map(
 								( method: RecommendedPaymentMethod ) => (
@@ -189,6 +225,12 @@ export default function PaymentMethodsSelection() {
 									className="settings-payments-methods__show-more"
 									onClick={ () => {
 										setIsExpanded( ! isExpanded );
+
+										// Check for overflow after expanding hidden payment methods.
+										// Use setTimeout to ensure the DOM is updated before checking for overflow.
+										setTimeout( () => {
+											checkHasOverflow();
+										}, 0 );
 									} }
 									tabIndex={ 0 }
 									aria-expanded={ isExpanded }
@@ -203,7 +245,14 @@ export default function PaymentMethodsSelection() {
 						) }
 					</div>
 				</div>
-				<div className="woocommerce-recommended-payment-methods__list_footer">
+				<div
+					className={ clsx(
+						'woocommerce-recommended-payment-methods__list_footer',
+						{
+							'has-border': hasOverflow,
+						}
+					) }
+				>
 					<Button
 						className="components-button is-primary"
 						onClick={ () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -184,20 +184,22 @@ export default function PaymentMethodsSelection() {
 						</div>
 						{ /* Show button only if not expanded and there are initially hidden items */ }
 						{ ! isExpanded && hiddenCount > 0 && (
-							<Button
-								className="settings-payments-methods__show-more"
-								onClick={ () => {
-									setIsExpanded( ! isExpanded );
-								} }
-								tabIndex={ 0 }
-								aria-expanded={ isExpanded }
-							>
-								{ sprintf(
-									/* translators: %s: number of hidden payment methods */
-									__( 'Show more (%s)', 'woocommerce' ),
-									hiddenCount
-								) }
-							</Button>
+							<div className="settings-payments-methods__show-more--wrapper">
+								<Button
+									className="settings-payments-methods__show-more"
+									onClick={ () => {
+										setIsExpanded( ! isExpanded );
+									} }
+									tabIndex={ 0 }
+									aria-expanded={ isExpanded }
+								>
+									{ sprintf(
+										/* translators: %s: number of hidden payment methods */
+										__( 'Show more (%s)', 'woocommerce' ),
+										hiddenCount
+									) }
+								</Button>
+							</div>
 						) }
 					</div>
 				</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -197,7 +197,10 @@
 			padding: $gap-large;
 			background: $white;
 			flex-shrink: 0;
-			border-top: 1px solid $gray-200;
+
+			&.has-border {
+				border-top: 1px solid $gray-200;
+			}
 
 			@media screen and (max-width: $break-medium) {
 				padding: $gap;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -6,23 +6,25 @@
 	.settings-payments-methods__container {
 		width: 100%;
 
+		.settings-payments-methods__show-more--wrapper {
+			border-top: 1px solid $gray-100;
+		}
+
 		.settings-payments-methods__show-more {
 			display: block;
 			cursor: pointer;
-			margin: $gap $gap-large 0;
+			margin: $gap $gap-large;
 			box-shadow: none;
 			color: var(--wp-admin-theme-color);
 			text-align: left;
 
 			@media screen and (max-width: $break-medium) {
-				margin: $gap $gap 0;
+				margin: $gap $gap;
 			}
 		}
 
 		// Override styles for woocommerce list items.
 		.woocommerce-list {
-			border-bottom: 1px solid $gray-100;
-
 			&__item {
 				padding: 2 * $gap-smaller 4 * $gap-smaller;
 				border-color: $gray-100;
@@ -186,10 +188,6 @@
 				@media screen and (max-width: $break-medium) {
 					padding: 0;
 				}
-
-				.woocommerce-list {
-					margin-bottom: $gap;
-				}
 			}
 		}
 
@@ -199,6 +197,7 @@
 			padding: $gap-large;
 			background: $white;
 			flex-shrink: 0;
+			border-top: 1px solid $gray-200;
 
 			@media screen and (max-width: $break-medium) {
 				padding: $gap;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses a couple of visual refinements on the NOX Settings → Payments page. It removes the unnecessary top border from the header navigation to create a cleaner layout. Additionally, it introduces a top border above the Continue button on the Payment Methods selection step within the NOX In-context flow, providing clearer visual separation between the list of payment methods and the action button.

Closes WOOPLUG-4195.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="751" alt="Screenshot 2025-05-07 at 12 44 05" src="https://github.com/user-attachments/assets/92a42f15-2110-4bc9-9a0f-dd9a813536ac" /> | <img width="758" alt="Screenshot 2025-05-07 at 12 42 22" src="https://github.com/user-attachments/assets/01383414-af0a-4712-9694-46a37b5c55e5" /> |
| <img width="1345" alt="Screenshot 2025-05-07 at 12 43 39" src="https://github.com/user-attachments/assets/b1011dbb-2d95-4a3f-9887-58974b6435a1" /> | <img width="1346" alt="Screenshot 2025-05-07 at 12 42 40" src="https://github.com/user-attachments/assets/16fc0da7-4fc8-4208-9fdb-5b663903233d" /> |
| <img width="1346" alt="Screenshot 2025-05-07 at 12 43 51" src="https://github.com/user-attachments/assets/17cdda82-26cb-46ef-aa6f-bfed927c7b47" /> | <img width="1346" alt="Screenshot 2025-05-07 at 12 42 59" src="https://github.com/user-attachments/assets/0c3c700b-c9de-452e-9a62-152551598957" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
**Prerequisites**
1. Create a blank Jurassic Ninja site from this branch (here is [a direct link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=update/WOOPLUG-4195-settings-payments-navigation-borders)).
2. Skip the core profiler and select the United States as the store country.
3. Install WooCommerce Payments 9.3.0 from WP.org.
4. Go to WooCommerce > Settings > Advanced > Features, and enable the Payments Settings (beta) feature if it is disabled. Click Save changes.
5. If you have a WooPayments account connected, please disconnect it.

**Testing instructions**
1. Navigate to WooCommerce > Settings > Payments.
2. Ensure the top border of the navigation is removed similarly to other Settings pages.
3. Click the Enable or Complete setup button for the WooPayments payment method.
4. Confirm that the Onboarding Modal opens and displays the Select payment methods screen.
6. Ensure a border is displayed above the Continue button on the bottom.
7. Click the Show more button.
8. Ensure no double borders are displayed below the last payment method item.

### Testing that has already taken place:
Check above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
