### PR TITLE
Product Filters: clean the canonical URL before use

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filters-clean-canonical-url
+++ b/plugins/woocommerce/changelog/fix-product-filters-clean-canonical-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: clean the canonical URL before use.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -39,13 +39,6 @@ class ProductFilters extends AbstractBlock {
 		$this->asset_data_registry->add( 'isProductArchive', is_shop() || is_product_taxonomy() );
 		$this->asset_data_registry->add( 'isSiteEditor', 'site-editor.php' === $pagenow );
 		$this->asset_data_registry->add( 'isWidgetEditor', 'widgets.php' === $pagenow || 'customize.php' === $pagenow );
-
-		$canonical_url_no_pagination = get_pagenum_link( 1 );
-		if ( is_singular() ) {
-			$canonical_url_no_pagination = get_permalink();
-		}
-
-		$this->asset_data_registry->add( 'canonicalUrl', html_entity_decode( $canonical_url_no_pagination ) );
 	}
 
 	/**
@@ -61,6 +54,9 @@ class ProductFilters extends AbstractBlock {
 
 		$query_id      = $block->context['queryId'] ?? 0;
 		$filter_params = $this->get_filter_params( $query_id );
+
+		$this->asset_data_registry->add( 'canonicalUrl', $this->get_canonical_url_no_pagination( $filter_params ) );
+
 		/**
 		 * Filter hook to modify the selected filter items.
 		 *
@@ -269,5 +265,49 @@ class ProductFilters extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		return null;
+	}
+
+	/**
+	 * Get the canonical URL without pagination.
+	 *
+	 * @param array $filter_params Filter parameters.
+	 * @return string Canonical URL without pagination.
+	 */
+	private function get_canonical_url_no_pagination( $filter_params ) {
+		$canonical_url_no_pagination = is_singular() ? get_permalink() : get_pagenum_link( 1 );
+
+		$parsed_url = wp_parse_url( html_entity_decode( $canonical_url_no_pagination ) );
+
+		foreach ( array_keys( $filter_params ) as $key ) {
+			$parsed_url['query'] = remove_query_arg( $key, $parsed_url['query'] );
+		}
+
+		$url = '';
+
+		if ( isset( $parsed_url['scheme'] ) ) {
+			$url .= $parsed_url['scheme'] . '://';
+		}
+
+		if ( isset( $parsed_url['host'] ) ) {
+			$url .= $parsed_url['host'];
+		}
+
+		if ( isset( $parsed_url['port'] ) ) {
+			$url .= ':' . $parsed_url['port'];
+		}
+
+		if ( isset( $parsed_url['path'] ) ) {
+			$url .= $parsed_url['path'];
+		}
+
+		if ( ! empty( $parsed_url['query'] ) ) {
+			$url .= '?' . $parsed_url['query'];
+		}
+
+		if ( isset( $parsed_url['fragment'] ) ) {
+			$url .= '#' . $parsed_url['fragment'];
+		}
+
+		return $url;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -276,6 +276,10 @@ class ProductFilters extends AbstractBlock {
 	private function get_canonical_url_no_pagination( $filter_params ) {
 		$canonical_url_no_pagination = is_singular() ? get_permalink() : get_pagenum_link( 1 );
 
+		if ( empty( $filter_params ) ) {
+			return $canonical_url_no_pagination;
+		}
+
 		$parsed_url = wp_parse_url( html_entity_decode( $canonical_url_no_pagination ) );
 
 		foreach ( array_keys( $filter_params ) as $key ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

If shoppers open a filtered collection or refresh page with filtered collection, the canonical URL will include filtered param, causing the problem with subsequence filter operation. More on this in the testing steps below.

This PR fixes that issue by clear the filter params from the canonical URL, so the diffing logic using on the canonical URL always works as expected.

Closes [WOOPLUG-4266](https://linear.app/a8c/issue/WOOPLUG-4266/canonical-url-includes-filtered-params-causing-issues-with-subsequent)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify the bug first with `trunk`.
2. Add the `Product Filters` block to the Product Catalog template.
3. Use the default sample products to test.
4. Visit the following URL: `http://woo.test/shop/?filter_stock_status=onbackorder&filter_color=gray&query_type_color=or`, replace `http://woo.test` with your local site.
5. Clear the filter.
6. Select `Out of Stock` filter.
7. See the old param still be included in the URL.

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/08c55f25-836d-41aa-ade7-9e3f2b945476" />

8. Checkout this branch and verify step 7 doesn't occur anymore, only current selected filters are included in the URL.


<!-- End testing instructions -->
