### PR TITLE
[Blueprint] Fix shipping settings export functionality

### DIFF
--- a/plugins/woocommerce/changelog/fix-blueprint-shipping-export
+++ b/plugins/woocommerce/changelog/fix-blueprint-shipping-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blueprint shipping settings export functionality

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsShipping.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Exporters/ExportWCSettingsShipping.php
@@ -4,28 +4,28 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Admin\Features\Blueprint\Exporters;
 
-use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
-use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 use Automattic\WooCommerce\Blueprint\Steps\RunSql;
 use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
 use Automattic\WooCommerce\Blueprint\Util;
 
 /**
- * Class ExportWCShipping
+ * Class ExportWCSettingsShipping
  *
- * Exports WooCommerce shipping settings and implements the StepExporter interface.
+ * Exports WooCommerce settings on the Shipping page.
  *
  * @package Automattic\WooCommerce\Admin\Features\Blueprint\Exporters
  */
-class ExportWCShipping implements StepExporter, HasAlias {
+class ExportWCSettingsShipping extends ExportWCSettings {
 	/**
 	 * Export WooCommerce shipping settings.
 	 *
 	 * @return array Array of RunSql|SetSiteOptions instances.
 	 */
 	public function export(): array {
+		$shipping_settings = parent::export();
+
 		$steps = array_merge(
-			array(),
+			array( $shipping_settings ),
 			$this->get_steps_for_classes_and_terms(),
 			$this->get_steps_for_zones(),
 			$this->get_steps_for_locations(),
@@ -195,5 +195,14 @@ class ExportWCShipping implements StepExporter, HasAlias {
 	 */
 	public function check_step_capabilities(): bool {
 		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Get the page ID for the settings page.
+	 *
+	 * @return string
+	 */
+	public function get_page_id(): string {
+		return 'shipping';
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/Init.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsTa
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsIntegrations;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsProducts;
 use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsSiteVisibility;
-use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCShipping;
+use Automattic\WooCommerce\Admin\Features\Blueprint\Exporters\ExportWCSettingsShipping;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
@@ -70,7 +70,7 @@ class Init {
 			ExportWCSettingsGeneral::class,
 			ExportWCSettingsProducts::class,
 			ExportWCSettingsTax::class,
-			ExportWCShipping::class,
+			ExportWCSettingsShipping::class,
 			ExportWCPaymentGateways::class,
 			ExportWCSettingsAccount::class,
 			ExportWCSettingsEmails::class,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Settings in `Settings > Shipping > Shipping Settings` were not being exported. 

<img width="892" alt="Screenshot 2025-05-08 at 14 40 34" src="https://github.com/user-attachments/assets/289b5da9-190d-4795-970c-9556ea0d8555" />

This is because the `ExportWCShipping` class didn't extend the `ExportWCSettings` class. This PR fixes the issue by extending the `ExportWCSettings` class with relevant changes and renaming it to `ExportWCSettingsShipping` for consistency.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping`
2. Add shipping zone, class, method, and settings, etc
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint`
4. Export the shipping settings
5. Check if the settings are exported correctly


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
