### PR TITLE
[Experimental] Reviews Title: Remove double quote around product title in reviews title

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4204-remove-quote-around-product-title
+++ b/plugins/woocommerce/changelog/wooplug-4204-remove-quote-around-product-title
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Experimental: Reviews Title: remove double quote around product title.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/reviews-title/edit.tsx
@@ -167,8 +167,8 @@ export default function Edit( {
 	);
 
 	const productTitle = isSiteEditor
-		? __( '"Product Title"', 'woocommerce' )
-		: `"${ rawTitle }"`;
+		? __( 'Product Title', 'woocommerce' )
+		: rawTitle;
 
 	const placeholder = getProductReviewsTitle(
 		showReviewsCount,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewsTitle.php
@@ -25,13 +25,11 @@ class ProductReviewsTitle extends AbstractBlock {
 		$show_product_title = ! empty( $attributes['showProductTitle'] ) && $attributes['showProductTitle'];
 		$show_reviews_count = ! empty( $attributes['showReviewsCount'] ) && $attributes['showReviewsCount'];
 		$reviews_count      = $product->get_review_count();
-		/* translators: %s: Product title. */
-		$product_title = sprintf( __( '&#8220;%s&#8221;', 'woocommerce' ), $product->get_title() );
 
 		if ( $show_reviews_count && $show_product_title ) {
 			return 1 === $reviews_count
 				/* translators: %s: Product title. */
-				? sprintf( __( 'One review for %s', 'woocommerce' ), $product_title )
+				? sprintf( __( 'One review for %s', 'woocommerce' ), $product->get_title() )
 				: sprintf(
 					/* translators: 1: Number of reviews, 2: Product title. */
 					_n(
@@ -41,18 +39,18 @@ class ProductReviewsTitle extends AbstractBlock {
 						'woocommerce'
 					),
 					number_format_i18n( $reviews_count ),
-					$product_title
+					$product->get_title()
 				);
 		}
 
 		if ( ! $show_reviews_count && $show_product_title ) {
 			return 1 === $reviews_count
 				/* translators: %s: Product title. */
-				? sprintf( __( 'Review for %s', 'woocommerce' ), $product_title )
+				? sprintf( __( 'Review for %s', 'woocommerce' ), $product->get_title() )
 				: sprintf(
 					/* translators: %s: Product title. */
 					__( 'Reviews for %s', 'woocommerce' ),
-					$product_title
+					$product->get_title()
 				);
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the double quote around the product title in the Product Reviews Title block, both in the frontend and editor. The title now displays as, for example, `Reviews for Product Name` instead of `Reviews for "Product Name"`.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="802" alt="image" src="https://github.com/user-attachments/assets/b7827b5b-9e12-43f0-8815-b1dd548e3408" /> | <img width="802" alt="image" src="https://github.com/user-attachments/assets/4a04ec18-5898-4cbb-8751-f04b394883d1" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add the `Blockified Product Details` block to the Single Product template.
2. Ensure the product title is shown in the reviews title (toggle on in block settings).
3. View the product page on the frontend.
4. Confirm that the reviews title does not include double quotes around the product name in both the editor and frontend.
5. Test with different review counts and product names to ensure correct formatting.

<!-- End testing instructions --> 
