### PR TITLE
Fix activity panel tab help button does not have accessible text

### DIFF
--- a/plugins/woocommerce/changelog/fix-58034
+++ b/plugins/woocommerce/changelog/fix-58034
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add aria label attribute to activity panel tab help button in WooCommerce admin settings home page.

--- a/plugins/woocommerce/client/admin/client/activity-panel/tab/index.js
+++ b/plugins/woocommerce/client/admin/client/activity-panel/tab/index.js
@@ -21,6 +21,12 @@ export const Tab = ( {
 
 	const tabKey = `activity-panel-tab-${ name }`;
 
+	// Add aria-label when no title is provided but name exists.
+	const ariaLabel =
+		! title && name
+			? name.charAt( 0 ).toUpperCase() + name.slice( 1 )
+			: undefined;
+
 	return (
 		<Button
 			role="tab"
@@ -30,6 +36,7 @@ export const Tab = ( {
 			key={ tabKey }
 			id={ tabKey }
 			data-testid={ tabKey }
+			aria-label={ ariaLabel }
 			onClick={ () => {
 				onTabClick( name );
 			} }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds aria label property on the activity panel tab help button on WordPress Admin > WooCommerce > Home page to fix the accessibility issue where icon-only buttons lacked discernible text for screen readers.

| Before | After |
| ------ | ----- |
| `<button type="button" aria-selected="false" role="tab" aria-controls="activity-panel-help" id="activity-panel-tab-help" data-testid="activity-panel-tab-help" class="components-button woocommerce-layout__activity-panel-tab">` | `<button type="button" aria-selected="false" role="tab" aria-controls="activity-panel-help" id="activity-panel-tab-help" data-testid="activity-panel-tab-help" aria-label="Help" class="components-button woocommerce-layout__activity-panel-tab">` |

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58034

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="500" alt="image" src="https://github.com/user-attachments/assets/45b55cb3-4723-43ae-bc61-26e98f24b159" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go the WordPress admin dashboard.
2. Navigate to WooCommerce > Home from the admin panel
3. Perform a full scan of the page using the [axe DevTools extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1).
4. Notice that there's no error for the `#activity-panel-tab-help` button:
6. Open browser dev tools and select the element with id `activity-panel-tab-help` using inspector.
7. Verify that this element has `aria-label` attribute set correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
