### PR TITLE
List Square as a recommended provider for merchants selling offline in supported regions

### DIFF
--- a/plugins/woocommerce/changelog/update-wooplug-4207-square-as-provider
+++ b/plugins/woocommerce/changelog/update-wooplug-4207-square-as-provider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+List Square as a recommended provider for merchants selling offline in supported regions.

--- a/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Suggestions/PaymentExtensionSuggestions.php
@@ -93,9 +93,10 @@ class PaymentExtensionSuggestions {
 	 * These are used to categorize the extensions and provide additional information to the system.
 	 * Some tags may carry special meaning and will be used to influence the suggestions' behavior.
 	 */
-	const TAG_PREFERRED   = 'preferred';
-	const TAG_MADE_IN_WOO = 'made_in_woo'; // For extensions developed by Woo.
-	const TAG_RECOMMENDED = 'recommended'; // For extensions that should be further emphasized.
+	const TAG_PREFERRED         = 'preferred';
+	const TAG_PREFERRED_OFFLINE = 'preferred_offline'; // For extensions that are preferred for offline payments.
+	const TAG_MADE_IN_WOO       = 'made_in_woo'; // For extensions developed by Woo.
+	const TAG_RECOMMENDED       = 'recommended'; // For extensions that should be further emphasized.
 
 	/**
 	 * The memoized extensions base details to avoid computing them multiple times during a request.
@@ -1989,8 +1990,12 @@ class PaymentExtensionSuggestions {
 				continue;
 			}
 
+			// Determine the extension details for the given country.
 			$extension_base_details = $this->get_extension_base_details( $extension_id ) ?? array();
 			$extension_details      = $this->with_country_details( $extension_base_details, $extension_country_details );
+
+			// Apply any changes to the extension details based on the store's state.
+			$extension_details = $this->with_store_state_details( $extension_id, $extension_details );
 
 			// Check if there is an incentive for this extension and attach its details.
 			$incentive = $this->get_extension_incentive( $extension_id, $country_code, $context );
@@ -2094,7 +2099,6 @@ class PaymentExtensionSuggestions {
 		return $this->suggestion_incentives->dismiss_incentive( $incentive_id, $suggestion_id, $context );
 	}
 
-
 	/**
 	 * Determine if a payment extension is allowed to be suggested.
 	 *
@@ -2109,88 +2113,6 @@ class PaymentExtensionSuggestions {
 		// Add per-extension exclusion logic here.
 		// Returning true for now to avoid excluding any extensions.
 		return true;
-	}
-
-	/**
-	 * Based on the WC onboarding profile, determine if the merchant is selling online.
-	 *
-	 * If the user skipped the profiler (no data points provided), we assume they are selling online.
-	 *
-	 * @return bool True if the merchant is selling online, false otherwise.
-	 */
-	private function is_merchant_selling_online(): bool {
-		/*
-		 * We consider a merchant to be selling online if:
-		 * - The profiler was skipped (no data points provided).
-		 *   OR
-		 * - The merchant answered 'Which one of these best describes you?' with 'I’m already selling' AND:
-		 *   - Didn't answer to the 'Are you selling online?' question.
-		 *      OR
-		 *   - Answered the 'Are you selling online?' question with either:
-		 *     - 'Yes, I’m selling online'.
-		 *        OR
-		 *     - 'I’m selling both online and offline'.
-		 *
-		 * @see plugins/woocommerce/client/admin/client/core-profiler/pages/UserProfile.tsx for the values.
-		 */
-		$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
-		if (
-			! isset( $onboarding_profile['business_choice'] ) ||
-			(
-				'im_already_selling' === $onboarding_profile['business_choice'] &&
-				(
-					! isset( $onboarding_profile['selling_online_answer'] ) ||
-					(
-						'yes_im_selling_online' === $onboarding_profile['selling_online_answer'] ||
-						'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
-					)
-				)
-			)
-		) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Based on the WC onboarding profile, determine if the merchant is selling offline.
-	 *
-	 * If the user skipped the profiler (no data points provided), we assume they are NOT selling offline.
-	 *
-	 * @return bool True if the merchant is selling offline, false otherwise.
-	 */
-	private function is_merchant_selling_offline(): bool {
-		/*
-		 * We consider a merchant to be selling offline if:
-		 * - The profiler was NOT skipped (data points provided).
-		 *   AND
-		 * - The merchant answered 'Which one of these best describes you?' with 'I’m already selling' AND:
-		 *   - Answered the 'Are you selling online?' question with either:
-		 *     - 'No, I’m selling offline'.
-		 *        OR
-		 *     - 'I’m selling both online and offline'.
-		 *
-		 * @see plugins/woocommerce/client/admin/client/core-profiler/pages/UserProfile.tsx for the values.
-		 */
-		$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
-		if (
-			isset( $onboarding_profile['business_choice'] ) &&
-			(
-				'im_already_selling' === $onboarding_profile['business_choice'] &&
-				(
-					isset( $onboarding_profile['selling_online_answer'] ) &&
-					(
-						'no_im_selling_offline' === $onboarding_profile['selling_online_answer'] ||
-						'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
-					)
-				)
-			)
-		) {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**
@@ -2312,6 +2234,31 @@ class PaymentExtensionSuggestions {
 
 		// Merge any remaining country details so they overwrite the base details.
 		return array_merge( $base_details, $country_details );
+	}
+
+	/**
+	 * Apply customizations to the extension details based on the store's state.
+	 *
+	 * The customizations may be general or specific to certain extensions.
+	 * The store's state refers to various aspects of the store's configuration, collected data,
+	 * store setup/launch process, onboarding task completion, etc.
+	 *
+	 * @param string $extension_id      The extension ID.
+	 * @param array  $extension_details The extension details.
+	 *
+	 * @return array The modified extension details.
+	 */
+	private function with_store_state_details( string $extension_id, array $extension_details ): array {
+		// For Square, we add the preferred tags if the merchant self-identified as selling offline via the core profiler.
+		if ( self::SQUARE === $extension_id && $this->is_merchant_selling_offline() ) {
+			if ( empty( $extension_details['tags'] ) ) {
+				$extension_details['tags'] = array();
+			}
+			$extension_details['tags'][] = self::TAG_PREFERRED;
+			$extension_details['tags'][] = self::TAG_PREFERRED_OFFLINE;
+		}
+
+		return $extension_details;
 	}
 
 	/**
@@ -3411,5 +3358,87 @@ class PaymentExtensionSuggestions {
 		$standardized['_incentive']  = $extension_details['_incentive'] ?? null;
 
 		return $standardized;
+	}
+
+	/**
+	 * Based on the WC onboarding profile, determine if the merchant is selling online.
+	 *
+	 * If the user skipped the profiler (no data points provided), we assume they are selling online.
+	 *
+	 * @return bool True if the merchant is selling online, false otherwise.
+	 */
+	private function is_merchant_selling_online(): bool {
+		/*
+		 * We consider a merchant to be selling online if:
+		 * - The profiler was skipped (no data points provided).
+		 *   OR
+		 * - The merchant answered 'Which one of these best describes you?' with 'I’m already selling' AND:
+		 *   - Didn't answer to the 'Are you selling online?' question.
+		 *      OR
+		 *   - Answered the 'Are you selling online?' question with either:
+		 *     - 'Yes, I’m selling online'.
+		 *        OR
+		 *     - 'I’m selling both online and offline'.
+		 *
+		 * @see plugins/woocommerce/client/admin/client/core-profiler/pages/UserProfile.tsx for the values.
+		 */
+		$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
+		if (
+			! isset( $onboarding_profile['business_choice'] ) ||
+			(
+				'im_already_selling' === $onboarding_profile['business_choice'] &&
+				(
+					! isset( $onboarding_profile['selling_online_answer'] ) ||
+					(
+						'yes_im_selling_online' === $onboarding_profile['selling_online_answer'] ||
+						'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
+					)
+				)
+			)
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Based on the WC onboarding profile, determine if the merchant is selling offline.
+	 *
+	 * If the user skipped the profiler (no data points provided), we assume they are NOT selling offline.
+	 *
+	 * @return bool True if the merchant is selling offline, false otherwise.
+	 */
+	private function is_merchant_selling_offline(): bool {
+		/*
+		 * We consider a merchant to be selling offline if:
+		 * - The profiler was NOT skipped (data points provided).
+		 *   AND
+		 * - The merchant answered 'Which one of these best describes you?' with 'I’m already selling' AND:
+		 *   - Answered the 'Are you selling online?' question with either:
+		 *     - 'No, I’m selling offline'.
+		 *        OR
+		 *     - 'I’m selling both online and offline'.
+		 *
+		 * @see plugins/woocommerce/client/admin/client/core-profiler/pages/UserProfile.tsx for the values.
+		 */
+		$onboarding_profile = get_option( OnboardingProfile::DATA_OPTION, array() );
+		if (
+			isset( $onboarding_profile['business_choice'] ) &&
+			(
+				'im_already_selling' === $onboarding_profile['business_choice'] &&
+				(
+					isset( $onboarding_profile['selling_online_answer'] ) &&
+					(
+						'no_im_selling_offline' === $onboarding_profile['selling_online_answer'] ||
+						'im_selling_both_online_and_offline' === $onboarding_profile['selling_online_answer']
+					)
+				)
+			)
+		) {
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR updates the payment provider recommendation logic to highlight Square as the third recommended option when a merchant indicates they sell offline in any capacity during the WooCommerce Core Profiler setup.

Behavior Summary:
- If a merchant selects “I’m already selling” > “No, I’m selling offline”, Square will appear as the 3rd recommended payment method, as long as their store is in a supported region.
- If a merchant selects “I’m already selling” > “I’m selling both online and offline”, Square is also shown as the 3rd recommendation in supported regions.
- If the merchant is outside a supported region, Square will not be recommended, even if they sell offline.
- If the Core Profiler is skipped or the merchant is selling only online, Square is not shown as a recommended payment provider.

Closes WOOPLUG-4207

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="983" alt="Screenshot 2025-05-15 at 10 34 02" src="https://github.com/user-attachments/assets/23d5b88c-2800-4d97-9195-97f45aea2472" />  |  <img width="1237" alt="Screenshot 2025-05-15 at 10 52 26" src="https://github.com/user-attachments/assets/7e8efec8-5120-4806-afe6-3215c586a080" />  |

### How to test the changes in this Pull Request:
- Create a new JurassicNinja site with WooCommerce on this PR's live branch and WooCommerce Beta Tester (here is [a direct JN create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=update/WOOPLUG-4207-square-for-offline-stores))
- Go to the newly created site's WP admin dashboard.
- Navigate to Jetpack > Beta Tester and ensure WooCommerce is on the branch associated with this PR.

### Testing selling online

- Go through the WooCommerce profiler (click on the "WooCommerce" menu item if it doesn't start automatically), click on "Setup my store", choose "I’m already selling" and select "Yes, I’m selling online". Click "Continue".
<img width="967" alt="Screenshot 2025-05-15 at 10 47 14" src="https://github.com/user-attachments/assets/4f24a902-5984-4223-aa09-9cab791d64a9" />

- Select "United States" from "Where is your store located?" and click Continue.
- Skip the next step.
- Click on the "Payments" menu on the sidebar.
- Ensure Square is not displayed in the suggested providers list.
<img width="983" alt="Screenshot 2025-05-15 at 10 34 02" src="https://github.com/user-attachments/assets/23d5b88c-2800-4d97-9195-97f45aea2472" />

- Click on the "Other payment options" to expand the options.
- Ensure Square is displayed as a second suggestion.
<img width="940" alt="Screenshot 2025-05-15 at 10 34 13" src="https://github.com/user-attachments/assets/7e04d36b-05ec-4336-8df1-3251ab4dd659" />

- From the country selector dropdown on the top right, select "Austria".
- Ensure Square is not displayed in the suggested providers list.
- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.

<img width="932" alt="Screenshot 2025-05-15 at 10 37 10" src="https://github.com/user-attachments/assets/308d5456-6791-4186-a596-b2de75e1ad0d" />


### Testing selling offline

- Navigate to Tools -> WCA Test Helper > Tools.
- Click the "Run" button next to the "Reset Onboarding Wizard".
- Go to WooCommerce > Home, ensure the WooCommerce profiler is displayed again.
- Click on "Setup my store", choose "I’m already selling" and select "No, I’m selling offline". Click "Continue".
<img width="976" alt="Screenshot 2025-05-15 at 10 47 23" src="https://github.com/user-attachments/assets/d6cf189f-b307-4756-a534-fc117d9c52a4" />

- Select "Austria" from "Where is your store located?" and click Continue.
- Skip the next step.
- Click on the "Payments" menu on the sidebar.
- Ensure Square is not displayed in the suggested providers list.
- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.

<img width="932" alt="Screenshot 2025-05-15 at 10 37 10" src="https://github.com/user-attachments/assets/308d5456-6791-4186-a596-b2de75e1ad0d" />

- From the country selector dropdown on the top right, select "United States".
- Ensure Square is displayed in the suggested providers list as the 3rd suggestion.
<img width="1237" alt="Screenshot 2025-05-15 at 10 52 26" src="https://github.com/user-attachments/assets/7e8efec8-5120-4806-afe6-3215c586a080" />

- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.
<img width="1139" alt="Screenshot 2025-05-15 at 11 00 48" src="https://github.com/user-attachments/assets/7d5e969e-d0ee-413d-9bc9-e9952a32bc4e" />


### Testing selling online & offline

- Navigate to Tools -> WCA Test Helper > Tools.
- Click the "Run" button next to the "Reset Onboarding Wizard".
- Go to WooCommerce > Home, ensure the WooCommerce profiler is displayed again.
- Click on "Setup my store", choose "I’m already selling" and select "I'm selling both online & offline". Click "Continue".

<img width="905" alt="Screenshot 2025-05-15 at 10 47 33" src="https://github.com/user-attachments/assets/a914769e-eaca-403c-acd0-e479b9f7097b" />

- Select "United States" from "Where is your store located?" and click Continue.
- Skip the next step.
- Click on the "Payments" menu on the sidebar.
- Ensure Square is displayed in the suggested providers list as the 3rd suggestion.
<img width="1237" alt="Screenshot 2025-05-15 at 10 52 26" src="https://github.com/user-attachments/assets/7e8efec8-5120-4806-afe6-3215c586a080" />

- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.

<img width="1139" alt="Screenshot 2025-05-15 at 11 00 48" src="https://github.com/user-attachments/assets/7d5e969e-d0ee-413d-9bc9-e9952a32bc4e" />

- From the country selector dropdown on the top right, select "Austria".
- Ensure Square is not displayed in the suggested providers list.
- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.

<img width="932" alt="Screenshot 2025-05-15 at 10 37 10" src="https://github.com/user-attachments/assets/308d5456-6791-4186-a596-b2de75e1ad0d" />

- From the country selector dropdown on the top right, select "France".
- Ensure Square is displayed in the suggested providers list as the 3rd suggestion.

<img width="1237" alt="Screenshot 2025-05-15 at 10 52 26" src="https://github.com/user-attachments/assets/7e8efec8-5120-4806-afe6-3215c586a080" />

- Drag the Square provider to the second position.
- Reload the page and ensure Square is in the second position.

<img width="1251" alt="Screenshot 2025-05-15 at 11 08 53" src="https://github.com/user-attachments/assets/d670a69f-d4f1-46bc-b236-d07f71791f34" />

- Click the three dots button next to the Square option and click the "Hide suggestion".

<img width="981" alt="Screenshot 2025-05-15 at 11 12 42" src="https://github.com/user-attachments/assets/e84ff89d-0c1e-4e36-8f1b-f78940b6f4b9" />

- Ensure the Square option is no longer displayed in the provider suggestions list.

<img width="983" alt="Screenshot 2025-05-15 at 10 34 02" src="https://github.com/user-attachments/assets/23d5b88c-2800-4d97-9195-97f45aea2472" />

- Click on the "Other payment options" to expand the options.
- Ensure Square is displayed as the second option.

<img width="940" alt="Screenshot 2025-05-15 at 10 34 13" src="https://github.com/user-attachments/assets/7e04d36b-05ec-4336-8df1-3251ab4dd659" />

### Testing skipping core profiler

- Navigate to Tools -> WCA Test Helper > Tools.
- Click the "Run" button next to the "Reset Onboarding Wizard".
- Go to WooCommerce > Home, ensure the WooCommerce profiler is displayed again.
- Click on "Skip guided setup".
- Select "France" as store country and click Continue.
- Click on the "Payments" menu on the sidebar.
- Ensure Square is not displayed in the suggested providers list.
<img width="983" alt="Screenshot 2025-05-15 at 10 34 02" src="https://github.com/user-attachments/assets/23d5b88c-2800-4d97-9195-97f45aea2472" />

- Click on the "Other payment options" to expand the options.
- Ensure Square is displayed as a second suggestion.
<img width="940" alt="Screenshot 2025-05-15 at 10 34 13" src="https://github.com/user-attachments/assets/7e04d36b-05ec-4336-8df1-3251ab4dd659" />

- From the country selector dropdown on the top right, select "Austria".
- Ensure Square is not displayed in the suggested providers list.
- Click on the "Other payment options" to expand the options.
- Ensure Square is not displayed as an option.

<img width="932" alt="Screenshot 2025-05-15 at 10 37 10" src="https://github.com/user-attachments/assets/308d5456-6791-4186-a596-b2de75e1ad0d" />

### Testing that has already taken place:
Check the above instructions.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
