### PR TITLE
Prevent hidden fields being validated during checkout

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4295-hidden-but-required-fields-prevent-checkout
+++ b/plugins/woocommerce/changelog/wooplug-4295-hidden-but-required-fields-prevent-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent hidden fields being considered during validation

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -311,6 +311,16 @@ class WC_Customer extends WC_Legacy_Customer {
 				continue;
 			}
 
+			// If the field is hidden in the country-specific locale, we can skip it.
+			if ( isset( $country_locale[ $key ]['hidden'] ) && true === wc_string_to_bool( $country_locale[ $key ]['hidden'] ) ) {
+				continue;
+			}
+
+			// Check if the field is hidden in the default locale, if so, we can skip too (because it wasn't hidden in country-specific locale).
+			if ( isset( $default_locale[ $key ]['hidden'] ) && true === wc_string_to_bool( $default_locale[ $key ]['hidden'] ) ) {
+				continue;
+			}
+
 			$locale_to_check = isset( $country_locale[ $key ]['required'] ) ? $country_locale : $default_locale;
 
 			// If the locale requires the field return false.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -484,8 +484,11 @@ class OrderController {
 		$address = array_merge( $address, $additional_fields );
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
-			// Skip validation if field is not required or hidden.
-			if ( true !== $address_field['required'] || true === wc_string_to_bool( $address_field['hidden'] ?? false ) ) {
+			// Skip validation if field is not required or if it is hidden.
+			if (
+				true !== wc_string_to_bool( $address_field['required'] ?? false ) ||
+				true === wc_string_to_bool( $address_field['hidden'] ?? false )
+			) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -485,7 +485,7 @@ class OrderController {
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
 			// Skip validation if field is not required or hidden.
-			if ( true !== $address_field['required'] || true === $address_field['hidden'] ) {
+			if ( true !== $address_field['required'] || true === wc_string_to_bool( $address_field['hidden'] ?? false ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -484,8 +484,8 @@ class OrderController {
 		$address = array_merge( $address, $additional_fields );
 
 		foreach ( $current_locale as $address_field_key => $address_field ) {
-			// Skip validation if field is not required.
-			if ( true !== $address_field['required'] ) {
+			// Skip validation if field is not required or hidden.
+			if ( true !== $address_field['required'] || true === $address_field['hidden'] ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Checkout.php
@@ -688,6 +688,7 @@ class Checkout extends MockeryTestCase {
 			function ( $locale ) {
 				$locale['FR']['state']['label']    = 'French state';
 				$locale['FR']['state']['required'] = true;
+				$locale['FR']['state']['hidden']   = false;
 				$locale['DE']['state']['label']    = 'German state';
 				$locale['DE']['state']['required'] = true;
 				return $locale;

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -58,19 +58,16 @@ class OrderControllerTests extends TestCase {
 		$this->set_shipping_address( $order );
 		$order->save();
 
-		$class = new OrderController();
-		$this->assertNull( $class->validate_existing_order_before_payment( $order ) );
+		$this->assertNull( $this->sut->validate_existing_order_before_payment( $order ) );
 	}
 
 	/**
 	 * test_validate_selected_shipping_methods_throws
 	 */
 	public function test_validate_selected_shipping_methods_throws() {
-		$class = new OrderController();
-
 		$this->expectException( RouteException::class );
-		$class->validate_selected_shipping_methods( true, array( false ) );
-		$class->validate_selected_shipping_methods( true, null );
+		$this->sut->validate_selected_shipping_methods( true, array( false ) );
+		$this->sut->validate_selected_shipping_methods( true, null );
 	}
 
 	/**
@@ -83,13 +80,11 @@ class OrderControllerTests extends TestCase {
 		$default_zone->add_shipping_method( $flat_rate->id );
 		$default_zone->save();
 
-		$class = new OrderController();
-
 		$registered_methods = \WC_Shipping_Zones::get_zone( 0 )->get_shipping_methods();
 		$valid_method       = array_shift( $registered_methods );
 
-		$this->assertNull( $class->validate_selected_shipping_methods( true, array( $valid_method->id . ':' . $valid_method->instance_id ) ) );
-		$this->assertNull( $class->validate_selected_shipping_methods( false, array( 'free-shipping' ) ) );
+		$this->assertNull( $this->sut->validate_selected_shipping_methods( true, array( $valid_method->id . ':' . $valid_method->instance_id ) ) );
+		$this->assertNull( $this->sut->validate_selected_shipping_methods( false, array( 'free-shipping' ) ) );
 	}
 
 	/**
@@ -112,9 +107,8 @@ class OrderControllerTests extends TestCase {
 		$order->apply_coupon( $coupon );
 		$order->save();
 
-		$class = new OrderController();
 		try {
-			$class->validate_order_before_payment( $order );
+			$this->sut->validate_order_before_payment( $order );
 		} finally {
 			$this->assertEmpty( $order->get_coupon_codes() );
 		}
@@ -156,9 +150,8 @@ class OrderControllerTests extends TestCase {
 		$order->save();
 		$this->assertEquals( array( 'fake-coupon' ), $order->get_coupon_codes() );
 
-		$class = new OrderController();
 		try {
-			$class->validate_existing_order_before_payment( $order );
+			$this->sut->validate_existing_order_before_payment( $order );
 		} finally {
 			$this->assertEmpty( $order->get_coupon_codes() );
 		}
@@ -176,8 +169,7 @@ class OrderControllerTests extends TestCase {
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();
 
-		$class = new OrderController();
-		$class->validate_order_before_payment( $order );
+		$this->sut->validate_order_before_payment( $order );
 	}
 
 	/**
@@ -193,13 +185,13 @@ class OrderControllerTests extends TestCase {
 		$order->save();
 
 		/** @var \WC_Order_Item_Product $item */
-		$item = reset( $order->get_items() );
+		$array = $order->get_items();
+		$item  = reset( $array );
 		$this->assertInstanceOf( \WC_Order_Item_Product::class, $item );
 
 		WC()->cart->add_to_cart( $item->get_product()->get_id() );
 
-		$class = new OrderController();
-		$class->validate_order_before_payment( $order );
+		$this->sut->validate_order_before_payment( $order );
 	}
 
 	/**
@@ -215,8 +207,7 @@ class OrderControllerTests extends TestCase {
 		$order->save();
 
 		// There is no need to update the cart here, we just check the order.
-		$class = new OrderController();
-		$class->validate_existing_order_before_payment( $order );
+		$this->sut->validate_existing_order_before_payment( $order );
 	}
 
 	/**
@@ -232,8 +223,7 @@ class OrderControllerTests extends TestCase {
 		$this->set_shipping_address( $order );
 		$order->save();
 
-		$class = new OrderController();
-		$class->validate_order_before_payment( $order );
+		$this->sut->validate_order_before_payment( $order );
 	}
 
 	/**
@@ -251,8 +241,7 @@ class OrderControllerTests extends TestCase {
 		$this->set_shipping_address( $order );
 		$order->save();
 
-		$class = new OrderController();
-		$class->validate_order_before_payment( $order );
+		$this->sut->validate_order_before_payment( $order );
 	}
 
 	/**
@@ -267,8 +256,7 @@ class OrderControllerTests extends TestCase {
 		$order->apply_coupon( $coupon );
 		$order->save();
 
-		$class = new OrderController();
-		$class->validate_order_before_payment( $order );
+		$this->sut->validate_order_before_payment( $order );
 		$this->assertEquals( array( 'valid-coupon' ), $order->get_coupon_codes() );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -276,8 +276,9 @@ class OrderControllerTests extends TestCase {
 	 * Helper method to set shipping address on an order.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param array     $override_data Optional data to override the default shipping address.
 	 */
-	private function set_shipping_address( \WC_Order $order ) {
+	private function set_shipping_address( \WC_Order $order, $override_data = [] ) {
 		$order->set_shipping_country( 'US' );
 		$order->set_shipping_first_name( 'John' );
 		$order->set_shipping_last_name( 'Doe' );
@@ -285,5 +286,9 @@ class OrderControllerTests extends TestCase {
 		$order->set_shipping_city( 'Test City' );
 		$order->set_shipping_state( 'CA' );
 		$order->set_shipping_postcode( '12345' );
+
+		foreach ( $override_data as $key => $value ) {
+			$order->{"set_shipping_$key"}( $value );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -15,6 +15,42 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 class OrderControllerTests extends TestCase {
 	/**
+	 * The system under test.
+	 *
+	 * @var OrderController
+	 */
+	private $sut;
+
+	/**
+	 * Set up before test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new class() extends OrderController {
+			/**
+			 * Check all required address fields are set and return errors if not. Parent is protected.
+			 *
+			 * @param \WC_Order $order Order object.
+			 * @param string    $address_type billing or shipping address, used in error messages.
+			 * @param \WP_Error $errors Error object.
+			 */
+			public function validate_address_fields( \WC_Order $order, $address_type, \WP_Error $errors ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+				parent::validate_address_fields( $order, $address_type, $errors );
+			}
+		};
+	}
+
+	/**
+	 * Tear down after test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->sut = null;
+	}
+
+	/**
 	 * test_validate_existing_order_before_payment_valid_data.
 	 */
 	public function test_validate_existing_order_before_payment_valid_data() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -47,6 +47,7 @@ class OrderControllerTests extends TestCase {
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
+		WC()->countries->locale = null;
 		$this->sut = null;
 	}
 
@@ -258,6 +259,70 @@ class OrderControllerTests extends TestCase {
 
 		$this->sut->validate_order_before_payment( $order );
 		$this->assertEquals( array( 'valid-coupon' ), $order->get_coupon_codes() );
+	}
+
+	/**
+	 * test_validate_address_fields_valid_address.
+	 */
+	public function test_validate_address_fields_valid_address() {
+		$order = WC_Helper_Order::create_order();
+		$this->set_shipping_address( $order );
+		$order->save();
+
+		$errors = new \WP_Error();
+		$this->sut->validate_address_fields( $order, 'shipping', $errors );
+
+		$this->assertEmpty( $errors->get_error_messages() );
+	}
+
+	/**
+	 * test_validate_address_fields_invalid_address.
+	 */
+	public function test_validate_address_fields_invalid_address() {
+		$order = WC_Helper_Order::create_order();
+		$this->set_shipping_address(
+			$order,
+			[
+				'postcode' => '',
+			]
+		);
+		$order->save();
+
+		$errors = new \WP_Error();
+		$this->sut->validate_address_fields( $order, 'shipping', $errors );
+		$this->assertEquals( 'ZIP Code is required', $errors->get_error_message() );
+	}
+	/**
+	 * test_validate_address_fields_invalid_address.
+	 */
+	public function test_validate_address_fields_required_hidden_fields_not_validates() {
+		$order = WC_Helper_Order::create_order();
+		$this->set_shipping_address(
+			$order,
+			[
+				'postcode' => '',
+			]
+		);
+		$order->save();
+
+		/**
+		 * Hide the postcode field for US locale.
+		 *
+		 * @param array $locales All country locales.
+		 *
+		 * @return array
+		 */
+		$hide_postcode = function ( $locales ) {
+			$locales['US']['postcode']['hidden'] = true;
+			return $locales;
+		};
+
+		add_filter( 'woocommerce_get_country_locale', $hide_postcode );
+
+		$errors = new \WP_Error();
+		$this->sut->validate_address_fields( $order, 'shipping', $errors );
+		$this->assertEmpty( $errors->get_error_messages() );
+		remove_filter( 'woocommerce_get_country_locale', $hide_postcode );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/OrderControllerTests.php
@@ -48,7 +48,7 @@ class OrderControllerTests extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		WC()->countries->locale = null;
-		$this->sut = null;
+		$this->sut              = null;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- If a field is marked as hidden in locale, validation will be skipped. This prevents fields that are required, but hidden from blocking the checkout.
- This PR also sets the newly added `cart_context` when hydrating cart/checkout routes on non-store API requests.
- Update `OrderController` tests to use a wrapper class to allow testing a protected method.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4295

(For Bug Fixes) Bug introduced in PR: possibly https://github.com/woocommerce/woocommerce/pull/55879/

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/7b0597cfc83d456d836b5ebc72e762a1 | https://www.loom.com/share/c1537499447741ecaef7fe38d68d64da) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet
```php
add_filter( 'woocommerce_get_country_locale', function( $locale ){
	$locale['GB']['postcode']['hidden'] = true;
	$locale['GB']['postcode']['required'] = true;
	return $locale;
} );
```

2. Check out using a UK address, postcode should be hidden and you should be able to check out without errors.
3. Check out using a different address, e.g. one in US. Do not fill ZIP Code, ensure it shows, and is required. Ensure an error is shown when trying to check out without entering ZIP code.
4. Change the snippet to:
```php
add_filter( 'woocommerce_get_country_locale', function( $locale ){
	$locale['GB']['postcode']['required'] = false;
	return $locale;
} );
```
5. Check out using a UK address, ensure you can check out without entering a postcode.
6. Repeat these tests on the Shortcode checkout.

#### Testing with additional fields (blocks only)

1. Install and activate https://github.com/woocommerce/additional-checkout-fields-tester
2. Check out ensuring the required fields from that plugin are required, and the optional ones do not block checkout when not given a value.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
