### PR TITLE
Revert "Product Collection - Cross-sell product: fix Product Selector when the selected product is deleted"

### DIFF
--- a/plugins/woocommerce/changelog/57717-fix-wooplug-2976-product-collection-cross-sells-product-selection-error-when
+++ b/plugins/woocommerce/changelog/57717-fix-wooplug-2976-product-collection-cross-sells-product-selection-error-when
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Product Collection - Cross-sell product: fix Product Selector when the selected product is deleted.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/ProductPicker.tsx
@@ -2,13 +2,16 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
 import { Icon, info } from '@wordpress/icons';
 import ProductControl from '@woocommerce/editor-components/product-control';
 import type { SelectedOption } from '@woocommerce/block-hocs';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Placeholder,
+	// @ts-expect-error Using experimental features
 	__experimentalHStack as HStack,
+	// @ts-expect-error Using experimental features
 	__experimentalText as Text,
 } from '@wordpress/components';
 
@@ -23,6 +26,7 @@ const ProductPicker = (
 		isDeletedProductReference: boolean;
 	}
 ) => {
+	const blockProps = useBlockProps();
 	const { attributes, isDeletedProductReference } = props;
 
 	const collection = getCollectionByName( attributes.collection );
@@ -48,34 +52,36 @@ const ProductPicker = (
 		  );
 
 	return (
-		<Placeholder className="wc-blocks-product-collection__editor-product-picker">
-			<HStack alignment="center">
-				<Icon
-					icon={ info }
-					className="wc-blocks-product-collection__info-icon"
-				/>
-				<Text>{ infoText }</Text>
-			</HStack>
-			<ProductControl
-				selected={
-					attributes.query?.productReference as SelectedOption
-				}
-				onChange={ ( value = [] ) => {
-					const isValidId = ( value[ 0 ]?.id ?? null ) !== null;
-					if ( isValidId ) {
-						props.setAttributes( {
-							query: {
-								...attributes.query,
-								productReference: value[ 0 ].id,
-							},
-						} );
+		<div { ...blockProps }>
+			<Placeholder className="wc-blocks-product-collection__editor-product-picker">
+				<HStack alignment="center">
+					<Icon
+						icon={ info }
+						className="wc-blocks-product-collection__info-icon"
+					/>
+					<Text>{ infoText }</Text>
+				</HStack>
+				<ProductControl
+					selected={
+						attributes.query?.productReference as SelectedOption
 					}
-				} }
-				messages={ {
-					search: __( 'Select a product', 'woocommerce' ),
-				} }
-			/>
-		</Placeholder>
+					onChange={ ( value = [] ) => {
+						const isValidId = ( value[ 0 ]?.id ?? null ) !== null;
+						if ( isValidId ) {
+							props.setAttributes( {
+								query: {
+									...attributes.query,
+									productReference: value[ 0 ].id,
+								},
+							} );
+						}
+					} }
+					messages={ {
+						search: __( 'Select a product', 'woocommerce' ),
+					} }
+				/>
+			</Placeholder>
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -155,7 +155,7 @@ const ProductCollectionContent = ( {
 	}
 
 	return (
-		<>
+		<div { ...blockProps }>
 			{ attributes.__privatePreviewState?.isPreview &&
 				props.isSelected && (
 					<Button
@@ -176,7 +176,7 @@ const ProductCollectionContent = ( {
 			<InspectorAdvancedControls { ...props } />
 			<ToolbarControls { ...props } />
 			<div { ...innerBlocksProps } style={ style } />
-		</>
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/editor-container-block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/editor-container-block.tsx
@@ -4,13 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { debounce } from '@woocommerce/base-utils';
 import { Placeholder } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
 import { EditorContainerBlockProps } from '@woocommerce/blocks/reviews/types';
 
 /**
  * Internal dependencies
  */
 import EditorBlock from './editor-block';
-import { getSortArgs } from './utils.js';
+import { getBlockClassName, getSortArgs } from './utils.js';
 
 const EditorContainerBlock = ( {
 	attributes,
@@ -38,6 +39,10 @@ const EditorContainerBlock = ( {
 		! showReviewImage &&
 		! showProductName;
 
+	const blockProps = useBlockProps( {
+		className: getBlockClassName( attributes ),
+	} );
+
 	if ( isAllContentHidden ) {
 		return (
 			<Placeholder icon={ icon } label={ name }>
@@ -50,7 +55,7 @@ const EditorContainerBlock = ( {
 	}
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<EditorBlock
 				attributes={ attributes }
 				categoryIds={ categoryIds }
@@ -63,7 +68,7 @@ const EditorContainerBlock = ( {
 				productId={ productId }
 				reviewsToDisplay={ reviewsOnPageLoad }
 			/>
-		</>
+		</div>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	PanelBody,
@@ -32,8 +32,6 @@ const ReviewsByProductEditor = ( {
 	setAttributes,
 }: ReviewsByProductEditorProps ) => {
 	const { editMode, productId } = attributes;
-
-	const blockProps = useBlockProps();
 
 	const renderProductControlItem = ( args ) => {
 		const { item = 0 } = args;
@@ -151,7 +149,7 @@ const ReviewsByProductEditor = ( {
 	const buttonTitle = __( 'Edit selected product', 'woocommerce' );
 
 	return (
-		<div { ...blockProps }>
+		<>
 			{ getBlockControls( editMode, setAttributes, buttonTitle ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
@@ -165,7 +163,7 @@ const ReviewsByProductEditor = ( {
 				name={ __( 'Reviews by Product', 'woocommerce' ) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</div>
+		</>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
@@ -242,7 +242,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				.locator( 'visible=true' );
 			await expect( products ).toHaveCount( 9 );
 
-			const previewButtonLocator = editor.canvas.getByTestId(
+			// Check if the preview button is visible
+			const previewButtonLocator = block.getByTestId(
 				SELECTORS.previewButtonTestID
 			);
 			await expect( previewButtonLocator ).toBeVisible();
@@ -304,10 +305,10 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 					.label
 			);
 
-			const previewButtonLocator = editor.canvas.getByTestId(
+			// Check if the preview button is visible
+			const previewButtonLocator = block.getByTestId(
 				SELECTORS.previewButtonTestID
 			);
-
 			await expect( previewButtonLocator ).toBeVisible();
 
 			// Check if products are visible
@@ -374,8 +375,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 					collection.id as Collections
 				);
 
-				// Check if the preview button is visible
-				const previewButtonLocator = editor.canvas.getByTestId(
+				const block = editor.canvas.getByLabel( collection.label );
+				const previewButtonLocator = block.getByTestId(
 					SELECTORS.previewButtonTestID
 				);
 
@@ -391,7 +392,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				collection.id as Collections
 			);
 
-			const previewButtonLocator = editor.canvas.getByTestId(
+			const block = editor.canvas.getByLabel( collection.label );
+			const previewButtonLocator = block.getByTestId(
 				SELECTORS.previewButtonTestID
 			);
 
@@ -406,7 +408,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				collection.id as Collections
 			);
 
-			const previewButtonLocator = editor.canvas.getByTestId(
+			const block = editor.canvas.getByLabel( collection.label );
+			const previewButtonLocator = block.getByTestId(
 				SELECTORS.previewButtonTestID
 			);
 
@@ -562,7 +565,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 						collection.id as Collections
 					);
 
-					const previewButtonLocator = editor.canvas.getByTestId(
+					const block = editor.canvas.getByLabel( collection.label );
+					const previewButtonLocator = block.getByTestId(
 						SELECTORS.previewButtonTestID
 					);
 
@@ -600,7 +604,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				await expect( editorProductPicker ).toBeHidden();
 
 				// Check visibility of preview label
-				const previewButtonLocator = editor.canvas.getByTestId(
+				const block = editor.canvas.getByLabel( collection.label );
+				const previewButtonLocator = block.getByTestId(
 					SELECTORS.previewButtonTestID
 				);
 
@@ -615,7 +620,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 					collection.id as Collections
 				);
 
-				const previewButtonLocator = editor.canvas.getByTestId(
+				const block = editor.canvas.getByLabel( collection.label );
+				const previewButtonLocator = block.getByTestId(
 					SELECTORS.previewButtonTestID
 				);
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/editor/create-woocommerce-blocks.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/editor/create-woocommerce-blocks.spec.js
@@ -24,117 +24,27 @@ const singleProductPrice = '555.00';
 // All WooCommerce blocks except:
 // - default cart and checkout blocks, mini-cart
 // - Product Gallery (Beta) - it's not intended to be used in posts
-
-/**
- * The key of the object is the block name
- * The value is custom function to check the block
- * If the value is null, there is a default check for the block
- */
-const blocks = {
-	'All Reviews': null,
-	'Best Sellers': null,
-	'Cross-Sells': async ( canvas ) => {
-		await canvas
-			.getByRole( 'listitem' )
-			.filter( { hasText: /^Simplest Product$/ } )
-			.click();
-		await expect(
-			canvas
-				.getByRole( 'document', {
-					name: `Block: Cross-Sells`,
-					exact: true,
-				} )
-				.first()
-		).toBeVisible();
-	},
-	'Customer account': null,
-	'Featured Category': async ( canvas ) => {
-		await canvas
-			.getByRole( 'listitem' )
-			.filter( { hasText: 'simple category' } )
-			.click();
-
-		await canvas.getByRole( 'button', { name: 'Done' } ).click();
-
-		await expect(
-			canvas.getByRole( 'document', { name: `Block: Featured Category` } )
-		).toBeVisible();
-	},
-	'Featured Product': async ( canvas ) => {
-		await canvas
-			.getByRole( 'listitem' )
-			.filter( { hasText: /^Simplest Product$/ } )
-			.click();
-
-		await canvas.getByRole( 'button', { name: 'Done' } ).click();
-
-		await expect(
-			canvas.getByRole( 'document', { name: `Block: Featured Product` } )
-		).toBeVisible();
-	},
-	'Featured Products': null,
-	'Hand-Picked Products': null,
-	'New Arrivals': null,
-	'On Sale Products': null,
-	'Product Categories List': null,
-	'Product Collection': null,
-	'Product Search': null,
-	'Reviews by Category': async ( canvas ) => {
-		const block = canvas.getByRole( 'document', {
-			name: `Block: Reviews by Category`,
-		} );
-
-		await block.filter( { hasText: 'simple category' } ).click();
-		await canvas.getByRole( 'button', { name: 'Done' } ).click();
-
-		await expect( block ).toBeVisible();
-	},
-	'Reviews by Product': async ( canvas ) => {
-		await canvas
-			.locator( '.wc-block-reviews-by-product' )
-			.getByLabel( simpleProductName )
-			.click();
-		await canvas
-			.locator( '.wc-block-reviews-by-product' )
-			.getByRole( 'button', {
-				name: 'Done',
-				exact: true,
-			} )
-			.click();
-
-		// verify added blocks into page
-		await expect(
-			canvas.getByRole( 'document', {
-				name: `Block: Reviews by Product`,
-				exact: true,
-			} )
-		).toBeVisible();
-	},
-	'Single Product': async ( canvas ) => {
-		await canvas
-			.getByRole( 'listitem' )
-			.filter( { hasText: /^Simplest Product$/ } )
-			.click();
-
-		await canvas.getByRole( 'button', { name: 'Done' } ).click();
-
-		await expect(
-			canvas.getByRole( 'document', { name: `Block: Single Product` } )
-		).toBeVisible();
-	},
-	'Store Notices': null,
-	'Top Rated Products': null,
-	Upsells: async ( canvas ) => {
-		await canvas
-			.getByRole( 'listitem' )
-			.filter( { hasText: /^Simplest Product$/ } )
-			.click();
-
-		await expect(
-			canvas.getByRole( 'document', { name: `Block: Upsells` } )
-		).toBeVisible();
-	},
-};
+const blocks = [
+	'All Reviews',
+	'Best Sellers',
+	'Cross-Sells',
+	'Customer account',
+	'Featured Category',
+	'Featured Product',
+	'Featured Products',
+	'Hand-Picked Products',
+	'New Arrivals',
+	'On Sale Products',
+	'Product Categories List',
+	'Product Collection',
+	'Product Search',
+	'Reviews by Category',
+	'Reviews by Product',
+	'Single Product',
+	'Store Notices',
+	'Top Rated Products',
+	'Upsells',
+];
 
 let productId, shippingZoneId, productTagId, attributeId, productCategoryId;
 
@@ -258,23 +168,39 @@ test.describe(
 
 			const wordPressVersion = await getInstalledWordPressVersion();
 
-			for ( const [ blockName, check ] of Object.entries( blocks ) ) {
-				await test.step( `Insert ${ blockName } block`, async () => {
-					await insertBlock( page, blockName, wordPressVersion );
+			for ( let i = 0; i < blocks.length; i++ ) {
+				await test.step( `Insert ${ blocks[ i ] } block`, async () => {
+					await insertBlock( page, blocks[ i ], wordPressVersion );
 
 					const canvas = await getCanvas( page );
 
 					// eslint-disable-next-line playwright/no-conditional-in-test
-					if ( check ) {
-						await check( canvas );
-						return;
+					if ( blocks[ i ] === 'Reviews by Product' ) {
+						// Use click() instead of check().
+						// check() causes occasional flakiness:
+						//     - "Error: locator.check: Clicking the checkbox did not change its state"
+						await canvas
+							.locator( '.wc-block-reviews-by-product' )
+							.getByLabel( simpleProductName )
+							.click();
+						await canvas
+							.locator( '.wc-block-reviews-by-product' )
+							.getByRole( 'button', {
+								name: 'Done',
+								exact: true,
+							} )
+							.click();
+						// Click on the Reviews by Product block to show the Block Tools to be used later.
+						await canvas
+							.getByLabel( 'Block: Reviews by Product' )
+							.click();
 					}
 
 					// verify added blocks into page
 					await expect(
 						canvas
 							.getByRole( 'document', {
-								name: `Block: ${ blockName }`,
+								name: `Block: ${ blocks[ i ] }`,
 								exact: true,
 							} )
 							.first()
@@ -294,12 +220,12 @@ test.describe(
 			// check all blocks inside the page after publishing
 			// except the product price due to invisibility and false-positive
 			const canvas = await getCanvas( page );
-			for ( const [ blockName ] of Object.entries( blocks ) ) {
+			for ( let i = 1; i < blocks.length; i++ ) {
 				// verify added blocks into page
 				await expect(
 					canvas
 						.getByRole( 'document', {
-							name: `Block: ${ blockName }`,
+							name: `Block: ${ blocks[ i ] }`,
 							exact: true,
 						} )
 						.first()


### PR DESCRIPTION
Reverts woocommerce/woocommerce#57717. See this comment https://github.com/woocommerce/woocommerce/pull/57717#pullrequestreview-2829440987

With Code Freeze approaching, it’s better to fix this carefully rather than rushing. For this reason, I'm reverting the PR.