### PR TITLE
Add a check in get_refunds() to ensure only `WC_Order_Refund` objects are returned

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4158-ask-from-alessandro-monteiro
+++ b/plugins/woocommerce/changelog/wooplug-4158-ask-from-alessandro-monteiro
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a check in get_refunds() to ensure only `WC_Order_Refund` objects are returned

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use WC_Order_Refund;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -117,9 +118,9 @@ class WC_Order extends WC_Abstract_Order {
 	 * Refunds for an order. Use {@see get_refunds()} instead.
 	 *
 	 * @deprecated 2.2.0
-	 * @var stdClass|WC_Order[]
+	 * @var WC_Order_Refund[]
 	 */
-	public $refunds;
+	public $refunds = array();
 
 	/**
 	 * When a payment is complete this function is called.
@@ -2120,28 +2121,39 @@ class WC_Order extends WC_Abstract_Order {
 	*/
 
 	/**
-	 * Get order refunds.
+	 * Returns an array of WC_Order_Refund objects for the order.
 	 *
+	 * Utilizes object cache to store refunds to avoid extra DB calls.
+	 *
+	 * @see WC_Order_Data_Store_CPT::prime_refund_caches_for_order()
 	 * @since 2.2
-	 * @return array of WC_Order_Refund objects
+	 *
+	 * @return WC_Order_Refund[]
 	 */
 	public function get_refunds() {
-		$cache_key   = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $this->get_id();
-		$cached_data = wp_cache_get( $cache_key, $this->cache_group );
+		$cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $this->get_id();
+		$refunds   = wp_cache_get( $cache_key, $this->cache_group );
 
-		if ( false !== $cached_data ) {
-			return $cached_data;
+		if ( false === $refunds ) {
+			$refunds = wc_get_orders(
+				array(
+					'type'   => 'shop_order_refund',
+					'parent' => $this->get_id(),
+					'limit'  => -1,
+				)
+			);
+			wp_cache_set( $cache_key, $refunds, $this->cache_group );
 		}
 
-		$this->refunds = wc_get_orders(
-			array(
-				'type'   => 'shop_order_refund',
-				'parent' => $this->get_id(),
-				'limit'  => -1,
-			)
-		);
+		$this->refunds = array();
 
-		wp_cache_set( $cache_key, $this->refunds, $this->cache_group );
+		if ( ! empty( $refunds ) && is_array( $refunds ) ) {
+			foreach ( $refunds as $refund ) {
+				if ( $refund instanceof WC_Order_Refund ) {
+					$this->refunds[] = $refund;
+				}
+			}
+		}
 
 		return $this->refunds;
 	}

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -10,7 +10,6 @@ use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Utilities\NumberUtil;
-use WC_Order_Refund;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -54,8 +54,8 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 
 		$parent_order_id  = $order->get_parent_id();
 		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $parent_order_id;
-		wp_cache_delete( $refund_cache_key, 'orders' );
 		wp_delete_post( $id );
+		wp_cache_delete( $refund_cache_key, 'orders' );
 		$order->set_id( 0 );
 
 		/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -46,17 +46,24 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 	 * @param array    $args Array of args to pass to the delete method.
 	 */
 	public function delete( &$order, $args = array() ) {
-		$id               = $order->get_id();
-		$parent_order_id  = $order->get_parent_id();
-		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $parent_order_id;
+		$id = $order->get_id();
 
 		if ( ! $id ) {
 			return;
 		}
 
-		wp_delete_post( $id );
+		$parent_order_id  = $order->get_parent_id();
+		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $parent_order_id;
 		wp_cache_delete( $refund_cache_key, 'orders' );
+		wp_delete_post( $id );
 		$order->set_id( 0 );
+
+		/**
+		 * Fires when a refund is deleted.
+		 *
+		 * @param int $id The refund ID.
+		 * @since 3.0.0
+		 */
 		do_action( 'woocommerce_delete_order_refund', $id );
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1517,7 +1517,7 @@ WHERE
 	}
 
 	/**
-	 * Helper function to get posts data for an order in bullk. We use to this to compute posts object in bulk so that we can compare it with COT data.
+	 * Helper function to get posts data for an order in bulk. We use to this to compute posts object in bulk so that we can compare it with COT data.
 	 *
 	 * @param array $orders    List of orders mapped by $order_id.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Update `WC_Order::get_refunds()` to ensure only valid `WC_Order_Refund` objects are returned.
- The method now checks each cached refund and only includes it in the result if it is an instance of `WC_Order_Refund`.
- This prevents possible issues if the cache is polluted with invalid or unexpected data types.

Closes #57733

### How to test the changes in this Pull Request:

1. Create an order and add one or more refunds.
2. Confirm the refunds are displayed correctly--refresh the page a few times to confirm it still works
3. Go to My Account > Orders and check refunds are displayed correctly there as well
4. Install an object caching plugin and confirm refunds are displayed between page loads in admin and in my account.

### Testing that has already taken place:

- Manual testing with valid and invalid cache data.
- Confirmed that only `WC_Order_Refund` objects are returned from `get_refunds()`.
- I installed a random object caching plugin (Docket) so try some others if possible. The original issue was potentially related to Redis.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix: Ensure `WC_Order::get_refunds()` only returns valid `WC_Order_Refund` objects, filtering out any invalid or unexpected data from the cache.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

N/A

</details>
