### PR TITLE
Fix deprecation warning when passing null to explode()

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4302-php-deprecation-in-email-cc-and-bcc
+++ b/plugins/woocommerce/changelog/wooplug-4302-php-deprecation-in-email-cc-and-bcc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deprecation warning when passing null to explode()

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -569,7 +569,6 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_cc_recipient() {
-		$cc = $this->cc;
 		/**
 		 * Filter the Cc recipient for the email.
 		 *
@@ -578,7 +577,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param object   $object The object (ie, product or order) this email relates to, if any.
 		 * @param WC_Email $email  WC_Email instance managing the email.
 		 */
-		$cc  = apply_filters( 'woocommerce_email_cc_recipient_' . $this->id, $cc, $this->object, $this );
+		$cc  = apply_filters( 'woocommerce_email_cc_recipient_' . $this->id, $this->cc, $this->object, $this );
 		$ccs = array_map( 'trim', explode( ',', $cc ) );
 		$ccs = array_filter( $ccs, 'is_email' );
 		$ccs = array_map( 'sanitize_email', $ccs );
@@ -591,16 +590,15 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_bcc_recipient() {
-		$bcc = $this->bcc;
 		/**
 		 * Filter the Bcc recipient for the email.
 		 *
 		 * @since 9.8.0
-		 * @param string   $bcc    CC recipient.
+		 * @param string   $bcc    Bcc recipient.
 		 * @param object   $object The object (ie, product or order) this email relates to, if any.
 		 * @param WC_Email $email  WC_Email instance managing the email.
 		 */
-		$bcc  = apply_filters( 'woocommerce_email_bcc_recipient_' . $this->id, $bcc, $this->object, $this );
+		$bcc  = apply_filters( 'woocommerce_email_bcc_recipient_' . $this->id, $this->bcc, $this->object, $this );
 		$bccs = array_map( 'trim', explode( ',', $bcc ) );
 		$bccs = array_filter( $bccs, 'is_email' );
 		$bccs = array_map( 'sanitize_email', $bccs );

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -558,7 +558,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param WC_Email $email     WC_Email instance managing the email.
 		 */
 		$recipient  = apply_filters( 'woocommerce_email_recipient_' . $this->id, $this->recipient, $this->object, $this );
-		$recipients = array_map( 'trim', explode( ',', $recipient ) );
+		$recipients = array_map( 'trim', explode( ',', $recipient ?? '' ) );
 		$recipients = array_filter( $recipients, 'is_email' );
 		return implode( ', ', $recipients );
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -312,8 +312,8 @@ class WC_Email extends WC_Settings_API {
 		$this->email_type = $this->get_option( 'email_type' );
 		$this->enabled    = $this->get_option( 'enabled' );
 		if ( FeaturesUtil::feature_is_enabled( 'email_improvements' ) ) {
-			$this->cc  = $this->get_option( 'cc' );
-			$this->bcc = $this->get_option( 'bcc' );
+			$this->cc  = $this->get_option( 'cc', '' );
+			$this->bcc = $this->get_option( 'bcc', '' );
 		}
 
 		if ( $this->block_email_editor_enabled ) {
@@ -578,7 +578,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param WC_Email $email  WC_Email instance managing the email.
 		 */
 		$cc  = apply_filters( 'woocommerce_email_cc_recipient_' . $this->id, $this->cc, $this->object, $this );
-		$ccs = array_map( 'trim', explode( ',', $cc ) );
+		$ccs = array_map( 'trim', explode( ',', $cc ?? '' ) );
 		$ccs = array_filter( $ccs, 'is_email' );
 		$ccs = array_map( 'sanitize_email', $ccs );
 		return implode( ', ', $ccs );
@@ -599,7 +599,7 @@ class WC_Email extends WC_Settings_API {
 		 * @param WC_Email $email  WC_Email instance managing the email.
 		 */
 		$bcc  = apply_filters( 'woocommerce_email_bcc_recipient_' . $this->id, $this->bcc, $this->object, $this );
-		$bccs = array_map( 'trim', explode( ',', $bcc ) );
+		$bccs = array_map( 'trim', explode( ',', $bcc ?? '' ) );
 		$bccs = array_filter( $bccs, 'is_email' );
 		$bccs = array_map( 'sanitize_email', $bccs );
 		return implode( ', ', $bccs );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By default, the `get_option()` method returns `null` as an empty value, which is later used in `explode()`, which generates a deprecation warning since PHP 8.1. This PR changes it to an empty string. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4302, closes #58036, closes #58043.

(For Bug Fixes) Bug introduced in PR #54939.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. This is more of a code thing, not visible in the UI to test.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
