### PR TITLE
Update Product Brands template name

### DIFF
--- a/plugins/woocommerce/changelog/57904-update-product-brands-template-name
+++ b/plugins/woocommerce/changelog/57904-update-product-brands-template-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Product Brands template name from 'Taxonomy Product Brand' to 'Products by Brand'

--- a/plugins/woocommerce/includes/blocks/class-wc-brands-block-template-utils-duplicated.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-brands-block-template-utils-duplicated.php
@@ -249,6 +249,8 @@ class BlockTemplateUtilsDuplicated {
 				return __( 'Product Category', 'woocommerce' );
 			case 'taxonomy-product_tag':
 				return __( 'Product Tag', 'woocommerce' );
+			case 'taxonomy-product_brand':
+				return __( 'Products by Brand', 'woocommerce' );
 			default:
 				// Replace all hyphens and underscores with spaces.
 				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- This PR updates the template name for the `Product Brands `taxonomy from `Taxonomy Product Brand` to `Products by Brand` to improve user-friendliness and align with other WooCommerce template naming conventions.

- Currently, the Product Brands template appears as `Taxonomy Product Brand`in the block editor, while similar templates have more user-friendly names like `Products by Category` and `Products by Tag`. This inconsistency makes the interface less intuitive for users.

Closes #52748 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/363e795b-c95f-42e1-8b10-5dac525c5eab) | ![after](https://github.com/user-attachments/assets/406d2b4d-6573-4760-9a53-636cfe617c68) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you have a block theme activated (e.g., Twenty Twenty-Five)
2. Navigate to _Appearance > Editor > Templates_
3. Look for the WooCommerce Product Brands template
4. Verify that the template name now shows as `Products by Brand` instead of `Taxonomy Product Brand`
5. Confirm that the template still functions correctly when edited and viewed on the frontend

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
