### PR TITLE
Fixed items sorting by price when applying discounts

### DIFF
--- a/plugins/woocommerce/changelog/58013-fix-wooplug-410
+++ b/plugins/woocommerce/changelog/58013-fix-wooplug-410
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed items sorting by price when applying discounts.

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -292,8 +292,8 @@ class WC_Discounts {
 	 * @return int
 	 */
 	protected function sort_by_price( $a, $b ) {
-		$price_1 = $a->price * $a->quantity;
-		$price_2 = $b->price * $b->quantity;
+		$price_1 = $a->product->get_price();
+		$price_2 = $b->product->get_price();
 		if ( $price_1 === $price_2 ) {
 			return 0;
 		}

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -292,8 +292,8 @@ class WC_Discounts {
 	 * @return int
 	 */
 	protected function sort_by_price( $a, $b ) {
-		$price_1 = $a->product->get_price();
-		$price_2 = $b->product->get_price();
+		$price_1 = $a->quantity > 1 ? $a->price / $a->quantity : $a->price;
+		$price_2 = $b->quantity > 1 ? $b->price / $b->quantity : $b->price;
 		if ( $price_1 === $price_2 ) {
 			return 0;
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
@@ -123,6 +123,103 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test set items from cart/order and sorting them by price.
+	 */
+	public function test_set_items_and_sort_by_price() {
+		// Create dummy product - price will be 10.
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->store_product( $product_1 );
+
+		// Create a more expensive product.
+		$product_2 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 20 ) );
+		$this->store_product( $product_2 );
+
+		// Add products to the cart.
+		WC()->cart->add_to_cart( $product_1->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_2->get_id(), 1 );
+
+		$discounts = new WC_Discounts();
+
+		// 'sort_by_price' is called when setting items from the cart.
+		$discounts->set_items_from_cart( WC()->cart );
+		$items = $discounts->get_items();
+		$this->assertEquals( 2, count( $items ) );
+		
+		// Get sorted items.
+		$first_item  = array_values( $items )[0];
+		$second_item = array_values( $items )[1];
+
+		// Ensure that the most expensive product is sorted first.
+		$this->assertEquals( $first_item->product->get_id(), $product_2->get_id() );
+		$this->assertEquals( $second_item->product->get_id(), $product_1->get_id() );
+
+		WC()->cart->empty_cart();
+
+		// Add products to the cart.
+		// This time add the cheaper product 5 times to the cart, so that
+		// the subtotal of product 1 > product 2.
+		WC()->cart->add_to_cart( $product_1->get_id(), 5 );
+		WC()->cart->add_to_cart( $product_2->get_id(), 1 );
+
+		// 'sort_by_price' is called when setting items from the cart.
+		$discounts->set_items_from_cart( WC()->cart );
+		$items = $discounts->get_items();
+		$this->assertEquals( 2, count( $items ) );
+
+		// Get sorted items.
+		$first_item  = array_values( $items )[0];
+		$second_item = array_values( $items )[1];
+
+		// Ensure that the most expensive product is still sorted first.
+		$this->assertEquals( $first_item->product->get_id(), $product_2->get_id() );
+		$this->assertEquals( $second_item->product->get_id(), $product_1->get_id() );
+
+		// Add products to a dummy order.
+		$order = new WC_Order();
+		$order->add_product( $product_1, 1 );
+		$order->add_product( $product_2, 1 );
+		$order->calculate_totals();
+		$order->save();
+		$this->store_order( $order );
+
+		// 'sort_by_price' is called when setting items from the order.
+		$discounts->set_items_from_order( $order );
+
+		$items = $discounts->get_items();
+		$this->assertEquals( 2, count( $items ) );
+
+		// Get sorted items.
+		$first_item  = array_values( $items )[0];
+		$second_item = array_values( $items )[1];
+
+		// Ensure that the most expensive product is sorted first.
+		$this->assertEquals( $first_item->product->get_id(), $product_2->get_id() );
+		$this->assertEquals( $second_item->product->get_id(), $product_1->get_id() );
+
+		// Add products to a dummy order.
+		$order = new WC_Order();
+		$order->add_product( $product_1, 5 );
+		$order->add_product( $product_2, 1 );
+		$order->calculate_totals();
+		$order->save();
+		$this->store_order( $order );
+
+		// 'sort_by_price' is called when setting items from the order.
+		$discounts->set_items_from_order( $order );
+
+		$items = $discounts->get_items();
+		$this->assertEquals( 2, count( $items ) );
+
+		// Get sorted items.
+		$first_item  = array_values( $items )[0];
+		$second_item = array_values( $items )[1];
+
+		// Ensure that the most expensive product is still sorted first.
+		$this->assertEquals( $first_item->product->get_id(), $product_2->get_id() );
+		$this->assertEquals( $second_item->product->get_id(), $product_1->get_id() );
+	}
+
+	/**
 	 * Test applying a coupon (make sure it changes prices).
 	 */
 	public function test_apply_coupon() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
@@ -144,7 +144,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts->set_items_from_cart( WC()->cart );
 		$items = $discounts->get_items();
 		$this->assertEquals( 2, count( $items ) );
-		
+
 		// Get sorted items.
 		$first_item  = array_values( $items )[0];
 		$second_item = array_values( $items )[1];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The `WC_Discounts` class sorts items by price after setting them, so that expensive products are always first in the `->items` array. This helps when applying coupon discounts, as if coupons can apply only to a specific amount of products, then they should apply to the most expensive ones. 

The function that sorts items by price, though, `sort_by_price` has some key errors: 
- This function is supposed to sort items by price, but instead it sorts items by subtotal (which is the price multiplied by the quantity). This results in sorting a cheap product with bigger quantity as more expensive than an expensive product.
- This function multiplies the price of the item it gets as an argument with the quantity to calculate the subtotal, but when it is called from `set_items` ([ref](https://github.com/woocommerce/woocommerce/blob/6cb793e7fb1622451541c2aac25c867768d866f0/plugins/woocommerce/includes/class-wc-discounts.php#L61-L65)) via `WC_Cart_Totals::calculate_discounts` and `set_cart_items` ([ref](https://github.com/woocommerce/woocommerce/blob/6cb793e7fb1622451541c2aac25c867768d866f0/plugins/woocommerce/includes/class-wc-discounts.php#L73C18-L73C37)) the `$item->price` already has the subtotal value. So, this additional multiplication is redundant.

This PR updates the `sort_by_price` function so that it uses the price of the single unit, rather than the item subtotal when sorting items to ensure that products are compared based on their unit price and avoid changing the sort order, when the item quantity changes.

A unit test to validate that flow has been added as well. 

Closes #30070

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![Markup on 2025-05-15 at 10:37:57](https://github.com/user-attachments/assets/ce9d83c9-4852-4c83-b48c-634ee3c4be97) |  ![Markup on 2025-05-15 at 10:37:17](https://github.com/user-attachments/assets/c2efedd1-e5ba-42c9-972e-e1a07ef337ab) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Setup**

1. Create two products, one more expensive and one cheaper, e.g. Product A $45 and Product B $18.
2. Go to Marketing > Coupons.
3. Create a Percentage discount coupon with an amount of your choice, e.g. 10%.
4. Go to the Usage Limit tab and set Limit usage to X items to 1. 

**Cart**

Start with `trunk`:
1. Add both products to the cart with quantity = 1.
2. Apply the coupon. 
3. Ensure that the coupon discounts 10% from the most expensive product. 
4. Increase the quantity of the cheaper product, so that its subtotal is greater than the subtotal of the expensive product. 
5. Notice that the coupon now discounts the cheaper product and the discount amount is less than it was previously. 

Check out this branch: 
1. Add both products to the cart with quantity = 1.
2. Apply the coupon. 
3. Ensure that the coupon discounts 10% from the most expensive product. 
4. Increase the quantity of the cheaper product, so that its subtotal is greater than the subtotal of the expensive product. 
5. Ensure that the coupon still discounts 10% from the most expensive product. 

**Order**
Start with `trunk`:
1. Create a custom order and add both products with quantity = 1.
2. Apply the coupon. 
3. Ensure that the coupon discounts 10% from the most expensive product. 
4. Create another order and add both products. Increase the quantity of the cheaper product, so that its subtotal is greater than the subtotal of the expensive product. 
5. Apply the coupon. 
6. Notice that the coupon now discounts the cheaper product and the discount amount is less than it was previously. 

Check out this branch: 
1. Create a custom order and add both products with quantity = 1.
2. Apply the coupon. 
3. Ensure that the coupon discounts 10% from the most expensive product. 
4. Create another order and add both products. Increase the quantity of the cheaper product, so that its subtotal is greater than the subtotal of the expensive product. 
5. Apply the coupon. 
6. Notice that the coupon continues to discount the most expensive product.
7. Create another order and add both products with quantity = 1.
8. From the Products tab, delete the most expensive product.
9. Back to the order, apply the coupon. 
10. Ensure that it applies to the non-deleted product, even if it is not the most expensive one, as coupons cannot apply to deleted products.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixed items sorting by price when applying discounts.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
