### PR TITLE
[Experimental] Blockified Add to Cart + Options block: update strings

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-string-updates
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-string-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update Add to Cart + Options block titles and descriptions
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options",
 	"title": "Add to Cart + Options (Beta)",
-	"description": "Create an \"Add To Cart\" composition by using blocks",
+	"description": "Use blocks to create an \"Add to cart\" area that's customized for different product types, such as variable and grouped. ",
 	"category": "woocommerce-product-elements",
 	"attributes": {
 		"isDescendantOfAddToCartWithOptions": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/add-to-cart-with-options",
-	"title": "Add to Cart with Options (Experimental)",
+	"title": "Add to Cart + Options (Beta)",
 	"description": "Create an \"Add To Cart\" composition by using blocks",
 	"category": "woocommerce-product-elements",
 	"attributes": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/downgrade-notice/index.tsx
@@ -43,7 +43,7 @@ export const DowngradeNotice = ( {
 	blockClientId: string;
 } ) => {
 	const notice = __(
-		'Switch back to the classic Add to Cart with Options block.',
+		'Switch back to the classic Add to Cart + Options block.',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-grouped-product-selector",
-	"title": "Grouped Product Selector (Experimental)",
+	"title": "Grouped Product Selector (Beta)",
 	"description": "Display a group of products that can be added to the cart.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-cta/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-cta/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-grouped-product-selector-item-cta",
-	"title": "Grouped Product Selector Item CTA (Experimental)",
-	"description": "A CTA for a child product within the Grouped Product Selector block. Depending on the product type and properties, this might be a button, a checkbox or a link.",
+	"title": "Grouped Product: Item Selector (Beta)",
+	"description": "Add a way of selecting a child product within the Grouped Product block. Depending on the type of product and its properties, this might be a button, a checkbox, or a link.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-template/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-grouped-product-selector-item",
-	"title": "Grouped Product Selector Item Template (Experimental)",
+	"title": "Grouped Product: Template (Beta)",
 	"description": "A list item template that represents a child product within the Grouped Product Selector block.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/quantity-selector/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-quantity-selector",
-	"title": "Quantity Selector (Experimental)",
-	"description": "Display an input field with stepper to select the number of products to add to cart.",
+	"title": "Product Quantity (Beta)",
+	"description": "Display an input field customers can use to select the number of products to add to their cart. ",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-item-template/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-item-template/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-variation-selector-item",
-	"title": "Variation Selector Item Template (Experimental)",
-	"description": "A list item template that represents an attribute within the Variation Selector block.",
+	"title": "Variation Selector: Template (Beta)",
+	"description": "A template for attribute name and options that will be applied to all variable products with attributes.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-variation-selector-attribute-name",
-	"title": "Variation Selector Attribute Name (Experimental)",
-	"description": "The name of a given variable product attribute.",
+	"title": "Variation Selector: Attribute Name (Beta)",
+	"description": "Format the name of an attribute associated with a variable product.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"ancestor": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-variation-selector-attribute-options",
-	"title": "Variation Selector Attribute Options (Experimental)",
-	"description": "The attribute options of a given variable product attribute.",
+	"title": "Variation Selector: Attribute Options (Beta)",
+	"description": "Display the attribute options associated with a variable product.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"ancestor": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-with-options-variation-selector",
-	"title": "Variation Selector (Experimental)",
-	"description": "Display a dropdown to select a variation to add to cart.",
+	"title": "Variation Selector (Beta)",
+	"description": "Display any product variations available to select from and add to cart.",
 	"category": "woocommerce-product-elements",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-form",
 	"title": "Add to Cart with Options",
-	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
+	"description": "Display a button that lets customers add a product to their cart. Use the added options to optimize for different product types.",
 	"category": "woocommerce-product-elements",
 	"attributes": {
 		"quantitySelectorStyle": {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/components/upgrade-notice/index.tsx
@@ -44,20 +44,20 @@ export const UpgradeNotice = ( {
 } ) => {
 	const notice = createInterpolateElement(
 		__(
-			'Upgrade the Add to Cart with Options block to <strongText /> for more features!',
+			'Gain access to more customization options when you upgrade to the <strongText />.',
 			'woocommerce'
 		),
 		{
 			strongText: (
 				<strong>
-					{ __( `a new blockified experience`, 'woocommerce' ) }
+					{ __( `blockified experience`, 'woocommerce' ) }
 				</strong>
 			),
 		}
 	);
 
 	const buttonLabel = __(
-		'Upgrade to the blockified Add to Cart with Options block',
+		'Upgrade to the Add to Cart + Options block',
 		'woocommerce'
 	);
 

--- a/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/plugins/woocommerce/client/blocks/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -62,7 +62,7 @@ The majority of our feature flagging is blocks, this is a list of them:
    	- [PHP flag](https://github.com/woocommerce/woocommerce/blob/9897737880dcbef9831ee41799684dab1960d94f/plugins/woocommerce/src/Blocks/BlockTypesController.php#L417)
    	- [Webpack flag](https://github.com/woocommerce/woocommerce/blob/9897737880dcbef9831ee41799684dab1960d94f/plugins/woocommerce-blocks/bin/webpack-entries.js#L168)
     - [JS flag](https://github.com/woocommerce/woocommerce/blob/9897737880dcbef9831ee41799684dab1960d94f/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/index.tsx#L14)
-- Add to Cart with Options (Experimental)
+- Add to Cart + Options (Experimental)
     - [PHP flag](https://github.com/woocommerce/woocommerce/blob/a0f9d159e5196983d93064762fd20a510de57d55/plugins/woocommerce/src/Blocks/BlockTypesController.php#L456)
     - [Webpack flag](https://github.com/woocommerce/woocommerce/blob/a0f9d159e5196983d93064762fd20a510de57d55/plugins/woocommerce-blocks/bin/webpack-entries.js#L23)
     - [JS flag](https://github.com/woocommerce/woocommerce/blob/9897737880dcbef9831ee41799684dab1960d94f/plugins/woocommerce-blocks/assets/js/blocks/order-confirmation/create-account/index.tsx#L14)

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -510,7 +510,9 @@ test.describe( `${ blockData.name } Block`, () => {
 		await editor.selectBlocks( addToCartFormBlock );
 
 		await page
-			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.getByRole( 'button', {
+				name: 'Upgrade to the Add to Cart + Options block',
+			} )
 			.click();
 
 		await expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -514,9 +514,7 @@ test.describe( `${ blockData.name } Block`, () => {
 			.click();
 
 		await expect(
-			editor.canvas.getByLabel(
-				'Block: Quantity Selector (Experimental)'
-			)
+			editor.canvas.getByLabel( 'Block: Product Quantity (Beta)' )
 		).toBeVisible();
 
 		const addToCartWithOptionsBlock = await editor.getBlockByName(
@@ -527,9 +525,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		await page.getByRole( 'button', { name: 'Switch back' } ).click();
 
 		await expect(
-			editor.canvas.getByLabel(
-				'Block: Quantity Selector (Experimental)'
-			)
+			editor.canvas.getByLabel( 'Block: Product Quantity (Beta)' )
 		).toBeHidden();
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -488,7 +488,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		} );
 	} );
 
-	test( 'can be migrated to the blockified Add to Cart with Options block', async ( {
+	test( 'can be migrated to the blockified Add to Cart + Options block', async ( {
 		page,
 		editor,
 		blockUtils,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -20,7 +20,7 @@ const test = base.extend< { pageObject: AddToCartWithOptionsPage } >( {
 	},
 } );
 
-test.describe( 'Add to Cart with Options Block', () => {
+test.describe( 'Add to Cart + Options Block', () => {
 	test( 'allows modifying the template parts', async ( {
 		page,
 		pageObject,
@@ -38,7 +38,7 @@ test.describe( 'Add to Cart with Options Block', () => {
 		await editor.insertBlock( { name: pageObject.BLOCK_SLUG } );
 
 		await pageObject.insertParagraphInTemplatePart(
-			'This is a test paragraph added to the Add to Cart with Options template part.'
+			'This is a test paragraph added to the Add to Cart + Options template part.'
 		);
 
 		await editor.saveSiteEditorEntities();
@@ -47,7 +47,7 @@ test.describe( 'Add to Cart with Options Block', () => {
 
 		await expect(
 			page.getByText(
-				'This is a test paragraph added to the Add to Cart with Options template part.'
+				'This is a test paragraph added to the Add to Cart + Options template part.'
 			)
 		).toBeVisible();
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
@@ -24,7 +24,7 @@ const test = base.extend< { pageObject: AddToCartWithOptionsPage } >( {
 	},
 } );
 
-test.describe( `Add to Cart with Options Block (block theme with templates)`, () => {
+test.describe( `Add to Cart + Options Block (block theme with templates)`, () => {
 	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
 	} );
@@ -50,7 +50,7 @@ test.describe( `Add to Cart with Options Block (block theme with templates)`, ()
 		await pageObject.switchProductType( 'External/Affiliate product' );
 
 		await pageObject.insertParagraphInTemplatePart(
-			'This is a test paragraph added to the Add to Cart with Options template part.'
+			'This is a test paragraph added to the Add to Cart + Options template part.'
 		);
 
 		await editor.saveSiteEditorEntities();
@@ -59,13 +59,13 @@ test.describe( `Add to Cart with Options Block (block theme with templates)`, ()
 
 		await expect(
 			page.getByText(
-				'This is a test paragraph added to the Add to Cart with Options template part.'
+				'This is a test paragraph added to the Add to Cart + Options template part.'
 			)
 		).toBeVisible();
 
 		await expect(
 			page.getByText(
-				'External Product Add to cart with Options template loaded from theme'
+				'External Product Add to Cart + Options template loaded from theme'
 			)
 		).toBeVisible();
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
@@ -65,7 +65,7 @@ test.describe( `Add to Cart + Options Block (block theme with templates)`, () =>
 
 		await expect(
 			page.getByText(
-				'External Product Add to Cart + Options template loaded from theme'
+				'External Product Add to Cart With Options template loaded from theme'
 			)
 		).toBeVisible();
 	} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -93,7 +93,9 @@ class AddToCartWithOptionsPage {
 		await this.editor.selectBlocks( addToCartFormBlock );
 
 		await this.page
-			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.getByRole( 'button', {
+				name: 'Upgrade to the Add to Cart + Options block',
+			} )
 			.click();
 	}
 }

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -10,7 +10,7 @@ class AddToCartWithOptionsPage {
 	private editor: Editor;
 	private requestUtils: RequestUtils;
 	BLOCK_SLUG = 'woocommerce/add-to-cart-with-options';
-	BLOCK_NAME = 'Add to Cart with Options (Experimental)';
+	BLOCK_NAME = 'Add to Cart + Options (Beta)';
 
 	constructor( {
 		page,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -196,9 +196,7 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 			.click();
 
 		await expect(
-			editor.canvas.getByLabel(
-				'Block: Quantity Selector (Experimental)'
-			)
+			editor.canvas.getByLabel( 'Block: Product Quantity (Beta)' )
 		).toBeVisible();
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -172,13 +172,13 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 		}
 	} );
 
-	test( 'hooks are attached to the page when using the Add to Cart with Options block', async ( {
+	test( 'hooks are attached to the page when using the Add to Cart + Options block', async ( {
 		page,
 		admin,
 		editor,
 		requestUtils,
 	} ) => {
-		/* Switch to the blockified Add to Cart with Options block to be able to test all hooks */
+		/* Switch to the blockified Add to Cart + Options block to be able to test all hooks */
 		await requestUtils.setFeatureFlag( 'experimental-blocks', true );
 		await requestUtils.setFeatureFlag( 'blockified-add-to-cart', true );
 		await admin.visitSiteEditor( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -192,7 +192,9 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 		await editor.selectBlocks( addToCartFormBlock );
 
 		await page
-			.getByRole( 'button', { name: 'Upgrade to the blockified' } )
+			.getByRole( 'button', {
+				name: 'Upgrade to the Add to Cart + Options block',
+			} )
 			.click();
 
 		await expect(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/constants.ts
@@ -126,7 +126,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 
 			await page.goto( '/product/wordpress-pennant/' );
 		},
-		templateName: 'External Product Add to Cart + Options',
+		templateName: 'External Product Add To Cart With Options',
 		templatePath: 'external-product-add-to-cart-with-options',
 		templateType: 'wp_template_part',
 		canBeOverriddenByThemes: true,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/constants.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/constants.ts
@@ -126,7 +126,7 @@ export const CUSTOMIZABLE_WC_TEMPLATES: TemplateCustomizationTest[] = [
 
 			await page.goto( '/product/wordpress-pennant/' );
 		},
-		templateName: 'External Product Add To Cart With Options',
+		templateName: 'External Product Add to Cart + Options',
 		templatePath: 'external-product-add-to-cart-with-options',
 		templateType: 'wp_template_part',
 		canBeOverriddenByThemes: true,

--- a/plugins/woocommerce/client/blocks/tests/e2e/themes/theme-with-woo-templates/block-template-parts/external-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/client/blocks/tests/e2e/themes/theme-with-woo-templates/block-template-parts/external-product-add-to-cart-with-options.html
@@ -1,5 +1,5 @@
 <!-- wp:paragraph -->
-<p>External Product Add to cart with Options template loaded from theme</p>
+<p>External Product Add to Cart With Options template loaded from theme</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"small"} /-->

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -94,16 +94,16 @@ class BlockTemplatesRegistry {
 	}
 
 	/**
-	 * Add Add to Cart with Options to the default template part areas.
+	 * Add Add to Cart + Options to the default template part areas.
 	 *
 	 * @param array $default_area_definitions An array of supported area objects.
-	 * @return array The supported template part areas including the Add to Cart with Options one.
+	 * @return array The supported template part areas including the Add to Cart + Options one.
 	 */
 	public function register_add_to_cart_with_options_template_part_area( $default_area_definitions ) {
 		$add_to_cart_with_options_template_part_area = array(
 			'area'        => 'add-to-cart-with-options',
-			'label'       => __( 'Add to Cart with Options', 'woocommerce' ),
-			'description' => __( 'The Add to Cart with Options templates allow defining a different layout for each product type.', 'woocommerce' ),
+			'label'       => __( 'Add to Cart + Options', 'woocommerce' ),
+			'description' => __( 'The Add to Cart + Options templates allow defining a different layout for each product type.', 'woocommerce' ),
 			'icon'        => 'add-to-cart-with-options',
 			'area_tag'    => 'add-to-cart-with-options',
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -66,7 +66,7 @@ class AddToCartWithOptions extends AbstractBlock {
 	}
 
 	/**
-	 * Modifies the block context for product button blocks when inside the Add to Cart with Options block.
+	 * Modifies the block context for product button blocks when inside the Add to Cart + Options block.
 	 *
 	 * @param array $context The block context.
 	 * @param array $block   The parsed block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\Enums\ProductType;
 use WP_Block;
 
 /**
- * Utility methods used for the Add to Cart with Options block.
+ * Utility methods used for the Add to Cart + Options block.
  * {@internal This class and its methods are not intended for public use.}
  */
 class Utils {

--- a/plugins/woocommerce/src/Blocks/Templates/ExternalProductAddToCartWithOptionsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ExternalProductAddToCartWithOptionsTemplate.php
@@ -36,7 +36,7 @@ class ExternalProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_title() {
-		return _x( 'External Product Add to Cart with Options', 'Template name', 'woocommerce' );
+		return _x( 'External Product Add to Cart + Options', 'Template name', 'woocommerce' );
 	}
 
 	/**
@@ -45,6 +45,6 @@ class ExternalProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_description() {
-		return __( 'Template used to display the Add to Cart with Options form for External Products.', 'woocommerce' );
+		return __( 'Template used to display the Add to Cart + Options form for External Products.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/GroupedProductAddToCartWithOptionsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/GroupedProductAddToCartWithOptionsTemplate.php
@@ -36,7 +36,7 @@ class GroupedProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_title() {
-		return _x( 'Grouped Product Add to Cart with Options', 'Template name', 'woocommerce' );
+		return _x( 'Grouped Product Add to Cart + Options', 'Template name', 'woocommerce' );
 	}
 
 	/**
@@ -45,6 +45,6 @@ class GroupedProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_description() {
-		return __( 'Template used to display the Add to Cart with Options form for Grouped Products.', 'woocommerce' );
+		return __( 'Template used to display the Add to Cart + Options form for Grouped Products.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/SimpleProductAddToCartWithOptionsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SimpleProductAddToCartWithOptionsTemplate.php
@@ -36,7 +36,7 @@ class SimpleProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_title() {
-		return _x( 'Simple Product Add to Cart with Options', 'Template name', 'woocommerce' );
+		return _x( 'Simple Product Add to Cart + Options', 'Template name', 'woocommerce' );
 	}
 
 	/**
@@ -45,6 +45,6 @@ class SimpleProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_description() {
-		return __( 'Template used to display the Add to Cart with Options form for Simple Products.', 'woocommerce' );
+		return __( 'Template used to display the Add to Cart + Options form for Simple Products.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Templates/VariableProductAddToCartWithOptionsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/VariableProductAddToCartWithOptionsTemplate.php
@@ -36,7 +36,7 @@ class VariableProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_title() {
-		return _x( 'Variable Product Add to Cart with Options', 'Template name', 'woocommerce' );
+		return _x( 'Variable Product Add to Cart + Options', 'Template name', 'woocommerce' );
 	}
 
 	/**
@@ -45,6 +45,6 @@ class VariableProductAddToCartWithOptionsTemplate extends AbstractTemplatePart {
 	 * @return string
 	 */
 	public function get_template_description() {
-		return __( 'Template used to display the Add to Cart with Options form for Variable Products.', 'woocommerce' );
+		return __( 'Template used to display the Add to Cart + Options form for Variable Products.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -84,25 +84,25 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 		// Single Products contain the Add to Cart button and the quantity selector blocks.
-		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The Simple Product Add to Cart with Options contains the product button block.' );
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The Simple Product Add to Cart + Options contains the product button block.' );
 		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button reads "Add to cart".' );
-		$this->assertStringContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The Simple Product Add to Cart with Options contains the quantity selector block.' );
+		$this->assertStringContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The Simple Product Add to Cart + Options contains the quantity selector block.' );
 
 		$product    = new \WC_Product_External();
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 		// External Products contain the Add to Cart button block but do not contain the quantity selector block.
-		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The External Product Add to Cart with Options contains the product button block.' );
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-button', $markup, 'The External Product Add to Cart + Options contains the product button block.' );
 		$this->assertStringContainsString( 'Buy product', $markup, 'The External Product Add to Cart Button reads "Buy product".' );
-		$this->assertStringNotContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The External Product Add to Cart with Options does not contain the quantity selector block.' );
+		$this->assertStringNotContainsString( 'woocommerce/add-to-cart-with-options-quantity-selector', $markup, 'The External Product Add to Cart + Options does not contain the quantity selector block.' );
 
 		$product    = new WC_Product_Custom();
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
 		// Third-party product types use their own template.
-		$this->assertStringContainsString( 'Custom Product Type Add to Cart Form', $markup, 'The Custom Product Type Add to Cart with Options contains the custom product type add to cart form.' );
+		$this->assertStringContainsString( 'Custom Product Type Add to Cart Form', $markup, 'The Custom Product Type Add to Cart + Options contains the custom product type add to cart form.' );
 
 		remove_action( 'woocommerce_custom_add_to_cart', array( $this, 'print_custom_product_type_add_to_cart_markup' ) );
 	}
@@ -152,15 +152,15 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the wrapper hook.' );
-		$this->assertStringContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the inner hooks.' );
+		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart + Options correctly renders the contents from the wrapper hook.' );
+		$this->assertStringContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart + Options doesn\'t render the contents from the inner hooks.' );
 
 		$product->set_stock_status( 'outofstock' );
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart with Options correctly renders the contents from the wrapper hook if the product is out of stock.' );
-		$this->assertStringNotContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart with Options doesn\'t render the contents from the inner hooks if the product is out of stock.' );
+		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart + Options correctly renders the contents from the wrapper hook if the product is out of stock.' );
+		$this->assertStringNotContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart + Options doesn\'t render the contents from the inner hooks if the product is out of stock.' );
 
 		remove_action( 'woocommerce_simple_add_to_cart', array( $this, 'hook_into_add_to_cart_action' ) );
 		remove_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
@@ -178,17 +178,17 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$grouped_product_id = $grouped_product->save();
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringContainsString( 'type="number"', $markup, 'The Grouped Product Add to Cart with Options form contains a numeric input.' );
+		$this->assertStringContainsString( 'type="number"', $markup, 'The Grouped Product Add to Cart + Options form contains a numeric input.' );
 
 		$simple_product->set_sold_individually( true );
 		$simple_product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringContainsString( 'type="checkbox"', $markup, 'The Grouped Product Add to Cart with Options form contains a checkbox.' );
+		$this->assertStringContainsString( 'type="checkbox"', $markup, 'The Grouped Product Add to Cart + Options form contains a checkbox.' );
 
 		$simple_product->set_stock_status( 'outofstock' );
 		$simple_product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringContainsString( 'Read more', $markup, 'The Grouped Product Add to Cart with Options form contains a button.' );
+		$this->assertStringContainsString( 'Read more', $markup, 'The Grouped Product Add to Cart + Options form contains a button.' );
 	}
 
 	/**
@@ -201,18 +201,18 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$simple_product_id = $simple_product->save();
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $simple_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart with Options form does not contain a quantity selector block for sold individually products.' );
+		$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart + Options form does not contain a quantity selector block for sold individually products.' );
 
 		$simple_product->set_sold_individually( false );
 		$simple_product->set_manage_stock( true );
 		$simple_product->set_stock_quantity( 1 );
 		$simple_product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $simple_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart with Options form does not contain a quantity selector block for products with manage stock set to true and stock quantity set to 1.' );
+		$this->assertStringNotContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart + Options form does not contain a quantity selector block for products with manage stock set to true and stock quantity set to 1.' );
 
 		$simple_product->set_stock_quantity( 10 );
 		$simple_product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $simple_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart with Options form contains a quantity selector block for products with manage stock set to true and stock quantity > 1.' );
+		$this->assertStringContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart + Options form contains a quantity selector block for products with manage stock set to true and stock quantity > 1.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See DSGWOO-268.

This PR updates several block names and description in the Add to Cart + Options block.

Notes:

* The block name changed from `Add to Cart with Options` to `Add to Cart + Options`, but in code I left it as `AddToCartWithOptions` / `add-to-cart-with-options` as the `+` sign can't be used.
* I took the opportunity to replace `Experimental` with `Beta`, as we are targeting to release the beta in WC 10.0.

### How to test the changes in this Pull Request:

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.
3. Use the blocks and compare their strings with the document linked in DSGWOO-268.
