### PR TITLE
Render marketplace banner in main admin layout component

### DIFF
--- a/plugins/woocommerce/changelog/57857-update-WCCOM-1057-in-app-banner-position
+++ b/plugins/woocommerce/changelog/57857-update-WCCOM-1057-in-app-banner-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Move marketplace banner to main WC Admin layout component to ensure it always appear at the top of the page.

--- a/plugins/woocommerce/client/admin/client/layout/index.tsx
+++ b/plugins/woocommerce/client/admin/client/layout/index.tsx
@@ -52,6 +52,7 @@ import { Header } from '../header';
 import { Footer } from './footer';
 import { TransientNotices } from './transient-notices';
 import { usePageClasses, Page } from './hooks/use-page-classes';
+import MarketplaceBanner from '../marketplace/components/banner/banner';
 
 const BaseLayout = ( { page }: { page: Page } ) => {
 	const { activePlugins, installedPlugins, isJetpackConnected } = useSelect(
@@ -70,6 +71,7 @@ const BaseLayout = ( { page }: { page: Page } ) => {
 	const matchFromRouter = useMatch( location.pathname );
 	const params = useParams();
 	const match = { params, url: matchFromRouter?.pathname };
+	const isMarketplacePage = location.pathname.includes( '/extensions' );
 
 	usePageClasses( page );
 
@@ -147,6 +149,7 @@ const BaseLayout = ( { page }: { page: Page } ) => {
 		>
 			<SlotFillProvider>
 				<div className="woocommerce-layout">
+					{ isMarketplacePage && <MarketplaceBanner /> }
 					{ showHeader && (
 						<Header
 							sections={

--- a/plugins/woocommerce/client/admin/client/marketplace/components/header/header.tsx
+++ b/plugins/woocommerce/client/admin/client/marketplace/components/header/header.tsx
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import './header.scss';
-import Banner from '../banner/banner';
 import HeaderTitle from '../header-title/header-title';
 import HeaderAccount from '../header-account/header-account';
 import Tabs from '../tabs/tabs';
@@ -11,7 +10,6 @@ import Search from '../search/search';
 export default function Header() {
 	return (
 		<div className="woocommerce-marketplace__header-container">
-			<Banner />
 			<header className="woocommerce-marketplace__header">
 				<HeaderTitle />
 				<Tabs


### PR DESCRIPTION
- This ensures the banner will apear above any admin notices being rendered in the marketplace

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We show a banner at the top of the in-app marketplace, but if admin notices appear in the marketplace pages, those are being rendered above the banner, which doesn't look great. We're moving the banner to the top of the `BaseLayout` component itself, from its current position in the marketplace `Header` component.
<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WCCOM-1057](https://linear.app/a8c/issue/WCCOM-1057/wc-core-in-app-banner)

(For Bug Fixes) Bug introduced in PR #55597 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

**Before**
![Home_‹_WooCommerce_‹_WP_Test_Site_—_WooCommerce](https://github.com/user-attachments/assets/c8ba05f9-e7a0-4a3b-9237-0239857a38b4)
 
**After**
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/user-attachments/assets/d4b37069-b102-4f14-a54d-ccefd303670c)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1 .Check out this branch.
2. Navigate to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
3. Visit the [Marketplace](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
4. If you don't see any admin notices on the page, add this snippet to `functions.php` or the Code Snippets plugin to force the DB update notice to appear:
```php
add_action( 'admin_init', function() {
    // Set DB version to an old value to trigger the update requirement.
    update_option( 'woocommerce_db_version', '9.7.0' );

    // Remove any existing db update admin note (actioned or not).
    if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
        $notes_class = 'Automattic\\WooCommerce\\Admin\\Notes\\Notes';
        $note = $notes_class::get_note_by_name( 'wc-update-db-reminder' );
        if ( $note ) {
            $note->delete();
        }
    }

    // Recreate the note (will be set to 'unactioned').
    if ( class_exists( 'WC_Notes_Run_Db_Update' ) ) {
        new WC_Notes_Run_Db_Update();
    }
});
```
5. Confirm the marketplace banner appears above the admin notice, as in the screenshot above. Also check mobile views.
6. Dismiss the admin notice and confirm the marketplace header is properly positioned below the banner now that the notice is gone.
![Extensions_‹_WooCommerce_‹_woocommerce](https://github.com/user-attachments/assets/d162d4cb-5ef3-4ab3-89b5-9d8e11f0746c)

7. View some other WC-Admin pages, like WooCommerce ->Home or ->Orders, and confirm the banner does not appear there.
8. Test around this issue.


**Note:** As the banner is no longer part of the marketplace header it is no longer sticky along with the header, but will scroll off the top of the page.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Move marketplace banner to main WC Admin layout component to ensure it always appear at the top of the page.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
