### PR TITLE
Fix/store api send cors headers

### DIFF
--- a/plugins/woocommerce/changelog/fix-store-api-send-cors-headers
+++ b/plugins/woocommerce/changelog/fix-store-api-send-cors-headers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes variable naming and uses all hook args to reduce duplication
+
+

--- a/plugins/woocommerce/src/StoreApi/Authentication.php
+++ b/plugins/woocommerce/src/StoreApi/Authentication.php
@@ -20,7 +20,7 @@ class Authentication {
 		add_filter( 'rest_authentication_errors', array( $this, 'check_authentication' ) );
 		add_filter( 'rest_authentication_errors', array( $this, 'opt_in_checkout_endpoint' ), 9, 1 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_logged_in_cookie' ) );
-		add_filter( 'rest_pre_serve_request', array( $this, 'send_cors_headers' ), 10, 3 );
+		add_filter( 'rest_pre_serve_request', array( $this, 'send_cors_headers' ), 10, 4 );
 		add_filter( 'rest_allowed_cors_headers', array( $this, 'allowed_cors_headers' ) );
 		add_filter( 'rest_exposed_cors_headers', array( $this, 'exposed_cors_headers' ) );
 
@@ -63,12 +63,13 @@ class Authentication {
 	 *
 	 * Users of valid Cart Tokens are also allowed access from any origin.
 	 *
-	 * @param bool             $value  Whether the request has already been served.
-	 * @param \WP_REST_Server  $server The REST server instance.
-	 * @param \WP_REST_Request $request The REST request instance.
+	 * @param bool              $served Whether the request has already been served.
+	 * @param \WP_REST_Response $result The response object.
+	 * @param \WP_REST_Request  $request The request object.
+	 * @param \WP_REST_Server   $server The REST server instance.
 	 * @return bool
 	 */
-	public function send_cors_headers( $value, $server, $request ) {
+	public function send_cors_headers( $served, $result, $request, $server ) {
 		$origin = get_http_origin();
 
 		if ( 'null' !== $origin ) {
@@ -76,7 +77,6 @@ class Authentication {
 		}
 
 		// Send standard CORS headers.
-		$server = rest_get_server();
 		$server->send_header( 'Access-Control-Allow-Methods', 'OPTIONS, GET, POST, PUT, PATCH, DELETE' );
 		$server->send_header( 'Access-Control-Allow-Credentials', 'true' );
 		$server->send_header( 'Vary', 'Origin', false );
@@ -93,7 +93,7 @@ class Authentication {
 			exit;
 		}
 
-		return $value;
+		return $served;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

@tjcafferkey noticed that the arguments passed to `send_cors_headers` were incorrectly named and not taking full advantage of passed props. https://github.com/woocommerce/woocommerce/pull/57152#discussion_r2084755489 This PR resolves this.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make a rest request to Store API `store.local/wp-json/wc/store/v1/cart`
2. Check custom headers are still set:

```
Access-Control-Allow-Methods | OPTIONS, GET, POST, PUT, PATCH, DELETE
Access-Control-Allow-Credentials | true
Vary | Origin
```

<!-- End testing instructions -->

### Testing that has already taken place:

Requests via API client.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
