### PR TITLE
Product Filters: fix filter blocks visibility after navigation

### DIFF
--- a/plugins/woocommerce/changelog/fix-filter-blocks-visibility
+++ b/plugins/woocommerce/changelog/fix-filter-blocks-visibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Product Filters: fix filter blocks visibility after navigation
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -161,6 +161,6 @@
 }
 
 // We don't want zero specificity for this style.
-.wc-block-product-filters .hidden {
+.wc-block-product-filter--hidden {
 	display: none;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/style.scss
@@ -159,3 +159,8 @@
 		}
 	}
 }
+
+// We don't want zero specificity for this style.
+.wc-block-product-filters .hidden {
+	display: none;
+}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -35,15 +35,16 @@ final class ProductFilterActive extends AbstractBlock {
 		);
 
 		$wrapper_attributes = array(
-			'data-wp-interactive'  => 'woocommerce/product-filters',
-			'data-wp-key'          => wp_unique_prefixed_id( $this->get_full_block_name() ),
-			'data-wp-context'      => wp_json_encode(
+			'data-wp-interactive'   => 'woocommerce/product-filters',
+			'data-wp-key'           => wp_unique_prefixed_id( $this->get_full_block_name() ),
+			'data-wp-context'       => wp_json_encode(
 				array(
 					'filterType' => 'active',
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 			),
-			'data-wp-bind--hidden' => '!state.hasActiveFilters',
+			'data-wp-bind--hidden'  => '!state.hasActiveFilters',
+			'data-wp-class--hidden' => '!state.hasActiveFilters',
 		);
 
 		wp_interactivity_state(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterActive.php
@@ -35,16 +35,16 @@ final class ProductFilterActive extends AbstractBlock {
 		);
 
 		$wrapper_attributes = array(
-			'data-wp-interactive'   => 'woocommerce/product-filters',
-			'data-wp-key'           => wp_unique_prefixed_id( $this->get_full_block_name() ),
-			'data-wp-context'       => wp_json_encode(
+			'data-wp-interactive'  => 'woocommerce/product-filters',
+			'data-wp-key'          => wp_unique_prefixed_id( $this->get_full_block_name() ),
+			'data-wp-context'      => wp_json_encode(
 				array(
 					'filterType' => 'active',
 				),
 				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 			),
-			'data-wp-bind--hidden'  => '!state.hasActiveFilters',
-			'data-wp-class--hidden' => '!state.hasActiveFilters',
+			'data-wp-bind--hidden' => '!state.hasActiveFilters',
+			'data-wp-class--wc-block-product-filter--hidden' => '!state.hasActiveFilters',
 		);
 
 		wp_interactivity_state(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -228,6 +228,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		if ( empty( $filter_context['items'] ) ) {
 			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'hidden';
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -228,7 +228,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		if ( empty( $filter_context['items'] ) ) {
 			$wrapper_attributes['hidden'] = true;
-			$wrapper_attributes['class']  = 'hidden';
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -180,7 +180,7 @@ final class ProductFilterPrice extends AbstractBlock {
 
 		if ( $min_range === $max_range || ! $max_range ) {
 			$wrapper_attributes['hidden'] = true;
-			$wrapper_attributes['class']  = 'hidden';
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
 			return sprintf(
 				'<div %1$s>%2$s</div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -179,8 +179,10 @@ final class ProductFilterPrice extends AbstractBlock {
 		);
 
 		if ( $min_range === $max_range || ! $max_range ) {
+			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'hidden';
 			return sprintf(
-				'<div %1$s hidden>%2$s</div>',
+				'<div %1$s>%2$s</div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
 				array_reduce(
 					$block->parsed_block['innerBlocks'],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -159,6 +159,7 @@ final class ProductFilterRating extends AbstractBlock {
 
 		if ( empty( $filter_options ) ) {
 			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'hidden';
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -159,7 +159,7 @@ final class ProductFilterRating extends AbstractBlock {
 
 		if ( empty( $filter_options ) ) {
 			$wrapper_attributes['hidden'] = true;
-			$wrapper_attributes['class']  = 'hidden';
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -162,7 +162,7 @@ final class ProductFilterStatus extends AbstractBlock {
 
 		if ( empty( $filter_options ) ) {
 			$wrapper_attributes['hidden'] = true;
-			$wrapper_attributes['class']  = 'hidden';
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
 		}
 
 		return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -162,6 +162,7 @@ final class ProductFilterStatus extends AbstractBlock {
 
 		if ( empty( $filter_options ) ) {
 			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'hidden';
 		}
 
 		return sprintf(


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
In other filter blocks except Price, we inject the hidden attribute through the `get_block_wrapper_attributes()` function, which sets the attribute like this: `hidden="1"`. iAPI keeps this attribute so it's injected to the DOM after navigation.

The Price Filter block doesn't use the `get_block_wrapper_attributes()` function, but declares the `hidden` attribute directly, without the value (`="1"`). iAPI discards that attribute so the "empty" Price filter block is visible after navigation.

This PR fixes the issue by using the `get_block_wrapper_attributes()` function for the Price filter block as well. In addition, we add a `.hidden` class and use it for all filter blocks to better control the visibility of the filter blocks. The `hidden` attribute is still used for accessibility reasons.

Closes [WOOPLUG-4245](https://linear.app/a8c/issue/WOOPLUG-4245/price-filter-block-visibility-issue-after-navigation)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1026" alt="image" src="https://github.com/user-attachments/assets/413f6d0d-8250-4ca9-b7fa-97a154bf8be2" />      |   <img width="1026" alt="image" src="https://github.com/user-attachments/assets/a8f334be-c809-448f-86b0-78a26b9d64b5" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the Product Filters block to the Product Catalog template.
2. Enable Product Count for Attribute and Status blocks.
3. On the frontend, select a filter that has `1` as the count.
4. On `trunk`, verify the Price title is still visible.
5. On this PR, verify the Price filter block and its title are hidden.