### PR TITLE
[Experimental] Extend Product Details block using Block Hooks API and `create_block` util functions

### DIFF
--- a/plugins/woocommerce/changelog/try-extend-product-details-using-block-hooks-api
+++ b/plugins/woocommerce/changelog/try-extend-product-details-using-block-hooks-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Experimental Product Details: allow 3PDs to add custom items to the Product Details block.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -19,7 +19,11 @@ import { ProductDetailsEditProps } from './types';
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
 		'woocommerce/accordion-group',
-		{},
+		{
+			metadata: {
+				isProductDetailsInnerBlock: true,
+			},
+		},
 		[
 			[
 				'woocommerce/accordion-item',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionHeader.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionHeader.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\Accordion;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Blocks\Utils\BlockUtils;
 /**
  * AccordionHeader class.
  */
@@ -18,4 +19,81 @@ class AccordionHeader extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'accordion-header';
+
+	public static function create_block( $attrs ) {
+		$block_type_name = 'woocommerce/accordion-header';
+
+		$attrs = BlockUtils::filter_block_attributes( $block_type_name, $attrs );
+
+		$block = array(
+			'blockName'   => $block_type_name,
+			'attrs'       => $attrs,
+			'innerBlocks' => array(),
+		);
+
+		// TODO: Add other icons.
+		$icons = array(
+			'plus' => function ( $args = array() ) {
+				$defaults = array(
+					'width'  => 24,
+					'height' => 24,
+				);
+
+				$args = wp_parse_args( $args, $defaults );
+
+				return <<<END
+				<svg
+					width="{$args['width']}"
+					height="{$args['height']}"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+					aria-hidden="true"
+				>
+					<path
+						d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z"
+						fill="currentColor"
+					/>
+				</svg>
+				END;
+			}
+		);
+
+		$heading_classes = array( 'accordion-item__heading' );
+		// TODO: Add conditional classes based on attributes.
+
+		// Create the icon HTML
+		$icon_classes = array( 'accordion-item__toggle-icon' );
+		if ( ! empty( $attrs['icon'] ) ) {
+			$icon = $icons[$attrs['icon']];
+			if ( is_callable( $icon ) ) {
+				$icon = call_user_func( $icon, array( 'width' => '1.2em', 'height' => '1.2em' ) );
+			} else {
+				$icon = '';
+			}
+			$icon_classes[] = "has-icon-{$attrs['icon']}";
+		}
+
+		$icon_class_string = implode( ' ', $icon_classes );
+
+		// Define tag name based on level
+		$tag_name = "h{$attrs['level']}";
+
+		$block_wrapper_attributes = BlockUtils::get_block_wrapper_attributes(
+			$block,
+			array( 'class' => implode( ' ', $heading_classes ) )
+		);
+
+		$block['innerContent'] = array(
+			"<{$tag_name} {$block_wrapper_attributes}>",
+			"<button class=\"accordion-item__toggle\">",
+			"<span>{$attrs['title']}</span>",
+			"<span class=\"{$icon_class_string}\" style=\"width:1.2em;height:1.2em;\">",
+			$icon,
+			"</span>",
+			"</button>",
+			"</{$tag_name}>"
+		);
+		return $block;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionItem.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionItem.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\Accordion;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Blocks\Utils\BlockUtils;
 /**
  * AccordionItem class.
  */
@@ -75,5 +76,26 @@ class AccordionItem extends AbstractBlock {
 		}
 
 		return $content;
+	}
+
+	public static function create_block( $attrs, $inner_blocks = array() ) {
+		$block_type_name = 'woocommerce/accordion-item';
+
+		$attrs = BlockUtils::filter_block_attributes( $block_type_name, $attrs );
+
+		$block = array(
+			'blockName'   => $block_type_name,
+			'attrs'       => $attrs,
+			'innerBlocks' => $inner_blocks,
+		);
+
+		$block_wrapper_attributes = BlockUtils::get_block_wrapper_attributes( $block );
+
+		$block['innerContent'] = array_merge(
+			array( "<div $block_wrapper_attributes>" ),
+			array_fill( 0, count( $inner_blocks ), null ),
+			array( "</div>" )
+		);
+		return $block;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionPanel.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Accordion/AccordionPanel.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\Accordion;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Blocks\Utils\BlockUtils;
 /**
  * AccordionPanel class.
  */
@@ -18,4 +19,28 @@ class AccordionPanel extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'accordion-panel';
+
+	public static function create_block( $attrs, $inner_blocks = array() ) {
+		$block_type_name = 'woocommerce/accordion-panel';
+
+		$attrs = BlockUtils::filter_block_attributes( $block_type_name, $attrs );
+
+		$block = array(
+			'blockName'   => $block_type_name,
+			'attrs'       => $attrs,
+			'innerBlocks' => $inner_blocks,
+		);
+
+		$block_wrapper_attributes = BlockUtils::get_block_wrapper_attributes( $block );
+
+		$block['innerContent'] = array_merge(
+			array(
+				"<div $block_wrapper_attributes>",
+				'<div class="accordion-content__wrapper">',
+			),
+			array_fill( 0, count( $inner_blocks ), null ),
+			array( '</div>', '</div>' )
+		);
+		return $block;
+	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Block;
 use WP_HTML_Tag_Processor;
+use WP_Block_Supports;
 
 /**
  * BlockifiedProductDetails class.
@@ -23,6 +24,93 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 */
 	protected function get_block_type_style() {
 		return null;
+	}
+
+	/**
+	 * Initialize the block type.
+	 *
+	 * @return void
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		/**
+		 * Filter the items that are hooked into the Product Details block.
+		 *
+		 * @hook woocommerce_product_details_hooked_items
+		 *
+		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
+		 * @return {array} The items that are hooked into the Product Details block.
+		 */
+		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
+
+		$validated_hooked_items = array_filter( $hooked_items, function( $item ) {
+			return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+		} );
+
+		foreach ( $validated_hooked_items as $item ) {
+			$this->register_product_details_item( $item['title'], $item['content'] );
+		}
+	}
+
+	/**
+	 * Register a product details item using Block Hooks API.
+	 *
+	 * @param string $title The title of the item.
+	 * @param string $content The content of the item.
+	 * @return void
+	 */
+	protected function register_product_details_item($title, $content) {
+		$slug = sanitize_title( $title );
+
+		add_filter(
+			'hooked_block_types',
+			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) use ( $slug ) {
+				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
+					$hooked_block_types[] = $slug;
+				}
+				return $hooked_block_types;
+			},
+			10,
+			4
+		);
+
+		add_filter(
+			"hooked_block_{$slug}",
+			function (
+				$parsed_hooked_block,
+				$hooked_block_type,
+				$relative_position,
+				$parsed_anchor_block,
+				$context
+			) use ( $title, $content ) {
+
+				if ( is_null( $parsed_hooked_block ) ) {
+					return $parsed_hooked_block;
+				}
+
+				// TODO: Verify that the anchor Accordion Group block is a child of the Product Details block.
+				if ( 'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] || $relative_position !== 'last_child' ) {
+					return $parsed_hooked_block;
+				}
+
+				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
+				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+				<!-- /wp:woocommerce/accordion-header -->
+
+				<!-- wp:woocommerce/accordion-panel -->
+				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
+				<!-- /wp:woocommerce/accordion-panel --></div>
+				<!-- /wp:woocommerce/accordion-item -->';
+
+				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
+
+				return $accordion_item_block[0];
+			},
+			10,
+			5
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -34,92 +34,37 @@ class BlockifiedProductDetails extends AbstractBlock {
 		parent::initialize();
 
 		/**
-		 * Filter the items that are hooked into the Product Details block.
+		 * Filter the blocks that are hooked into the Product Details block.
 		 *
-		 * @hook woocommerce_product_details_hooked_items
+		 * @hook woocommerce_product_details_hooked_blocks
 		 *
 		 * @since 10.0.0
-		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
-		 * @return {array} The items that are hooked into the Product Details block.
+		 * @param {array} $hooked_blocks The blocks that are hooked into the Product Details block.
+		 * @return {array} The blocks that are hooked into the Product Details block.
 		 */
-		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
+		$hooked_blocks = apply_filters( 'woocommerce_product_details_hooked_blocks', [] );
 
-		$validated_hooked_items = array_filter(
-			$hooked_items,
-			function ( $item ) {
-				return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+		$validated_hooked_blocks = array_filter(
+			$hooked_blocks,
+			function ( $block ) {
+				return isset( $block['title'] ) && isset( $block['content'] ) && is_string( $block['title'] ) && is_string( $block['content'] );
 			}
 		);
 
-		foreach ( $validated_hooked_items as $item ) {
-			$this->register_product_details_item( $item['title'], $item['content'] );
+		foreach ( $validated_hooked_blocks as $block ) {
+			$this->register_hooked_blocks( $block['title'], $block['content'] );
 		}
 	}
 
 	/**
-	 * Register a product details item using Block Hooks API.
+	 * Get the frontend script handle for this block type.
 	 *
-	 * @param string $title The title of the item.
-	 * @param string $content The content of the item.
-	 * @return void
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string|null
 	 */
-	protected function register_product_details_item( $title, $content ) {
-		$slug = sanitize_title( $title );
-
-		add_filter(
-			'hooked_block_types',
-			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
-				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
-					$hooked_block_types[] = $slug;
-				}
-				return $hooked_block_types;
-			},
-			10,
-			3
-		);
-
-		add_filter(
-			"hooked_block_{$slug}",
-			function (
-				$parsed_hooked_block,
-				$hooked_block_type,
-				$relative_position,
-				$parsed_anchor_block
-			) use (
-				$title,
-				$content
-			) {
-
-				if ( is_null( $parsed_hooked_block ) ) {
-					return $parsed_hooked_block;
-				}
-
-				if (
-					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
-					'last_child' !== $relative_position ||
-					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
-					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
-				) {
-					return array();
-				}
-
-				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
-				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-				<!-- /wp:woocommerce/accordion-header -->
-
-				<!-- wp:woocommerce/accordion-panel -->
-				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
-				<!-- /wp:woocommerce/accordion-panel --></div>
-				<!-- /wp:woocommerce/accordion-item -->';
-
-				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
-
-				return $accordion_item_block[0];
-			},
-			10,
-			4
-		);
+	protected function get_block_type_script( $key = null ) {
+		return null;
 	}
 
 	/**
@@ -202,13 +147,68 @@ class BlockifiedProductDetails extends AbstractBlock {
 	}
 
 	/**
-	 * Get the frontend script handle for this block type.
+	 * Register a product details item using Block Hooks API.
 	 *
-	 * @see $this->register_block_type()
-	 * @param string $key Data to get, or default to everything.
-	 * @return array|string|null
+	 * @param string $title The title of the item.
+	 * @param string $content The content of the item.
+	 * @return void
 	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
+	private function register_hooked_blocks( $title, $content ) {
+		$slug = sanitize_title( $title );
+
+		add_filter(
+			'hooked_block_types',
+			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
+				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
+					$hooked_block_types[] = $slug;
+				}
+				return $hooked_block_types;
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			"hooked_block_{$slug}",
+			function (
+				$parsed_hooked_block,
+				$hooked_block_type,
+				$relative_position,
+				$parsed_anchor_block
+			) use (
+				$title,
+				$content
+			) {
+
+				if ( is_null( $parsed_hooked_block ) ) {
+					return $parsed_hooked_block;
+				}
+
+				if (
+					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
+					'last_child' !== $relative_position ||
+					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
+					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
+				) {
+					return array();
+				}
+
+				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
+				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+				<!-- /wp:woocommerce/accordion-header -->
+
+				<!-- wp:woocommerce/accordion-panel -->
+				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
+				<!-- /wp:woocommerce/accordion-panel --></div>
+				<!-- /wp:woocommerce/accordion-item -->';
+
+				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
+
+				return $accordion_item_block[0];
+			},
+			10,
+			4
+		);
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -77,69 +77,104 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		return $this->hide_empty_accordion_items( $content, $block );
+		$parsed_block = $block->parsed_block;
+		$parsed_block = $this->hide_empty_accordion_items( $parsed_block, $block->context );
+
+		$inner_content = array_reduce(
+			$parsed_block['innerBlocks'],
+			function ( $carry, $parsed_inner_block ) use ( $block ) {
+				$carry .= ( new \WP_Block( $parsed_inner_block, $block->context ) )->render();
+				return $carry;
+			},
+			''
+		);
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes(),
+			$inner_content
+		);
 	}
 
 	/**
 	 * Hide empty accordion items.
 	 *
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array $parsed_block Parsed block.
+	 * @param array $context Context.
 	 *
-	 * @return string Rendered block output.
+	 * @return array Parsed block.
 	 */
-	private function hide_empty_accordion_items( $content, $block ) {
-		$accordion_items = $this->find_accordion_items( $block->parsed_block );
-
-		if ( ! $accordion_items ) {
-			return $content;
+	private function hide_empty_accordion_items( $parsed_block, $context ) {
+		if ( ! $this->has_accordion( $parsed_block ) ) {
+			return $parsed_block;
 		}
 
-		$accordion_items_visibility = array_map(
-			function ( $item ) use ( $block ) {
-				$content_block          = end( $item['innerBlocks'] );
-				$rendered_content_block = ( new WP_Block( $content_block, $block->context ) )->render();
-				$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
-
-				return $p->next_tag( 'img' ) ||
-					$p->next_tag( 'iframe' ) ||
-					$p->next_tag( 'video' ) ||
-					$p->next_tag( 'meter' ) ||
-					! empty( wp_strip_all_tags( $rendered_content_block, true ) );
-			},
-			$accordion_items
-		);
-
-		$p = new WP_HTML_Tag_Processor( $content );
-
-		$counter = 0;
-		while ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-accordion-item' ) ) ) {
-			if ( ! $accordion_items_visibility[ $counter ] ) {
-				$p->set_attribute( 'style', 'display:none;' );
-				$p->set_attribute( 'hidden', true );
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
+			foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+				$parsed_block['innerBlocks'][ $key ] = $this->mark_accordion_item_hidden( $inner_block, $context );
 			}
-			++$counter;
+			$parsed_block['innerBlocks']  = array_values( array_filter( $parsed_block['innerBlocks'] ) );
+			$openning_tag                 = reset( $parsed_block['innerContent'] );
+			$closing_tag                  = end( $parsed_block['innerContent'] );
+			$parsed_block['innerContent'] = array_merge(
+				array( $openning_tag ),
+				array_fill( 0, count( $parsed_block['innerBlocks'] ), null ),
+				array( $closing_tag )
+			);
+			return $parsed_block;
 		}
 
-		return $p->get_updated_html();
+		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+			$parsed_block['innerBlocks'][ $key ] = $this->hide_empty_accordion_items( $inner_block, $context );
+		}
+
+		return $parsed_block;
 	}
 
 	/**
-	 * Find accordion items.
+	 * Mark an accordion item as hidden if it has no content.
 	 *
-	 * @param array $block Block instance.
+	 * @param array $item Item to mark.
+	 * @param array $context Context.
 	 *
-	 * @return array|false Accordion items.
+	 * @return array Item.
 	 */
-	private function find_accordion_items( $block ) {
-		if ( 'woocommerce/accordion-group' === $block['blockName'] ) {
-			return $block['innerBlocks'];
+	private function mark_accordion_item_hidden( $item, $context ) {
+		$content_block          = end( $item['innerBlocks'] );
+		$rendered_content_block = ( new WP_Block( $content_block, $context ) )->render();
+		$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
+
+		$has_content = $p->next_tag( 'img' ) ||
+			$p->next_tag( 'iframe' ) ||
+			$p->next_tag( 'video' ) ||
+			$p->next_tag( 'meter' ) ||
+			! empty( wp_strip_all_tags( $rendered_content_block, true ) );
+
+		if ( ! $has_content ) {
+			return array();
 		}
 
-		foreach ( $block['innerBlocks'] as $inner_block ) {
-			$items = $this->find_accordion_items( $inner_block );
-			if ( $items ) {
-				return $items;
+		return $item;
+	}
+
+	/**
+	 * Check if a parsed block has an accordion.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 *
+	 * @return bool True if the block has an accordion, false otherwise.
+	 */
+	private function has_accordion( $parsed_block ) {
+		if (
+			'woocommerce/accordion-group' === $parsed_block['blockName'] &&
+			! empty( $parsed_block['attrs']['metadata']['isProductDetailsInnerBlock'] )
+		) {
+			return true;
+		}
+
+		foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
+			if ( $this->has_accordion( $inner_block ) ) {
+				return true;
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -38,14 +38,18 @@ class BlockifiedProductDetails extends AbstractBlock {
 		 *
 		 * @hook woocommerce_product_details_hooked_items
 		 *
+		 * @since 10.0.0
 		 * @param {array} $hooked_items The items that are hooked into the Product Details block.
 		 * @return {array} The items that are hooked into the Product Details block.
 		 */
 		$hooked_items = apply_filters( 'woocommerce_product_details_hooked_items', [] );
 
-		$validated_hooked_items = array_filter( $hooked_items, function( $item ) {
-			return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
-		} );
+		$validated_hooked_items = array_filter(
+			$hooked_items,
+			function ( $item ) {
+				return isset( $item['title'] ) && isset( $item['content'] ) && is_string( $item['title'] ) && is_string( $item['content'] );
+			}
+		);
 
 		foreach ( $validated_hooked_items as $item ) {
 			$this->register_product_details_item( $item['title'], $item['content'] );
@@ -59,7 +63,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @param string $content The content of the item.
 	 * @return void
 	 */
-	protected function register_product_details_item($title, $content) {
+	protected function register_product_details_item( $title, $content ) {
 		$slug = sanitize_title( $title );
 
 		add_filter(
@@ -80,8 +84,11 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$parsed_hooked_block,
 				$hooked_block_type,
 				$relative_position,
-				$parsed_anchor_block,
-			) use ( $title, $content ) {
+				$parsed_anchor_block
+			) use (
+				$title,
+				$content
+			) {
 
 				if ( is_null( $parsed_hooked_block ) ) {
 					return $parsed_hooked_block;
@@ -89,7 +96,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 				if (
 					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
-					$relative_position !== 'last_child' ||
+					'last_child' !== $relative_position ||
 					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
 					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
 				) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Block;
 use WP_HTML_Tag_Processor;
-use WP_Block_Supports;
 
 /**
  * BlockifiedProductDetails class.
@@ -65,14 +64,14 @@ class BlockifiedProductDetails extends AbstractBlock {
 
 		add_filter(
 			'hooked_block_types',
-			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) use ( $slug ) {
+			function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $slug ) {
 				if ( 'woocommerce/accordion-group' === $anchor_block_type && 'last_child' === $relative_position ) {
 					$hooked_block_types[] = $slug;
 				}
 				return $hooked_block_types;
 			},
 			10,
-			4
+			3
 		);
 
 		add_filter(
@@ -82,16 +81,19 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$hooked_block_type,
 				$relative_position,
 				$parsed_anchor_block,
-				$context
 			) use ( $title, $content ) {
 
 				if ( is_null( $parsed_hooked_block ) ) {
 					return $parsed_hooked_block;
 				}
 
-				// TODO: Verify that the anchor Accordion Group block is a child of the Product Details block.
-				if ( 'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] || $relative_position !== 'last_child' ) {
-					return $parsed_hooked_block;
+				if (
+					'woocommerce/accordion-group' !== $parsed_anchor_block['blockName'] ||
+					$relative_position !== 'last_child' ||
+					! isset( $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock'] ) ||
+					! $parsed_anchor_block['attrs']['metadata']['isProductDetailsInnerBlock']
+				) {
+					return array();
 				}
 
 				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
@@ -109,7 +111,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 				return $accordion_item_block[0];
 			},
 			10,
-			5
+			4
 		);
 	}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -228,19 +228,14 @@ class BlockifiedProductDetails extends AbstractBlock {
 					return array();
 				}
 
-				$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
-				<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-				<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-				<!-- /wp:woocommerce/accordion-header -->
-
-				<!-- wp:woocommerce/accordion-panel -->
-				<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">%2$s</div></div>
-				<!-- /wp:woocommerce/accordion-panel --></div>
-				<!-- /wp:woocommerce/accordion-item -->';
-
-				$accordion_item_block = parse_blocks( sprintf( $accordion_item_template, $title, $content ) );
-
-				return $accordion_item_block[0];
+				return Accordion\AccordionItem::create_block(
+					array(), // Attributes for Accordion Item block.
+					array(
+						// Inner blocks of the Accordion Item block: Header and Panel.
+						Accordion\AccordionHeader::create_block( array( 'title' => $title ) ),
+						Accordion\AccordionPanel::create_block( array(), parse_blocks( $content ) )
+					)
+				);
 			},
 			10,
 			4

--- a/plugins/woocommerce/src/Blocks/Utils/BlockUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockUtils.php
@@ -1,0 +1,38 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+use WP_Block_Type_Registry;
+use WP_Block_Supports;
+
+/**
+ * Utility methods used for creating static WooCommerce Blocks on the server side.
+ */
+class BlockUtils {
+	public static function get_block_wrapper_attributes( $block, $extra_wrapper_attributes = array() ) {
+		$previous_block_to_render = WP_Block_Supports::$block_to_render;
+
+		WP_Block_Supports::$block_to_render = $block;
+
+		$block_wrapper_attributes = get_block_wrapper_attributes( $extra_wrapper_attributes );
+
+		WP_Block_Supports::$block_to_render = $previous_block_to_render;
+
+		return $block_wrapper_attributes;
+	}
+
+	public static function filter_block_attributes( $block_type_name, $attrs ) {
+		$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block_type_name );
+		$known_attribute_names = $block_type->get_attributes();
+
+		$known_attributes = array();
+
+		foreach ( $known_attribute_names as $attribute_name => $attribute_definition ) {
+			if ( isset( $attrs[ $attribute_name ] ) ) {
+				$known_attributes[ $attribute_name ] = $attrs[ $attribute_name ];
+			} elseif ( isset( $attribute_definition['default'] ) ) {
+				$known_attributes[ $attribute_name ] = $attribute_definition['default'];
+			}
+		}
+		return $known_attributes;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Variation of https://github.com/woocommerce/woocommerce/pull/57893. The only difference is that the additional Accordion Item block (and its contents) aren't created from block markup, but using helper functions that create the relevant Accordion Item, Accordion Header, and Accordion Panel blocks in "parsed block" format from scratch -- allowing for different values of attributes, thus providing for greater versatility and reusability. Those helpers are added as public static functions to their respective PHP classes.

Refer to https://github.com/woocommerce/woocommerce/pull/57893 for screenshots, testing instructions etc.