### PR TITLE
Product Filters: Validate cached data before use

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4189-product-filters-validate-cached-data-before-use
+++ b/plugins/woocommerce/changelog/wooplug-4189-product-filters-validate-cached-data-before-use
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Product Filters: add some data validation and type guard for filter data.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -277,7 +277,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 		foreach ( $counts as $key => $value ) {
 			$attribute_counts[] = array(
 				'term'  => $key,
-				'count' => $value,
+				'count' => intval( $value ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -233,8 +233,8 @@ final class ProductFilterPrice extends AbstractBlock {
 		$price_results = $container->get( FilterDataProvider::class )->with( $container->get( QueryClauses::class ) )->get_filtered_price( $query_vars );
 
 		return array(
-			'min_price' => intval( floor( floatval( $price_results->min_price ?? 0 ) ) ),
-			'max_price' => intval( ceil( floatval( $price_results->max_price ?? 0 ) ) ),
+			'min_price' => intval( floor( floatval( $price_results['min_price'] ?? 0 ) ) ),
+			'max_price' => intval( ceil( floatval( $price_results['max_price'] ?? 0 ) ) ),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -228,7 +228,7 @@ final class ProductFilterRating extends AbstractBlock {
 		foreach ( $counts as $key => $value ) {
 			$data[] = array(
 				'rating' => $key,
-				'count'  => $value,
+				'count'  => intval( $value ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -211,7 +211,7 @@ final class ProductFilterStatus extends AbstractBlock {
 		foreach ( $counts as $key => $value ) {
 			$data[] = array(
 				'status' => $key,
-				'count'  => $value,
+				'count'  => intval( $value ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -43,15 +43,15 @@ class FilterData {
 		 *
 		 * @since 9.9.0
 		 *
-		 * @param mixed  $results      The results for current query.
+		 * @param array  $results      The results for current query.
 		 * @param string $filter_type  The type of filter. Accepts price|stock|rating|attribute.
 		 * @param array  $query_vars   The query arguments to calculate the filter data.
 		 * @param array  $extra        Some filter types require extra arguments for calculation, like attribute.
-		 * @return mixed The filtered results or null to continue with default processing.
+		 * @return array The filtered results or null to continue with default processing.
 		 */
 		$pre_filter_counts = apply_filters( 'woocommerce_pre_product_filter_data', null, 'price', $query_vars, array() );
 
-		if ( isset( $pre_filter_counts ) ) {
+		if ( is_array( $pre_filter_counts ) ) {
 			return $pre_filter_counts;
 		}
 
@@ -90,7 +90,7 @@ class FilterData {
 		 * We're using the query as is, same as Core does.
 		 */
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_row( $price_filter_sql );
+		$results = (array) $wpdb->get_row( $price_filter_sql );
 
 		/**
 		 * Filters the product filter data before it is returned.
@@ -98,11 +98,11 @@ class FilterData {
 		 * @hook woocommerce_product_filter_data
 		 * @since 9.9.0
 		 *
-		 * @param mixed  $results      The results for current query.
+		 * @param array  $results      The results for current query.
 		 * @param string $filter_type  The type of filter. Accepts price|stock|rating|attribute.
 		 * @param array  $query_vars   The query arguments to calculate the filter data.
 		 * @param array  $extra        Some filter types require extra arguments for calculation, like attribute.
-		 * @return mixed The filtered results
+		 * @return array The filtered results
 		 */
 		$results = apply_filters( 'woocommerce_product_filter_data', $results, 'price', $query_vars, array() );
 
@@ -124,7 +124,7 @@ class FilterData {
 		 */
 		$pre_filter_counts = apply_filters( 'woocommerce_pre_product_filter_data', null, 'stock', $query_vars, array() ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
-		if ( isset( $pre_filter_counts ) ) {
+		if ( is_array( $pre_filter_counts ) ) {
 			return $pre_filter_counts;
 		}
 
@@ -194,7 +194,7 @@ class FilterData {
 		 */
 		$pre_filter_counts = apply_filters( 'woocommerce_pre_product_filter_data', null, 'rating', $query_vars, array() ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
-		if ( isset( $pre_filter_counts ) ) {
+		if ( is_array( $pre_filter_counts ) ) {
 			return $pre_filter_counts;
 		}
 
@@ -262,7 +262,7 @@ class FilterData {
 		 */
 		$pre_filter_counts = apply_filters( 'woocommerce_pre_product_filter_data', null, 'attribute', $query_vars, array( 'taxonomy' => $attribute_to_count ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
-		if ( isset( $pre_filter_counts ) ) {
+		if ( is_array( $pre_filter_counts ) ) {
 			return $pre_filter_counts;
 		}
 
@@ -357,6 +357,7 @@ class FilterData {
 		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::TRANSIENT_GROUP );
 
 		if ( empty( $cache['version'] ) ||
+			! is_array( $cache['value'] ) ||
 			empty( $cache['value'] ) ||
 			$transient_version !== $cache['version']
 		) {
@@ -373,6 +374,10 @@ class FilterData {
 	 * @param mix    $value Value to set.
 	 */
 	private function set_cache( $key, $value ) {
+		if ( ! is_array( $value ) ) {
+			return;
+		}
+
 		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::TRANSIENT_GROUP );
 		$transient_value   = array(
 			'version' => $transient_version,

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -372,10 +372,12 @@ class FilterData {
 	 *
 	 * @param string $key   Transient key.
 	 * @param mix    $value Value to set.
+	 *
+	 * @return bool True if the cache was set, false otherwise.
 	 */
 	private function set_cache( $key, $value ) {
 		if ( ! is_array( $value ) ) {
-			return;
+			return false;
 		}
 
 		$transient_version = WC_Cache_Helper::get_transient_version( CacheController::TRANSIENT_GROUP );


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR enhances the Product Filters component by validating cached data before use to prevent potential errors. The changes ensure that filter data is consistently handled as arrays throughout the codebase.

Changes include:
- Updated `FilterData.php` to enforce array type consistency for filter results
- Changed `isset()` checks to more specific `is_array()` validations
- Added validation to ensure cached values are properly structured arrays
- Improved type hinting in docblocks to clearly indicate array return types
- Cast `$wpdb->get_row()` result to array to ensure consistent data type
- Unified filter data type to use arrays for all filter types

When an unexpected data type is stored in the cache or returned from a filter, it could cause PHP errors or unexpected behavior. This PR prevents those issues by validating data types and ensuring consistent array handling throughout the filter data pipeline.

I considered schema validation, but I decided to not use it to avoid potential performance impacts.

Closes WOOPLUG-4189.

### How to test the changes in this Pull Request:

1. Add the Product Filters block to the Product Catalog template.
2. Smoke test the editor and the frontend to ensure there are no regression.
3. On a new page, add the Product Collection block, then add the Product Filters block inside the Product Collection block.
4. Smoke test the editor and the frontend to ensure there are no regression.
