### PR TITLE
Add support for Personalization Tags in the Button block

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-3654-personalization-tags-does-not-support-buttons
+++ b/packages/js/email-editor/changelog/wooplug-3654-personalization-tags-does-not-support-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow using Personalization Tags as button text or URL

--- a/packages/js/email-editor/src/blocks/core/block-edit.tsx
+++ b/packages/js/email-editor/src/blocks/core/block-edit.tsx
@@ -16,7 +16,7 @@ const setUrlAttribute =
 		const { setAttributes } = props;
 		const wrappedSetAttributes = useCallback(
 			( attributes: UrlAttributes ) => {
-				// Remove the `http://` prefix that is being set automaticlaly by the link control.
+				// Remove the `http://` prefix that is being set automatically by the link control.
 				if (
 					attributes?.url &&
 					attributes.url?.startsWith( 'http://[' )

--- a/packages/js/email-editor/src/blocks/core/block-edit.tsx
+++ b/packages/js/email-editor/src/blocks/core/block-edit.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { useCallback } from '@wordpress/element';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+interface UrlAttributes {
+	url?: string;
+	[ key: string ]: unknown;
+}
+
+const setUrlAttribute =
+	( BlockEdit: React.ElementType ) =>
+	( props: BlockEditProps< unknown > ) => {
+		const { setAttributes } = props;
+		const wrappedSetAttributes = useCallback(
+			( attributes: UrlAttributes ) => {
+				// Remove the `http://` prefix that is being set automaticlaly by the link control.
+				if (
+					attributes?.url &&
+					attributes.url?.startsWith( 'http://[' )
+				) {
+					attributes.url = attributes.url.replace( 'http://[', '[' );
+				}
+				setAttributes( attributes );
+			},
+			[ setAttributes ]
+		);
+		return (
+			<BlockEdit { ...props } setAttributes={ wrappedSetAttributes } />
+		);
+	};
+
+function filterSetUrlAttribute(): void {
+	addFilter(
+		'editor.BlockEdit',
+		'woocommerce-email-editor/filter-set-url-attribute',
+		setUrlAttribute
+	);
+}
+
+export { filterSetUrlAttribute };

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -64,7 +64,7 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
-	// Get the current block content
+	// Get the current block attributes
 	const blockAttributes: object = useSelect( ( select ) => {
 		const attributes =
 			// @ts-expect-error getBlockAttributes expects one argument, but TS thinks it expects none
@@ -157,7 +157,7 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 							`<!--[${ updatedTag }]-->`
 						);
 						updateBlockAttributes( selectedBlockId, {
-							content: updatedContent,
+							[ blockContentKey ]: updatedContent,
 						} );
 					} }
 				/>

--- a/packages/js/email-editor/src/blocks/core/rich-text.tsx
+++ b/packages/js/email-editor/src/blocks/core/rich-text.tsx
@@ -65,12 +65,22 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
 	// Get the current block content
-	const blockContent: string = useSelect( ( select ) => {
+	const blockAttributes: object = useSelect( ( select ) => {
 		const attributes =
 			// @ts-expect-error getBlockAttributes expects one argument, but TS thinks it expects none
 			select( 'core/block-editor' ).getBlockAttributes( selectedBlockId );
-		return attributes?.content?.originalHTML || attributes?.content || ''; // After first saving the content does not have property originalHTML, so we need to check for content as well
+
+		return attributes;
 	} );
+
+	// Some blocks, such as the Button block, store the content in `text` attribute.
+	const blockContentKey = 'text' in blockAttributes ? 'text' : 'content';
+
+	// After first saving the content does not have property originalHTML, so we need to check for content as well
+	const blockContent =
+		blockAttributes?.[ blockContentKey ]?.originalHTML ||
+		blockAttributes?.[ blockContentKey ] ||
+		'';
 
 	const handleInsert = useCallback(
 		( tag: string, linkText: string | null ) => {
@@ -113,10 +123,16 @@ function PersonalizationTagsButton( { contentRef }: Props ) {
 			}
 
 			updateBlockAttributes( selectedBlockId, {
-				content: updatedContent,
+				[ blockContentKey ]: updatedContent,
 			} );
 		},
-		[ blockContent, contentRef, selectedBlockId, updateBlockAttributes ]
+		[
+			blockContent,
+			blockContentKey,
+			contentRef,
+			selectedBlockId,
+			updateBlockAttributes,
+		]
 	);
 
 	return (

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -24,8 +24,10 @@ import { enhanceButtonBlock } from './core/button';
 import { enhanceButtonsBlock } from './core/buttons';
 import { alterSupportConfiguration } from './core/general-block-support';
 import { enhanceQuoteBlock } from './core/quote';
+import { filterSetUrlAttribute } from './core/block-edit';
 
 export function initBlocks() {
+	filterSetUrlAttribute();
 	deactivateStackOnMobile();
 	hideExpandOnClick();
 	disableImageFilter();

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -3,6 +3,8 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -24,6 +26,16 @@ const CategorySection = ( {
 	closeCallback: () => void;
 	openLinkModal: ( tag: PersonalizationTag ) => void;
 } ) => {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const selectedBlockId = useSelect( ( select ) =>
+		select( blockEditorStore ).getSelectedBlockClientId()
+	);
+	const selectedBlock = useSelect( ( select ) =>
+		// @ts-expect-error getBlock expects one argument, but TS thinks it expects none
+		select( blockEditorStore ).getBlock( selectedBlockId )
+	);
+	const canSetURL = [ 'core/button' ].includes( selectedBlock?.name );
+
 	const categoriesToRender: [ string, PersonalizationTag[] ][] =
 		activeCategory === null
 			? Object.entries( groupedTags ) // Render all categories
@@ -38,58 +50,85 @@ const CategorySection = ( {
 							{ category }
 						</div>
 						<div className="woocommerce-personalization-tags-modal-category-group">
-							{ items.map( ( item ) => (
-								<div
-									className="woocommerce-personalization-tags-modal-category-group-item"
-									key={ item.token }
-								>
-									<div className="woocommerce-personalization-tags-modal-item-text">
-										<strong>{ item.name }</strong>
-										{ item.valueToInsert }
-									</div>
+							{ items.map( ( item ) => {
+								// TODO: Improve logic for detecting URL tags.
+								const isURLTag = /\Wurl\W/.test( item.token );
+
+								return (
 									<div
-										style={ {
-											display: 'flex',
-											flexDirection: 'column',
-											alignItems: 'flex-end',
-										} }
+										className="woocommerce-personalization-tags-modal-category-group-item"
+										key={ item.token }
 									>
-										<Button
-											variant="link"
-											onClick={ () => {
-												if ( onInsert ) {
-													onInsert(
-														item.valueToInsert,
-														false
-													);
-												}
+										<div className="woocommerce-personalization-tags-modal-item-text">
+											<strong>{ item.name }</strong>
+											{ item.valueToInsert }
+										</div>
+										<div
+											style={ {
+												display: 'flex',
+												flexDirection: 'column',
+												alignItems: 'flex-end',
 											} }
 										>
-											{ __( 'Insert', 'woocommerce' ) }
-										</Button>
-										{ category ===
-											__( 'Link', 'woocommerce' ) &&
-											canInsertLink && (
-												<>
-													<Button
-														variant="link"
-														onClick={ () => {
-															closeCallback();
-															openLinkModal(
-																item
-															);
-														} }
-													>
-														{ __(
-															'Insert as link',
-															'woocommerce'
-														) }
-													</Button>
-												</>
+											<Button
+												variant="link"
+												onClick={ () => {
+													if ( onInsert ) {
+														onInsert(
+															item.valueToInsert,
+															false
+														);
+													}
+												} }
+											>
+												{ __(
+													'Insert',
+													'woocommerce'
+												) }
+											</Button>
+											{ canSetURL && isURLTag && (
+												<Button
+													variant="link"
+													onClick={ () => {
+														updateBlockAttributes(
+															selectedBlockId,
+															{
+																url: item.valueToInsert,
+															}
+														);
+														closeCallback();
+													} }
+												>
+													{ __(
+														'Set as URL',
+														'woocommerce'
+													) }
+												</Button>
 											) }
+											{ category ===
+												__( 'Link', 'woocommerce' ) &&
+												canInsertLink && (
+													<>
+														<Button
+															variant="link"
+															onClick={ () => {
+																closeCallback();
+																openLinkModal(
+																	item
+																);
+															} }
+														>
+															{ __(
+																'Insert as link',
+																'woocommerce'
+															) }
+														</Button>
+													</>
+												) }
+										</div>
 									</div>
-								</div>
-							) ) }
+								);
+							} ) }
 						</div>
 					</div>
 				)

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -50,7 +50,8 @@ const CategorySection = ( {
 						</div>
 						<div className="woocommerce-personalization-tags-modal-category-group">
 							{ items.map( ( item ) => {
-								// TODO: Improve logic for detecting URL tags.
+								// Detects if the personalization tag is expected to return a URL by checking the token name,
+								// since personalization tags lack explicit return type definitions.
 								const isURLTag = /\burl\b/.test( item.token );
 
 								return (

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -31,7 +31,6 @@ const CategorySection = ( {
 		select( blockEditorStore ).getSelectedBlockClientId()
 	);
 	const selectedBlock = useSelect( ( select ) =>
-		// @ts-expect-error getBlock expects one argument, but TS thinks it expects none
 		select( blockEditorStore ).getBlock( selectedBlockId )
 	);
 	const canSetURL = [ 'core/button' ].includes( selectedBlock?.name );

--- a/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
+++ b/packages/js/email-editor/src/components/personalization-tags/category-section.tsx
@@ -52,7 +52,7 @@ const CategorySection = ( {
 						<div className="woocommerce-personalization-tags-modal-category-group">
 							{ items.map( ( item ) => {
 								// TODO: Improve logic for detecting URL tags.
-								const isURLTag = /\Wurl\W/.test( item.token );
+								const isURLTag = /\burl\b/.test( item.token );
 
 								return (
 									<div

--- a/packages/js/email-editor/src/types/index.ts
+++ b/packages/js/email-editor/src/types/index.ts
@@ -9,7 +9,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import {
 	ActionCreatorsOf,
 	ConfigOf,
-	CurriedSelectorsOf,
 	DataRegistry,
 	StoreDescriptor as GenericStoreDescriptor,
 	UseSelectReturn,
@@ -44,11 +43,11 @@ declare module '@wordpress/data' {
 
 	type TKey = keyof StoreMap;
 	type TStore< T > = T extends keyof StoreMap ? StoreMap[ T ] : never;
-	type TSelectors< T > = CurriedSelectorsOf< TStore< T > >;
+	type TSelectors< T > = ConfigOf< TStore< T > >[ 'selectors' ];
 	type TActions< T > = ActionCreatorsOf< ConfigOf< TStore< T > > >;
 	type TSelectFunction = < T extends TKey | StoreDescriptor >(
 		store: T
-	) => T extends TKey ? TSelectors< T > : CurriedSelectorsOf< T >;
+	) => T extends TKey ? TSelectors< T > : ConfigOf< T >[ 'selectors' ];
 	type TMapSelect = (
 		select: TSelectFunction,
 		registry: DataRegistry
@@ -60,7 +59,7 @@ declare module '@wordpress/data' {
 	// fix return type for select(storeDescriptor)
 	export function select< T extends GenericStoreDescriptor< any > >(
 		store: T
-	): CurriedSelectorsOf< T >;
+	): ConfigOf< T >[ 'selectors' ];
 
 	// dispatch('store-name')
 	function dispatch< T extends string >( store: T ): TActions< T >;

--- a/packages/js/email-editor/src/types/wordpress-modules.ts
+++ b/packages/js/email-editor/src/types/wordpress-modules.ts
@@ -52,10 +52,7 @@ declare module '@wordpress/keyboard-shortcuts' {
 	export const store: { name: 'core/keyboard-shortcuts' } & StoreDescriptor< {
 		reducer: () => unknown;
 		selectors: {
-			getShortcutRepresentation: (
-				state: unknown,
-				scope: string
-			) => unknown;
+			getShortcutRepresentation: ( scope: string ) => unknown;
 		};
 		actions: {
 			registerShortcut: ( options: any ) => object;
@@ -72,7 +69,7 @@ declare module '@wordpress/preferences' {
 	export const store: { name: 'core/preferences' } & StoreDescriptor< {
 		reducer: () => unknown;
 		selectors: {
-			get: < T >( state: unknown, scope: string, name: string ) => T;
+			get: < T >( scope: string, name: string ) => T;
 		};
 	} >;
 	export const PreferenceToggleMenuItem: any;
@@ -105,7 +102,7 @@ declare module '@wordpress/notices' {
 			) => void;
 		};
 		selectors: {
-			getNotices: ( state: unknown, context?: string ) => Notice[];
+			getNotices: ( context?: string ) => Notice[];
 			removeNotice: ( id: string, context?: string ) => void;
 		};
 	} >;

--- a/packages/php/email-editor/changelog/wooplug-3654-personalization-tags-does-not-support-buttons
+++ b/packages/php/email-editor/changelog/wooplug-3654-personalization-tags-does-not-support-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Handle Personalization Tags in href attributes

--- a/packages/php/email-editor/src/Engine/class-personalizer.php
+++ b/packages/php/email-editor/src/Engine/class-personalizer.php
@@ -122,6 +122,25 @@ class Personalizer {
 					$content_processor->remove_attribute( 'data-link-href' );
 					$content_processor->remove_attribute( 'contenteditable' );
 				}
+			} elseif ( $content_processor->get_token_type() === '#tag' && $content_processor->get_tag() === 'A' ) {
+				$href = $content_processor->get_attribute( 'href' );
+
+				if ( ! $href || ! preg_match( '/\[[a-z-\/]+\]/', urldecode( $href ), $matches ) ) {
+					continue;
+				}
+
+				$token = $this->parse_token( $matches[0] );
+				$tag   = $this->tags_registry->get_by_token( $token['token'] );
+
+				if ( ! $tag ) {
+					continue;
+				}
+
+				$value = $tag->execute_callback( $this->context, $token['arguments'] );
+
+				if ( $value ) {
+					$content_processor->set_attribute( 'href', $value );
+				}
 			}
 		}
 

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -179,4 +179,54 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 			$this->personalizer->personalize_content( $html_content )
 		);
 	}
+
+	/**
+	 * Test personalizing content with a tag in href attribute.
+	 */
+	public function testPersonalizeContentWithHrefTag(): void {
+		// Register a tag in the registry.
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Store URL',
+				'woocommerce/store-url',
+				'Store',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $args parameter is not used in this test.
+					return $context['store_url'] ?? 'https://example.com';
+				}
+			)
+		);
+
+		$this->personalizer->set_context( array( 'store_url' => 'https://myshop.com' ) );
+		$html_content = '<a href="http://[woocommerce/store-url]">Click here</a>';
+		$this->assertSame( '<a href="https://myshop.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+	}
+
+	/**
+	 * Test personalizing content with a tag in href attribute with URL encoding.
+	 */
+	public function testPersonalizeContentWithEncodedHrefTag(): void {
+		// Register a tag in the registry.
+		$this->tags_registry->register(
+			new Personalization_Tag(
+				'Store URL',
+				'woocommerce/store-url',
+				'Store',
+				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $args parameter is not used in this test.
+					return $context['store_url'] ?? 'https://example.com';
+				}
+			)
+		);
+
+		$this->personalizer->set_context( array( 'store_url' => 'https://myshop.com' ) );
+		$html_content = '<a href="http://%5Bwoocommerce/store-url%5D">Click here</a>';
+		$this->assertSame( '<a href="https://myshop.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+	}
+
+	/**
+	 * Test personalizing content with a non-existent tag in href attribute.
+	 */
+	public function testPersonalizeContentWithNonExistentHrefTag(): void {
+		$html_content = '<a href="http://[woocommerce/non-existent-tag]">Click here</a>';
+		$this->assertSame( '<a href="http://[woocommerce/non-existent-tag]">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Personalizer_Test.php
@@ -191,14 +191,13 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 				'woocommerce/store-url',
 				'Store',
 				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $args parameter is not used in this test.
-					return $context['store_url'] ?? 'https://example.com';
+					return 'https://example.com';
 				}
 			)
 		);
 
-		$this->personalizer->set_context( array( 'store_url' => 'https://myshop.com' ) );
 		$html_content = '<a href="http://[woocommerce/store-url]">Click here</a>';
-		$this->assertSame( '<a href="https://myshop.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame( '<a href="https://example.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
 	}
 
 	/**
@@ -212,14 +211,13 @@ class Personalizer_Test extends \Email_Editor_Integration_Test_Case {
 				'woocommerce/store-url',
 				'Store',
 				function ( $context, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- The $args parameter is not used in this test.
-					return $context['store_url'] ?? 'https://example.com';
+					return 'https://example.com';
 				}
 			)
 		);
 
-		$this->personalizer->set_context( array( 'store_url' => 'https://myshop.com' ) );
 		$html_content = '<a href="http://%5Bwoocommerce/store-url%5D">Click here</a>';
-		$this->assertSame( '<a href="https://myshop.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
+		$this->assertSame( '<a href="https://example.com">Click here</a>', $this->personalizer->personalize_content( $html_content ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR includes the following updates:
* Resolves the issue with inserting personalization tag as a text for the Button block.
* Adds new action "Set as URL" in the Personalization Tags modal for the Button block.
* Implements a workaround to allow adding or editing personalization tags manually from the link control component without prefixing them with `http://`.
* Adds support for personalization tags in `href` attributes for `<a>` tags.

Closes [WOOPLUG-3654: Personalization Tags does not support buttons](https://linear.app/a8c/issue/WOOPLUG-3654/personalization-tags-does-not-support-buttons) .

### Screenshots or screen recordings:

| Screenshots | |
| ----- | ----- |
| ![AZOAZ002kwiDY4jB](https://github.com/user-attachments/assets/1d46e6d2-2b58-451c-9b59-8a7257b47b89) | ![Sk0k0dIMHcFHLztn](https://github.com/user-attachments/assets/d031dc80-b976-47d6-87c7-485e9016c396) |


### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**.
2. Open an email in the editor WooCommerce → Settings → **Emails**.
3. Add a Button block and open the Personalization Tags modal from the toolbar.
4. Confirm the "Insert" inserts the tag correctly as a button text.
5. Confirm the "Set as URL" action, available on URL related personalization tags, sets the URL for the button correctly.
6. Confirm editing the personalization tag manually from the link control doesn't prefix the tag with `http://`.
7. Preview the email and confirm the personalization tags used as button text or URL are replaced with the expected values.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Allow using Personalization Tags as button text or URL

</details>
