### PR TITLE
Product Collection: fix the invisible attributes changes forcing to review them

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-4279-product-collection-in-template-part-prompts-review-changes
+++ b/plugins/woocommerce/changelog/fix-wooplug-4279-product-collection-in-template-part-prompts-review-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Collection: prevent attributes updates even without user touching the block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/edit/product-collection-content.tsx
@@ -9,7 +9,7 @@ import {
 import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
@@ -129,12 +129,18 @@ const ProductCollectionContent = ( {
 		};
 	}
 
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
 	/**
-	 * Because of issue https://github.com/WordPress/gutenberg/issues/7342,
+	 * Because of issue https://github.com/WordPress/gutenberg/issues/7342.
 	 * We are using this workaround to set default attributes.
 	 */
 	useEffect(
 		() => {
+			// This is a pattern used in core. We should follow it until we can remove the
+			// queryId attribute completely, as planned in https://github.com/woocommerce/woocommerce/issues/51671.
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( defaultAttributesValue );
 			isInitialAttributesSet.current = true;
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -3,7 +3,7 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
-import { select, useDispatch, useSelect } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import type { BlockEditProps, Block } from '@wordpress/blocks';
 import {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -3,7 +3,7 @@
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
-import { select, useSelect } from '@wordpress/data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import type { BlockEditProps, Block } from '@wordpress/blocks';
 import {
@@ -394,18 +394,22 @@ export const useSetPreviewState = ( {
 		if ( ! setPreviewState && ! isUsingReferencePreviewMode ) {
 			const isGenericArchiveTemplate =
 				location.type === LocationType.Archive && termId === null;
+			const isPreview = isGenericArchiveTemplate
+				? !! attributes?.query?.inherit
+				: false;
 
-			setAttributes( {
-				__privatePreviewState: {
-					isPreview: isGenericArchiveTemplate
-						? !! attributes?.query?.inherit
-						: false,
-					previewMessage: __(
-						'Actual products will vary depending on the page being viewed.',
-						'woocommerce'
-					),
-				},
-			} );
+			// Avoid setting preview state if it's already set to false.
+			if ( isPreview ) {
+				setAttributes( {
+					__privatePreviewState: {
+						isPreview,
+						previewMessage: __(
+							'Actual products will vary depending on the page being viewed.',
+							'woocommerce'
+						),
+					},
+				} );
+			}
 		}
 	}, [
 		attributes?.query?.inherit,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The issue was caused mainly by `__privatePreviewState` attribute update which should be prevented. I added a guard not to update it when the actual preview state doesn't change. It's still not perfect solution as in some other cases, when actual preview state IS CHANGING, the changes would still require attention but that handles majority of cases.

Closes https://linear.app/a8c/issue/WOOPLUG-4279/product-collection-in-template-part-prompts-review-changes-warning

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1030" alt="image" src="https://github.com/user-attachments/assets/aa484cfb-0540-4a92-9481-f67a96b5fbaa" />     |    <img width="1027" alt="image" src="https://github.com/user-attachments/assets/ff278f24-a30c-4b5d-a877-152a5a93d885" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the Product Collection block in some template part (or create custom one)
2. In a fresh tab or after refresh go to the Editor > Patterns -> All template parts
3. Enter the same template-part and leave
5. **Expected:** The edit-save button section in the bottom left of the editor does not change to the "Review 1 change"
6. Switch to `trunk` and repeat steps 2-3
7. You'd see the "Review 1 change"

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
