### PR TITLE
Accept both wrapped and unwrapped JSON schema for additional fields

### DIFF
--- a/plugins/woocommerce/changelog/57965-fix-schema-conditional-accept-both-types
+++ b/plugins/woocommerce/changelog/57965-fix-schema-conditional-accept-both-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Accept both wrapped and unwrapped JSON for Checkout additional fields.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-fields.ts
@@ -72,10 +72,23 @@ export const useFormFields = < T extends keyof FormFields >(
 				}
 			}
 			if ( hasSchemaRules( defaultConfig, 'hidden' ) ) {
-				const schema = {
-					type: 'object',
-					properties: defaultConfig.hidden,
-				};
+				let schema = {};
+				if (
+					Object.keys( defaultConfig.hidden ).some(
+						( key ) =>
+							key === 'cart' ||
+							key === 'checkout' ||
+							key === 'customer'
+					)
+				) {
+					schema = {
+						type: 'object',
+						properties: defaultConfig.hidden,
+					};
+				} else {
+					schema = defaultConfig.hidden;
+				}
+
 				try {
 					const result = parser.validate( schema, data );
 					field.hidden = result;

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/additional-checkout-fields.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/additional-checkout-fields.php
@@ -132,20 +132,17 @@ class Additional_Checkout_Fields_Test_Helper {
 					),
 
 				),
-				'required' => array(
-					'type'       => 'object',
-					'properties' => array(
-						'cart' => array(
-							'properties' => array(
-								'totals' => array(
-									'properties' => array(
-										'totalPrice' => array(
-											'minimum' => 5900,
-										),
+				'required' => array( // Intentionally passing an unwrapped rule set.
+					'cart' => array(
+						'properties' => array(
+							'totals' => array(
+								'properties' => array(
+									'totalPrice' => array(
+										'minimum' => 5900,
 									),
 								),
-
 							),
+
 						),
 					),
 				),

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/additional-checkout-fields.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/additional-checkout-fields.php
@@ -116,12 +116,15 @@ class Additional_Checkout_Fields_Test_Helper {
 				'location' => 'order',
 				'type'     => 'checkbox',
 				'hidden'   => array(
-					'cart' => array(
-						'properties' => array(
-							'totals' => array(
-								'properties' => array(
-									'totalPrice' => array(
-										'maximum' => 4000,
+					'type'       => 'object',
+					'properties' => array(
+						'cart' => array(
+							'properties' => array(
+								'totals' => array(
+									'properties' => array(
+										'totalPrice' => array(
+											'maximum' => 4000,
+										),
 									),
 								),
 							),
@@ -130,16 +133,19 @@ class Additional_Checkout_Fields_Test_Helper {
 
 				),
 				'required' => array(
-					'cart' => array(
-						'properties' => array(
-							'totals' => array(
-								'properties' => array(
-									'totalPrice' => array(
-										'minimum' => 5900,
+					'type'       => 'object',
+					'properties' => array(
+						'cart' => array(
+							'properties' => array(
+								'totals' => array(
+									'properties' => array(
+										'totalPrice' => array(
+											'minimum' => 5900,
+										),
 									),
 								),
-							),
 
+							),
 						),
 					),
 				),

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
@@ -57,6 +57,16 @@ class Validation {
 	}
 
 	/**
+	 * Check if the schema is unwrapped (has cart, checkout, customer, as top level keys).
+	 *
+	 * @param array $schema The schema to check.
+	 * @return bool
+	 */
+	private static function schema_is_unwrapped( $schema ) {
+		return isset( $schema['cart'] ) || isset( $schema['checkout'] ) || isset( $schema['customer'] );
+	}
+
+	/**
 	 * Validate the field rules.
 	 *
 	 * @param DocumentObject $document_object The document object to validate.
@@ -64,6 +74,13 @@ class Validation {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_document_object( DocumentObject $document_object, $rules ) {
+		if ( self::schema_is_unwrapped( $rules ) ) {
+			$rules = [
+				'type'       => 'object',
+				'properties' => $rules,
+			];
+		}
+
 		try {
 			$validator = new Validator();
 			$result    = $validator->validate(
@@ -124,6 +141,13 @@ class Validation {
 
 		if ( empty( $rules ) ) {
 			return true;
+		}
+
+		if ( self::schema_is_unwrapped( $rules ) ) {
+			$rules = [
+				'type'       => 'object',
+				'properties' => $rules,
+			];
 		}
 
 		if ( empty( self::$meta_schema_json ) ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFieldsSchema/Validation.php
@@ -76,22 +76,24 @@ class Validation {
 	public static function validate_document_object( DocumentObject $document_object, $rules ) {
 		if ( self::schema_is_unwrapped( $rules ) ) {
 			$rules = [
+				'$schema'    => 'http://json-schema.org/draft-07/schema#',
 				'type'       => 'object',
 				'properties' => $rules,
 			];
+		} else {
+			if ( ! isset( $rules['$schema'] ) ) {
+				$rules['$schema'] = 'http://json-schema.org/draft-07/schema#';
+			}
+			if ( ! isset( $rules['type'] ) ) {
+				$rules['type'] = 'object';
+			}
 		}
 
 		try {
 			$validator = new Validator();
 			$result    = $validator->validate(
 				Helper::toJSON( $document_object->get_data() ),
-				Helper::toJSON(
-					[
-						'$schema'    => 'http://json-schema.org/draft-07/schema#',
-						'type'       => 'object',
-						'properties' => $rules,
-					]
-				)
+				Helper::toJSON( $rules )
 			);
 
 			if ( ! $result->hasError() ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/AdditionalFields.php
@@ -2596,7 +2596,7 @@ class AdditionalFields extends MockeryTestCase {
 								'properties' => array(
 									'country' => array(
 										'type' => 'string',
-										'enum' => 'GB',
+										'enum' => array( 'GB' ),
 									),
 								),
 							),


### PR DESCRIPTION
This PR fixes a minor issue in which we didn't accept wrapped JSON schema for `hidden` prop in additional fields, only for `required` one, meaning code examples from the docs wouldn't have worked.
Closes https://github.com/woocommerce/woocommerce/issues/58488
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following snippet somewhere:
```php

add_action(
	'woocommerce_init',
	function () {
		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'plugin-namespace/wrapped-field',
				'label'    => 'Wrapped field',
				'location' => 'address',
				'type'     => 'checkbox',
				'hidden'   => array(
					'type'       => 'object',
					'properties' => array(
						'customer' => array(
							'properties' => array(
								'address' => array(
									'properties' => array(
										'country' => array(
											'const' => 'US',
										),
									),
								),
							),
						),
					),
				),
				'required' => array(
					'type'       => 'object',
					'properties' => array(
						'customer' => array(
							'properties' => array(
								'address' => array(
									'properties' => array(
										'country' => array(
											'not' => array(
												'const' => 'US',
											),
										),
									),
								),
							),
						),
					),
				),
			),
		);

		woocommerce_register_additional_checkout_field(
			array(
				'id'       => 'plugin-namespace/unwrapped-field',
				'label'    => 'Unwrapped field',
				'location' => 'address',
				'type'     => 'checkbox',
				'hidden'   => array(
					'customer' => array(
						'properties' => array(
							'address' => array(
								'properties' => array(
									'country' => array(
										'const' => 'US',
									),
								),
							),
						),
					),

				),
				'required' => array(
					'customer' => array(
						'properties' => array(
							'address' => array(
								'properties' => array(
									'country' => array(
										'not' => array(
											'const' => 'US',
										),
									),
								),
							),
						),
					),

				),
			),
		);
	}
);

```
2. On Checkout, notice that you have 2 new checkboxes, both are required,
3. If you switch country to US, both fields should be hidden.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Accept both wrapped and unwrapped JSON for Checkout additional fields.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of additional checkout fields in WooCommerce to support both wrapped and unwrapped JSON formats, ensuring smoother checkout experiences and compatibility with various field configurations.
	- Corrected validation schema formats for checkout fields to enhance data consistency and prevent errors during checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->