### PR TITLE
Product Filters: fix Chips items and Show more buttons font family

### DIFF
--- a/plugins/woocommerce/changelog/fix-chip-item-font-family
+++ b/plugins/woocommerce/changelog/fix-chip-item-font-family
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Product Filters: fix Chips item font family for theme that doesn't set the font-family for generic button element.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
@@ -89,6 +89,7 @@ input[type="checkbox"].wc-block-product-filter-checkbox-list__input:checked {
 .wc-block-product-filter-checkbox-list__show-more {
 	text-decoration: underline;
 	appearance: none;
+	font-family: inherit;
 	background: transparent;
 	border: none;
 	padding: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -53,6 +53,7 @@
 .wc-block-product-filter-chips__show-more {
 	text-decoration: underline;
 	appearance: none;
+	font-family: inherit;
 	background: transparent;
 	border: none;
 	padding: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -11,6 +11,7 @@
 	background: transparent;
 	border-radius: 2px;
 	font-size: 0.875em;
+	font-family: inherit;
 	cursor: pointer;
 	color: var(--wc-product-filter-chips-text, currentColor);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the issue with the style of Chips and Checkbox List blocks that uses the incorrect font family with themes that don't set the `font-family` property for the generic `button` element. We reset the button style for Chips items and Show more button using `appearance: none;`, so the `font-family` property can fall back to the browser default. This is not a theme compatibility fix because the Chips items and Show more buttons should look good by itself.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPLUG-4244](https://linear.app/a8c/issue/WOOPLUG-4244/chips-item-block-uses-incorrect-font-family-with-certain-themes)

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1026" alt="image" src="https://github.com/user-attachments/assets/a53f7e88-fdd6-4f4d-b057-e28de766d368" />     |   <img width="1026" alt="image" src="https://github.com/user-attachments/assets/523fd006-cd27-474f-8225-12d87238b996" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Before checking out this PR, test `trunk` with [Pixl theme](https://wordpress.org/themes/pixl/).
2. Add Product Filters block to the Product Catalog template.
3. Set Attribute block display style to Chips.
4. Verify the font family of Chips items on the frontend is Arial, not `"DM Mono", sans-serif`.
5. Check out and build this PR.
6. Verify the Chips item font family is `"DM Mono", sans-serif`.