### PR TITLE
Core API tests - update flaky refund tests

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4127-ci-core-api-tests-flaky-refund-tests
+++ b/plugins/woocommerce/changelog/wooplug-4127-ci-core-api-tests-flaky-refund-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update a test to help reduce flakiness
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/refunds/refunds.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/refunds/refunds.test.js
@@ -44,7 +44,7 @@ test.describe( 'Refunds API tests', () => {
 		);
 		const createOrderResponseJSON = await createOrderResponse.json();
 
-		//save id for deletion later
+		// save id for deletion later
 		orderId = createOrderResponseJSON.id;
 
 		// Setup the expected refund object
@@ -56,6 +56,20 @@ test.describe( 'Refunds API tests', () => {
 				},
 			],
 		};
+
+		// call API to create a refund. This is done on setup because the other tests depend on it.
+		const response = await request.post(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
+			{
+				data: expectedRefund,
+			}
+		);
+		const responseJSON = await response.json();
+		expect( response.status() ).toEqual( 201 );
+		expect( responseJSON.id ).toBeDefined();
+
+		// Save the refund ID
+		expectedRefund.id = responseJSON.id;
 	} );
 
 	test.afterAll( async ( { request } ) => {
@@ -72,20 +86,6 @@ test.describe( 'Refunds API tests', () => {
 	} );
 
 	test( 'can create a refund', async ( { request } ) => {
-		// call API to create a refund
-		const response = await request.post(
-			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
-			{
-				data: expectedRefund,
-			}
-		);
-		const responseJSON = await response.json();
-		expect( response.status() ).toEqual( 201 );
-		expect( responseJSON.id ).toBeDefined();
-
-		// Save the refund ID
-		expectedRefund.id = responseJSON.id;
-
 		// Verify that the order was refunded.
 		// call API to get the order
 		const getOrderResponse = await request.get(
@@ -121,10 +121,15 @@ test.describe( 'Refunds API tests', () => {
 		const response = await request.get( `./wp-json/wc/v3/refunds/` );
 		const responseJSON = await response.json();
 		expect( response.status() ).toEqual( 200 );
-		expect( responseJSON ).toHaveLength( 1 );
-		expect( responseJSON[ 0 ].id ).toEqual( expectedRefund.id );
-		expect( responseJSON[ 0 ].reason ).toEqual( expectedRefund.reason );
-		expect( responseJSON[ 0 ].amount ).toEqual( expectedRefund.amount );
+		// Ensure at least one refund is returned
+		expect( responseJSON.length ).toBeGreaterThan( 0 );
+		// Find the refund with the expected ID
+		const foundRefund = responseJSON.find(
+			( r ) => r.id === expectedRefund.id
+		);
+		expect( foundRefund ).toBeDefined();
+		expect( foundRefund.reason ).toEqual( expectedRefund.reason );
+		expect( foundRefund.amount ).toEqual( expectedRefund.amount );
 	} );
 
 	test( 'can list all refunds', async ( { request } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/api-tests/refunds/refunds.test.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/api-tests/refunds/refunds.test.js
@@ -1,19 +1,17 @@
 const { test, expect } = require( '../../../fixtures/api-tests-fixtures' );
 const { refund } = require( '../../../data' );
 
-test.describe( 'Refunds API tests', () => {
-	let expectedRefund;
-	let orderId;
-	let productId;
+let productId;
+let expectedRefund;
+let orderId;
 
+test.describe( 'Refunds API tests', () => {
 	test.beforeAll( async ( { request } ) => {
 		// Create a product and save its product ID
 		const product = {
 			name: 'Simple Product for Refunds API tests',
 			regular_price: '100',
 		};
-
-		// call API to create a product
 		const createProductResponse = await request.post(
 			`./wp-json/wc/v3/products`,
 			{
@@ -21,33 +19,7 @@ test.describe( 'Refunds API tests', () => {
 			}
 		);
 		const createProductResponseJSON = await createProductResponse.json();
-
-		// Save product id for testing later
 		productId = createProductResponseJSON.id;
-
-		// Create an order with a product line item, and save its Order ID
-		const order = {
-			status: 'pending',
-			line_items: [
-				{
-					product_id: productId,
-				},
-			],
-		};
-
-		// Call API to create an order (containing the previously created product id)
-		const createOrderResponse = await request.post(
-			`./wp-json/wc/v3/orders`,
-			{
-				data: order,
-			}
-		);
-		const createOrderResponseJSON = await createOrderResponse.json();
-
-		// save id for deletion later
-		orderId = createOrderResponseJSON.id;
-
-		// Setup the expected refund object
 		expectedRefund = {
 			...refund,
 			line_items: [
@@ -56,8 +28,43 @@ test.describe( 'Refunds API tests', () => {
 				},
 			],
 		};
+	} );
 
-		// call API to create a refund. This is done on setup because the other tests depend on it.
+	test.beforeEach( async ( { request } ) => {
+		const order = {
+			status: 'pending',
+			line_items: [
+				{
+					product_id: productId,
+				},
+			],
+		};
+		const createOrderResponse = await request.post(
+			`./wp-json/wc/v3/orders`,
+			{
+				data: order,
+			}
+		);
+		const createOrderResponseJSON = await createOrderResponse.json();
+		orderId = createOrderResponseJSON.id;
+	} );
+
+	test.afterEach( async ( { request } ) => {
+		await request
+			.delete( `./wp-json/wc/v3/orders/${ orderId }`, {
+				data: { force: true },
+			} )
+			.catch( () => {} );
+	} );
+
+	test.afterAll( async ( { request } ) => {
+		// Cleanup the created product
+		await request.delete( `./wp-json/wc/v3/products/${ productId }`, {
+			data: { force: true },
+		} );
+	} );
+
+	test( 'can create a refund', async ( { request } ) => {
 		const response = await request.post(
 			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
 			{
@@ -67,34 +74,14 @@ test.describe( 'Refunds API tests', () => {
 		const responseJSON = await response.json();
 		expect( response.status() ).toEqual( 201 );
 		expect( responseJSON.id ).toBeDefined();
-
-		// Save the refund ID
-		expectedRefund.id = responseJSON.id;
-	} );
-
-	test.afterAll( async ( { request } ) => {
-		// Cleanup the created product and order
-		// call API to delete the product
-		await request.delete( `./wp-json/wc/v3/products/${ productId }`, {
-			data: { force: true },
-		} );
-
-		// call API to delete the order
-		await request.delete( `./wp-json/wc/v3/orders/${ orderId }`, {
-			data: { force: true },
-		} );
-	} );
-
-	test( 'can create a refund', async ( { request } ) => {
 		// Verify that the order was refunded.
-		// call API to get the order
 		const getOrderResponse = await request.get(
 			`./wp-json/wc/v3/orders/${ orderId }`
 		);
 		const getOrderResponseJSON = await getOrderResponse.json();
 		expect( getOrderResponseJSON.refunds ).toHaveLength( 1 );
 		expect( getOrderResponseJSON.refunds[ 0 ].id ).toEqual(
-			expectedRefund.id
+			responseJSON.id
 		);
 		expect( getOrderResponseJSON.refunds[ 0 ].reason ).toEqual(
 			expectedRefund.reason
@@ -105,27 +92,39 @@ test.describe( 'Refunds API tests', () => {
 	} );
 
 	test( 'can retrieve a refund', async ( { request } ) => {
-		// call API to retrieve the refund from the order
-		const response = await request.get(
-			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ expectedRefund.id }`
+		const refundCreateResponse = await request.post(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
+			{
+				data: expectedRefund,
+			}
 		);
-		const responseJSON = await response.json();
-		expect( response.status() ).toEqual( 200 );
-		expect( responseJSON.id ).toEqual( expectedRefund.id );
+		const refundJSON = await refundCreateResponse.json();
+		const refundGetResponse = await request.get(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ refundJSON.id }`
+		);
+		const responseJSON = await refundGetResponse.json();
+		expect( refundGetResponse.status() ).toEqual( 200 );
+		expect( responseJSON.id ).toEqual( refundJSON.id );
 	} );
 
 	test( 'can retrieve refund info from refund endpoint', async ( {
 		request,
 	} ) => {
-		// call API to retrieve the refund from the order
-		const response = await request.get( `./wp-json/wc/v3/refunds/` );
-		const responseJSON = await response.json();
-		expect( response.status() ).toEqual( 200 );
-		// Ensure at least one refund is returned
+		const refundCreateResponse = await request.post(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
+			{
+				data: expectedRefund,
+			}
+		);
+		const refundJSON = await refundCreateResponse.json();
+		const refundsListResponse = await request.get(
+			`./wp-json/wc/v3/refunds/`
+		);
+		const responseJSON = await refundsListResponse.json();
+		expect( refundsListResponse.status() ).toEqual( 200 );
 		expect( responseJSON.length ).toBeGreaterThan( 0 );
-		// Find the refund with the expected ID
 		const foundRefund = responseJSON.find(
-			( r ) => r.id === expectedRefund.id
+			( r ) => r.id === refundJSON.id
 		);
 		expect( foundRefund ).toBeDefined();
 		expect( foundRefund.reason ).toEqual( expectedRefund.reason );
@@ -133,42 +132,47 @@ test.describe( 'Refunds API tests', () => {
 	} );
 
 	test( 'can list all refunds', async ( { request } ) => {
-		// call API to retrieve all the refunds
-		const response = await request.get(
+		const refundCreateResponse = await request.post(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
+			{
+				data: expectedRefund,
+			}
+		);
+		const refundJSON = await refundCreateResponse.json();
+		const refundsListResponse = await request.get(
 			`./wp-json/wc/v3/orders/${ orderId }/refunds`
 		);
-		const responseJSON = await response.json();
-		expect( response.status() ).toEqual( 200 );
+		const responseJSON = await refundsListResponse.json();
+		expect( refundsListResponse.status() ).toEqual( 200 );
 		expect( responseJSON ).toHaveLength( 1 );
-		expect( responseJSON[ 0 ].id ).toEqual( expectedRefund.id );
+		expect( responseJSON[ 0 ].id ).toEqual( refundJSON.id );
 	} );
 
 	test( 'can delete a refund', async ( { request } ) => {
-		// call API to delete the previously created refund
-		const response = await request.delete(
-			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ expectedRefund.id }`,
+		const refundCreateResponse = await request.post(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds`,
+			{
+				data: expectedRefund,
+			}
+		);
+		const refundJSON = await refundCreateResponse.json();
+		const refundDeleteResponse = await request.delete(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ refundJSON.id }`,
 			{
 				data: { force: true },
 			}
 		);
-		const responseJSON = await response.json();
-
-		expect( response.status() ).toEqual( 200 );
-		expect( responseJSON.id ).toEqual( expectedRefund.id );
-
-		// Verify that the refund cannot be retrieved
-		// call API to attempt to retrieve the refund that was previously deleted
-		const retrieveRefundResponse = await request.get(
-			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ expectedRefund.id }`
+		const responseJSON = await refundDeleteResponse.json();
+		expect( refundDeleteResponse.status() ).toEqual( 200 );
+		expect( responseJSON.id ).toEqual( refundJSON.id );
+		const refundRetrieveResponse = await request.get(
+			`./wp-json/wc/v3/orders/${ orderId }/refunds/${ refundJSON.id }`
 		);
-		expect( retrieveRefundResponse.status() ).toEqual( 404 );
-
-		// Verify that the order no longer has a refund
-		// call API to retrieve the order
-		const retrieveOrderResponse = await request.get(
+		expect( refundRetrieveResponse.status() ).toEqual( 404 );
+		const orderRetrieveResponse = await request.get(
 			`./wp-json/wc/v3/orders/${ orderId }`
 		);
-		const retrieveOrderResponseJSON = await retrieveOrderResponse.json();
+		const retrieveOrderResponseJSON = await orderRetrieveResponse.json();
 		expect( retrieveOrderResponseJSON.refunds ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cause of the flakiness is not 100% clear but I noticed that the tests are written in a way that require them to be ran in sequence, and based on the logs (https://github.com/woocommerce/woocommerce/actions/runs/14775338381/job/41482508330) it looks like they can run in parallel. So to address the issue I've tweaked the tests to run independently of one another so each test creates an order, does the refund, then cleans up after itself.

Closes #57667

### How to test the changes in this Pull Request:

N/A. CI should pass (Core API Tests).

### Testing that has already taken place:

Running CI locally, but I couldn't get them to fail.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
