### PR TITLE
PTK Pattern: improve guard

### DIFF
--- a/plugins/woocommerce/changelog/57847-fix-implement-better-patch-cache
+++ b/plugins/woocommerce/changelog/57847-fix-implement-better-patch-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+PTK Pattern: improve guard

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -261,7 +261,7 @@ class BlockPatterns {
 				$pattern['categories'] = array_map(
 					function ( $category ) {
 						foreach ( self::CATEGORIES_PREFIXES as $prefix ) {
-							if ( strpos( $category['title'] ?? '', $prefix ) !== false ) {
+							if ( strpos( $category['title'], $prefix ) !== false ) {
 								$parsed_category   = str_replace( $prefix, '', $category['title'] );
 								$parsed_category   = str_replace( '_', ' ', $parsed_category );
 								$category['title'] = ucfirst( $parsed_category );

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -242,8 +242,10 @@ class BlockPatterns {
 	 * @param array $patterns The patterns to parse.
 	 * @return array The parsed patterns.
 	 */
-	private function parse_categories( array $patterns ) {
-
+	private function parse_categories( $patterns ) {
+		if ( ! is_array( $patterns ) ) {
+			return array();
+		}
 		return array_map(
 			function ( $pattern ) {
 				if ( ! isset( $pattern['categories'] ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -243,16 +243,25 @@ class BlockPatterns {
 	 * @return array The parsed patterns.
 	 */
 	private function parse_categories( array $patterns ) {
-		if ( ! isset( $patterns['categories'] ) || ! is_array( $patterns['categories'] ) ) {
-			return array();
-		}
 
 		return array_map(
 			function ( $pattern ) {
+				if ( ! isset( $pattern['categories'] ) ) {
+					$pattern['categories'] = array();
+				}
+
+				$values = array_values( $pattern['categories'] );
+
+				foreach ( $values as $value ) {
+					if ( ! isset( $value['title'] ) || ! isset( $value['slug'] ) ) {
+						$pattern['categories'] = array();
+					}
+				}
+
 				$pattern['categories'] = array_map(
 					function ( $category ) {
 						foreach ( self::CATEGORIES_PREFIXES as $prefix ) {
-							if ( strpos( $category['title'], $prefix ) !== false ) {
+							if ( strpos( $category['title'] ?? '', $prefix ) !== false ) {
 								$parsed_category   = str_replace( $prefix, '', $category['title'] );
 								$parsed_category   = str_replace( '_', ' ', $parsed_category );
 								$category['title'] = ucfirst( $parsed_category );

--- a/plugins/woocommerce/src/Blocks/BlockPatterns.php
+++ b/plugins/woocommerce/src/Blocks/BlockPatterns.php
@@ -210,7 +210,7 @@ class BlockPatterns {
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
 
 		$patterns = $this->ptk_patterns_store->get_patterns();
-		if ( empty( $patterns ) ) {
+		if ( empty( $patterns ) || ! is_array( $patterns ) ) {
 			// Only log once per day by using a transient.
 			$transient_key = 'wc_ptk_pattern_store_warning';
 			// By only logging when patterns are empty and no fetch is scheduled,

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/homepage.spec.js
@@ -326,7 +326,7 @@ test.describe( 'Homepage tracking banner', { tag: tags.NOT_E2E }, () => {
 		).toBeVisible();
 	} );
 
-	test.skip(
+	test(
 		'Should not show the "Want more patterns?" banner when tracking is allowed',
 		{ tag: tags.SKIP_ON_PRESSABLE },
 		async ( { baseURL, pageObject } ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR improves the guard implemented with #57759.

The malformed data was structured in this way:


```json
"categories": {
  "": {
    "slug": null,
    "title": null,
    "description": null
  }
}  
```

Instead, the correct structure is:

```json
"categories": {
  "category1": {
    "slug": "string",
    "title": "string",
    "description": "string"
    }, 
  "category2": {
    "slug": "string",
    "title": "string",
    "description": "string"
  },
 }
```

For this reason, we need to check for the presence of the categories object and ensure that each category has the "title" and "slug" defined. These two values are used in the codebase:


https://github.com/woocommerce/woocommerce/blob/088e63b775d0bab1d6fad00d94c81ed77404f122/plugins/woocommerce/src/Blocks/Patterns/PTKPatternsStore.php#L244-L262

https://github.com/woocommerce/woocommerce/blob/088e63b775d0bab1d6fad00d94c81ed77404f122/plugins/woocommerce/src/Blocks/BlockPatterns.php#L270-L283


This is just a better patch, but the right implemented will be implemented with the #57809


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. [Install `Transients Manager` plugin ](https://wordpress.org/plugins/transients-manager/).
2. Visit `wp-admin/tools.php?page=transients-manager`.
3. Click on `Delete All`.
4. Visit `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
5. Enable tracking.
6. Save.
7. Visit `wp-admin/admin.php?page=wc-admin`.
8. Click on `Customize Your Store.
9. Click on `Use the store designer`.
10. Click on `Design Your Homepeage`.
11. Click on `Intro`.
12. Expect to see more than 4 patterns:
https://github.com/user-attachments/assets/c4bc2dae-4852-457e-9f0a-326c640284e6

13. Replace [this line](https://github.com/woocommerce/woocommerce/blob/72863ce6d4c2bdf735d868790184df2431193932/plugins/woocommerce/src/Blocks/BlockPatterns.php#L221) with:

```php
		$patterns = json_decode(
			"[\n\t{\n\t\t\"ID\": 450,\n\t\t\"site_id\": 231214916,\n\t\t\"title\": \"Intro: Heading with image and two columns above\",\n\t\t\"name\": \"intro-heading-with-image-and-two-columns-above-copy\",\n\t\t\"description\": \"\",\n\t\t\"ai_description\": \"\",\n\t\t\"html\": \"<!-- wp:group {\\\"metadata\\\":{\\\"name\\\":\\\"Intro\\\"},\\\"align\\\":\\\"full\\\",\\\"style\\\":{\\\"spacing\\\":{\\\"padding\\\":{\\\"top\\\":\\\"calc( 0.5 * var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal)))\\\",\\\"bottom\\\":\\\"calc( 0.5 * var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal)))\\\",\\\"left\\\":\\\"var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-left, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal))\\\",\\\"right\\\":\\\"var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal))\\\"},\\\"margin\\\":{\\\"top\\\":\\\"0\\\",\\\"bottom\\\":\\\"0\\\"}}},\\\"layout\\\":{\\\"type\\\":\\\"constrained\\\",\\\"justifyContent\\\":\\\"center\\\"}} -->\\n<div class=\\\"wp-block-group alignfull\\\" style=\\\"margin-top:0;margin-bottom:0;padding-top:calc( 0.5 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)));padding-right:var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal));padding-bottom:calc( 0.5 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)));padding-left:var(--wp--style--root--padding-left, var(--wp--custom--gap--horizontal))\\\"><!-- wp:spacer {\\\"height\\\":\\\"calc( 0.25 * var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal)))\\\"} -->\\n<div style=\\\"height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))\\\" aria-hidden=\\\"true\\\" class=\\\"wp-block-spacer\\\"></div>\\n<!-- /wp:spacer -->\\n\\n<!-- wp:group {\\\"align\\\":\\\"wide\\\",\\\"layout\\\":{\\\"type\\\":\\\"default\\\"}} -->\\n<div class=\\\"wp-block-group alignwide\\\"><!-- wp:columns {\\\"verticalAlignment\\\":\\\"top\\\",\\\"align\\\":\\\"wide\\\"} -->\\n<div class=\\\"wp-block-columns alignwide are-vertically-aligned-top\\\"><!-- wp:column {\\\"verticalAlignment\\\":\\\"top\\\",\\\"width\\\":\\\"\\\",\\\"layout\\\":{\\\"type\\\":\\\"constrained\\\",\\\"justifyContent\\\":\\\"left\\\",\\\"contentSize\\\":\\\"480px\\\"}} -->\\n<div class=\\\"wp-block-column is-vertically-aligned-top\\\"><!-- wp:heading -->\\n<h2 class=\\\"wp-block-heading\\\">Stay dry in style</h2>\\n<!-- /wp:heading --></div>\\n<!-- /wp:column -->\\n\\n<!-- wp:column {\\\"verticalAlignment\\\":\\\"top\\\",\\\"width\\\":\\\"40%\\\"} -->\\n<div class=\\\"wp-block-column is-vertically-aligned-top\\\" style=\\\"flex-basis:40%\\\"><!-- wp:paragraph -->\\n<p>Designed for both fashion and function, our rain jackets offers sleek styles and waterproof protection to keep you dry in any downpour.</p>\\n<!-- /wp:paragraph -->\\n\\n<!-- wp:buttons -->\\n<div class=\\\"wp-block-buttons\\\"><!-- wp:button --><div class=\\\"wp-block-button\\\"><a class=\\\"wp-block-button__link wp-element-button\\\">Discover collection</a></div><!-- /wp:button --></div>\\n<!-- /wp:buttons --></div>\\n<!-- /wp:column --></div>\\n<!-- /wp:columns -->\\n\\n<!-- wp:spacer {\\\"height\\\":\\\"calc( 0.25 * var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal)))\\\"} -->\\n<div style=\\\"height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))\\\" aria-hidden=\\\"true\\\" class=\\\"wp-block-spacer\\\"></div>\\n<!-- /wp:spacer -->\\n\\n<!-- wp:image {\\\"id\\\":75,\\\"aspectRatio\\\":\\\"16/9\\\",\\\"scale\\\":\\\"cover\\\",\\\"sizeSlug\\\":\\\"full\\\",\\\"linkDestination\\\":\\\"none\\\"} -->\\n<figure class=\\\"wp-block-image size-full\\\"><img src=\\\"https://wooblockpatterns.wpcomstaging.com/wp-content/uploads/2024/06/man-person-winter-photography-statue-coat.png\\\" alt=\\\"\\\" class=\\\"wp-image-75\\\" style=\\\"aspect-ratio:16/9;object-fit:cover\\\"/></figure>\\n<!-- /wp:image --></div>\\n<!-- /wp:group -->\\n\\n<!-- wp:spacer {\\\"height\\\":\\\"calc( 0.25 * var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dstyle\\\\u002d\\\\u002droot\\\\u002d\\\\u002dpadding-right, var(\\\\u002d\\\\u002dwp\\\\u002d\\\\u002dcustom\\\\u002d\\\\u002dgap\\\\u002d\\\\u002dhorizontal)))\\\"} -->\\n<div style=\\\"height:calc( 0.25 * var(--wp--style--root--padding-right, var(--wp--custom--gap--horizontal)))\\\" aria-hidden=\\\"true\\\" class=\\\"wp-block-spacer\\\"></div>\\n<!-- /wp:spacer --></div>\\n<!-- /wp:group -->\",\n\t\t\"disallow_after\": [],\n\t\t\"dependencies\": [],\n\t\t\"categories\": {\n\t\t\t\"\": {\n\t\t\t\t\"slug\": null,\n\t\t\t\t\"title\": null,\n\t\t\t\t\"description\": null\n\t\t\t}\n\t\t},\n\t\t\"virtual_theme_categories\": [],\n\t\t\"tags\": [],\n\t\t\"pattern_meta\": [],\n\t\t\"source_url\": \"https://wooblockpatterns.wpcomstaging.com/2024/07/10/intro-heading-with-image-and-two-columns-above-copy/\",\n\t\t\"modified_date\": \"2025-05-06 14:29:32\",\n\t\t\"preview_data\": [],\n\t\t\"post_type\": \"wp_block\",\n\t\t\"is_included_in_big_sky\": 0\n\t}]",
			true
		);
```

15. Refresh WordPress. 
16. Ensure that you don't see any fatal. 
17. Click on `Design Your Homepeage`.
18. Click on `Intro`.
19. You should see only 4 patterns.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

PTK Pattern: improve guard

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
