### PR TITLE
Product Details: `woocommerce_product_tabs` compatibility layer

### DIFF
--- a/plugins/woocommerce/changelog/try-product-details-compatibility-layer
+++ b/plugins/woocommerce/changelog/try-product-details-compatibility-layer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Experimental Product Details: add compatibility layer for woocommerce_product_tabs
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -98,27 +98,126 @@ class BlockifiedProductDetails extends AbstractBlock {
 			}
 		);
 
-		$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
-		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-		<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-		<!-- /wp:woocommerce/accordion-header -->
-
-		<!-- wp:woocommerce/accordion-panel -->
-		<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper"><!-- wp:html -->%2$s<!-- /wp:html --></div></div>
-		<!-- /wp:woocommerce/accordion-panel --></div>
-		<!-- /wp:woocommerce/accordion-item -->';
-
 		$accordion_blocks = array();
 
 		foreach ( $product_tabs as $key => $tab ) {
 			ob_start();
 			call_user_func( $tab['callback'], $key, $tab );
 			$tab_content        = ob_get_clean();
-			$tab_content_block  = parse_blocks( sprintf( $accordion_item_template, $tab['title'], $tab_content ) );
-			$accordion_blocks[] = $tab_content_block[0];
+			$accordion_blocks[] = $this->create_accordion_item_from_template(
+				$this->get_accordion_item_template( $parsed_block ),
+				$tab['title'],
+				'<!-- wp:html -->' . $tab_content . '<!-- /wp:html -->'
+			);
 		}
 
 		return $this->inject_parsed_accordion_blocks( $parsed_block, $accordion_blocks );
+	}
+
+	/**
+	 * Create an accordion item from a template.
+	 *
+	 * @param array  $template Template.
+	 * @param string $title Title.
+	 * @param string $content Content.
+	 *
+	 * @return array Accordion item.
+	 */
+	private function create_accordion_item_from_template( $template, $title, $content ) {
+		foreach ( $template['innerBlocks'] as &$block ) {
+			if ( 'woocommerce/accordion-header' === $block['blockName'] ) {
+				$block['innerContent'] = array_map(
+					function ( $inner_content ) use ( $title ) {
+						return str_replace( '{{title}}', $title, $inner_content );
+					},
+					$block['innerContent']
+				);
+			}
+			if ( 'woocommerce/accordion-panel' === $block['blockName'] ) {
+				$block['innerBlocks']  = parse_blocks( $content );
+				$openning_tag          = reset( $block['innerContent'] );
+				$closing_tag           = end( $block['innerContent'] );
+				$block['innerContent'] = array_merge(
+					array( $openning_tag ),
+					array_fill( 0, count( $block['innerBlocks'] ), null ),
+					array( $closing_tag )
+				);
+			}
+		}
+
+		return $template;
+	}
+
+	/**
+	 * Get the accordion item template.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 *
+	 * @return array Accordion item template.
+	 */
+	private function get_accordion_item_template( $parsed_block ) {
+		$current_accordion_item = $this->get_current_accordion_item( $parsed_block );
+
+		$default_template = parse_blocks(
+			'<!-- wp:woocommerce/accordion-item -->
+			<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>{{title}}</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">
+			<!-- wp:paragraph --><p>{{content}}</p><!-- /wp:paragraph -->
+			</div></div>
+			<!-- /wp:woocommerce/accordion-panel --></div>
+			<!-- /wp:woocommerce/accordion-item -->'
+		)[0];
+
+		if ( ! $current_accordion_item ) {
+			return $default_template;
+		}
+
+		foreach ( $current_accordion_item['innerBlocks'] as &$inner_block ) {
+			if ( 'woocommerce/accordion-header' === $inner_block['blockName'] ) {
+				$inner_block['innerContent'] = array_map(
+					function ( $inner_content ) {
+						return preg_replace( '/<span>.*?<\/span>/', '<span>{{title}}</span>', $inner_content );
+					},
+					$inner_block['innerContent']
+				);
+			}
+			/**
+			 * If the accordion panel is empty, the innerContent will be a single string item with
+			 * both opening and closing tags. We need to replace it with the default template for
+			 * create_accordion_item_from_template.
+			 */
+			if ( 'woocommerce/accordion-panel' === $inner_block['blockName'] && empty( $inner_block['innerBlocks'] ) ) {
+				$inner_block['innerContent'] = $default_template['innerBlocks'][1]['innerContent'];
+			}
+		}
+
+		return $current_accordion_item;
+	}
+
+	/**
+	 * Get the current accordion item.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 *
+	 * @return array Current accordion item.
+	 */
+	private function get_current_accordion_item( $parsed_block ) {
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] && ! empty( $parsed_block['innerBlocks'] ) ) {
+			return end( $parsed_block['innerBlocks'] );
+		}
+
+		foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
+			$current_accordion_item = $this->get_current_accordion_item( $inner_block );
+			if ( $current_accordion_item ) {
+				return $current_accordion_item;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -104,8 +104,7 @@ class BlockifiedProductDetails extends AbstractBlock {
 			ob_start();
 			call_user_func( $tab['callback'], $key, $tab );
 			$tab_content        = ob_get_clean();
-			$accordion_blocks[] = $this->create_accordion_item_from_template(
-				$this->get_accordion_item_template( $parsed_block ),
+			$accordion_blocks[] = $this->create_accordion_item_block(
 				$tab['title'],
 				'<!-- wp:html -->' . $tab_content . '<!-- /wp:html -->'
 			);
@@ -115,15 +114,28 @@ class BlockifiedProductDetails extends AbstractBlock {
 	}
 
 	/**
-	 * Create an accordion item from a template.
+	 * Create an accordion item block.
 	 *
-	 * @param array  $template Template.
-	 * @param string $title Title.
-	 * @param string $content Content.
+	 * @param string $title Title of the accordion item.
+	 * @param string $content Content of the accordion item as block markup.
 	 *
 	 * @return array Accordion item.
 	 */
-	private function create_accordion_item_from_template( $template, $title, $content ) {
+	private function create_accordion_item_block( $title, $content ) {
+		$template = parse_blocks(
+			'<!-- wp:woocommerce/accordion-item -->
+			<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>{{title}}</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">
+			<!-- wp:paragraph --><p>{{content}}</p><!-- /wp:paragraph -->
+			</div></div>
+			<!-- /wp:woocommerce/accordion-panel --></div>
+			<!-- /wp:woocommerce/accordion-item -->'
+		)[0];
+
 		foreach ( $template['innerBlocks'] as &$block ) {
 			if ( 'woocommerce/accordion-header' === $block['blockName'] ) {
 				$block['innerContent'] = array_map(
@@ -146,78 +158,6 @@ class BlockifiedProductDetails extends AbstractBlock {
 		}
 
 		return $template;
-	}
-
-	/**
-	 * Get the accordion item template.
-	 *
-	 * @param array $parsed_block Parsed block.
-	 *
-	 * @return array Accordion item template.
-	 */
-	private function get_accordion_item_template( $parsed_block ) {
-		$current_accordion_item = $this->get_current_accordion_item( $parsed_block );
-
-		$default_template = parse_blocks(
-			'<!-- wp:woocommerce/accordion-item -->
-			<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>{{title}}</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
-			<!-- /wp:woocommerce/accordion-header -->
-
-			<!-- wp:woocommerce/accordion-panel -->
-			<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">
-			<!-- wp:paragraph --><p>{{content}}</p><!-- /wp:paragraph -->
-			</div></div>
-			<!-- /wp:woocommerce/accordion-panel --></div>
-			<!-- /wp:woocommerce/accordion-item -->'
-		)[0];
-
-		if ( ! $current_accordion_item ) {
-			return $default_template;
-		}
-
-		foreach ( $current_accordion_item['innerBlocks'] as &$inner_block ) {
-			if ( 'woocommerce/accordion-header' === $inner_block['blockName'] ) {
-				$inner_block['innerContent'] = array_map(
-					function ( $inner_content ) {
-						return preg_replace( '/<span>.*?<\/span>/', '<span>{{title}}</span>', $inner_content );
-					},
-					$inner_block['innerContent']
-				);
-			}
-			/**
-			 * If the accordion panel is empty, the innerContent will be a single string item with
-			 * both opening and closing tags. We need to replace it with the default template for
-			 * create_accordion_item_from_template.
-			 */
-			if ( 'woocommerce/accordion-panel' === $inner_block['blockName'] && empty( $inner_block['innerBlocks'] ) ) {
-				$inner_block['innerContent'] = $default_template['innerBlocks'][1]['innerContent'];
-			}
-		}
-
-		return $current_accordion_item;
-	}
-
-	/**
-	 * Get the current accordion item.
-	 *
-	 * @param array $parsed_block Parsed block.
-	 *
-	 * @return array Current accordion item.
-	 */
-	private function get_current_accordion_item( $parsed_block ) {
-		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] && ! empty( $parsed_block['innerBlocks'] ) ) {
-			return end( $parsed_block['innerBlocks'] );
-		}
-
-		foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
-			$current_accordion_item = $this->get_current_accordion_item( $inner_block );
-			if ( $current_accordion_item ) {
-				return $current_accordion_item;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -35,69 +35,197 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		return $this->hide_empty_accordion_items( $content, $block );
+		$parsed_block = $block->parsed_block;
+		$parsed_block = $this->hide_empty_accordion_items( $parsed_block, $block->context );
+		$parsed_block = $this->inject_compatible_tabs( $parsed_block );
+
+		$inner_content = array_reduce(
+			$parsed_block['innerBlocks'],
+			function ( $carry, $parsed_inner_block ) use ( $block ) {
+				$carry .= ( new \WP_Block( $parsed_inner_block, $block->context ) )->render();
+				return $carry;
+			},
+			''
+		);
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes(),
+			$inner_content
+		);
+	}
+
+	/**
+	 * Inject compatible tabs.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 *
+	 * @return array Parsed block.
+	 */
+	private function inject_compatible_tabs( $parsed_block ) {
+		if ( ! $this->has_accordion( $parsed_block ) ) {
+			return $parsed_block;
+		}
+
+		/**
+		 * Filter the product tabs in the product details block.
+		 *
+		 * @since 3.3.0
+		 * @param array $tabs Array of product tabs.
+		 */
+		$product_tabs = apply_filters(
+			'woocommerce_product_tabs',
+			array()
+		);
+
+		$default_tabs_callbacks = array(
+			'woocommerce_product_description_tab',
+			'woocommerce_product_additional_information_tab',
+			'comments_template',
+		);
+
+		$product_tabs = array_filter(
+			$product_tabs,
+			function ( $tab ) use ( $default_tabs_callbacks ) {
+				return ! in_array( $tab['callback'], $default_tabs_callbacks, true );
+			}
+		);
+
+		usort(
+			$product_tabs,
+			function ( $a, $b ) {
+				return $a['priority'] <=> $b['priority'];
+			}
+		);
+
+		$accordion_item_template = '<!-- wp:woocommerce/accordion-item -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+		<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>%1$s</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+		<!-- /wp:woocommerce/accordion-header -->
+
+		<!-- wp:woocommerce/accordion-panel -->
+		<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper"><!-- wp:html -->%2$s<!-- /wp:html --></div></div>
+		<!-- /wp:woocommerce/accordion-panel --></div>
+		<!-- /wp:woocommerce/accordion-item -->';
+
+		$accordion_blocks = array();
+
+		foreach ( $product_tabs as $key => $tab ) {
+			ob_start();
+			call_user_func( $tab['callback'], $key, $tab );
+			$tab_content        = ob_get_clean();
+			$tab_content_block  = parse_blocks( sprintf( $accordion_item_template, $tab['title'], $tab_content ) );
+			$accordion_blocks[] = $tab_content_block[0];
+		}
+
+		return $this->inject_parsed_accordion_blocks( $parsed_block, $accordion_blocks );
+	}
+
+	/**
+	 * Inject parsed accordion blocks.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 * @param array $accordion_blocks Accordion blocks.
+	 *
+	 * @return array Parsed block.
+	 */
+	private function inject_parsed_accordion_blocks( $parsed_block, $accordion_blocks ) {
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
+			$parsed_block['innerBlocks']  = array_merge( $parsed_block['innerBlocks'], $accordion_blocks );
+			$parsed_block['innerBlocks']  = array_values( array_filter( $parsed_block['innerBlocks'] ) );
+			$openning_tag                 = reset( $parsed_block['innerContent'] );
+			$closing_tag                  = end( $parsed_block['innerContent'] );
+			$parsed_block['innerContent'] = array_merge(
+				array( $openning_tag ),
+				array_fill( 0, count( $parsed_block['innerBlocks'] ), null ),
+				array( $closing_tag )
+			);
+			return $parsed_block;
+		}
+
+		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+			$parsed_block['innerBlocks'][ $key ] = $this->inject_parsed_accordion_blocks( $inner_block, $accordion_blocks );
+		}
+
+		return $parsed_block;
 	}
 
 	/**
 	 * Hide empty accordion items.
 	 *
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
+	 * @param array $parsed_block Parsed block.
+	 * @param array $context Context.
 	 *
-	 * @return string Rendered block output.
+	 * @return array Parsed block.
 	 */
-	private function hide_empty_accordion_items( $content, $block ) {
-		$accordion_items = $this->find_accordion_items( $block->parsed_block );
-
-		if ( ! $accordion_items ) {
-			return $content;
+	private function hide_empty_accordion_items( $parsed_block, $context ) {
+		if ( ! $this->has_accordion( $parsed_block ) ) {
+			return $parsed_block;
 		}
 
-		$accordion_items_visibility = array_map(
-			function ( $item ) use ( $block ) {
-				$content_block          = end( $item['innerBlocks'] );
-				$rendered_content_block = ( new WP_Block( $content_block, $block->context ) )->render();
-				$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
-
-				return $p->next_tag( 'img' ) ||
-					$p->next_tag( 'iframe' ) ||
-					$p->next_tag( 'video' ) ||
-					$p->next_tag( 'meter' ) ||
-					! empty( wp_strip_all_tags( $rendered_content_block, true ) );
-			},
-			$accordion_items
-		);
-
-		$p = new WP_HTML_Tag_Processor( $content );
-
-		$counter = 0;
-		while ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-accordion-item' ) ) ) {
-			if ( ! $accordion_items_visibility[ $counter ] ) {
-				$p->set_attribute( 'style', 'display:none;' );
-				$p->set_attribute( 'hidden', true );
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
+			foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+				$parsed_block['innerBlocks'][ $key ] = $this->mark_accordion_item_hidden( $inner_block, $context );
 			}
-			++$counter;
+			$parsed_block['innerBlocks']  = array_values( array_filter( $parsed_block['innerBlocks'] ) );
+			$openning_tag                 = reset( $parsed_block['innerContent'] );
+			$closing_tag                  = end( $parsed_block['innerContent'] );
+			$parsed_block['innerContent'] = array_merge(
+				array( $openning_tag ),
+				array_fill( 0, count( $parsed_block['innerBlocks'] ), null ),
+				array( $closing_tag )
+			);
+			return $parsed_block;
 		}
 
-		return $p->get_updated_html();
+		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+			$parsed_block['innerBlocks'][ $key ] = $this->hide_empty_accordion_items( $inner_block, $context );
+		}
+
+		return $parsed_block;
 	}
 
 	/**
-	 * Find accordion items.
+	 * Mark an accordion item as hidden if it has no content.
 	 *
-	 * @param array $block Block instance.
+	 * @param array $item Item to mark.
+	 * @param array $context Context.
 	 *
-	 * @return array|false Accordion items.
+	 * @return array Item.
 	 */
-	private function find_accordion_items( $block ) {
-		if ( 'woocommerce/accordion-group' === $block['blockName'] ) {
-			return $block['innerBlocks'];
+	private function mark_accordion_item_hidden( $item, $context ) {
+		$content_block          = end( $item['innerBlocks'] );
+		$rendered_content_block = ( new WP_Block( $content_block, $context ) )->render();
+		$p                      = new WP_HTML_Tag_Processor( $rendered_content_block );
+
+		$has_content = $p->next_tag( 'img' ) ||
+			$p->next_tag( 'iframe' ) ||
+			$p->next_tag( 'video' ) ||
+			$p->next_tag( 'meter' ) ||
+			! empty( wp_strip_all_tags( $rendered_content_block, true ) );
+
+		if ( ! $has_content ) {
+			return array();
 		}
 
-		foreach ( $block['innerBlocks'] as $inner_block ) {
-			$items = $this->find_accordion_items( $inner_block );
-			if ( $items ) {
-				return $items;
+		return $item;
+	}
+
+	/**
+	 * Check if a parsed block has an accordion.
+	 *
+	 * @param array $parsed_block Parsed block.
+	 *
+	 * @return bool True if the block has an accordion, false otherwise.
+	 */
+	private function has_accordion( $parsed_block ) {
+		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
+			return true;
+		}
+
+		foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
+			if ( $this->has_accordion( $inner_block ) ) {
+				return true;
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/BlockifiedProductDetails.php
@@ -37,7 +37,16 @@ class BlockifiedProductDetails extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		$parsed_block = $block->parsed_block;
 		$parsed_block = $this->hide_empty_accordion_items( $parsed_block, $block->context );
-		$parsed_block = $this->inject_compatible_tabs( $parsed_block );
+
+		/**
+		 * Filter to disable the compatibility layer for the blockified templates.
+		 *
+		 * @see AddToCartWithOptions::render() for full documentation.
+		 * @since 7.6.0
+		 */
+		if ( ! apply_filters( 'woocommerce_disable_compatibility_layer', false ) ) {
+			$parsed_block = $this->inject_compatible_tabs( $parsed_block );
+		}
 
 		$inner_content = array_reduce(
 			$parsed_block['innerBlocks'],
@@ -122,42 +131,24 @@ class BlockifiedProductDetails extends AbstractBlock {
 	 * @return array Accordion item.
 	 */
 	private function create_accordion_item_block( $title, $content ) {
-		$template = parse_blocks(
-			'<!-- wp:woocommerce/accordion-item -->
+		$template = '<!-- wp:woocommerce/accordion-item -->
 			<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
-			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button class="accordion-item__toggle"><span>{{title}}</span><span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span></button></h3>
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading">
+			<button class="accordion-item__toggle">
+			<span>%1$s</span>
+			<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor"></path></svg></span>
+			</button>
+			</h3>
 			<!-- /wp:woocommerce/accordion-header -->
 
 			<!-- wp:woocommerce/accordion-panel -->
 			<div class="wp-block-woocommerce-accordion-panel"><div class="accordion-content__wrapper">
-			<!-- wp:paragraph --><p>{{content}}</p><!-- /wp:paragraph -->
+			%2$s
 			</div></div>
 			<!-- /wp:woocommerce/accordion-panel --></div>
-			<!-- /wp:woocommerce/accordion-item -->'
-		)[0];
+			<!-- /wp:woocommerce/accordion-item -->';
 
-		foreach ( $template['innerBlocks'] as &$block ) {
-			if ( 'woocommerce/accordion-header' === $block['blockName'] ) {
-				$block['innerContent'] = array_map(
-					function ( $inner_content ) use ( $title ) {
-						return str_replace( '{{title}}', $title, $inner_content );
-					},
-					$block['innerContent']
-				);
-			}
-			if ( 'woocommerce/accordion-panel' === $block['blockName'] ) {
-				$block['innerBlocks']  = parse_blocks( $content );
-				$openning_tag          = reset( $block['innerContent'] );
-				$closing_tag           = end( $block['innerContent'] );
-				$block['innerContent'] = array_merge(
-					array( $openning_tag ),
-					array_fill( 0, count( $block['innerBlocks'] ), null ),
-					array( $closing_tag )
-				);
-			}
-		}
-
-		return $template;
+		return parse_blocks( sprintf( $template, $title, $content ) )[0];
 	}
 
 	/**
@@ -172,10 +163,10 @@ class BlockifiedProductDetails extends AbstractBlock {
 		if ( 'woocommerce/accordion-group' === $parsed_block['blockName'] ) {
 			$parsed_block['innerBlocks']  = array_merge( $parsed_block['innerBlocks'], $accordion_blocks );
 			$parsed_block['innerBlocks']  = array_values( array_filter( $parsed_block['innerBlocks'] ) );
-			$openning_tag                 = reset( $parsed_block['innerContent'] );
+			$opening_tag                  = reset( $parsed_block['innerContent'] );
 			$closing_tag                  = end( $parsed_block['innerContent'] );
 			$parsed_block['innerContent'] = array_merge(
-				array( $openning_tag ),
+				array( $opening_tag ),
 				array_fill( 0, count( $parsed_block['innerBlocks'] ), null ),
 				array( $closing_tag )
 			);
@@ -207,10 +198,10 @@ class BlockifiedProductDetails extends AbstractBlock {
 				$parsed_block['innerBlocks'][ $key ] = $this->mark_accordion_item_hidden( $inner_block, $context );
 			}
 			$parsed_block['innerBlocks']  = array_values( array_filter( $parsed_block['innerBlocks'] ) );
-			$openning_tag                 = reset( $parsed_block['innerContent'] );
+			$opening_tag                  = reset( $parsed_block['innerContent'] );
 			$closing_tag                  = end( $parsed_block['innerContent'] );
 			$parsed_block['innerContent'] = array_merge(
-				array( $openning_tag ),
+				array( $opening_tag ),
 				array_fill( 0, count( $parsed_block['innerBlocks'] ), null ),
 				array( $closing_tag )
 			);

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\BlockifiedProductDetails;
+
+use WC_Helper_Product;
+
+/**
+ * Tests for the BlockifiedProductDetails block type
+ */
+class BlockifiedProductDetails extends \WP_UnitTestCase {
+
+	/**
+	 * Page ID
+	 *
+	 * @var @string
+	 */
+	private static $page_id;
+
+	/**
+	 * Product
+	 *
+	 * @var @WC_Product
+	 */
+	private static $product;
+
+	/**
+	 * Create Simple Product and Page
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		self::$product = WC_Helper_Product::create_simple_product( false );
+		WC_Helper_Product::create_product_review( self::$product );
+
+		self::$page_id = wp_insert_post(
+			[
+				'post_title'  => 'Test Product Page',
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			],
+			true
+		);
+	}
+	/**
+	 * Set up product and page for each test
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $post, $product;
+
+		$post = get_post( self::$page_id );
+		setup_postdata( $post );
+		$product            = self::$product;
+		$GLOBALS['product'] = $product;
+	}
+
+	/**
+	 * Reset postdata after each test
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		wp_reset_postdata();
+	}
+
+	/**
+	 * Delete the product and page after all tests
+	 *
+	 * @return void
+	 */
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		wp_delete_post( self::$page_id, true );
+		WC_Helper_Product::delete_product( self::$product->get_id() );
+	}
+
+
+	/**
+	 * Test Product Details render function when `woocommerce_product_tabs` hook isn't used
+	 * IMPORTANT: The current test doesn't validate the entire HTML, but only the text content inside the HTML.
+	 * This is because some ids are generated dynamically via wp_unique_id that it is not straightforward to mock.
+	 */
+	public function test_product_details_render_with_no_hook() {
+
+		$template = file_get_contents( __DIR__ . '/test_product_details_render_with_no_hook_template.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$serialized_blocks = do_blocks( $template );
+
+		$expected_serialized_blocks                    = file_get_contents( __DIR__ . '/test_product_details_render_with_no_hook_expected_result.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$serialized_blocks_without_whitespace          = wp_strip_all_tags( $serialized_blocks, true );
+		$expected_serialized_blocks_without_whitespace = wp_strip_all_tags( $expected_serialized_blocks, true );
+		$this->assertEquals( $serialized_blocks_without_whitespace, $expected_serialized_blocks_without_whitespace, '' );
+	}
+
+	/**
+	 * Test Product Details render function when `woocommerce_product_tabs` hook is used.
+	 * IMPORTANT: The current test doesn't validate the entire HTML, but only the text content inside the HTML.
+	 * This is because some ids are generated dynamically via wp_unique_id that it is not straightforward to mock.
+	 */
+	public function test_product_details_render_with_hook() {
+		add_filter(
+			'woocommerce_product_tabs',
+			function ( $tabs ) {
+				$tabs['custom_info_tab'] = array(
+					'title'    => 'Custom Info',
+					'priority' => 50,
+					'callback' => function () {
+						echo '<p>This is the content for the custom info tab.</p>';
+					},
+				);
+
+				$tabs['specifications_tab'] = array(
+					'title'    => 'Specifications',
+					'priority' => 60,
+					'callback' => function () {
+						echo '<h2>Specifications</h2>
+						<p>Here you can list product specifications.</p>';
+					},
+				);
+
+				return $tabs;
+			}
+		);
+
+		$template = file_get_contents( __DIR__ . '/test_product_details_render_with_hook_template.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$serialized_blocks = do_blocks( $template );
+
+		$expected_serialized_blocks = file_get_contents( __DIR__ . '/test_product_details_render_with_hook_expected_result.html' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$serialized_blocks_without_whitespace          = wp_strip_all_tags( $serialized_blocks, true );
+		$expected_serialized_blocks_without_whitespace = wp_strip_all_tags( $expected_serialized_blocks, true );
+
+		$this->assertEquals( $serialized_blocks_without_whitespace, $expected_serialized_blocks_without_whitespace, '' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_hook_expected_result.html
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_hook_expected_result.html
@@ -1,0 +1,148 @@
+<div data-block-name="woocommerce/blockified-product-details" class="wp-block-woocommerce-blockified-product-details">
+	<div data-block-name="woocommerce/accordion-group"
+		data-wc-context="{&quot;autoclose&quot;:false,&quot;isOpen&quot;:[]}"
+		data-wc-interactive="{&quot;namespace&quot;:&quot;woocommerce\/accordion&quot;}"
+		class="wp-block-woocommerce-accordion-group is-layout-flow wp-block-woocommerce-accordion-group-is-layout-flow">
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-2&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-2-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-2" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Description Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-2" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-2-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				data-is-selected="true" class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Description Body</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-3&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-3-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-3" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Additional Information Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-3" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-3-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Additional Information Body</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-4&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-4-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-4" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Reviews Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-4" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-4-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Reviews Body</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-4&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-4-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-4" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Custom Info</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-4" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-4-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>This is the content for the custom info tab.</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-4&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-4-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-4" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Specifications</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-4" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-4-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<h2>Specifications</h2>
+					<p>Here you can list product specifications.</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_hook_template.html
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_hook_template.html
@@ -1,0 +1,74 @@
+<!-- wp:woocommerce/blockified-product-details -->
+<div class="wp-block-woocommerce-blockified-product-details"><!-- wp:woocommerce/accordion-group {"autoclose":false} -->
+	<div class="wp-block-woocommerce-accordion-group"><!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Description Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Description Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+
+		<!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Additional Information Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Additional Information Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+
+		<!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Reviews Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+
+			<!-- wp:woocommerce/accordion-panel {"isSelected":true} -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Reviews Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+	</div>
+	<!-- /wp:woocommerce/accordion-group -->
+</div>
+<!-- /wp:woocommerce/blockified-product-details -->

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_no_hook_expected_result.html
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_no_hook_expected_result.html
@@ -1,0 +1,91 @@
+<div data-block-name="woocommerce/blockified-product-details" class="wp-block-woocommerce-blockified-product-details">
+	<div data-block-name="woocommerce/accordion-group"
+		data-wc-context="{&quot;autoclose&quot;:false,&quot;isOpen&quot;:[]}"
+		data-wc-interactive="{&quot;namespace&quot;:&quot;woocommerce\/accordion&quot;}"
+		class="wp-block-woocommerce-accordion-group is-layout-flow wp-block-woocommerce-accordion-group-is-layout-flow">
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-2&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-2-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-2" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Description Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-2" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-2-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				data-is-selected="true" class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Description Body</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-3&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-3-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-3" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Additional Information Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-3" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-3-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Additional Information Body</p>
+				</div>
+			</div>
+		</div>
+		<div data-block-name="woocommerce/accordion-item" data-wc-class--is-open="state.isOpen"
+			data-wc-context="{&quot;id&quot;:&quot;woocommerce-accordion-item-4&quot;,&quot;openByDefault&quot;:false}"
+			data-wc-init="callbacks.initIsOpen"
+			class="wp-block-woocommerce-accordion-item is-layout-flow wp-block-woocommerce-accordion-item-is-layout-flow">
+			<h3
+				class="wp-block-woocommerce-accordion-header accordion-item__heading is-layout-flow wp-block-woocommerce-accordion-header-is-layout-flow">
+				<button aria-controls="woocommerce-accordion-item-4-panel" data-wc-bind--aria-expanded="state.isOpen"
+					data-wc-on--click="actions.toggle" id="woocommerce-accordion-item-4" class="accordion-item__toggle"
+					aria-expanded="false">
+					<span>Reviews Header</span>
+					<span class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em">
+						<svg width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg>
+					</span>
+				</button>
+			</h3>
+			<div aria-labelledby="woocommerce-accordion-item-4" data-wc-bind--inert="!state.isOpen"
+				id="woocommerce-accordion-item-4-panel" role="region" data-block-name="woocommerce/accordion-panel"
+				class="wp-block-woocommerce-accordion-panel" inert="">
+				<div
+					class="accordion-content__wrapper is-layout-flow wp-block-woocommerce-accordion-panel-is-layout-flow">
+					<p>Reviews Body</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_no_hook_template.html
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/test_product_details_render_with_no_hook_template.html
@@ -1,0 +1,70 @@
+<!-- wp:woocommerce/blockified-product-details -->
+<div class="wp-block-woocommerce-blockified-product-details">
+	<!-- wp:woocommerce/accordion-group {"autoclose": false} -->
+	<div class="wp-block-woocommerce-accordion-group"><!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Description Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Description Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+		<!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Additional Information Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+			<!-- wp:woocommerce/accordion-panel -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Additional Information Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+		<!-- wp:woocommerce/accordion-item {"openByDefault": false} -->
+		<div class="wp-block-woocommerce-accordion-item"><!-- wp:woocommerce/accordion-header -->
+			<h3 class="wp-block-woocommerce-accordion-header accordion-item__heading"><button
+					class="accordion-item__toggle"><span>Reviews Header</span><span
+						class="accordion-item__toggle-icon has-icon-plus" style="width:1.2em;height:1.2em"><svg
+							width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none"
+							xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+							<path d="M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z" fill="currentColor">
+							</path>
+						</svg></span></button></h3>
+			<!-- /wp:woocommerce/accordion-header -->
+			<!-- wp:woocommerce/accordion-panel {"isSelected":true} -->
+			<div class="wp-block-woocommerce-accordion-panel">
+				<div class="accordion-content__wrapper"><!-- wp:paragraph -->
+					<p>Reviews Body</p>
+					<!-- /wp:paragraph -->
+				</div>
+			</div>
+			<!-- /wp:woocommerce/accordion-panel -->
+		</div>
+		<!-- /wp:woocommerce/accordion-item -->
+	</div>
+	<!-- /wp:woocommerce/accordion-group -->
+</div>
+<!-- /wp:woocommerce/blockified-product-details -->


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR adds the tabs added through the `woocommerce_product_tabs` block to the new Product Details block. The logic is similar to #54787 but adjusted to work better with https://github.com/woocommerce/woocommerce/pull/57893.

Closes https://github.com/woocommerce/woocommerce/issues/54731
Closes WOOPLUG-3048
Replaces https://github.com/woocommerce/woocommerce/pull/54787

### How to test the changes in this Pull Request:
_Copied from #54787._
1. Edit the Single Product Template.
2. Add `Blockified Product Details` block
3. Customize the block.
4. Save the template.
5. Visit a Single Product page.
6. Ensure that your changes are visible.
7. Install [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/).
8. Visit `/wp-admin/admin.php?page=add-snippet`
9. Copy-paste this code:


```php
		add_filter(
			'woocommerce_product_tabs',
			function ( $tabs ) {
				$tabs['custom_info_tab'] = array(
					'title'    => 'Custom Info',
					'priority' => 50,
					'callback' => function () {
						echo '<p>This is the content for the custom info tab.</p>';
					},
				);

				$tabs['specifications_tab'] = array(
					'title'    => 'Specifications',
					'priority' => 60,
					'callback' => function () {
						echo '<h2>Specifications</h2>';
						echo '<p>Here you can list product specifications.</p>';
					},
				);

				return $tabs;
			}
	);
```

This code adds two new accordions.
10. Visit a Single Product page.
11. Ensure that the new two accordions are added and work fine.

<!-- End testing instructions -->