### PR TITLE
[Experimental] Extend Product Details block using Block Hooks API

### DIFF
--- a/plugins/woocommerce/changelog/try-extend-product-details-using-block-hooks-api
+++ b/plugins/woocommerce/changelog/try-extend-product-details-using-block-hooks-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Experimental Product Details: allow 3PDs to add custom items to the Product Details block.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -21,7 +21,7 @@ const TEMPLATE: InnerBlockTemplate[] = [
 		'woocommerce/accordion-group',
 		{
 			metadata: {
-				isProductDetailsInnerBlock: true,
+				isDescendantOfProductDetails: true,
 			},
 		},
 		[

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -19,7 +19,11 @@ import { ProductDetailsEditProps } from './types';
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
 		'woocommerce/accordion-group',
-		{},
+		{
+			metadata: {
+				isProductDetailsInnerBlock: true,
+			},
+		},
 		[
 			[
 				'woocommerce/accordion-item',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Block;
 use WP_HTML_Tag_Processor;
+use WP_Block_Supports;
 
 /**
  * BlockifiedProductDetails class.
@@ -23,6 +24,93 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 */
 	protected function get_block_type_style() {
 		return null;
+	}
+
+	/**
+	 * Initialize the block type.
+	 *
+	 * @return void
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		/**
+		 * Filter the items that are hooked into the Product Details block.
+		 *
+		 * @hook woocommerce_product_details_hooked_items
+		 *
+		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
+		 * @return {array} The items that are hooked into the Product Details block.
+		 */
+		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
+
+		$validated_hooked_items = array_filter( $hooked_items, function( $item ) {
+			return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+		} );
+
+		foreach ( $validated_hooked_items as $item ) {
+			$this->register_product_details_item( $item['title'], $item['content'] );
+		}
+	}
+
+	/**
+	 * Register a product details item using Block Hooks API.
+	 *
+	 * @param string $title The title of the item.
+	 * @param string $content The content of the item.
+	 * @return void
+	 */
+	protected function register_product_details_item($title, $content) {
+		$slug = sanitize_title( $title );
+
+		add_filter(
+			'hooked_block_types',
+			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) use ( $slug ) {
+				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
+					$hooked_block_types[] = $slug;
+				}
+				return $hooked_block_types;
+			},
+			10,
+			4
+		);
+
+		add_filter(
+			"hooked_block_{$slug}",
+			function (
+				$parsed_hooked_block,
+				$hooked_block_type,
+				$relative_position,
+				$parsed_anchor_block,
+				$context
+			) use ( $title, $content ) {
+
+				if ( is_null( $parsed_hooked_block ) ) {
+					return $parsed_hooked_block;
+				}
+
+				// TODO: Verify that the anchor Accordion Group block is a child of the Product Details block.
+				if ( 'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] || $relative_position !== 'last_child' ) {
+					return $parsed_hooked_block;
+				}
+
+				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
+				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+				<!-- /wp:woocommerce/accordion-header -->
+
+				<!-- wp:woocommerce/accordion-panel -->
+				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
+				<!-- /wp:woocommerce/accordion-panel --></div>
+				<!-- /wp:woocommerce/accordion-item -->';
+
+				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
+
+				return $accordion_item_block[0];
+			},
+			10,
+			5
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -293,7 +293,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 	private function has_accordion( $parsed_block ) {
 		if (
 			'woocommerce/accordion-group' === $parsed_block['blockName'] &&
-			! empty( $parsed_block['attrs']['metadata']['isProductDetailsInnerBlock'] )
+			! empty( $parsed_block['attrs']['metadata']['isDescendantOfProductDetails'] )
 		) {
 			return true;
 		}
@@ -348,8 +348,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 				if (
 					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
 					'last_child' !== $relative_position ||
-					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
-					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
+					empty( $parsed_anchor_block['attrs']['metadata']['isDescendantOfProductDetails'] )
 				) {
 					return array();
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -291,7 +291,10 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return bool True if the block has an accordion, false otherwise.
 	 */
 	private function has_accordion( $parsed_block ) {
-		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
+		if (
+			'woocommerce/accordion-group' === $parsed_block['blockName'] &&
+			! empty( $parsed_block['attrs']['metadata']['isProductDetailsInnerBlock'] )
+		) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -44,36 +44,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 		 */
 		$hooked_blocks = apply_filters( 'woocommerce_product_details_hooked_blocks', [] );
 
-		$logger = wc_get_logger();
-
-		$validated_hooked_blocks = array_filter(
-			$hooked_blocks,
-			function ( $block ) use ( $logger ) {
-				$invalid = ! is_array( $block ) ||
-				! isset( $block['title'] ) ||
-				! isset( $block['content'] ) ||
-				! is_string( $block['title'] ) ||
-				! is_string( $block['content'] );
-
-				$parsed_content = parse_blocks( $block['content'] );
-
-				foreach ( $parsed_content as $content_block ) {
-					if ( ! isset( $content_block['blockName'] ) ) {
-						$invalid = true;
-						break;
-					}
-				}
-
-				if ( $invalid ) {
-					$logger->error( 'Invalid hooked block data. Expected array with `title` and `content` keys with string values. Content must be valid block markup.', $block );
-					return false;
-				}
-
-				return true;
-			}
-		);
-
-		foreach ( $validated_hooked_blocks as $block ) {
+		foreach ( $this->validate_hooked_blocks( $hooked_blocks ) as $block ) {
 			$this->register_hooked_blocks( $block['title'], $block['content'] );
 		}
 	}
@@ -330,6 +301,58 @@ class BlockifiedProductDetails extends AbstractBlock {
 	}
 
 	/**
+	 * Validate hooked blocks data. Remove duplicated entries with the same title
+	 * and invalid entries with invalid content. Log errors to the WC logger.
+	 *
+	 * @param array $hooked_blocks { Hooked blocks data.
+	 *   @type string $title Title of the hooked block.
+	 *   @type string $content Content of the hooked block, as block markup.
+	 * }
+	 *
+	 * @return array Validated hooked blocks.
+	 */
+	private function validate_hooked_blocks( $hooked_blocks ) {
+		$logger                  = wc_get_logger();
+		$validated_hooked_blocks = [];
+
+		foreach ( $hooked_blocks as $block ) {
+			$invalid = ! is_array( $block ) ||
+			! isset( $block['title'] ) ||
+			! isset( $block['content'] ) ||
+			! is_string( $block['title'] ) ||
+			! is_string( $block['content'] );
+
+			$parsed_content = parse_blocks( $block['content'] );
+
+			foreach ( $parsed_content as $content_block ) {
+				if ( ! isset( $content_block['blockName'] ) ) {
+					$invalid = true;
+					break;
+				}
+			}
+
+			if ( $invalid ) {
+				$logger->error( 'Invalid hooked block data. Expected array with `title` and `content` keys with string values. Content must be valid block markup.', $block );
+				continue;
+			}
+
+			if ( array_filter(
+				$validated_hooked_blocks,
+				function ( $hooked_block ) use ( $block ) {
+					return $hooked_block['title'] === $block['title'];
+				}
+			) ) {
+				$logger->error( 'Duplicate hooked block data. Hooked block with title `' . $block['title'] . '` is already registered.', $block );
+				continue;
+			}
+
+			$validated_hooked_blocks[] = $block;
+		}
+
+		return $validated_hooked_blocks;
+	}
+
+	/**
 	 * Register a product details item using Block Hooks API.
 	 *
 	 * @param string $title The title of the item.
@@ -342,7 +365,11 @@ class BlockifiedProductDetails extends AbstractBlock {
 		add_filter(
 			'hooked_block_types',
 			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
-				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
+				if (
+					'woocommerce/accordion-group' === $anchor_block_type &&
+					'last_child' === $relative_position &&
+					! in_array( $slug, $hooked_block_types, true )
+				) {
 					$hooked_block_types[] = $slug;
 				}
 				return $hooked_block_types;
@@ -372,7 +399,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 					'last_child' !== $relative_position ||
 					empty( $parsed_anchor_block['attrs']['metadata']['isDescendantOfProductDetails'] )
 				) {
-					return array();
+					return null;
 				}
 
 				return $this->create_accordion_item_block( $title, $content );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -38,14 +38,18 @@ class BlockifiedProductDetails extends AbstractBlock {
 		 *
 		 * @hook woocommerce_product_details_hooked_items
 		 *
+		 * @since 10.0.0
 		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
 		 * @return {array} The items that are hooked into the Product Details block.
 		 */
 		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
 
-		$validated_hooked_items = array_filter( $hooked_items, function( $item ) {
-			return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
-		} );
+		$validated_hooked_items = array_filter(
+			$hooked_items,
+			function ( $item ) {
+				return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+			}
+		);
 
 		foreach ( $validated_hooked_items as $item ) {
 			$this->register_product_details_item( $item['title'], $item['content'] );
@@ -59,7 +63,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @param string $content The content of the item.
 	 * @return void
 	 */
-	protected function register_product_details_item($title, $content) {
+	protected function register_product_details_item( $title, $content ) {
 		$slug = sanitize_title( $title );
 
 		add_filter(
@@ -80,8 +84,11 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$parsed_hooked_block,
 				$hooked_block_type,
 				$relative_position,
-				$parsed_anchor_block,
-			) use ( $title, $content ) {
+				$parsed_anchor_block
+			) use (
+				$title,
+				$content
+			) {
 
 				if ( is_null( $parsed_hooked_block ) ) {
 					return $parsed_hooked_block;
@@ -89,7 +96,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 				if (
 					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
-					$relative_position !== 'last_child' ||
+					'last_child' !== $relative_position ||
 					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
 					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
 				) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -354,19 +354,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 					return array();
 				}
 
-				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
-				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-				<!-- /wp:woocommerce/accordion-header -->
-
-				<!-- wp:woocommerce/accordion-panel -->
-				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
-				<!-- /wp:woocommerce/accordion-panel --></div>
-				<!-- /wp:woocommerce/accordion-item -->';
-
-				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
-
-				return $accordion_item_block[0];
+				return $this->create_accordion_item_block( $title, $content );
 			},
 			10,
 			4

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -34,92 +34,37 @@ class BlockifiedProductDetails extends AbstractBlock {
 		parent::initialize();
 
 		/**
-		 * Filter the items that are hooked into the Product Details block.
+		 * Filter the blocks that are hooked into the Product Details block.
 		 *
-		 * @hook woocommerce_product_details_hooked_items
+		 * @hook woocommerce_product_details_hooked_blocks
 		 *
 		 * @since 10.0.0
-		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
-		 * @return {array} The items that are hooked into the Product Details block.
+		 * @param {array} $hooked_blocks The blocks that are hooked into the Product Details block.
+		 * @return {array} The blocks that are hooked into the Product Details block.
 		 */
-		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
+		$hooked_blocks = apply_filters( 'woocommerce_product_details_hooked_blocks', [] );
 
-		$validated_hooked_items = array_filter(
-			$hooked_items,
-			function ( $item ) {
-				return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+		$validated_hooked_blocks = array_filter(
+			$hooked_blocks,
+			function ( $block ) {
+				return isset( $block['title'] ) && isset( $block['content'] ) && is_string( $block['title'] ) && is_string( $block['content'] );
 			}
 		);
 
-		foreach ( $validated_hooked_items as $item ) {
-			$this->register_product_details_item( $item['title'], $item['content'] );
+		foreach ( $validated_hooked_blocks as $block ) {
+			$this->register_hooked_blocks( $block['title'], $block['content'] );
 		}
 	}
 
 	/**
-	 * Register a product details item using Block Hooks API.
+	 * Get the frontend script handle for this block type.
 	 *
-	 * @param string $title The title of the item.
-	 * @param string $content The content of the item.
-	 * @return void
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
 	 */
-	protected function register_product_details_item( $title, $content ) {
-		$slug = sanitize_title( $title );
-
-		add_filter(
-			'hooked_block_types',
-			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
-				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
-					$hooked_block_types[] = $slug;
-				}
-				return $hooked_block_types;
-			},
-			10,
-			3
-		);
-
-		add_filter(
-			"hooked_block_{$slug}",
-			function (
-				$parsed_hooked_block,
-				$hooked_block_type,
-				$relative_position,
-				$parsed_anchor_block
-			) use (
-				$title,
-				$content
-			) {
-
-				if ( is_null( $parsed_hooked_block ) ) {
-					return $parsed_hooked_block;
-				}
-
-				if (
-					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
-					'last_child' !== $relative_position ||
-					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
-					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
-				) {
-					return array();
-				}
-
-				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
-				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-				<!-- /wp:woocommerce/accordion-header -->
-
-				<!-- wp:woocommerce/accordion-panel -->
-				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
-				<!-- /wp:woocommerce/accordion-panel --></div>
-				<!-- /wp:woocommerce/accordion-item -->';
-
-				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
-
-				return $accordion_item_block[0];
-			},
-			10,
-			4
-		);
+	protected function get_block_type_script( $key = null ) {
+		return null;
 	}
 
 	/**
@@ -360,13 +305,68 @@ class BlockifiedProductDetails extends AbstractBlock {
 	}
 
 	/**
-	 * Get the frontend script handle for this block type.
+	 * Register a product details item using Block Hooks API.
 	 *
-	 * @see $this->register_block_type()
-	 * @param string $key Data to get, or default to everything.
-	 * @return array|string|null
+	 * @param string $title The title of the item.
+	 * @param string $content The content of the item.
+	 * @return void
 	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
+	private function register_hooked_blocks( $title, $content ) {
+		$slug = sanitize_title( $title );
+
+		add_filter(
+			'hooked_block_types',
+			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
+				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
+					$hooked_block_types[] = $slug;
+				}
+				return $hooked_block_types;
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			"hooked_block_{$slug}",
+			function (
+				$parsed_hooked_block,
+				$hooked_block_type,
+				$relative_position,
+				$parsed_anchor_block
+			) use (
+				$title,
+				$content
+			) {
+
+				if ( is_null( $parsed_hooked_block ) ) {
+					return $parsed_hooked_block;
+				}
+
+				if (
+					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
+					'last_child' !== $relative_position ||
+					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
+					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
+				) {
+					return array();
+				}
+
+				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
+				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+				<!-- /wp:woocommerce/accordion-header -->
+
+				<!-- wp:woocommerce/accordion-panel -->
+				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
+				<!-- /wp:woocommerce/accordion-panel --></div>
+				<!-- /wp:woocommerce/accordion-item -->';
+
+				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
+
+				return $accordion_item_block[0];
+			},
+			10,
+			4
+		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Block;
 use WP_HTML_Tag_Processor;
-use WP_Block_Supports;
 
 /**
  * BlockifiedProductDetails class.
@@ -65,14 +64,14 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 		add_filter(
 			'hooked_block_types',
-			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) use ( $slug ) {
+			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
 				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
 					$hooked_block_types[] = $slug;
 				}
 				return $hooked_block_types;
 			},
 			10,
-			4
+			3
 		);
 
 		add_filter(
@@ -82,16 +81,19 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$hooked_block_type,
 				$relative_position,
 				$parsed_anchor_block,
-				$context
 			) use ( $title, $content ) {
 
 				if ( is_null( $parsed_hooked_block ) ) {
 					return $parsed_hooked_block;
 				}
 
-				// TODO: Verify that the anchor Accordion Group block is a child of the Product Details block.
-				if ( 'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] || $relative_position !== 'last_child' ) {
-					return $parsed_hooked_block;
+				if (
+					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
+					$relative_position !== 'last_child' ||
+					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
+					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
+				) {
+					return array();
 				}
 
 				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
@@ -109,7 +111,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 				return $accordion_item_block[0];
 			},
 			10,
-			5
+			4
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -44,10 +44,32 @@ class BlockifiedProductDetails extends AbstractBlock {
 		 */
 		$hooked_blocks = apply_filters( 'woocommerce_product_details_hooked_blocks', [] );
 
+		$logger = wc_get_logger();
+
 		$validated_hooked_blocks = array_filter(
 			$hooked_blocks,
-			function ( $block ) {
-				return isset( $block['title'] ) && isset( $block['content'] ) && is_string( $block['title'] ) && is_string( $block['content'] );
+			function ( $block ) use ( $logger ) {
+				$invalid = ! is_array( $block ) ||
+				! isset( $block['title'] ) ||
+				! isset( $block['content'] ) ||
+				! is_string( $block['title'] ) ||
+				! is_string( $block['content'] );
+
+				$parsed_content = parse_blocks( $block['content'] );
+
+				foreach ( $parsed_content as $content_block ) {
+					if ( ! isset( $content_block['blockName'] ) ) {
+						$invalid = true;
+						break;
+					}
+				}
+
+				if ( $invalid ) {
+					$logger->error( 'Invalid hooked block data. Expected array with `title` and `content` keys with string values. Content must be valid block markup.', $block );
+					return false;
+				}
+
+				return true;
 			}
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -317,10 +317,10 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 		foreach ( $hooked_blocks as $block ) {
 			$invalid = ! is_array( $block ) ||
-			! isset( $block['title'] ) ||
-			! isset( $block['content'] ) ||
-			! is_string( $block['title'] ) ||
-			! is_string( $block['content'] );
+					! isset( $block['title'] ) ||
+					! isset( $block['content'] ) ||
+					! is_string( $block['title'] ) ||
+					! is_string( $block['content'] );
 
 			$parsed_content = parse_blocks( $block['content'] );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -284,10 +284,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return bool True if the block has an accordion, false otherwise.
 	 */
 	private function has_accordion( $parsed_block ) {
-		if (
-			'woocommerce/accordion-group' === $parsed_block['blockName'] &&
-			! empty( $parsed_block['attrs']['metadata']['isDescendantOfProductDetails'] )
-		) {
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -44,8 +44,8 @@ class BlockifiedProductDetails extends AbstractBlock {
 		 */
 		$hooked_blocks = apply_filters( 'woocommerce_product_details_hooked_blocks', [] );
 
-		foreach ( $this->validate_hooked_blocks( $hooked_blocks ) as $block ) {
-			$this->register_hooked_blocks( $block['title'], $block['content'] );
+		foreach ( $this->validate_hooked_blocks( $hooked_blocks ) as $slug => $block ) {
+			$this->register_hooked_block( $slug, $block );
 		}
 	}
 
@@ -336,17 +336,19 @@ class BlockifiedProductDetails extends AbstractBlock {
 				continue;
 			}
 
-			if ( array_filter(
-				$validated_hooked_blocks,
-				function ( $hooked_block ) use ( $block ) {
-					return $hooked_block['title'] === $block['title'];
-				}
-			) ) {
-				$logger->error( 'Duplicate hooked block data. Hooked block with title `' . $block['title'] . '` is already registered.', $block );
+			$slug = sanitize_title( $block['title'] );
+
+			/**
+			 * If the block is already registered, replace the block. We use the
+			 * last registered block for the same slug. This makes overriding
+			 * hooked block easier.
+			 */
+			if ( isset( $validated_hooked_blocks[ $slug ] ) ) {
+				$validated_hooked_blocks[ $slug ] = $block;
 				continue;
 			}
 
-			$validated_hooked_blocks[] = $block;
+			$validated_hooked_blocks[ $slug ] = $block;
 		}
 
 		return $validated_hooked_blocks;
@@ -355,13 +357,11 @@ class BlockifiedProductDetails extends AbstractBlock {
 	/**
 	 * Register a product details item using Block Hooks API.
 	 *
-	 * @param string $title The title of the item.
-	 * @param string $content The content of the item.
+	 * @param string $slug The slug of the item.
+	 * @param array  $block The block data.
 	 * @return void
 	 */
-	private function register_hooked_blocks( $title, $content ) {
-		$slug = sanitize_title( $title );
-
+	private function register_hooked_block( $slug, $block ) {
 		add_filter(
 			'hooked_block_types',
 			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
@@ -380,21 +380,9 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 		add_filter(
 			"hooked_block_{$slug}",
-			function (
-				$parsed_hooked_block,
-				$hooked_block_type,
-				$relative_position,
-				$parsed_anchor_block
-			) use (
-				$title,
-				$content
-			) {
-
-				if ( is_null( $parsed_hooked_block ) ) {
-					return $parsed_hooked_block;
-				}
-
+			function ( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) use ( $block ) {
 				if (
+					is_null( $parsed_hooked_block ) ||
 					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
 					'last_child' !== $relative_position ||
 					empty( $parsed_anchor_block['attrs']['metadata']['isDescendantOfProductDetails'] )
@@ -402,7 +390,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 					return null;
 				}
 
-				return $this->create_accordion_item_block( $title, $content );
+				return $this->create_accordion_item_block( $block['title'], $block['content'] );
 			},
 			10,
 			4

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -319,12 +319,14 @@ class BlockifiedProductDetails extends AbstractBlock {
 					! is_string( $block['title'] ) ||
 					! is_string( $block['content'] );
 
-			$parsed_content = parse_blocks( $block['content'] );
+			if ( ! $invalid ) {
+				$parsed_content = parse_blocks( $block['content'] );
 
-			foreach ( $parsed_content as $content_block ) {
-				if ( ! isset( $content_block['blockName'] ) ) {
-					$invalid = true;
-					break;
+				foreach ( $parsed_content as $content_block ) {
+					if ( ! isset( $content_block['blockName'] ) ) {
+						$invalid = true;
+						break;
+					}
 				}
 			}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockifiedProductDetailsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockifiedProductDetailsMock.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+
+/**
+ * BlockifiedProductDetailsMock used to test BlockifiedProductDetails block functions.
+ */
+class BlockifiedProductDetailsMock extends BlockifiedProductDetails {
+
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+
+	/**
+	 * Mock implementation of register_block_type method.
+	 *
+	 * @return void
+	 */
+	protected function register_block_type() {}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a mechanism to extend the Product Details block with additional accordions using the Block Hooks API. It allows developers to add custom accordion items to the Product Details block using the `woocommerce_product_details_hooked_items` filter. By providing a title and editor-generated block markup, developers can easily register a new product details item, which is visible not only on the front end but also in the editor.

Some design decisions:
- Using custom metadata to distinguish between Accordion blocks so that we can inject the hooked blocks into the Product Details Accordion only. The metadata is hardcoded in the Product Details inner blocks template. Themes need to ensure their Single Product template has metadata for hooked blocks to work.
   - This may sound fragile, as the user can remove the whole Accordion block in the Site Editor and then add it back, the metadata will be lost. But in that case, even if we don't use metadata, Block Hooks won't work with blocks added after the hooked blocks are registered. In other words, Block Hooks will only add blocks to the anchor blocks defined in the template at the time hooked blocks are registered, and it's a design choice. Because of that, using a custom/hardcoded metadata here is not fragile.
   - Whatever the metadata name we use here, we need to stick with it forever. I'm using `isProductDetailInnerBlock`, but open to change for more consistent, feedback is welcome :).
- Only supporting `last_child` position. It means that developers can't programmatically add an item after `Description` and before `Additional Information`, for example. It doesn't mean we can't support that, but we want to keep the hook simple and encourage changing the order of hooked blocks using the editor. The order of hooked blocks can be manipulated using filter priority, though. I'm open to changing this and supporting more positions, up for debate.
- I looked at modifying the template to inject the custom metadata like WordPress does with Block Hooks API itself, but we can not modify it **before** Block Hooks does its job, so it's not an option.

Closes [WOOPLUG-4235](https://linear.app/a8c/issue/WOOPLUG-4235/add-support-for-extending-product-details-block-with-custom-accordions)

### How to test the changes in this Pull Request:
1. Add the `Blockified Product Details` block to the `Single Product` template.
1. Create a simple plugin with the following code:
```php
<?php
/**
 * Plugin Name: WooCommerce Product Details Extension Demo
 * Description: Demonstrates how to extend the WooCommerce Product Details block via Block Hooks API.
 * Version: 1.0.0
 */
add_filter( 'woocommerce_product_details_hooked_blocks', function( $items ) {
    $items[] = [
        'title' => 'Custom Information',
        'content' => '<!-- wp:paragraph --><p>This is custom information added to the product details block using Block Hooks API!</p><!-- /wp:paragraph -->',
    ];
    $items[] = [
        'title' => 'Custom Information',
        'content' => '<!-- wp:paragraph --><p>This is the duplicated item with the same title. This will replace the former one.</p><!-- /wp:paragraph -->',
    ];
    $items[] = [
        'title' => 'Invalid Content',
        'content' => '<p>This item will be filtered out and logged as a WC error because the content is not a valid block markup.</p>',
    ];
    return $items;
});
```
2. Activate the plugin.
3. Visit a product page.
4. Verify that a new "Custom Information" accordion appears alongside the default accordions.
5. Verify that the accordion opens and closes properly when clicked.
6. Edit the `Single Product` template in the Site Editor, see the "Custom Information" accordion added with the paragraph block.
7. Verify the invalid item doesn't show up in the editor or on the front end.

### Screenshots or screen recordings:

| Editor | Frontend |
| ------ | ----- |
|  <img width="1513" alt="image" src="https://github.com/user-attachments/assets/11d32824-0201-4b2d-9937-dd87f597dd64" />  | <img width="1513" alt="image" src="https://github.com/user-attachments/assets/0aa6e6a0-9b8e-425a-8b1b-26c5e721e4f1" />  | 
