### PR TITLE
Product Filter Rating: update the product count setting label

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4225-unify-filter-blocks-setting-labels
+++ b/plugins/woocommerce/changelog/wooplug-4225-unify-filter-blocks-setting-labels
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Product Filter Rating: Rename the product count setting label and move it to the bottom, aligning with other filter blocks.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/components/inspector.tsx
@@ -64,12 +64,6 @@ export const Inspector = ( {
 	return (
 		<InspectorControls key="inspector">
 			<PanelBody title={ __( 'Display', 'woocommerce' ) }>
-				<ToggleControl
-					label={ __( 'Display product count', 'woocommerce' ) }
-					checked={ showCounts }
-					onChange={ setCountVisibility }
-					__nextHasNoMarginBottom
-				/>
 				<RadioControl
 					label={ __( 'Minimum rating', 'woocommerce' ) }
 					selected={ minRating }
@@ -117,6 +111,12 @@ export const Inspector = ( {
 						},
 					] }
 					onChange={ setMinRating }
+				/>
+				<ToggleControl
+					label={ __( 'Product counts', 'woocommerce' ) }
+					checked={ showCounts }
+					onChange={ setCountVisibility }
+					__nextHasNoMarginBottom
 				/>
 			</PanelBody>
 		</InspectorControls>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR standardizes the "Product counts" setting label in the Rating Filter block and repositions it to the bottom of the Display panel, aligning with the UI patterns used in other filter blocks. This change creates a more consistent UI experience across all product filter blocks and helps merchants find the same settings in the same location across different filter blocks easier.

Closes WOOPLUG-4225.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1025" alt="image" src="https://github.com/user-attachments/assets/a1e0291b-aff5-4a5f-88f3-686e5e29ead9" />| <img width="1025" alt="image" src="https://github.com/user-attachments/assets/36912b39-5036-4289-aabc-29d61baf9af3" /> |

### How to test the changes in this Pull Request:

1. Add the `Product Filters` block into the Product Catalog template.
2. Focus on the Rating block.
3. See the `Product counts` setting at the bottom of the display panel.