### PR TITLE
Send Order Cancellation Email to Customers

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1059-enhancement-send-order-cancellation-email-to-customers
+++ b/plugins/woocommerce/changelog/wooplug-1059-enhancement-send-order-cancellation-email-to-customers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a new email Order Cancellation to Customers

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -268,6 +268,7 @@ class WC_Emails {
 
 		$this->emails['WC_Email_New_Order']                 = include __DIR__ . '/emails/class-wc-email-new-order.php';
 		$this->emails['WC_Email_Cancelled_Order']           = include __DIR__ . '/emails/class-wc-email-cancelled-order.php';
+		$this->emails['WC_Email_Customer_Cancelled_Order']  = include __DIR__ . '/emails/class-wc-email-customer-cancelled-order.php';
 		$this->emails['WC_Email_Failed_Order']              = include __DIR__ . '/emails/class-wc-email-failed-order.php';
 		$this->emails['WC_Email_Customer_Failed_Order']     = include __DIR__ . '/emails/class-wc-email-customer-failed-order.php';
 		$this->emails['WC_Email_Customer_On_Hold_Order']    = include __DIR__ . '/emails/class-wc-email-customer-on-hold-order.php';

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-cancelled-order.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Class WC_Email_Customer_Cancelled_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Email_Customer_Cancelled_Order', false ) ) :
+
+	/**
+	 * Cancelled Order Email for Customers.
+	 *
+	 * An email sent to the customer when an order is cancelled.
+	 *
+	 * @class       WC_Email_Customer_Cancelled_Order
+	 * @version     1.0.0
+	 * @package     WooCommerce\Classes\Emails
+	 * @extends     WC_Email
+	 */
+	class WC_Email_Customer_Cancelled_Order extends WC_Email {
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_cancelled_order';
+			$this->customer_email = true;
+			$this->title          = __( 'Cancelled order', 'woocommerce' );
+			$this->template_html  = 'emails/customer-cancelled-order.php';
+			$this->template_plain = 'emails/plain/customer-cancelled-order.php';
+			$this->placeholders   = array(
+				'{order_date}'              => '',
+				'{order_number}'            => '',
+				'{order_billing_full_name}' => '',
+			);
+
+			// Triggers for this email.
+			add_action( 'woocommerce_order_status_processing_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			// Must be after parent's constructor which sets `email_improvements_enabled` property.
+			$this->description = $this->email_improvements_enabled
+				? __( 'This email is sent to customers when their orders are cancelled.', 'woocommerce' )
+				: __( 'Cancelled order emails are sent to customers when their orders have been marked cancelled (if they were previously processing or on-hold).', 'woocommerce' );
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since  1.0.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( '[{site_title}]: Your order #{order_number} has been cancelled', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  1.0.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return $this->email_improvements_enabled
+				? __( 'Order cancelled: #{order_number}', 'woocommerce' )
+				: __( 'Order Cancelled: #{order_number}', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
+
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                                    = $order;
+				$this->recipient                                 = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']              = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}']            = $this->object->get_order_number();
+				$this->placeholders['{order_billing_full_name}'] = $this->object->get_formatted_billing_full_name();
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html,
+				array(
+					'order'              => $this->object,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain,
+				array(
+					'order'              => $this->object,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get block editor email template content.
+		 *
+		 * @return string
+		 */
+		public function get_block_editor_email_template_content() {
+			return wc_get_template_html(
+				$this->template_block_content,
+				array(
+					'order'         => $this->object,
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 1.0.0
+		 * @return string
+		 */
+		public function get_default_additional_content() {
+			return __( 'We hope to see you again soon.', 'woocommerce' );
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			/* translators: %s: list of placeholders */
+			$placeholder_text  = sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . esc_html( implode( '</code>, <code>', array_keys( $this->placeholders ) ) ) . '</code>' );
+			$this->form_fields = array(
+				'enabled'            => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'no',
+				),
+				'subject'            => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					'description' => $placeholder_text,
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'            => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					'description' => $placeholder_text,
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'additional_content' => array(
+					'title'       => __( 'Additional content', 'woocommerce' ),
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'css'         => 'width:400px; height: 75px;',
+					'placeholder' => __( 'N/A', 'woocommerce' ),
+					'type'        => 'textarea',
+					'default'     => $this->get_default_additional_content(),
+					'desc_tip'    => true,
+				),
+				'email_type'         => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+			if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
+				$this->form_fields['cc']  = $this->get_cc_field();
+				$this->form_fields['bcc'] = $this->get_bcc_field();
+			}
+		}
+	}
+
+endif;
+
+return new WC_Email_Customer_Cancelled_Order();

--- a/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/WCTransactionalEmails/WCTransactionalEmails.php
@@ -21,6 +21,7 @@ class WCTransactionalEmails {
 	 */
 	public static $core_transactional_emails = array(
 		'cancelled_order',
+		'customer_cancelled_order',
 		'customer_completed_order',
 		'customer_failed_order',
 		'customer_invoice',

--- a/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.0.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -29,15 +29,6 @@ printf( esc_html__( 'Order cancelled: #%s,', 'woocommerce' ), '<!--[woocommerce/
 ?>
 </h2>
 <!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>
-<?php
-	/* translators: %s: Customer first name */
-	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
-<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -50,7 +50,7 @@ printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--
 <p>
 <?php
 /* translators: %s: Store admin email */
-printf( esc_html__( 'If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+printf( esc_html__( 'We hope to see you again soon.', 'woocommerce' ) );
 ?>
 </p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Customer cancelled order email - block template.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/block/customer-cancelled-order.php.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Block
+ * @version 9.9.0
+ */
+
+use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">
+<?php
+/* translators: %s: Order number */
+printf( esc_html__( 'Order Cancelled: #%s', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
+?>
+</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+<?php
+/* translators: %s: Customer first name */
+printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
+?>
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>
+<?php
+/* translators: %s: Order number */
+printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
+?>
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
+<div class="wp-block-woo-email-content"> <?php echo esc_html( BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER ); ?> </div>
+<!-- /wp:woo/email-content -->
+
+<!-- wp:paragraph -->
+<p>
+<?php
+/* translators: %s: Store admin email */
+printf( esc_html__( 'If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+?>
+</p>
+<!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -6,7 +6,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.0.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -23,9 +23,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-/*
+/**
+ * Hook: woocommerce_email_header.
+ *
  * @hooked WC_Emails::email_header() Output the email header
-*/
+ * @since 2.5.0
+ */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php
@@ -41,7 +44,9 @@ if ( $email_improvements_enabled ) {
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>
 
 <?php
-/*
+/**
+ * Hook: woocommerce_email_order_details.
+ *
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -49,14 +54,20 @@ if ( $email_improvements_enabled ) {
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/*
+/**
+ * Hook: woocommerce_email_order_meta.
+ *
  * @hooked WC_Emails::order_meta() Shows order meta data.
+ * @since 2.5.0
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/*
+/**
+ * Hook: woocommerce_email_customer_details.
+ *
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
+ * @since 2.5.0
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
@@ -69,7 +80,10 @@ if ( $additional_content ) {
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }
 
-/*
+/**
+ * Hook: woocommerce_email_footer.
+ *
  * @hooked WC_Emails::email_footer() Output the email footer
+ * @since 2.5.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -34,10 +34,10 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 echo $email_improvements_enabled ? '<div class="email-introduction">' : '';
 /* translators: %1$s: Order number */
-$text = __( 'We\'re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+$text = __( 'We’re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
 if ( $email_improvements_enabled ) {
 	/* translators: %1$s: Order number */
-	$text = __( 'We\'re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+	$text = __( 'We’re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
 }
 ?>
 <p><?php printf( esc_html( $text ), esc_html( $order->get_order_number() ) ); ?></p>

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.0.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Customer cancelled order email
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-cancelled-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails
+ * @version 9.8.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+*/
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php
+echo $email_improvements_enabled ? '<div class="email-introduction">' : '';
+/* translators: %1$s: Order number */
+$text = __( 'We\'re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+if ( $email_improvements_enabled ) {
+	/* translators: %1$s: Order number */
+	$text = __( 'We\'re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+}
+?>
+<p><?php printf( esc_html( $text ), esc_html( $order->get_order_number() ) ); ?></p>
+<?php echo $email_improvements_enabled ? '</div>' : ''; ?>
+
+<?php
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+	echo $email_improvements_enabled ? '</td></tr></table>' : '';
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.8.0
+ * @version 10.0.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
@@ -33,7 +33,9 @@ if ( $email_improvements_enabled ) {
 }
 echo sprintf( esc_html( $text ), esc_html( $order->get_order_number() ) ) . "\n\n";
 
-/*
+/**
+ * Hook: woocommerce_email_order_details.
+ *
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -43,14 +45,20 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n----------------------------------------\n\n";
 
-/*
+/**
+ * Hook: woocommerce_email_order_meta.
+ *
  * @hooked WC_Emails::order_meta() Shows order meta data.
+ * @since 2.5.0
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/*
+/**
+ * Hook: woocommerce_email_customer_details.
+ *
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
+ * @since 2.5.0
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
@@ -64,4 +72,10 @@ if ( $additional_content ) {
 	echo "\n\n----------------------------------------\n\n";
 }
 
-echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );
+/**
+ * Hook: woocommerce_email_footer.
+ *
+ * @hooked WC_Emails::email_footer() Output the email footer
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Customer cancelled order email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-cancelled-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 9.8.0
+ */
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+defined( 'ABSPATH' ) || exit;
+
+$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %1$s: Order number */
+$text = __( 'We\'re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+if ( $email_improvements_enabled ) {
+	/* translators: %1$s: Order number */
+	$text = __( 'We\'re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+}
+echo sprintf( esc_html( $text ), esc_html( $order->get_order_number() ) ) . "\n\n";
+
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n----------------------------------------\n\n";
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n\n----------------------------------------\n\n";
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-cancelled-order.php
@@ -26,10 +26,10 @@ echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %1$s: Order number */
-$text = __( 'We\'re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+$text = __( 'We’re sorry to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
 if ( $email_improvements_enabled ) {
 	/* translators: %1$s: Order number */
-	$text = __( 'We\'re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
+	$text = __( 'We’re getting in touch to let you know that your order #%1$s has been cancelled.', 'woocommerce' );
 }
 echo sprintf( esc_html( $text ), esc_html( $order->get_order_number() ) ) . "\n\n";
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The order cancellation email only gets sent to the admin but not the customer. This pull request adds a new email to get sent to the customer as well. It's petty important for the customer to also be aware that their order was cancelled.

Closes: WOOPLUG-1059
Closes: #36692 

### Screenshots or screen recordings:

![Screenshot 2025-05-14 at 12 09 39](https://github.com/user-attachments/assets/cce40dfe-7192-4581-8399-7893b9e818f5)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Emails
2. Observe that there are two emails Cancelled order – one for the admin, and another for the Customers
3. As a Customer, create a new order
4. As an admin, cancel the order
5. Observe that the Cancelled order email was delivered to the customer

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
