### PR TITLE
Update sidewide query to allow for empty string and same value use case.

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3834-the-ajax-request-in-the-admin-interface-is-causing-the__sidewide_query
+++ b/plugins/woocommerce/changelog/wooplug-3834-the-ajax-request-in-the-admin-interface-is-causing-the__sidewide_query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Update sitewide stock query to account for empty string and values that are same as sitewide threshold.

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -251,6 +251,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 * Check to see if store is using sitewide threshold only. Meaning that it does not have any custom
 	 * stock threshold for a product.
 	 *
+	 * @param int|null $low_stock_threshold Low stock threshold.
 	 * @return bool
 	 */
 	protected function is_using_sitewide_stock_threshold_only( $low_stock_threshold = null ) {
@@ -262,11 +263,12 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			  meta_key='_low_stock_amount'
 			  AND meta_value > ''
 		";
-		$args = array();
+		$args         = array();
 		if ( $low_stock_threshold ) {
-			$query_string .= " AND meta_value != %d";
-			$args[] = $low_stock_threshold;
+			$query_string .= ' AND meta_value != %d';
+			$args[]        = $low_stock_threshold;
 		}
+		// phpcs:ignore -- not sure why phpcs complains about this line when prepare() is used here.
 		$count = $wpdb->get_var( $wpdb->prepare( $query_string, $args ) );
 		return 0 === (int) $count;
 	}

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -72,7 +72,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$status              = $request->get_param( 'status' );
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
-		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only();
+		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only( $low_stock_threshold );
 		$total_results                 = $this->get_count( $sidewide_stock_threshold_only, $status, $low_stock_threshold );
 
 		$response = rest_ensure_response( array( 'total' => $total_results ) );
@@ -191,7 +191,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$offset              = ( $page - 1 ) * $per_page;
 		$low_stock_threshold = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 
-		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only();
+		$sidewide_stock_threshold_only = $this->is_using_sitewide_stock_threshold_only( $low_stock_threshold );
 
 		$query_string = $this->get_query( $sidewide_stock_threshold_only );
 
@@ -253,9 +253,21 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 	 *
 	 * @return bool
 	 */
-	protected function is_using_sitewide_stock_threshold_only() {
+	protected function is_using_sitewide_stock_threshold_only( $low_stock_threshold = null ) {
 		global $wpdb;
-		$count = $wpdb->get_var( "select count(*) as total from {$wpdb->postmeta} where meta_key='_low_stock_amount'" );
+		$query_string = "
+			select count(*) as total
+			from {$wpdb->postmeta}
+			where 
+			  meta_key='_low_stock_amount'
+			  AND meta_value > ''
+		";
+		$args = array();
+		if ( $low_stock_threshold ) {
+			$query_string .= " AND meta_value != %d";
+			$args[] = $low_stock_threshold;
+		}
+		$count = $wpdb->get_var( $wpdb->prepare( $query_string, $args ) );
 		return 0 === (int) $count;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While working on https://github.com/woocommerce/woocommerce/pull/57852 I realized that we use the custom threshold query even when the custom threshold is an empty string or the same value as the store set threshold.
The custom query is less efficient, this will help catch those use cases.

This also came up in the original issue feedback: https://github.com/woocommerce/woocommerce/issues/57087#issuecomment-2864217395 

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Related #57087

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It's hard to test which query gets run as it is triggered to an Ajax call and "Query monitor" doesn't catch that.
If you wanted to you could add some `error_logs` in the PHP to check for certain. The test instructions below test if no errors happen.

1. Create a store finish the onboarding and create several products including variations.
2. Enable the "Enable stock management" under **WooCommerce > Settings > Products > Inventory**
3. Go to a couple of the products and update the **Quantity** ( under Inventory tab ) to below the store wide threshold ( default is 2 I believe )
4. Go to **WooCommerce > Home** and hide your task list ( if it is still displayed ) 
5. Once task list is hidden it should show a "Stock" accordion, the number should be correct with the number of products that have a stock below the store wide threshold.
6. Now go to a couple products and variations and set the **Low stock threshold** in the **Inventory** tab, to the same value as the store wide value under the **WooCommerce > Settings > Products > Inventory** settings.
7. Make sure the **Quantity** of the product is below the **Low stock threshold**
8. Go to **WooCommerce > Home** and make sure the count is correctly reflected.
9. Now go to a couple products and variations and set the **Low stock threshold** in the **Inventory** tab, to something different to that of the store wide threshold. ( you can mix/match ).
10. Make sure the **Quantity** of the product is below the **Low stock threshold**
11. Go to **WooCommerce > Home** and make sure the count is correctly reflected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
