### PR TITLE
Improved the Marketing > Coupons > Usage Restrictions tab to clarify fields relationship

### DIFF
--- a/plugins/woocommerce/changelog/57906-tweak-issue-31360
+++ b/plugins/woocommerce/changelog/57906-tweak-issue-31360
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improved the Marketing > Coupons > Usage Restrictions tab to clarify fields relationship

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5757,6 +5757,43 @@ img.help_tip {
 	}
 }
 
+#usage_restriction_coupon_data.woocommerce_options_panel {
+	.options_group {
+
+		border-bottom: 0px;
+
+		.hr-section.hr-section-coupon_restrictions {
+			display: flex;
+			flex-basis: 100%;
+			align-items: center;
+			font-size: 10.5px;
+			letter-spacing: 1px;
+			font-weight: 300;
+			text-transform: uppercase;
+			position: relative;
+			top: 8px;
+			padding-bottom: 10px;
+
+			&:before, &:after {
+				content: "";
+				flex-grow: 1;
+				background: #eee;
+				height: 1px;
+				font-size: 0px;
+				line-height: 0px;
+			}
+
+			&:before {
+				margin: 0 16px 0 0;
+			}
+
+			&:after {
+				margin: 0 0 0 16px;
+			}
+		}
+	}
+}
+
 #woocommerce-product-data,
 #woocommerce-coupon-data,
 .woocommerce {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5762,7 +5762,7 @@ img.help_tip {
 
 		border-bottom: 0px;
 
-		.hr-section.hr-section-coupon_restrictions {
+		.hr-section {
 			display: flex;
 			flex-basis: 100%;
 			align-items: center;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -188,7 +188,9 @@ class WC_Brands_Admin {
 			</select>
 			<?php
 				echo wc_help_tip( esc_html__( 'Product must not be associated with these brands for the coupon to remain valid or, for "Product Discounts", products associated with these brands will not be discounted.', 'woocommerce' ) );
-		?></div><?php
+		?>
+		</div>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -188,7 +188,7 @@ class WC_Brands_Admin {
 			</select>
 			<?php
 				echo wc_help_tip( esc_html__( 'Product must not be associated with these brands for the coupon to remain valid or, for "Product Discounts", products associated with these brands will not be discounted.', 'woocommerce' ) );
-		?>
+			?>
 		</div>
 		<?php
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -188,6 +188,7 @@ class WC_Brands_Admin {
 			</select>
 			<?php
 				echo wc_help_tip( esc_html__( 'Product must not be associated with these brands for the coupon to remain valid or, for "Product Discounts", products associated with these brands will not be discounted.', 'woocommerce' ) );
+		?></div><?php
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -5,7 +5,7 @@
  * Important: For internal use only by the Automattic\WooCommerce\Internal\Brands package.
  *
  * @package WooCommerce\Admin
- * @version 9.4.0
+ * @version x.x.x
  */
 
 declare( strict_types = 1);
@@ -143,6 +143,7 @@ class WC_Brands_Admin {
 		global $post;
 		// Brands.
 		?>
+		<div class="options_group"><div class="hr-section hr-section-coupon_restrictions"><?php echo esc_html__( 'And', 'woocommerce' ); ?></div>
 		<p class="form-field"><label for="product_brands"><?php esc_html_e( 'Product brands', 'woocommerce' ); ?></label>
 			<select id="product_brands" name="product_brands[]" style="width: 50%;"  class="wc-enhanced-select" multiple="multiple" data-placeholder="<?php esc_attr_e( 'Any brand', 'woocommerce' ); ?>">
 				<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -283,7 +283,6 @@ class WC_Meta_Box_Coupon_Data {
 			<?php do_action( 'woocommerce_coupon_options_usage_restriction', $coupon->get_id(), $coupon ); ?>
 			</div>
 			<div id="usage_limit_coupon_data" class="panel woocommerce_options_panel">
-				<div class="options_group"><div class="hr-section hr-section-coupon_restrictions"><?php echo esc_html__( 'And', 'woocommerce' ); ?></div>
 					<?php
 					// Usage limit per coupons.
 					woocommerce_wp_text_input(

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -283,6 +283,7 @@ class WC_Meta_Box_Coupon_Data {
 			<?php do_action( 'woocommerce_coupon_options_usage_restriction', $coupon->get_id(), $coupon ); ?>
 			</div>
 			<div id="usage_limit_coupon_data" class="panel woocommerce_options_panel">
+				<div class="options_group">
 					<?php
 					// Usage limit per coupons.
 					woocommerce_wp_text_input(

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -7,7 +7,7 @@
  * @author      WooThemes
  * @category    Admin
  * @package     WooCommerce\Admin\Meta Boxes
- * @version     2.1.0
+ * @version     x.x.x
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -182,7 +182,7 @@ class WC_Meta_Box_Coupon_Data {
 					)
 				);
 
-				echo '</div><div class="options_group">';
+				echo '</div><div class="options_group"><div class="hr-section hr-section-coupon_restrictions">' . esc_html__( 'And', 'woocommerce' ) . '</div>';
 
 				// Product ids.
 				?>
@@ -222,7 +222,7 @@ class WC_Meta_Box_Coupon_Data {
 				</p>
 				<?php
 
-				echo '</div><div class="options_group">';
+				echo '</div><div class="options_group"><div class="hr-section hr-section-coupon_restrictions">' . esc_html__( 'And', 'woocommerce' ) . '</div>';
 
 				// Categories.
 				?>
@@ -260,7 +260,7 @@ class WC_Meta_Box_Coupon_Data {
 					<?php echo wc_help_tip( __( 'Product categories that the coupon will not be applied to, or that cannot be in the cart in order for the "Fixed cart discount" to be applied.', 'woocommerce' ) ); ?>
 				</p>
 			</div>
-			<div class="options_group">
+			<div class="options_group"><div class="hr-section hr-section-coupon_restrictions"><?php echo esc_html__( 'And', 'woocommerce' ); ?></div>
 				<?php
 				// Customers.
 				woocommerce_wp_text_input(
@@ -283,7 +283,7 @@ class WC_Meta_Box_Coupon_Data {
 			<?php do_action( 'woocommerce_coupon_options_usage_restriction', $coupon->get_id(), $coupon ); ?>
 			</div>
 			<div id="usage_limit_coupon_data" class="panel woocommerce_options_panel">
-				<div class="options_group">
+				<div class="options_group"><div class="hr-section hr-section-coupon_restrictions"><?php echo esc_html__( 'And', 'woocommerce' ); ?></div>
 					<?php
 					// Usage limit per coupons.
 					woocommerce_wp_text_input(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the Marketing > Coupons > Usage Restrictions tab to clarify the relationships of the displayed fields/conditions. As mentioned in the original issue, it is not clear if these conditions have an 'and' relationship with each other, meaning that all conditions must apply at the same time for the coupon to be restricted. Some users said that they thought that they have an 'or' relationship, meaning that at least 1 of them should be true for the coupon to be restricted. 

To clarify this relationship, I have replaced the standard line separator between the conditions with a line separator that also has the word 'And'. 

**Question**: I only replaced the existing separators with new ones that have the word "And" within them. Should I add separators after each field, or will this make the UI too crowded?

Closes #31360 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![Markup on 2025-05-12 at 11:30:20](https://github.com/user-attachments/assets/78f1c7fd-aaad-4d5e-ae4d-4a066faa1b7d) | ![Markup on 2025-05-12 at 11:31:09](https://github.com/user-attachments/assets/bc1d1a0a-ce7e-4864-a47b-ecb1e84726d8) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Marketing > Coupons and click to edit a coupon or create a new one. 
2. Go to the Usage restriction tab.
3. See that the separator between sections contain the word "And".
4. Ensure that the rest of the tabs remain the same and you don't see any styling issues. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Improved the Marketing > Coupons > Usage Restrictions tab to clarify fields relationship

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
