### PR TITLE
[Experimental] Display a not-allowed cursor when trying to Add to Cart an invalid variation

### DIFF
--- a/plugins/woocommerce/changelog/fix-57724-show-disabled-cursor-when-no-valid-variation
+++ b/plugins/woocommerce/changelog/fix-57724-show-disabled-cursor-when-no-valid-variation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Display an not-allowed cursor when trying to Add to Cart an invalid variation
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -8,11 +8,14 @@ import type { CartVariationItem } from '@woocommerce/types';
 
 export type AvailableVariation = {
 	attributes: Record< string, string >;
+	variation_id: number;
 };
 
 export type Context = {
 	productId: number;
+	productType: string;
 	variation: CartVariationItem[];
+	variationId: number | null;
 	availableVariations: AvailableVariation[];
 	quantity: number;
 	tempQuantity: number;
@@ -66,6 +69,46 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 	};
 };
 
+const getMatchedVariation = (
+	availableVariations: AvailableVariation[],
+	variation: CartVariationItem[]
+) => {
+	if (
+		! Array.isArray( availableVariations ) ||
+		! Array.isArray( variation ) ||
+		availableVariations.length === 0 ||
+		variation.length === 0
+	) {
+		return null;
+	}
+	return availableVariations.find( ( availableVariation ) => {
+		return Object.entries( availableVariation.attributes ).every(
+			( [ attributeName, attributeValue ] ) => {
+				const attributeMatched = variation.some(
+					( variationAttribute ) => {
+						const formattedVariationAttribute =
+							'attribute_' +
+							variationAttribute.attribute.toLowerCase();
+
+						const isSameAttribute =
+							formattedVariationAttribute === attributeName;
+						if ( ! isSameAttribute ) {
+							return false;
+						}
+
+						return (
+							variationAttribute.value === attributeValue ||
+							( variationAttribute.value &&
+								attributeValue === '' )
+						);
+					}
+				);
+
+				return attributeMatched;
+			}
+		);
+	} );
+};
 const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
 	const event = new Event( 'change' );
 	inputElement.dispatchEvent( event );
@@ -74,6 +117,20 @@ const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
 const addToCartWithOptionsStore = store(
 	'woocommerce/add-to-cart-with-options',
 	{
+		state: {
+			get isFormValid() {
+				const { productType, availableVariations, variation } =
+					getContext< Context >();
+				if ( productType !== 'variable' ) {
+					return true;
+				}
+				const matchedVariation = getMatchedVariation(
+					availableVariations,
+					variation
+				);
+				return !! matchedVariation;
+			},
+		},
 		actions: {
 			setQuantity( value: number ) {
 				const context = getContext< Context >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -14,7 +14,7 @@ export type AvailableVariation = {
 export type Context = {
 	productId: number;
 	productType: string;
-	variation: CartVariationItem[];
+	selectedAttributes: CartVariationItem[];
 	variationId: number | null;
 	availableVariations: AvailableVariation[];
 	quantity: number;
@@ -71,20 +71,20 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 
 const getMatchedVariation = (
 	availableVariations: AvailableVariation[],
-	variation: CartVariationItem[]
+	selectedAttributes: CartVariationItem[]
 ) => {
 	if (
 		! Array.isArray( availableVariations ) ||
-		! Array.isArray( variation ) ||
+		! Array.isArray( selectedAttributes ) ||
 		availableVariations.length === 0 ||
-		variation.length === 0
+		selectedAttributes.length === 0
 	) {
 		return null;
 	}
 	return availableVariations.find( ( availableVariation ) => {
 		return Object.entries( availableVariation.attributes ).every(
 			( [ attributeName, attributeValue ] ) => {
-				const attributeMatched = variation.some(
+				const attributeMatched = selectedAttributes.some(
 					( variationAttribute ) => {
 						const formattedVariationAttribute =
 							'attribute_' +
@@ -119,14 +119,14 @@ const addToCartWithOptionsStore = store(
 	{
 		state: {
 			get isFormValid() {
-				const { productType, availableVariations, variation } =
+				const { productType, availableVariations, selectedAttributes } =
 					getContext< Context >();
 				if ( productType !== 'variable' ) {
 					return true;
 				}
 				const matchedVariation = getMatchedVariation(
 					availableVariations,
-					variation
+					selectedAttributes
 				);
 				return !! matchedVariation;
 			},
@@ -137,29 +137,31 @@ const addToCartWithOptionsStore = store(
 				context.quantity = value;
 			},
 			setAttribute( attribute: string, value: string ) {
-				const context = getContext< Context >();
-				const index = context.variation.findIndex(
-					( variation ) => variation.attribute === attribute
+				const { selectedAttributes } = getContext< Context >();
+				const index = selectedAttributes.findIndex(
+					( selectedAttribute ) =>
+						selectedAttribute.attribute === attribute
 				);
 				if ( index >= 0 ) {
-					context.variation[ index ] = {
+					selectedAttributes[ index ] = {
 						attribute,
 						value,
 					};
 				} else {
-					context.variation.push( {
+					selectedAttributes.push( {
 						attribute,
 						value,
 					} );
 				}
 			},
 			removeAttribute( attribute: string ) {
-				const context = getContext< Context >();
-				const index = context.variation.findIndex(
-					( variation ) => variation.attribute === attribute
+				const { selectedAttributes } = getContext< Context >();
+				const index = selectedAttributes.findIndex(
+					( selectedAttribute ) =>
+						selectedAttribute.attribute === attribute
 				);
 				if ( index >= 0 ) {
-					context.variation.splice( index, 1 );
+					selectedAttributes.splice( index, 1 );
 				}
 			},
 			increaseQuantity: (
@@ -209,7 +211,7 @@ const addToCartWithOptionsStore = store(
 					{ lock: universalLock }
 				);
 
-				const { productId, quantity, variation } =
+				const { productId, quantity, selectedAttributes } =
 					getContext< Context >();
 				const product = wooState.cart?.items.find(
 					( item ) => item.id === productId
@@ -219,7 +221,7 @@ const addToCartWithOptionsStore = store(
 				yield actions.addCartItem( {
 					id: productId,
 					quantity: currentQuantity + quantity,
-					variation,
+					variation: selectedAttributes,
 				} );
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -56,3 +56,7 @@
 		}
 	}
 }
+
+.wc-block-add-to-cart-with-options.is-invalid .wp-block-woocommerce-product-button .add_to_cart_button {
+	cursor: not-allowed;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -149,7 +149,7 @@ const { state, actions } = store(
 			},
 			get isPillDisabled() {
 				const { name, option } = getContext< PillsContext >();
-				const { variation, availableVariations } =
+				const { selectedAttributes, availableVariations } =
 					getContext< AddToCartWithOptionsStoreContext >(
 						'woocommerce/add-to-cart-with-options'
 					);
@@ -157,7 +157,7 @@ const { state, actions } = store(
 				return ! isAttributeValueValid( {
 					attributeName: name,
 					attributeValue: option.value,
-					selectedAttributes: variation,
+					selectedAttributes,
 					availableVariations,
 				} );
 			},
@@ -220,7 +220,7 @@ const { state, actions } = store(
 					case 'ArrowLeft': {
 						keyWasProcessed = true;
 						const context = getContext< PillsContext >();
-						const { variation, availableVariations } =
+						const { selectedAttributes, availableVariations } =
 							getContext< AddToCartWithOptionsStoreContext >(
 								'woocommerce/add-to-cart-with-options'
 							);
@@ -234,7 +234,7 @@ const { state, actions } = store(
 								isAttributeValueValid( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
-									selectedAttributes: variation,
+									selectedAttributes,
 									availableVariations,
 								} )
 							) {
@@ -259,7 +259,7 @@ const { state, actions } = store(
 					case 'ArrowRight': {
 						keyWasProcessed = true;
 						const context = getContext< PillsContext >();
-						const { variation, availableVariations } =
+						const { selectedAttributes, availableVariations } =
 							getContext< AddToCartWithOptionsStoreContext >(
 								'woocommerce/add-to-cart-with-options'
 							);
@@ -277,7 +277,7 @@ const { state, actions } = store(
 								isAttributeValueValid( {
 									attributeName: context.name,
 									attributeValue: context.options[ i ].value,
-									selectedAttributes: variation,
+									selectedAttributes,
 									availableVariations,
 								} )
 							) {
@@ -331,7 +331,7 @@ store(
 					return false;
 				}
 
-				const { variation, availableVariations } =
+				const { selectedAttributes, availableVariations } =
 					getContext< AddToCartWithOptionsStoreContext >(
 						'woocommerce/add-to-cart-with-options'
 					);
@@ -339,7 +339,7 @@ store(
 				return ! isAttributeValueValid( {
 					attributeName: name,
 					attributeValue: option.value,
-					selectedAttributes: variation,
+					selectedAttributes,
 					availableVariations,
 				} );
 			},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -167,26 +167,30 @@ class AddToCartWithOptions extends AbstractBlock {
 			$default_quantity = apply_filters( 'woocommerce_add_to_cart_quantity', 1, $product->get_id() );
 
 			$context = array(
-				'productId' => $product->get_id(),
-				'quantity'  => $default_quantity,
+				'productId'   => $product->get_id(),
+				'productType' => $product->get_type(),
+				'quantity'    => $default_quantity,
 			);
 
-			if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+			if ( $product->is_type( 'variable' ) ) {
 				$context['variation']           = array();
 				$context['availableVariations'] = $product->get_available_variations();
 			}
 
+			$wrapper_attributes = array(
+				'data-wp-interactive'       => 'woocommerce/add-to-cart-with-options',
+				'data-wp-context'           => wp_json_encode(
+					$context,
+					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+				),
+				'data-wp-on--submit'        => 'actions.handleSubmit',
+				'data-wp-class--is-invalid' => '!state.isFormValid',
+				'class'                     => $classes,
+				'style'                     => esc_attr( $classes_and_styles['styles'] ),
+			);
+
 			$wrapper_attributes = get_block_wrapper_attributes(
-				array(
-					'data-wp-interactive' => 'woocommerce/add-to-cart-with-options',
-					'data-wp-context'     => wp_json_encode(
-						$context,
-						JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-					),
-					'data-wp-on--submit'  => 'actions.handleSubmit',
-					'class'               => $classes,
-					'style'               => esc_attr( $classes_and_styles['styles'] ),
-				)
+				$wrapper_attributes
 			);
 
 			$hooks_before = '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -173,7 +173,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			);
 
 			if ( $product->is_type( 'variable' ) ) {
-				$context['variation']           = array();
+				$context['selectedAttributes']  = array();
 				$context['availableVariations'] = $product->get_available_variations();
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -177,20 +177,18 @@ class AddToCartWithOptions extends AbstractBlock {
 				$context['availableVariations'] = $product->get_available_variations();
 			}
 
-			$wrapper_attributes = array(
-				'data-wp-interactive'       => 'woocommerce/add-to-cart-with-options',
-				'data-wp-context'           => wp_json_encode(
-					$context,
-					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-				),
-				'data-wp-on--submit'        => 'actions.handleSubmit',
-				'data-wp-class--is-invalid' => '!state.isFormValid',
-				'class'                     => $classes,
-				'style'                     => esc_attr( $classes_and_styles['styles'] ),
-			);
-
 			$wrapper_attributes = get_block_wrapper_attributes(
-				$wrapper_attributes
+				array(
+					'data-wp-interactive'       => 'woocommerce/add-to-cart-with-options',
+					'data-wp-context'           => wp_json_encode(
+						$context,
+						JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+					),
+					'data-wp-on--submit'        => 'actions.handleSubmit',
+					'data-wp-class--is-invalid' => '!state.isFormValid',
+					'class'                     => $classes,
+					'style'                     => esc_attr( $classes_and_styles['styles'] ),
+				)
 			);
 
 			$hooks_before = '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #57724.
Closes WOOPLUG-4151.

This PR makes it so we know when the selected attributes in the _Variation Selector_ block match a valid variation. This way, we can change the cursor of the Add to Cart button to `not-allowed`. While my initial plan was to completely disable the Add to Cart button like in the classic templates, after researching it, it turns out that's not good for accessibility reasons, so it's better to still allow focusing on the button and clicking it.

Note: displaying errors will be handled in https://github.com/woocommerce/woocommerce/issues/57725.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.

#### Testing the PR

1. Create a variable product where some attribute combinations are allowed, and some others aren't.
2. Visit the product template in the frontend. Verify by default you see a `not allowed` cursor when hovering the add to cart button.
3. Select some attributes. Verify when they match a valid variation, the cursor on the button is no longer `not allowed`.

https://github.com/user-attachments/assets/75c4d1b5-5db2-4b83-a1fc-5a3b9b6ee108