### PR TITLE
Add Cursor AI Assistant Rules for Building the project

### DIFF
--- a/.cursor/rules/woo-build.mdc
+++ b/.cursor/rules/woo-build.mdc
@@ -1,0 +1,42 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Building the WooCommerce plugin
+
+This rule provides guidance for building the WooCommerce plugin and watching for changes in this repository.
+
+## Installing dependencies and building
+
+Specific dependencies and build instructions are listed in `README.md`.
+
+The commands to build are
+
+```bash
+# Ensure that correct version of Node is installed and being used
+nvm install
+# Install the PHP and Composer dependencies for all of the plugins, packages, and tools
+pnpm install -frozen-lockfile
+# Build all of the plugins, packages, and tools in the monorepo
+pnpm build
+```
+
+And the command must be run in the main repository directory.
+
+## Watching for changes
+
+To watch for changes use
+
+```bash
+pnpm --filter=@woocommerce/plugin-woocommerce watch:build
+```
+
+This is a development build which ensures experimental features are active.
+
+If there are problems with this command, ensure the dependencies were installed first, but generally unless this is the first build, `pnpm build` does not need to be ran prior.
+
+```bash
+nvm install
+pnpm install -frozen-lockfile
+```


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

I'm not sure how useful this is so we can close if its no benefit but following on from https://github.com/woocommerce/woocommerce/pull/55458, I noticed that if you ask the agent to build or watch it tries to incorrectly use various `npm` commands. This ensures that it is aware of the project dependencies and `pnpm` build commands so it provides the correct response.

### Changes proposed in this Pull Request:

Added explicit instructions for using `pnpm` instead of `npm` for build/watch commands. This prevents the agent from defaulting to `npm`, which was causing it to miss the correct monorepo scripts and instructions.

### Screenshots or screen recordings:

<!-- Not applicable -->

### How to test the changes in this Pull Request:

1. Attempt to run a build/watch command in the repo root and verify that the instructions now reference `pnpm` and work as expected.
2. Confirm that the agent no longer suggests `npm` for monorepo build/watch tasks.

### Testing that has already taken place:

- Manual verification that `pnpm --filter=@woocommerce/plugin-woocommerce watch:build` works and is referenced in docs/rules.
- Confirmed that the agent now finds and suggests the correct command.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message <!-- Add a changelog message here -->

Clarified build/watch instructions to use `pnpm` instead of `npm` to ensure correct monorepo script usage.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

N/A

</details>