### PR TITLE
Split product stock count for custom stock into two queries to improve performance

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3834-the-ajax-request-in-the-admin-interface-is-causing-the
+++ b/plugins/woocommerce/changelog/wooplug-3834-the-ajax-request-in-the-admin-interface-is-causing-the
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Split low stock count query for custom stock into two queries to improve performance.

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -74,7 +74,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
 		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only();
-		$total_results = 0;
+		$total_results                 = 0;
 		if ( $sidewide_stock_threshold_only ) {
 			$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
 			$count_query_results = $wpdb->get_results(
@@ -86,9 +86,9 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		} else {
 			// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
 			// Splitting the queries also speeds up the query.
-			$count_query_with_custom_stock_threshold_string  = $this->get_products_with_custom_stock_threshold_count_query_str();
+			$count_query_with_custom_stock_threshold_string    = $this->get_products_with_custom_stock_threshold_count_query_str();
 			$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
-			$count_query_with_custom_stock_threshold_results = $wpdb->get_results(
+			$count_query_with_custom_stock_threshold_results   = $wpdb->get_results(
 				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
 				$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
 			);
@@ -123,7 +123,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 
 		// set images and attributes.
 		$query_results['results'] = array_map(
-			function( $query_result ) {
+			function ( $query_result ) {
 				$product                  = wc_get_product( $query_result );
 				$query_result->images     = $this->get_images( $product );
 				$query_result->attributes = $this->get_attributes( $product );
@@ -363,7 +363,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 */
 	private function get_products_with_custom_stock_threshold_count_query_str() {
 		global $wpdb;
-		$query = $this->get_base_query(
+		$query    = $this->get_base_query(
 			array(
 				':selects'       => 'count(*) as total',
 				':orderAndLimit' => '',
@@ -372,7 +372,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$postmeta = array(
 			'select' => 'meta.meta_value AS low_stock_amount,',
 			'join'   => "JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
-			'wheres' => "AND wc_product_meta_lookup.stock_quantity <= CAST(meta.meta_value AS SIGNED)",
+			'wheres' => 'AND wc_product_meta_lookup.stock_quantity <= CAST(meta.meta_value AS SIGNED)',
 		);
 
 		return strtr(
@@ -392,7 +392,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 */
 	private function get_products_without_custom_stock_threshold_count_query_str() {
 		global $wpdb;
-		$query = $this->get_base_query(
+		$query    = $this->get_base_query(
 			array(
 				':selects'       => 'count(*) as total',
 				':orderAndLimit' => '',
@@ -401,7 +401,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$postmeta = array(
 			'select' => 'meta.meta_value AS low_stock_amount,',
 			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
-			'wheres' => "AND meta.post_id IS NULL AND wc_product_meta_lookup.stock_quantity <= %d",
+			'wheres' => 'AND meta.post_id IS NULL AND wc_product_meta_lookup.stock_quantity <= %d',
 		);
 
 		return strtr(

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -74,14 +74,34 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
 		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only();
-		$count_query_string            = $this->get_count_query( $sidewide_stock_threshold_only );
-		$count_query_results           = $wpdb->get_results(
-		// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-			$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
-		);
+		$total_results = 0;
+		if ( $sidewide_stock_threshold_only ) {
+			$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
+			$count_query_results = $wpdb->get_results(
+				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+				$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
+			);
 
-		$total_results = (int) $count_query_results[0]->total;
-		$response      = rest_ensure_response( array( 'total' => $total_results ) );
+			$total_results = (int) $count_query_results[0]->total;
+		} else {
+			// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
+			$count_query_with_custom_stock_threshold_string  = $this->get_products_with_custom_stock_threshold_count_query_str();
+			$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
+			error_log( $wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status, $low_stock_threshold ) );
+			error_log( $wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ) );
+			$count_query_with_custom_stock_threshold_results = $wpdb->get_results(
+				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+				$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status, $low_stock_threshold ),
+			);
+			$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
+				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+				$wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ),
+			);
+
+			$total_results = (int) $count_query_with_custom_stock_threshold_results[0]->total + (int) $count_query_without_custom_stock_threshold_results[0]->total;
+		}
+
+		$response = rest_ensure_response( array( 'total' => $total_results ) );
 		$response->header( 'X-WP-Total', $total_results );
 		$response->header( 'X-WP-TotalPages', 0 );
 
@@ -325,6 +345,64 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			      AND wc_product_meta_lookup.stock_quantity <= %d
 			    )
 		    )",
+		);
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => $postmeta['select'],
+				':postmeta_join'   => $postmeta['join'],
+				':postmeta_wheres' => $postmeta['wheres'],
+			)
+		);
+	}
+
+	/**
+	 * Get a query string for products with a custom stock threshold.
+	 *
+	 * @return string
+	 */
+	private function get_products_with_custom_stock_threshold_count_query_str() {
+		global $wpdb;
+		$query = $this->get_base_query(
+			array(
+				':selects'       => 'count(*) as total',
+				':orderAndLimit' => '',
+			)
+		);
+		$postmeta = array(
+			'select' => 'meta.meta_value AS low_stock_amount,',
+			'join'   => "JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
+			'wheres' => "AND wc_product_meta_lookup.stock_quantity <= CAST(meta.meta_value AS SIGNED)",
+		);
+
+		return strtr(
+			$query,
+			array(
+				':postmeta_select' => $postmeta['select'],
+				':postmeta_join'   => $postmeta['join'],
+				':postmeta_wheres' => $postmeta['wheres'],
+			)
+		);
+	}
+
+	/**
+	 * Get a query string for products without a custom stock threshold.
+	 *
+	 * @return string
+	 */
+	private function get_products_without_custom_stock_threshold_count_query_str() {
+		global $wpdb;
+		$query = $this->get_base_query(
+			array(
+				':selects'       => 'count(*) as total',
+				':orderAndLimit' => '',
+			)
+		);
+		$postmeta = array(
+			'select' => 'meta.meta_value AS low_stock_amount,',
+			'join'   => "LEFT JOIN {$wpdb->postmeta} AS meta ON wp_posts.ID = meta.post_id AND meta.meta_key = '_low_stock_amount' AND meta.meta_value > ''",
+			'wheres' => "AND meta.post_id IS NULL AND wc_product_meta_lookup.stock_quantity <= %d",
 		);
 
 		return strtr(

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -213,9 +213,9 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	/**
 	 * Get the count of low in stock products.
 	 *
-	 * @param bool $sidewide_stock_threshold_only
-	 * @param string $status
-	 * @param int $low_stock_threshold
+	 * @param bool   $sidewide_stock_threshold_only Boolean to check if the store is using sitewide stock threshold only.
+	 * @param string $status Post status.
+	 * @param int    $low_stock_threshold Low stock threshold.
 	 *
 	 * @return int
 	 */

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -85,13 +85,12 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			$total_results = (int) $count_query_results[0]->total;
 		} else {
 			// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
+			// Splitting the queries also speeds up the query.
 			$count_query_with_custom_stock_threshold_string  = $this->get_products_with_custom_stock_threshold_count_query_str();
 			$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
-			error_log( $wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status, $low_stock_threshold ) );
-			error_log( $wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ) );
 			$count_query_with_custom_stock_threshold_results = $wpdb->get_results(
 				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-				$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status, $low_stock_threshold ),
+				$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
 			);
 			$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
 				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -69,36 +69,11 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 * @return \WP_Error|\WP_HTTP_Response|\WP_REST_Response
 	 */
 	public function get_low_in_stock_count( $request ) {
-		global $wpdb;
 		$status              = $request->get_param( 'status' );
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
 		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only();
-		$total_results                 = 0;
-		if ( $sidewide_stock_threshold_only ) {
-			$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
-			$count_query_results = $wpdb->get_results(
-				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-				$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
-			);
-
-			$total_results = (int) $count_query_results[0]->total;
-		} else {
-			// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
-			// Splitting the queries also speeds up the query.
-			$count_query_with_custom_stock_threshold_string    = $this->get_products_with_custom_stock_threshold_count_query_str();
-			$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
-			$count_query_with_custom_stock_threshold_results   = $wpdb->get_results(
-				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-				$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
-			);
-			$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
-				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-				$wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ),
-			);
-
-			$total_results = (int) $count_query_with_custom_stock_threshold_results[0]->total + (int) $count_query_without_custom_stock_threshold_results[0]->total;
-		}
+		$total_results                 = $this->get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
 
 		$response = rest_ensure_response( array( 'total' => $total_results ) );
 		$response->header( 'X-WP-Total', $total_results );
@@ -226,19 +201,50 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			OBJECT_K
 		);
 
-		$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
-		$count_query_results = $wpdb->get_results(
-		// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
-			$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
-		);
-
-		$total_results = $count_query_results[0]->total;
+		$total_results = $this->get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
 
 		return array(
 			'results' => $query_results,
 			'total'   => (int) $total_results,
 			'pages'   => (int) ceil( $total_results / (int) $per_page ),
 		);
+	}
+
+	/**
+	 * Get the count of low in stock products.
+	 *
+	 * @param bool $sidewide_stock_threshold_only
+	 * @param string $status
+	 * @param int $low_stock_threshold
+	 *
+	 * @return int
+	 */
+	protected function get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold ) {
+		global $wpdb;
+		if ( $sidewide_stock_threshold_only ) {
+			$count_query_string  = $this->get_count_query( $sidewide_stock_threshold_only );
+			$count_query_results = $wpdb->get_results(
+				// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+				$wpdb->prepare( $count_query_string, $status, $low_stock_threshold ),
+			);
+
+			return (int) $count_query_results[0]->total;
+		}
+
+		// Split the query into two queries, one for products with a custom stock threshold and one for products without a custom stock threshold.
+		// Splitting the queries also speeds up the query.
+		$count_query_with_custom_stock_threshold_string    = $this->get_products_with_custom_stock_threshold_count_query_str();
+		$count_query_without_custom_stock_threshold_string = $this->get_products_without_custom_stock_threshold_count_query_str();
+		$count_query_with_custom_stock_threshold_results   = $wpdb->get_results(
+			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+			$wpdb->prepare( $count_query_with_custom_stock_threshold_string, $status ),
+		);
+		$count_query_without_custom_stock_threshold_results = $wpdb->get_results(
+			// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
+			$wpdb->prepare( $count_query_without_custom_stock_threshold_string, $status, $low_stock_threshold ),
+		);
+
+		return (int) $count_query_with_custom_stock_threshold_results[0]->total + (int) $count_query_without_custom_stock_threshold_results[0]->total;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
@@ -74,7 +74,7 @@ class WC_Admin_Tests_API_ProductsLowInStock extends WC_REST_Unit_Test_Case {
 	public function test_multiple_products_custom_low_stock() {
 		wp_set_current_user( $this->user );
 
-		// Create three products with different stock quantities
+		// Create three products with different stock quantities.
 		$product1 = WC_Helper_Product::create_simple_product();
 		$product1->set_manage_stock( true );
 		$product1->set_low_stock_amount( 5 );
@@ -109,10 +109,10 @@ class WC_Admin_Tests_API_ProductsLowInStock extends WC_REST_Unit_Test_Case {
 	public function test_multiple_products_global_low_stock() {
 		wp_set_current_user( $this->user );
 
-		// Set global low stock amount
+		// Set global low stock amount.
 		update_option( 'woocommerce_notify_low_stock_amount', 5 );
 
-		// Create three products without custom low stock amounts
+		// Create three products without custom low stock amounts.
 		$product1 = WC_Helper_Product::create_simple_product();
 		$product1->set_manage_stock( true );
 		$product1->set_stock_quantity( 4 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/products-lowinstock.php
@@ -67,4 +67,74 @@ class WC_Admin_Tests_API_ProductsLowInStock extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $product->get_id(), $data[0]['id'] );
 		$this->assertEquals( $order_time, $data[0]['last_order_date'] );
 	}
+
+	/**
+	 * Test multiple products with custom low stock amounts.
+	 */
+	public function test_multiple_products_custom_low_stock() {
+		wp_set_current_user( $this->user );
+
+		// Create three products with different stock quantities
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_manage_stock( true );
+		$product1->set_low_stock_amount( 5 );
+		$product1->set_stock_quantity( 4 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_manage_stock( true );
+		$product2->set_low_stock_amount( 3 );
+		$product2->set_stock_quantity( 2 );
+		$product2->save();
+
+		$product3 = WC_Helper_Product::create_simple_product();
+		$product3->set_manage_stock( true );
+		$product3->set_low_stock_amount( 10 );
+		$product3->set_stock_quantity( 15 );
+		$product3->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/count-low-in-stock' );
+		$request->set_param( 'low_in_stock', true );
+		$request->set_param( 'status', ProductStatus::PUBLISH );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, $data['total'] );
+	}
+
+	/**
+	 * Test multiple products with global low stock setting.
+	 */
+	public function test_multiple_products_global_low_stock() {
+		wp_set_current_user( $this->user );
+
+		// Set global low stock amount
+		update_option( 'woocommerce_notify_low_stock_amount', 5 );
+
+		// Create three products without custom low stock amounts
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_manage_stock( true );
+		$product1->set_stock_quantity( 4 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_manage_stock( true );
+		$product2->set_stock_quantity( 2 );
+		$product2->save();
+
+		$product3 = WC_Helper_Product::create_simple_product();
+		$product3->set_manage_stock( true );
+		$product3->set_stock_quantity( 6 );
+		$product3->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/count-low-in-stock' );
+		$request->set_param( 'low_in_stock', true );
+		$request->set_param( 'status', ProductStatus::PUBLISH );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, $data['total'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is the first item to improve the performance of the stock count request which gets triggered on any Woo Admin page, as we use it to add a notification to the **Activity** panel icon.

The endpoint runs one of two queries, depending if there are any products with a custom "Low stock threshold" defined. 
The query that gets run when their are "Low stock threshold" defined is inefficient and as shown in the original issue can be quite slow on a site with a very large amount of products: https://github.com/woocommerce/woocommerce/issues/57087#issuecomment-2848172801 

Splitting this query up seemed to greatly reduce the time when testing.

A follow up would be to implement caching. 

Partly addresses: #57087

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a store finish the onboarding and create several products including variations.
2. Enable the "Enable stock management" under **WooCommerce > Settings > Products > Inventory**
3. Go to a couple of the products and update the **Quantity** ( under Inventory tab ) to below the store wide threshold ( default is 2 I believe )
4. Go to **WooCommerce > Home** and hide your task list ( if it is still displayed ) 
5. Once task list is hidden it should show a "Stock" accordion, the number should be correct with the number of products that have a stock below the store wide threshold.
6. Now go to a couple products and variations and set the **Low stock threshold** in the **Inventory** tab, to something different to that of the store wide threshold. ( you can mix/match ).
7. Make sure the **Quantity** of the product is below the **Low stock threshold**
8. Go to **WooCommerce > Home** and make sure the count is correctly reflected.

**Bonus points**
Install and activate this plugin: [low-in-stock-debug.zip](https://github.com/user-attachments/files/20101314/low-in-stock-debug.zip)

1. Also install the WC Smooth Generator -> https://github.com/woocommerce/wc-smooth-generator
2. Create a large number of variable products over a couple thousand ( this may take a bit ) -> `wp wc generate products 2000 --type=variable`
3. Install the **Query Monitor** plugin and go to **Tools > Low In Stock Debug**
4. Look at the **Full Query with Meta** time and the time of the two combined queries below ( you can confirm with **Query Monitor** ( the time should be quite a bit faster ( less than half ) than the **Full Query with Meta** and the results should be the same ).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
