### PR TITLE
Fix flaky Custom Product Collection E2E tests by retrying activating custom plugin

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3099-flaky-test-collection-my-custom-collection-multiple-contexts
+++ b/plugins/woocommerce/changelog/wooplug-3099-flaky-test-collection-my-custom-collection-multiple-contexts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix flaky tests
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Fix flaky tests in Product Collection registration

**What:**
Added a retry mechanism with exponential backoff for plugin activation in the Product Collection registration tests. This addresses intermittent "socket hang up" errors that were occurring specifically for collections with product context and multiple contexts.

**Why:**
The tests were failing most likely due to a race condition between plugin activation and test execution (`socket hang up` while making PUT request). This issue has been observed in other repositories (see [web-languageforge#1402](https://github.com/sillsdev/web-languageforge/issues/1402)), suggesting it's not specific to our infrastructure.

The solution implements:
- Retry mechanism with exponential backoff
- Verification step to ensure plugin is fully activated
- Better error handling for both activation and verification failures

I could not reproduce the issue locally not a single time and it's not super super frequent on CI as well hence there's no 100% guarantee this will solve the issue. To test it, I'm running this specific suite on CI 3 times:

-  ✅ [Attempt 1](https://github.com/woocommerce/woocommerce/actions/runs/14902857622/job/41858619153?pr=57849)
- ✅ [Attempt 2](https://github.com/woocommerce/woocommerce/actions/runs/14902857622/job/41863997372?pr=57849)
- ✅ [Attempt 3](https://github.com/woocommerce/woocommerce/actions/runs/14902857622/job/41869293126?pr=57849)

Closes WOOPLUG-3099
Closes WOOPLUG-3027

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify the tests passed at first time - suite: `Blocks E2E 7/10`
- Collection "My Custom Collection - Multiple Contexts" should not show preview label in Product Catalog template
- Collection "My Custom Collection - Product Context" should not show preview label in Product Catalog template

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
