### PR TITLE
Allow saving cards if customer is creating an account

### DIFF
--- a/plugins/woocommerce/changelog/57834-add-collect-card-if-registration-on
+++ b/plugins/woocommerce/changelog/57834-add-collect-card-if-registration-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Allow saving cards if a guest customer is also creating an account.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -6,7 +6,8 @@ import {
 	useCheckoutSubmit,
 	useStoreCart,
 } from '@woocommerce/base-context/hooks';
-import { Icon, check } from '@wordpress/icons';
+import { check } from '@wordpress/icons';
+import { Icon } from '@wordpress/components';
 import Button from '@woocommerce/base-components/button';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -106,7 +106,7 @@ export const TotalsCoupon = ( {
 							className="wc-block-components-totals-coupon__input"
 							label={ __( 'Enter code', 'woocommerce' ) }
 							value={ couponValue }
-							ariaDescribedBy={ validationErrorId }
+							ariaDescribedBy={ validationErrorId || '' }
 							onChange={ ( newCouponValue ) => {
 								setCouponValue( newCouponValue );
 							} }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -10,6 +10,7 @@ import {
 	checkoutStore as checkoutStoreDescriptor,
 	paymentStore,
 } from '@woocommerce/block-data';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -48,18 +49,29 @@ const PaymentMethodCard = ( {
 		}
 	);
 
+	const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
+
+	// Work out if the customer can save the payment method.
+	const canSavePaymentMethod =
+		// They're already logged in.
+		customerId > 0 ||
+		// They're not logged in, but they're creating an account.
+		createAccount ||
+		// They're not logged in, but they must create an account.
+		! allowGuestCheckout;
+
 	useEffect( () => {
-		if ( ! createAccount && shouldSavePaymentMethod ) {
+		if ( ! canSavePaymentMethod && shouldSavePaymentMethod ) {
 			__internalSetShouldSavePaymentMethod( false );
 		}
-	}, [ shouldSavePaymentMethod, createAccount ] );
+	}, [ shouldSavePaymentMethod, canSavePaymentMethod ] );
 
 	const { __internalSetShouldSavePaymentMethod } =
 		useDispatch( paymentStore );
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }
-			{ ( customerId > 0 || createAccount ) && showSaveOption && (
+			{ canSavePaymentMethod && showSaveOption && (
 				<CheckboxControl
 					className="wc-block-components-payment-methods__save-card-info"
 					label={ __(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEditorContext } from '@woocommerce/base-context';
 import { CheckboxControl } from '@woocommerce/blocks-components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import {
 	checkoutStore as checkoutStoreDescriptor,
 	paymentStore,
@@ -34,21 +35,31 @@ const PaymentMethodCard = ( {
 	showSaveOption,
 }: PaymentMethodCardProps ) => {
 	const { isEditor } = useEditorContext();
-	const { shouldSavePaymentMethod, customerId } = useSelect( ( select ) => {
-		const paymentMethodStore = select( paymentStore );
-		const checkoutStore = select( checkoutStoreDescriptor );
-		return {
-			shouldSavePaymentMethod:
-				paymentMethodStore.getShouldSavePaymentMethod(),
-			customerId: checkoutStore.getCustomerId(),
-		};
-	} );
+	const { shouldSavePaymentMethod, customerId, createAccount } = useSelect(
+		( select ) => {
+			const paymentMethodStore = select( paymentStore );
+			const checkoutStore = select( checkoutStoreDescriptor );
+			return {
+				shouldSavePaymentMethod:
+					paymentMethodStore.getShouldSavePaymentMethod(),
+				customerId: checkoutStore.getCustomerId(),
+				createAccount: checkoutStore.getShouldCreateAccount(),
+			};
+		}
+	);
+
+	useEffect( () => {
+		if ( ! createAccount && shouldSavePaymentMethod ) {
+			__internalSetShouldSavePaymentMethod( false );
+		}
+	}, [ shouldSavePaymentMethod, createAccount ] );
+
 	const { __internalSetShouldSavePaymentMethod } =
 		useDispatch( paymentStore );
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }
-			{ customerId > 0 && showSaveOption && (
+			{ ( customerId > 0 || createAccount ) && showSaveOption && (
 				<CheckboxControl
 					className="wc-block-components-payment-methods__save-card-info"
 					label={ __(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -49,6 +49,9 @@ const PaymentMethodCard = ( {
 		}
 	);
 
+	const { __internalSetShouldSavePaymentMethod } =
+		useDispatch( paymentStore );
+
 	const allowGuestCheckout = getSetting( 'checkoutAllowsGuest', false );
 
 	// Work out if the customer can save the payment method.
@@ -64,10 +67,12 @@ const PaymentMethodCard = ( {
 		if ( ! canSavePaymentMethod && shouldSavePaymentMethod ) {
 			__internalSetShouldSavePaymentMethod( false );
 		}
-	}, [ shouldSavePaymentMethod, canSavePaymentMethod ] );
+	}, [
+		canSavePaymentMethod,
+		shouldSavePaymentMethod,
+		__internalSetShouldSavePaymentMethod,
+	] );
 
-	const { __internalSetShouldSavePaymentMethod } =
-		useDispatch( paymentStore );
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.tsx
@@ -36,18 +36,17 @@ const PaymentMethodCard = ( {
 	showSaveOption,
 }: PaymentMethodCardProps ) => {
 	const { isEditor } = useEditorContext();
-	const { shouldSavePaymentMethod, customerId, createAccount } = useSelect(
-		( select ) => {
+	const { shouldSavePaymentMethod, customerId, shouldCreateAccount } =
+		useSelect( ( select ) => {
 			const paymentMethodStore = select( paymentStore );
 			const checkoutStore = select( checkoutStoreDescriptor );
 			return {
 				shouldSavePaymentMethod:
 					paymentMethodStore.getShouldSavePaymentMethod(),
 				customerId: checkoutStore.getCustomerId(),
-				createAccount: checkoutStore.getShouldCreateAccount(),
+				shouldCreateAccount: checkoutStore.getShouldCreateAccount(),
 			};
-		}
-	);
+		}, [] );
 
 	const { __internalSetShouldSavePaymentMethod } =
 		useDispatch( paymentStore );
@@ -59,7 +58,7 @@ const PaymentMethodCard = ( {
 		// They're already logged in.
 		customerId > 0 ||
 		// They're not logged in, but they're creating an account.
-		createAccount ||
+		shouldCreateAccount ||
 		// They're not logged in, but they must create an account.
 		! allowGuestCheckout;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/edit.tsx
@@ -12,8 +12,8 @@ import { isExperimentalBlocksEnabled } from '@woocommerce/block-settings';
 import Block from './block';
 
 export type BlockAttributes = {
-	className: string;
-	disableProductDescriptions: boolean;
+	className?: string;
+	disableProductDescriptions?: boolean;
 };
 
 export const Edit = ( {
@@ -23,7 +23,7 @@ export const Edit = ( {
 	attributes: BlockAttributes;
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const { className, disableProductDescriptions } = attributes;
+	const { className = '', disableProductDescriptions = false } = attributes;
 	const blockProps = useBlockProps();
 
 	return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -164,6 +164,98 @@ describe( 'Testing Checkout', () => {
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'Allows saving payment method if the customer is creating an account or has already logged in', async () => {
+		await act( async () => {
+			const PaymentMethodContent = () => <div>A payment method</div>;
+			registerPaymentMethod( {
+				name: 'test-payment-method',
+				label: 'Payment method with cards',
+				content: <PaymentMethodContent />,
+				edit: <PaymentMethodContent />,
+				icons: null,
+				canMakePayment: () => true,
+				supports: {
+					showSavedCards: true,
+					showSaveOption: true,
+					features: [ 'products' ],
+				},
+				ariaLabel: 'Test Payment Method',
+			} );
+		} );
+
+		const { rerender } = render( <CheckoutBlock /> );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect(
+			screen.getByText( /Payment method with cards/i )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		await act( async () => {
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			allSettings.checkoutAllowsGuest = true;
+			allSettings.checkoutAllowsSignup = true;
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
+			dispatch( checkoutStore ).__internalSetShouldCreateAccount( true );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		await act( async () => {
+			dispatch( checkoutStore ).__internalSetShouldCreateAccount( false );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			allSettings.checkoutAllowsGuest = false;
+			allSettings.checkoutAllowsSignup = true;
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		// cleanup
+		await act( async () => {
+			allSettings.checkoutAllowsGuest = undefined;
+			allSettings.checkoutAllowsSignup = undefined;
+			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
+		} );
+	} );
+
 	it( 'Renders the shipping address card if the address is filled and the cart contains a shippable product', async () => {
 		act( () => {
 			const cartWithAddress = {
@@ -400,102 +492,6 @@ describe( 'Testing Checkout', () => {
 
 		await act( async () => {
 			// Restore initial settings
-			allSettings.checkoutAllowsGuest = undefined;
-			allSettings.checkoutAllowsSignup = undefined;
-			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
-		} );
-	} );
-
-	it( 'Allows saving payment method if the customer is creating an account or has already logged in', async () => {
-		await act( async () => {
-			const PaymentMethodContent = () => <div>A payment method</div>;
-			registerPaymentMethod( {
-				name: 'test-payment-method',
-				label: 'Payment method with cards',
-				content: <PaymentMethodContent />,
-				edit: <PaymentMethodContent />,
-				icons: null,
-				canMakePayment: () => true,
-				supports: {
-					showSavedCards: true,
-					showSaveOption: true,
-					features: [ 'products' ],
-				},
-				ariaLabel: 'Test Payment Method',
-			} );
-			dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
-		} );
-		await act( async () => {
-			dispatch( checkoutStore ).__internalSetCustomerId( 2 );
-		} );
-
-		const { rerender } = render( <CheckoutBlock /> );
-
-		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
-		expect(
-			screen.getByText( /Payment method with cards/i )
-		).toBeInTheDocument();
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Save payment information to my account for future purchases.',
-			} )
-		).toBeInTheDocument();
-
-		await act( async () => {
-			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
-		} );
-
-		rerender( <CheckoutBlock /> );
-
-		expect(
-			screen.queryByRole( 'checkbox', {
-				name: 'Save payment information to my account for future purchases.',
-			} )
-		).not.toBeInTheDocument();
-
-		await act( async () => {
-			allSettings.checkoutAllowsGuest = true;
-			allSettings.checkoutAllowsSignup = true;
-			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
-			dispatch( checkoutStore ).__internalSetShouldCreateAccount( true );
-		} );
-
-		rerender( <CheckoutBlock /> );
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Save payment information to my account for future purchases.',
-			} )
-		).toBeInTheDocument();
-
-		await act( async () => {
-			dispatch( checkoutStore ).__internalSetShouldCreateAccount( false );
-		} );
-
-		rerender( <CheckoutBlock /> );
-
-		expect(
-			screen.queryByRole( 'checkbox', {
-				name: 'Save payment information to my account for future purchases.',
-			} )
-		).not.toBeInTheDocument();
-
-		await act( async () => {
-			allSettings.checkoutAllowsGuest = false;
-			allSettings.checkoutAllowsSignup = true;
-		} );
-
-		rerender( <CheckoutBlock /> );
-
-		expect(
-			screen.getByRole( 'checkbox', {
-				name: 'Save payment information to my account for future purchases.',
-			} )
-		).toBeInTheDocument();
-
-		// cleanup
-		await act( async () => {
 			allSettings.checkoutAllowsGuest = undefined;
 			allSettings.checkoutAllowsSignup = undefined;
 			dispatch( checkoutStore ).__internalSetCustomerId( 1 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -165,7 +165,7 @@ describe( 'Testing Checkout', () => {
 	} );
 
 	it( 'Allows saving payment method if the customer is creating an account or has already logged in', async () => {
-		await act( async () => {
+	act( () => {
 			const PaymentMethodContent = () => <div>A payment method</div>;
 			registerPaymentMethod( {
 				name: 'test-payment-method',
@@ -185,9 +185,8 @@ describe( 'Testing Checkout', () => {
 
 		const { rerender } = render( <CheckoutBlock /> );
 
-		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect(
-			screen.getByText( /Payment method with cards/i )
+			await screen.findByText( /Payment method with cards/i )
 		).toBeInTheDocument();
 
 		expect(
@@ -196,7 +195,7 @@ describe( 'Testing Checkout', () => {
 			} )
 		).toBeInTheDocument();
 
-		await act( async () => {
+		act( () => {
 			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
 		} );
 
@@ -208,7 +207,7 @@ describe( 'Testing Checkout', () => {
 			} )
 		).not.toBeInTheDocument();
 
-		await act( async () => {
+		act( () => {
 			allSettings.checkoutAllowsGuest = true;
 			allSettings.checkoutAllowsSignup = true;
 			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
@@ -223,7 +222,7 @@ describe( 'Testing Checkout', () => {
 			} )
 		).toBeInTheDocument();
 
-		await act( async () => {
+		act( () => {
 			dispatch( checkoutStore ).__internalSetShouldCreateAccount( false );
 		} );
 
@@ -235,7 +234,7 @@ describe( 'Testing Checkout', () => {
 			} )
 		).not.toBeInTheDocument();
 
-		await act( async () => {
+		act( () => {
 			allSettings.checkoutAllowsGuest = false;
 			allSettings.checkoutAllowsSignup = true;
 		} );
@@ -249,7 +248,7 @@ describe( 'Testing Checkout', () => {
 		).toBeInTheDocument();
 
 		// cleanup
-		await act( async () => {
+		act( () => {
 			allSettings.checkoutAllowsGuest = undefined;
 			allSettings.checkoutAllowsSignup = undefined;
 			dispatch( checkoutStore ).__internalSetCustomerId( 1 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -4,7 +4,7 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { previewCart } from '@woocommerce/resource-previews';
 import { dispatch } from '@wordpress/data';
-import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
+import { cartStore, checkoutStore } from '@woocommerce/block-data';
 import { default as fetchMock } from 'jest-fetch-mock';
 import { allSettings } from '@woocommerce/settings';
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
@@ -161,7 +161,7 @@ describe( 'Testing Checkout', () => {
 	} );
 
 	it( 'Allows saving payment method if the customer is creating an account or has already logged in', async () => {
-	act( () => {
+		act( () => {
 			const PaymentMethodContent = () => <div>A payment method</div>;
 			registerPaymentMethod( {
 				name: 'test-payment-method',

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -4,11 +4,7 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { previewCart } from '@woocommerce/resource-previews';
 import { dispatch } from '@wordpress/data';
-import {
-	cartStore,
-	checkoutStore,
-	paymentStore,
-} from '@woocommerce/block-data';
+import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
 import { default as fetchMock } from 'jest-fetch-mock';
 import { allSettings } from '@woocommerce/settings';
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -4,7 +4,11 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { previewCart } from '@woocommerce/resource-previews';
 import { dispatch } from '@wordpress/data';
-import { CART_STORE_KEY, checkoutStore } from '@woocommerce/block-data';
+import {
+	cartStore,
+	checkoutStore,
+	paymentStore,
+} from '@woocommerce/block-data';
 import { default as fetchMock } from 'jest-fetch-mock';
 import { allSettings } from '@woocommerce/settings';
 
@@ -36,6 +40,7 @@ import Shipping from '../inner-blocks/checkout-order-summary-shipping/frontend';
 import Taxes from '../inner-blocks/checkout-order-summary-taxes/frontend';
 import { defaultCartState } from '../../../data/cart/default-state';
 import Checkout from '../block';
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 
 jest.mock( '@wordpress/data', () => {
 	const wpData = jest.requireActual( 'wordpress-data-wp-6-7' );
@@ -90,7 +95,9 @@ jest.mock( '../context', () => {
 	};
 } );
 
-import { useCheckoutBlockContext } from '../context';
+/** @type {jest.Mock} */
+const useCheckoutBlockContext =
+	jest.requireMock( '../context' ).useCheckoutBlockContext;
 
 const CheckoutBlock = () => {
 	return (
@@ -138,8 +145,8 @@ describe( 'Testing Checkout', () => {
 				return Promise.resolve( '' );
 			} );
 			// need to clear the store resolution state between tests.
-			dispatch( CART_STORE_KEY ).invalidateResolutionForStore();
-			dispatch( CART_STORE_KEY ).receiveCart( defaultCartState.cartData );
+			dispatch( cartStore ).invalidateResolutionForStore();
+			dispatch( cartStore ).receiveCart( defaultCartState.cartData );
 		} );
 	} );
 
@@ -210,7 +217,7 @@ describe( 'Testing Checkout', () => {
 
 		// Async is needed here despite the IDE warnings. Testing Library gives a warning if not awaited.
 		await act( () =>
-			dispatch( CART_STORE_KEY ).setShippingAddress( {
+			dispatch( cartStore ).setShippingAddress( {
 				first_name: 'First Name JP',
 				last_name: 'Last Name JP',
 				company: '',
@@ -233,7 +240,7 @@ describe( 'Testing Checkout', () => {
 
 		// Testing the default address format
 		await act( () =>
-			dispatch( CART_STORE_KEY ).setShippingAddress( {
+			dispatch( cartStore ).setShippingAddress( {
 				first_name: 'First Name GB',
 				last_name: 'Last Name GB',
 				company: '',
@@ -393,6 +400,102 @@ describe( 'Testing Checkout', () => {
 
 		await act( async () => {
 			// Restore initial settings
+			allSettings.checkoutAllowsGuest = undefined;
+			allSettings.checkoutAllowsSignup = undefined;
+			dispatch( checkoutStore ).__internalSetCustomerId( 1 );
+		} );
+	} );
+
+	it( 'Allows saving payment method if the customer is creating an account or has already logged in', async () => {
+		await act( async () => {
+			const PaymentMethodContent = () => <div>A payment method</div>;
+			registerPaymentMethod( {
+				name: 'test-payment-method',
+				label: 'Payment method with cards',
+				content: <PaymentMethodContent />,
+				edit: <PaymentMethodContent />,
+				icons: null,
+				canMakePayment: () => true,
+				supports: {
+					showSavedCards: true,
+					showSaveOption: true,
+					features: [ 'products' ],
+				},
+				ariaLabel: 'Test Payment Method',
+			} );
+			dispatch( paymentStore ).__internalUpdateAvailablePaymentMethods();
+		} );
+		await act( async () => {
+			dispatch( checkoutStore ).__internalSetCustomerId( 2 );
+		} );
+
+		const { rerender } = render( <CheckoutBlock /> );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect(
+			screen.getByText( /Payment method with cards/i )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		await act( async () => {
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			allSettings.checkoutAllowsGuest = true;
+			allSettings.checkoutAllowsSignup = true;
+			dispatch( checkoutStore ).__internalSetCustomerId( 0 );
+			dispatch( checkoutStore ).__internalSetShouldCreateAccount( true );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		await act( async () => {
+			dispatch( checkoutStore ).__internalSetShouldCreateAccount( false );
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			allSettings.checkoutAllowsGuest = false;
+			allSettings.checkoutAllowsSignup = true;
+		} );
+
+		rerender( <CheckoutBlock /> );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Save payment information to my account for future purchases.',
+			} )
+		).toBeInTheDocument();
+
+		// cleanup
+		await act( async () => {
 			allSettings.checkoutAllowsGuest = undefined;
 			allSettings.checkoutAllowsSignup = undefined;
 			dispatch( checkoutStore ).__internalSetCustomerId( 1 );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.js
@@ -11,6 +11,7 @@ import {
 } from '@woocommerce/block-data';
 import { default as fetchMock } from 'jest-fetch-mock';
 import { allSettings } from '@woocommerce/settings';
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 
 /**
  * Internal dependencies
@@ -40,7 +41,6 @@ import Shipping from '../inner-blocks/checkout-order-summary-shipping/frontend';
 import Taxes from '../inner-blocks/checkout-order-summary-taxes/frontend';
 import { defaultCartState } from '../../../data/cart/default-state';
 import Checkout from '../block';
-import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 
 jest.mock( '@wordpress/data', () => {
 	const wpData = jest.requireActual( 'wordpress-data-wp-6-7' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables the "save card for future use" if the guest customer is also opting in to create an account, or is forced to create an account. Previously it would only show if you're logged in already, missing this for first time guest users creating an account.

Closes WOOPLUG-4220
### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install a credit card based payment method like Stripe.
2. Enable guest checkout and creating account during Checkout.
3. In Checkout, guest, check the create account box.
4. Notice that save card checkbox is now visible, check it.
5. Place the order, add an item to cart, go to Checkout
6. Notice that the card is saved.
7. Disable guest checkout.
8. Go to Checkout incognito, notice that you can save the card.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Allow saving cards if a guest customer is also creating an account.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
