### PR TITLE
[Experimental] Use regular form in Add to Cart with Options when iAPI can't be used

### DIFF
--- a/plugins/woocommerce/changelog/fix-55699-add-to-cart-with-options-legacy-mode
+++ b/plugins/woocommerce/changelog/fix-55699-add-to-cart-with-options-legacy-mode
@@ -1,4 +1,5 @@
 Significance: patch
 Type: update
+Comment: Use regular form in Add to Cart with Options when iAPI can't be used
 
-Use regular form in Add to Cart with Options when iAPI can't be used
+

--- a/plugins/woocommerce/changelog/fix-55699-add-to-cart-with-options-legacy-mode
+++ b/plugins/woocommerce/changelog/fix-55699-add-to-cart-with-options-legacy-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use regular form in Add to Cart with Options when iAPI can't be used

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -309,7 +309,16 @@ class AddToCartWithOptions extends AbstractBlock {
 			if ( true || $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
 				// If an extension is hoooking into the form, we fall back to a regular HTML form.
 				$form_attributes = array(
-					'action'  => esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ),
+					'action'  => esc_url(
+						/**
+						 * Filter the add to cart form action.
+						 *
+						 * @since 10.0.0
+						 * @param string $permalink The product permalink.
+						 * @return string The add to cart form action.
+						 */
+						apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() )
+					),
 					'method'  => 'post',
 					'enctype' => 'multipart/form-data',
 				);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -196,20 +196,6 @@ class AddToCartWithOptions extends AbstractBlock {
 				$context['availableVariations'] = $available_variations_data;
 			}
 
-			$wrapper_attributes = get_block_wrapper_attributes(
-				array(
-					'data-wp-interactive'       => 'woocommerce/add-to-cart-with-options',
-					'data-wp-context'           => wp_json_encode(
-						$context,
-						JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-					),
-					'data-wp-on--submit'        => 'actions.handleSubmit',
-					'data-wp-class--is-invalid' => '!state.isFormValid',
-					'class'                     => $classes,
-					'style'                     => esc_attr( $classes_and_styles['styles'] ),
-				)
-			);
-
 			$hooks_before = '';
 			$hooks_after  = '';
 
@@ -307,12 +293,46 @@ class AddToCartWithOptions extends AbstractBlock {
 			$template_part_blocks = do_blocks( $template_part_contents );
 			remove_filter( 'render_block_context', array( $this, 'set_is_descendant_of_add_to_cart_with_options_context' ) );
 
+			$wrapper_attributes = array(
+				'class'               => $classes,
+				'style'               => esc_attr( $classes_and_styles['styles'] ),
+				'data-wp-interactive' => 'woocommerce/add-to-cart-with-options',
+				'data-wp-context'     => wp_json_encode(
+					$context,
+					JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+				),
+			);
+
+			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
+			$form_attributes         = '';
+			$empty_input             = '';
+			if ( true || $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
+				// If an extension is hoooking into the form, we fall back to a regular HTML form.
+				$form_attributes = array(
+					'action'  => esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ),
+					'method'  => 'post',
+					'enctype' => 'multipart/form-data',
+				);
+				if ( ProductType::SIMPLE === $product_type ) {
+					$empty_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+				} elseif ( ProductType::GROUPED === $product_type ) {
+					$empty_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+				}
+			} else {
+				// Otherwise, we use the Interactivity API.
+				$form_attributes = array(
+					'data-wp-on--submit'        => 'actions.handleSubmit',
+					'data-wp-class--is-invalid' => '!state.isFormValid',
+				);
+			}
+
 			$form_html = sprintf(
-				'<form %1$s>%2$s%3$s%4$s</form>',
-				$wrapper_attributes,
+				'<form %1$s>%2$s%3$s%4$s%5$s</form>',
+				get_block_wrapper_attributes( array_merge( $wrapper_attributes, $form_attributes ) ),
 				$hooks_before,
 				$template_part_blocks,
 				$hooks_after,
+				$empty_input
 			);
 
 			ob_start();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -305,9 +305,10 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
-			$empty_input             = '';
+			$hidden_input            = '';
 			if ( $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
-				// If an extension is hoooking into the form, we fall back to a regular HTML form.
+				// If an extension is hoooking into the form or we need to redirect to the cart,
+				// we fall back to a regular HTML form.
 				$form_attributes = array(
 					'action'  => esc_url(
 						/**
@@ -323,9 +324,9 @@ class AddToCartWithOptions extends AbstractBlock {
 					'enctype' => 'multipart/form-data',
 				);
 				if ( ProductType::SIMPLE === $product_type ) {
-					$empty_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+					$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
 				} elseif ( ProductType::GROUPED === $product_type ) {
-					$empty_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+					$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
 				}
 			} else {
 				// Otherwise, we use the Interactivity API.
@@ -341,7 +342,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				$hooks_before,
 				$template_part_blocks,
 				$hooks_after,
-				$empty_input
+				$hidden_input
 			);
 
 			ob_start();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -306,7 +306,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
 			$empty_input             = '';
-			if ( true || $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
+			if ( $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
 				// If an extension is hoooking into the form, we fall back to a regular HTML form.
 				$form_attributes = array(
 					'action'  => esc_url(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelectorItemCTA.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelectorItemCTA.php
@@ -33,7 +33,12 @@ class GroupedProductSelectorItemCTA extends AbstractBlock {
 	private function get_quantity_selector_markup( $product ) {
 		ob_start();
 
-		woocommerce_quantity_input( AddToCartWithOptionsUtils::get_quantity_input_args( $product ) );
+		woocommerce_quantity_input(
+			array_merge(
+				AddToCartWithOptionsUtils::get_quantity_input_args( $product ),
+				array( 'input_name' => 'quantity[' . $product->get_id() . ']' )
+			)
+		);
 
 		$quantity_html = ob_get_clean();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -122,7 +122,7 @@ class ProductButton extends AbstractBlock {
 		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
 		$ajax_add_to_cart_enabled = get_option( 'woocommerce_enable_ajax_add_to_cart' ) === 'yes';
 		$is_ajax_button           = $ajax_add_to_cart_enabled && ! $cart_redirect_after_add && $product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock();
-		$html_element             = $is_ajax_button ? 'button' : 'a';
+		$html_element             = $is_ajax_button || ( $is_descendent_of_add_to_cart_form && 'external' !== $product->get_type() ) ? 'button' : 'a';
 		$styles_and_classes       = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classname                = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );
 		$custom_width_classes     = isset( $attributes['width'] ) ? 'has-custom-width wp-block-button__width-' . $attributes['width'] : '';

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -215,4 +215,39 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $simple_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'data-block-name="woocommerce/add-to-cart-with-options-quantity-selector"', $markup, 'The Add to Cart with Options form contains a quantity selector block for products with manage stock set to true and stock quantity > 1.' );
 	}
+
+	/**
+	 * Tests that we render a regular HTML form when an extension hooks into the form or when cart redirect is enabled.
+	 *
+	 * @covers AddToCartWithOptions::render
+	 */
+	public function test_form_fallback() {
+		global $product;
+		$product = new \WC_Product_Simple();
+		$product->set_regular_price( 10 );
+		$product_id = $product->save();
+
+		update_option( 'woocommerce_cart_redirect_after_add', 'yes' );
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form has an action that redirects to the product page when redirect after add is enabled.' );
+		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when redirect after add is enabled.' );
+
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringNotContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form doesn\'t have an action that redirects to the product page when redirect after add is disabled.' );
+		$this->assertStringContainsString( 'data-wp-on--submit', $markup, 'The form has an on submit event when redirect after add is disabled.' );
+
+		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'action="' . $product->get_permalink() . '"', $markup, 'The form has an action that redirects to the product page when an extension hooks into the form.' );
+		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when an extension hooks into the form.' );
+
+		remove_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/55699.
Part of WOOPLUG-3215.

This PR adds the 'legacy mode'  to the blockified Add to cart with Options block, that means we fall back to a regular HTML form. That's required in two circumstances:

1. When an extension hooks into the form.
2. When the _Redirect to the cart page after successful addition_ option is set to true.

This PR implements it for simple and grouped products, variable products are still pending, and external products don't require any changes.

### How to test the changes in this Pull Request:
#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.
3. Go to _WooCommerce_ > _Settings_ > _Products_ and enable _Redirect to the cart page after successful addition_.

#### Testing the PR

#### Testing _Redirect to the cart page after successful addition_

1. In the frontend, visit the template of a simple product.
2. Add it to cart and verify you are redirected to the cart page and the product was added successfully.
3. Repeat with a grouped product.

#### Testing PHP hooks

4. Now, set _Redirect to the cart page after successful addition_ to false but add this PHP code snippet:
```PHP
add_action( 'woocommerce_before_add_to_cart_button', function() { echo 'hello world'; } );
```

5. In the frontend, visit the template of a simple product and add it to cart.
6. Verify it was added correctly to the cart (even though it caused a page refresh).
7. Repeat steps 5 and 6 with a grouped product.

#### Testing a real-life extension

8. Install Product Add-Ons.
9. Edit a simple product and add some add-ons to it.
10. In the frontend, add that product to the cart (while selecting some of the add-ons).
11. Verify the product was added correctly to cart, including the add-ons.