### PR TITLE
Update MailPoet and Klaviyo variant assignment to 50/50 split

### DIFF
--- a/plugins/woocommerce/changelog/58071-update-wooprd-522-update-klaviyo-visibility-in-core-profiler
+++ b/plugins/woocommerce/changelog/58071-update-wooprd-522-update-klaviyo-visibility-in-core-profiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update MailPoet and Klaviyo variant assignment to 50/50 split. This change updates the visibility configuration for MailPoet and Klaviyo plugins to create an equal 50/50 split in visibility, replacing the previous 70/30 split configuration.

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -215,7 +215,7 @@ class DefaultFreeExtensions {
 					array(
 						'type'        => 'option',
 						'option_name' => 'woocommerce_remote_variant_assignment',
-						'value'       => array( 1, 84 ), // 70% segment with klaviyo
+						'value'       => array( 1, 60 ), // 50% segment with klaviyo
 						'default'     => false,
 						'operation'   => 'range',
 					),
@@ -254,7 +254,7 @@ class DefaultFreeExtensions {
 					array(
 						'type'        => 'option',
 						'option_name' => 'woocommerce_remote_variant_assignment',
-						'value'       => array( 85, 120 ), // 30% segment with mailpoet
+						'value'       => array( 61, 120 ), // 50% segment with mailpoet
 						'default'     => false,
 						'operation'   => 'range',
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This PR updates the variant assignment configuration for MailPoet and Klaviyo plugins to create an equal 50/50 split in visibility. Previously, the configuration was set to a 70/30 split (MailPoet: 70%, Klaviyo: 30%).

Closes #522.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| MailPoet visible for 70% of stores (variant 1-84) | MailPoet visible for 50% of stores (variant 1-60) |
| Klaviyo visible for 30% of stores (variant 85-120) | Klaviyo visible for 50% of stores (variant 61-120) |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh WooCommerce installation
2. Verify the `woocommerce_remote_variant_assignment` option is set (it should be a random number between 1-120)
3. Test with different variant assignments:
   - For values 1-60: Verify MailPoet is visible
   - For values 61-120: Verify Klaviyo is visible
4. Verify that the visibility is mutually exclusive (stores should only see one of the plugins)

### Testing that has already taken place:

Environment details:
- Local development environment
- WordPress 6.4
- WooCommerce trunk
- Default theme
- No additional plugins installed

Testing performed:
- Verified variant assignments work as expected for both plugins
- Confirmed no existing tests were affected as there were no specific tests for the previous 70/30 split
- Tested visibility rules for both plugins across the full range of variant assignments

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update MailPoet and Klaviyo variant assignment to 50/50 split. This change updates the visibility configuration for MailPoet and Klaviyo plugins to create an equal 50/50 split in visibility, replacing the previous 70/30 split configuration.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>