### PR TITLE
[Experimental] Review Template: remove threading

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4205-reduce-thread-depth-to-one-as-review-doesnt-support-replies
+++ b/plugins/woocommerce/changelog/wooplug-4205-reduce-thread-depth-to-one-as-review-doesnt-support-replies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Expermental Review Template block: remove review thread logic.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
@@ -27,7 +27,6 @@ import { useCommentQueryArgs, useCommentTree } from './hooks';
 
 interface Comment {
 	commentId: number;
-	children?: Comment[];
 }
 
 interface ReviewTemplateInnerBlocksProps {
@@ -51,8 +50,6 @@ type ReviewTemplateAttributes = {
 
 const TEMPLATE = [
 	[ 'core/avatar' ],
-	[ 'core/comment-reply-link' ],
-	[ 'core/comment-edit-link' ],
 	[ 'woocommerce/product-review-author-name' ],
 	[ 'woocommerce/product-review-date' ],
 	[ 'woocommerce/product-review-content' ],
@@ -61,58 +58,28 @@ const TEMPLATE = [
 interface ReviewSettings {
 	perPage: number;
 	pageComments: boolean;
-	threadComments: boolean;
-	threadCommentsDepth: number;
 }
 
 const getCommentsPlaceholder = ( {
 	perPage,
 	pageComments,
-	threadComments,
-	threadCommentsDepth,
 }: ReviewSettings ) => {
-	// Limit commentsDepth to 3
-	const commentsDepth = ! threadComments
-		? 1
-		: Math.min( threadCommentsDepth, 3 );
+	const placeholderComments = [ { commentId: -1 } ];
 
-	const buildChildrenComment = ( commentsLevel: number ): Comment[] => {
-		// Render children comments until commentsDepth is reached
-		if ( commentsLevel < commentsDepth ) {
-			const nextLevel = commentsLevel + 1;
-
-			return [
-				{
-					commentId: -( commentsLevel + 3 ),
-					children: buildChildrenComment( nextLevel ),
-				},
-			];
-		}
-		return [];
-	};
-
-	// Add the first comment and its children
-	const placeholderComments = [
-		{ commentId: -1, children: buildChildrenComment( 1 ) },
-	];
-
-	// Add a second comment unless the break comments setting is active and set to less than 2, and there is one nested comment max
-	if ( ( ! pageComments || perPage >= 2 ) && commentsDepth < 3 ) {
+	// Add a second comment unless the break comments setting is active and set to less than 2
+	if ( ! pageComments || perPage >= 2 ) {
 		placeholderComments.push( {
 			commentId: -2,
-			children: [],
 		} );
 	}
 
-	// Add a third comment unless the break comments setting is active and set to less than 3, and there aren't nested comments
-	if ( ( ! pageComments || perPage >= 3 ) && commentsDepth < 2 ) {
+	// Add a third comment unless the break comments setting is active and set to less than 3
+	if ( ! pageComments || perPage >= 3 ) {
 		placeholderComments.push( {
 			commentId: -3,
-			children: [],
 		} );
 	}
 
-	// In case that the value is set but larger than 3 we truncate it to 3.
 	return placeholderComments;
 };
 
@@ -174,32 +141,6 @@ const ReviewTemplateInnerBlocks = memo( function ReviewTemplateInnerBlocks( {
 					comment.commentId === ( activeCommentId || firstCommentId )
 				}
 			/>
-
-			{ comment?.children && comment.children.length > 0 ? (
-				<ol>
-					{ comment.children.map(
-						(
-							{ commentId, ...childComment }: Comment,
-							index: number
-						) => (
-							<BlockContextProvider
-								key={ commentId || index }
-								value={ {
-									commentId: commentId < 0 ? null : commentId,
-								} }
-							>
-								<ReviewTemplateInnerBlocks
-									comment={ { commentId, ...childComment } }
-									activeCommentId={ activeCommentId }
-									setActiveCommentId={ setActiveCommentId }
-									blocks={ blocks }
-									firstCommentId={ firstCommentId }
-								/>
-							</BlockContextProvider>
-						)
-					) }
-				</ol>
-			) : null }
 		</li>
 	);
 } );
@@ -213,27 +154,22 @@ export default function ReviewTemplateEdit( {
 	const blockProps = useBlockProps();
 
 	const [ activeCommentId, setActiveCommentId ] = useState< number >( 0 );
-	const {
-		commentOrder,
-		threadCommentsDepth,
-		threadComments,
-		commentsPerPage,
-		pageComments,
-	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore ) as unknown as {
-			getSettings(): {
-				// eslint-disable-next-line @typescript-eslint/naming-convention
-				__experimentalDiscussionSettings: {
-					commentOrder: string;
-					threadCommentsDepth: number;
-					threadComments: boolean;
-					commentsPerPage: number;
-					pageComments: boolean;
+	const { commentOrder, commentsPerPage, pageComments } = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore ) as unknown as {
+				getSettings(): {
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					__experimentalDiscussionSettings: {
+						commentOrder: string;
+						commentsPerPage: number;
+						pageComments: boolean;
+					};
 				};
 			};
-		};
-		return getSettings().__experimentalDiscussionSettings;
-	}, [] );
+			return getSettings().__experimentalDiscussionSettings;
+		},
+		[]
+	);
 
 	const commentQuery = useCommentQueryArgs( {
 		postId: postId ?? 0,
@@ -246,7 +182,6 @@ export default function ReviewTemplateEdit( {
 				getBlocks( clientId: string ): BlockInstance[];
 			};
 			return {
-				// Request only top-level comments. Replies are embedded.
 				topLevelComments: commentQuery
 					? getEntityRecords( 'root', 'comment', commentQuery )
 					: null,
@@ -256,21 +191,16 @@ export default function ReviewTemplateEdit( {
 		[ clientId, commentQuery ]
 	);
 
-	// Generate a tree structure of comment IDs.
 	let commentTree = useCommentTree(
 		// Reverse the order of top comments if needed.
 		commentOrder === 'desc' && topLevelComments
 			? [
 					...( topLevelComments as Array< {
 						id: number;
-						// eslint-disable-next-line @typescript-eslint/naming-convention
-						_embedded?: { children?: Array< { id: number } > };
 					} > ),
 			  ].reverse()
 			: ( topLevelComments as Array< {
 					id: number;
-					// eslint-disable-next-line @typescript-eslint/naming-convention
-					_embedded?: { children?: Array< { id: number } > };
 			  } > )
 	);
 
@@ -286,8 +216,6 @@ export default function ReviewTemplateEdit( {
 		commentTree = getCommentsPlaceholder( {
 			perPage: commentsPerPage,
 			pageComments,
-			threadComments,
-			threadCommentsDepth,
 		} );
 	}
 
@@ -306,10 +234,8 @@ export default function ReviewTemplateEdit( {
 					(
 						{
 							commentId,
-							...commentData
 						}: {
 							commentId: number;
-							children: Comment[];
 						},
 						index: number
 					) => (
@@ -320,7 +246,7 @@ export default function ReviewTemplateEdit( {
 							} }
 						>
 							<ReviewTemplateInnerBlocks
-								comment={ { commentId, ...commentData } }
+								comment={ { commentId } }
 								activeCommentId={ activeCommentId }
 								setActiveCommentId={ setActiveCommentId }
 								blocks={ blocks }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/edit.tsx
@@ -23,7 +23,7 @@ import {
 /**
  * Internal dependencies
  */
-import { useCommentQueryArgs, useCommentTree } from './hooks';
+import { useCommentQueryArgs, useCommentList } from './hooks';
 
 interface Comment {
 	commentId: number;
@@ -64,23 +64,11 @@ const getCommentsPlaceholder = ( {
 	perPage,
 	pageComments,
 }: ReviewSettings ) => {
-	const placeholderComments = [ { commentId: -1 } ];
+	const numberOfComments = pageComments ? Math.min( perPage, 3 ) : 3;
 
-	// Add a second comment unless the break comments setting is active and set to less than 2
-	if ( ! pageComments || perPage >= 2 ) {
-		placeholderComments.push( {
-			commentId: -2,
-		} );
-	}
-
-	// Add a third comment unless the break comments setting is active and set to less than 3
-	if ( ! pageComments || perPage >= 3 ) {
-		placeholderComments.push( {
-			commentId: -3,
-		} );
-	}
-
-	return placeholderComments;
+	return Array.from( { length: numberOfComments }, ( _, i ) => ( {
+		commentId: -( i + 1 ),
+	} ) );
 };
 
 const ReviewTemplatePreview = ( {
@@ -191,7 +179,7 @@ export default function ReviewTemplateEdit( {
 		[ clientId, commentQuery ]
 	);
 
-	let commentTree = useCommentTree(
+	let commentTree = useCommentList(
 		// Reverse the order of top comments if needed.
 		commentOrder === 'desc' && topLevelComments
 			? [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -152,16 +152,15 @@ export const useCommentQueryArgs = ( { postId }: { postId: number } ) => {
 };
 
 /**
- * Generate a tree structure of comment IDs from a list of comment entities.
- * For product reviews, this is a flat list as reviews don't support threading.
+ * Generate a list of IDs from a list of review entities.
  */
-export const useCommentTree = (
+export const useCommentList = (
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	topLevelComments: Array< {
 		id: number;
 	} >
 ) => {
-	const commentTree = useMemo(
+	const commentList = useMemo(
 		() =>
 			topLevelComments?.map( ( { id }: { id: number } ) => {
 				return {
@@ -171,5 +170,5 @@ export const useCommentTree = (
 		[ topLevelComments ]
 	);
 
-	return commentTree;
+	return commentList;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-template/hooks.tsx
@@ -22,7 +22,6 @@ export const useCommentQueryArgs = ( { postId }: { postId: number } ) => {
 			order: 'asc',
 			context: 'embed',
 			parent: 0,
-			_embed: 'children',
 			type: 'review',
 		} ),
 		[]
@@ -153,39 +152,22 @@ export const useCommentQueryArgs = ( { postId }: { postId: number } ) => {
 };
 
 /**
- * Generate a tree structure of comment IDs from a list of comment entities. The
- * children of each comment are obtained from `_embedded`.
+ * Generate a tree structure of comment IDs from a list of comment entities.
+ * For product reviews, this is a flat list as reviews don't support threading.
  */
 export const useCommentTree = (
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	topLevelComments: Array< {
 		id: number;
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		_embedded?: { children?: Array< { id: number } > };
 	} >
 ) => {
 	const commentTree = useMemo(
 		() =>
-			topLevelComments?.map(
-				( {
-					id,
-					_embedded,
-				}: {
-					id: number;
-					// eslint-disable-next-line @typescript-eslint/naming-convention
-					_embedded?: { children?: Array< { id: number } > };
-				} ) => {
-					const [ children ] = _embedded?.children || [ [] ];
-					return {
-						commentId: id,
-						children: Array.isArray( children )
-							? children.map( ( child: { id: number } ) => ( {
-									commentId: child.id,
-							  } ) )
-							: [],
-					};
-				}
-			),
+			topLevelComments?.map( ( { id }: { id: number } ) => {
+				return {
+					commentId: id,
+				};
+			} ),
 		[ topLevelComments ]
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/template.ts
@@ -72,12 +72,6 @@ const TEMPLATE: InnerBlockTemplate[] = [
 											fontSize: 'small',
 										},
 									],
-									[
-										'core/comment-edit-link',
-										{
-											fontSize: 'small',
-										},
-									],
 								],
 							],
 							[ 'woocommerce/product-review-content' ],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewTemplate.php
@@ -33,13 +33,9 @@ class ProductReviewTemplate extends AbstractBlock {
 	 *
 	 * @param WP_Comment[] $comments        The array of comments.
 	 * @param WP_Block     $block           Block instance.
-	 * @param int          $current_depth   Current depth of comments, defaults to 1.
 	 * @return string
 	 */
-	protected function block_product_review_template_render_comments( $comments, $block, $current_depth = 1 ) {
-		$thread_comments       = get_option( 'thread_comments' );
-		$thread_comments_depth = get_option( 'thread_comments_depth' );
-
+	protected function block_product_review_template_render_comments( $comments, $block ) {
 		$content = '';
 		foreach ( $comments as $comment ) {
 			$comment_id           = $comment->comment_ID;
@@ -66,37 +62,7 @@ class ProductReviewTemplate extends AbstractBlock {
 
 			remove_filter( 'render_block_context', $filter_block_context, 1 );
 
-			$children = $comment->get_children();
-
-			/*
-			* We need to create the CSS classes BEFORE recursing into the children.
-			* This is because comment_class() uses globals like `$comment_alt`
-			* and `$comment_thread_alt` which are order-sensitive.
-			*
-			* The `false` parameter at the end means that we do NOT want the function
-			* to `echo` the output but to return a string.
-			* See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
-			*/
 			$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
-
-			// If the comment has children, recurse to create the HTML for the nested
-			// comments.
-			if ( ! empty( $children ) && ! empty( $thread_comments ) ) {
-				if ( $current_depth < $thread_comments_depth ) {
-					$inner_content  = $this->block_product_review_template_render_comments(
-						$children,
-						$block,
-						$current_depth + 1
-					);
-					$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
-				} else {
-					$block_content .= $this->block_product_review_template_render_comments(
-						$children,
-						$block,
-						$current_depth
-					);
-				}
-			}
 
 			$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR cleans up the Review Template block to remove the logic handling thread because review doesn't support threading. This PR also remove the nested placeholder review for preview in the Site Editor.

Closes WOOPLUG-4205

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/f5f73a4e-da9c-440a-88ba-5fe560ab0a41) | <img width="1026" alt="image" src="https://github.com/user-attachments/assets/a7c9dc84-f5a1-462d-a9f3-37ecf9ec18c8" /> |

### How to test the changes in this Pull Request:

1. Add the Blockified Product Details block to the Single Product template.
2. Open the Reviews accordion item.
3. See the review list is flat, don't see the thread.