### PR TITLE
UI improvements and style panel fixes in the email editor

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4200-edtitor-ui-updates
+++ b/packages/js/email-editor/changelog/wooplug-4200-edtitor-ui-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update email editor email preview, switch to template modal and style preview componets

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -171,10 +171,13 @@ function RawSendPreviewEmail() {
 						);
 					}
 				} }
+				className="woocommerce-send-preview-email__send-to-field"
 				value={ previewToEmail }
 				type="email"
 				ref={ sendToRef }
 				required
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 			/>
 			{ sendingPreviewStatus === SendingPreviewStatus.SUCCESS ? (
 				<p className="woocommerce-send-preview-modal-notice-success">

--- a/packages/js/email-editor/src/components/preview/send-preview-email.tsx
+++ b/packages/js/email-editor/src/components/preview/send-preview-email.tsx
@@ -148,39 +148,9 @@ function RawSendPreviewEmail() {
 				</div>
 			) : null }
 			<p>
-				{ createInterpolateElement(
-					__(
-						'Send yourself a test email to test how your email would look like in different email apps. You can also test your spam score by sending a test email to <link1>{$serviceName}</link1>. <link2>Learn more</link2>.',
-						'woocommerce'
-					).replace( '{$serviceName}', 'Mail Tester' ),
-					{
-						link1: (
-							// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-							<a
-								href="https://www.mail-tester.com/"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ () =>
-									recordEvent(
-										'send_preview_email_modal_send_test_email_to_mail_tester_link_clicked'
-									)
-								}
-							/>
-						),
-						link2: (
-							// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-							<a
-								href="https://kb.mailpoet.com/article/147-test-your-spam-score-with-mail-tester"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ () =>
-									recordEvent(
-										'send_preview_email_modal_learn_more_about_mail_tester_link_clicked'
-									)
-								}
-							/>
-						),
-					}
+				{ __(
+					'Send yourself a test email to test how your email would look like in different email apps.',
+					'woocommerce'
 				) }
 			</p>
 			<TextControl
@@ -222,7 +192,7 @@ function RawSendPreviewEmail() {
 						closeCallback();
 					} }
 				>
-					{ __( 'Close', 'woocommerce' ) }
+					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 				<Button
 					variant="primary"

--- a/packages/js/email-editor/src/components/preview/style.scss
+++ b/packages/js/email-editor/src/components/preview/style.scss
@@ -26,3 +26,7 @@
 	display: flex;
 	padding-top: 2px;
 }
+
+.woocommerce-send-preview-email__send-to-field {
+	margin-bottom: 8px;
+}

--- a/packages/js/email-editor/src/components/sidebar/edit-template-modal.tsx
+++ b/packages/js/email-editor/src/components/sidebar/edit-template-modal.tsx
@@ -30,7 +30,7 @@ export function EditTemplateModal( { close } ) {
 		<Modal size="medium" onRequestClose={ close } __experimentalHideHeader>
 			<p>
 				{ __(
-					'Note that the same template can be used by multiple emails, so any changes made here may affect other emails on the site. To switch back to editing the page content click the ‘Back’ button in the toolbar.',
+					'This template is used by multiple emails. Any changes made would affect other emails on the site. Are you sure you want to edit the template?',
 					'woocommerce'
 				) }
 			</p>
@@ -63,7 +63,7 @@ export function EditTemplateModal( { close } ) {
 						} }
 						disabled={ ! template.id }
 					>
-						{ __( 'Continue', 'woocommerce' ) }
+						{ __( 'Edit template', 'woocommerce' ) }
 					</Button>
 				</FlexItem>
 			</Flex>

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line
 	__experimentalVStack as VStack, // eslint-disable-line
@@ -13,6 +13,8 @@ import {
  * Internal dependencies
  */
 import { storeName } from '../../../store';
+import { useEmailStyles } from '../../../hooks';
+import { getCompressedVariableValue } from '../../../style-variables';
 
 const firstFrame = {
 	start: {
@@ -56,7 +58,7 @@ type Props = {
 
 /**
  * Component to render the styles preview based on the component from the site editor:
- * https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/global-styles/preview.js
+ * https://github.com/WordPress/gutenberg/blob/5c7c4e7751df5e05fc70a354cd0d81414ac9c7e7/packages/edit-site/src/components/global-styles/preview-styles.js
  *
  * @param root0
  * @param root0.label
@@ -68,23 +70,41 @@ export function Preview( {
 	isFocused,
 	withHoverView,
 }: Props ): JSX.Element {
-	const { styles, colors } = useSelect(
+	const { colors } = useSelect(
 		( select ) => ( {
-			styles: select( storeName ).getStyles(),
 			colors: select( storeName ).getPaletteColors(),
 		} ),
 		[]
 	);
 
-	const backgroundColor = styles?.color?.background || '#ffffff';
-	const headingFontFamily =
-		styles?.elements?.heading?.typography?.fontFamily || 'inherit';
-	const headingColor = styles?.elements?.heading?.color?.text || 'inherit';
+	const { styles } = useEmailStyles();
+
+	const backgroundColor = useMemo(
+		() =>
+			getCompressedVariableValue( styles?.color?.background ) ||
+			'#ffffff',
+		[ styles ]
+	);
+	const textColor = useMemo(
+		() => getCompressedVariableValue( styles?.color?.text ) || 'inherit',
+		[ styles ]
+	);
+	const headingColor = useMemo(
+		() =>
+			getCompressedVariableValue(
+				styles?.elements?.heading?.color?.text
+			) || textColor,
+		[ styles, textColor ]
+	);
+
 	const headingFontWeight =
 		styles?.elements?.heading?.typography?.fontWeight || 'inherit';
+	const headingFontFamily =
+		styles?.elements?.heading?.typography?.fontFamily || 'inherit';
 
-	const paletteColors = colors.theme.concat( colors.theme );
+	const paletteColors = colors.theme.concat( colors.default );
 
+	// We pick the first two colors that are not the background or the heading color
 	// https://github.com/WordPress/gutenberg/blob/7fa03fafeb421ab4c3604564211ce6007cc38e84/packages/edit-site/src/components/global-styles/hooks.js#L68-L73
 	const highlightedColors = paletteColors
 		.filter(

--- a/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/screens/preview.tsx
@@ -76,41 +76,67 @@ export function Preview( {
 		} ),
 		[]
 	);
-
+	const paletteColors = useMemo(
+		() => colors.theme.concat( colors.default ),
+		[ colors ]
+	);
 	const { styles } = useEmailStyles();
 
-	const backgroundColor = useMemo(
-		() =>
-			getCompressedVariableValue( styles?.color?.background ) ||
-			'#ffffff',
-		[ styles ]
-	);
-	const textColor = useMemo(
-		() => getCompressedVariableValue( styles?.color?.text ) || 'inherit',
-		[ styles ]
-	);
-	const headingColor = useMemo(
-		() =>
+	const {
+		backgroundColor,
+		headingColor,
+		textColorPaletteObject,
+		buttonBackgroundColorPaletteObject,
+	} = useMemo( () => {
+		const backgroundCol =
+			getCompressedVariableValue( styles?.color?.background ) || 'white';
+		const textCol =
+			getCompressedVariableValue( styles?.color?.text ) || 'black';
+		const headingCol =
+			getCompressedVariableValue( styles?.elements?.h1?.color?.text ) ||
+			textCol;
+		const linkColor =
+			getCompressedVariableValue( styles?.elements?.link?.color?.text ) ||
+			headingCol;
+		const buttonBackgroundCol =
 			getCompressedVariableValue(
-				styles?.elements?.heading?.color?.text
-			) || textColor,
-		[ styles, textColor ]
-	);
+				styles?.elements?.button?.color?.background
+			) || linkColor;
+
+		const textColorPaletteObj = paletteColors.find(
+			( { color } ) => color.toLowerCase() === textCol.toLowerCase()
+		);
+		const buttonBackgroundColorPaletteObj = paletteColors.find(
+			( { color } ) =>
+				color.toLowerCase() === buttonBackgroundCol.toLowerCase()
+		);
+
+		return {
+			backgroundColor: backgroundCol,
+			headingColor: headingCol,
+			buttonBackgroundColor: buttonBackgroundCol,
+			textColorPaletteObject: textColorPaletteObj,
+			buttonBackgroundColorPaletteObject: buttonBackgroundColorPaletteObj,
+		};
+	}, [ styles, paletteColors ] );
 
 	const headingFontWeight =
 		styles?.elements?.heading?.typography?.fontWeight || 'inherit';
 	const headingFontFamily =
 		styles?.elements?.heading?.typography?.fontFamily || 'inherit';
 
-	const paletteColors = colors.theme.concat( colors.default );
-
-	// We pick the first two colors that are not the background or the heading color
-	// https://github.com/WordPress/gutenberg/blob/7fa03fafeb421ab4c3604564211ce6007cc38e84/packages/edit-site/src/components/global-styles/hooks.js#L68-L73
-	const highlightedColors = paletteColors
+	// We pick the colors for the highlighted colors the same way as the site editor
+	// https://github.com/WordPress/gutenberg/blob/7b3850b6a39ce45948f09efe750451c6323a4613/packages/edit-site/src/components/global-styles/hooks.js#L83-L95
+	const highlightedColors = [
+		...( textColorPaletteObject ? [ textColorPaletteObject ] : [] ),
+		...( buttonBackgroundColorPaletteObject
+			? [ buttonBackgroundColorPaletteObject ]
+			: [] ),
+		...paletteColors,
+	]
 		.filter(
 			( { color } ) =>
-				color.toLowerCase() !== backgroundColor.toLowerCase() &&
-				color.toLowerCase() !== headingColor.toLowerCase()
+				color.toLowerCase() !== backgroundColor.toLowerCase()
 		)
 		.slice( 0, 2 );
 

--- a/packages/js/email-editor/src/components/styles-sidebar/utils.ts
+++ b/packages/js/email-editor/src/components/styles-sidebar/utils.ts
@@ -6,7 +6,7 @@ import deepmerge from 'deepmerge';
 /**
  * Internal dependencies
  */
-import { StyleProperties } from '../../hooks/use-email-styles';
+import { EmailStyles } from '../../store';
 
 const defaultStyleObject = {
 	typography: {},
@@ -25,34 +25,34 @@ const defaultStyleObject = {
  * @param merge
  */
 export const getHeadingElementStyles = (
-	styles: StyleProperties,
+	styles: EmailStyles,
 	headingLevel = 'heading',
 	merge = false
-): StyleProperties =>
+): EmailStyles =>
 	merge
 		? ( deepmerge.all( [
 				defaultStyleObject,
 				styles.elements.heading || {},
 				styles.elements[ headingLevel ] || {},
-		  ] ) as StyleProperties )
+		  ] ) as EmailStyles )
 		: ( {
 				...defaultStyleObject,
 				...( styles.elements.heading || {} ),
 				...( styles.elements[ headingLevel ] || {} ),
-		  } as StyleProperties );
+		  } as EmailStyles );
 
 export const getElementStyles = (
-	styles: StyleProperties,
+	styles: EmailStyles,
 	element: string,
 	headingLevel = 'heading',
 	merge = false
-): StyleProperties => {
+): EmailStyles => {
 	switch ( element ) {
 		case 'text':
 			return {
 				typography: styles.typography,
 				color: styles.color,
-			} as StyleProperties;
+			} as EmailStyles;
 		case 'heading':
 			return getHeadingElementStyles(
 				styles,
@@ -61,6 +61,6 @@ export const getElementStyles = (
 			);
 		default:
 			return ( styles.elements[ element ] ||
-				defaultStyleObject ) as StyleProperties;
+				defaultStyleObject ) as EmailStyles;
 	}
 };

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -14,6 +14,7 @@ import { initializeLayout } from './layouts/flex-email';
 import { InnerEditor } from './components/block-editor';
 import { createStore, storeName, editorCurrentPostType } from './store';
 import { initHooks } from './editor-hooks';
+import { initTextHooks } from './text-hooks';
 import { initEventCollector } from './events';
 import './style.scss';
 
@@ -52,6 +53,7 @@ export function initialize( elementId: string ) {
 	initializeLayout();
 	initBlocks();
 	initHooks();
+	initTextHooks();
 	const root = createRoot( container );
 	root.render( <WrappedEditor /> );
 }

--- a/packages/js/email-editor/src/hooks/use-email-css.ts
+++ b/packages/js/email-editor/src/hooks/use-email-css.ts
@@ -12,13 +12,10 @@ import deepmerge from 'deepmerge';
 import { EmailTheme, EmailBuiltStyles, storeName } from '../store';
 import { useUserTheme } from './use-user-theme';
 import { useGlobalStylesOutputWithConfig } from '../private-apis';
+import { unwrapCompressedPresetStyleVariable } from '../style-variables';
 
-// Utility to normalize spacing value to --wp--preset--spacing--<value> format
-function normalizeSpacingValue( value: string ): string {
-	if ( typeof value !== 'string' ) return value;
-	const match = value.match( /^var:preset\|spacing\|([a-zA-Z0-9-]+)$/ );
-	return match ? `var(--wp--preset--spacing--${ match[ 1 ] })` : value;
-}
+// Empty array to avoid re-rendering the component when the array is empty
+const EMPTY_ARRAY = [];
 
 export function useEmailCss() {
 	const { userTheme } = useUserTheme();
@@ -62,10 +59,10 @@ export function useEmailCss() {
 	}
 	const padding = mergedConfig.styles?.spacing?.padding;
 	if ( padding ) {
-		rootContainerStyles += `padding-left:${ normalizeSpacingValue(
+		rootContainerStyles += `padding-left:${ unwrapCompressedPresetStyleVariable(
 			padding.left
 		) };`;
-		rootContainerStyles += `padding-right:${ normalizeSpacingValue(
+		rootContainerStyles += `padding-right:${ unwrapCompressedPresetStyleVariable(
 			padding.right
 		) };`;
 	}
@@ -81,5 +78,5 @@ export function useEmailCss() {
 	}, [ styles, editorSettingsStyles, rootContainerStyles ] );
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return [ finalStyles || [] ];
+	return [ finalStyles || EMPTY_ARRAY ];
 }

--- a/packages/js/email-editor/src/hooks/use-email-styles.ts
+++ b/packages/js/email-editor/src/hooks/use-email-styles.ts
@@ -17,6 +17,10 @@ const EMPTY_OBJECT = {};
 
 interface ElementProperties {
 	typography: TypographyProperties;
+	color?: {
+		background: string;
+		text: string;
+	};
 }
 export interface StyleProperties {
 	spacing?: {

--- a/packages/js/email-editor/src/hooks/use-email-styles.ts
+++ b/packages/js/email-editor/src/hooks/use-email-styles.ts
@@ -8,44 +8,19 @@ import { useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { storeName, TypographyProperties } from '../store';
+import { storeName, EmailStyles } from '../store';
 import { useUserTheme } from './use-user-theme';
 
 // Shared reference to an empty object for cases where it is important to avoid
 // returning a new object reference on every invocation
 const EMPTY_OBJECT = {};
 
-interface ElementProperties {
-	typography: TypographyProperties;
-	color?: {
-		background: string;
-		text: string;
-	};
-}
-export interface StyleProperties {
-	spacing?: {
-		padding: {
-			top: string;
-			right: string;
-			bottom: string;
-			left: string;
-		};
-		blockGap: string;
-	};
-	typography?: TypographyProperties;
-	color?: {
-		background: string;
-		text: string;
-	};
-	elements?: Record< string, ElementProperties >;
-}
-
 interface EmailStylesData {
-	styles: StyleProperties;
-	userStyles: StyleProperties;
-	defaultStyles: StyleProperties;
+	styles: EmailStyles;
+	userStyles: EmailStyles;
+	defaultStyles: EmailStyles;
 	updateStyleProp: ( path, newValue ) => void;
-	updateStyles: ( newStyles: StyleProperties ) => void;
+	updateStyles: ( newStyles: EmailStyles ) => void;
 }
 
 /**

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -150,15 +150,16 @@ export type EmailStyles = {
 		text: string;
 	};
 	typography?: TypographyProperties;
-	elements?: {
-		heading: {
-			color: {
-				text: string;
-			};
-			typography: TypographyProperties;
-		};
-	};
+	elements?: Record< string, ElementStyleProperties >;
 };
+
+interface ElementStyleProperties {
+	typography: TypographyProperties;
+	color?: {
+		background: string;
+		text: string;
+	};
+}
 
 export type EmailBuiltStyles = {
 	css: string;

--- a/packages/js/email-editor/src/style-variables.ts
+++ b/packages/js/email-editor/src/style-variables.ts
@@ -1,0 +1,32 @@
+/**
+ * This module contains a set of utility functions to handle style variables and their compressed format.
+ * The compressed format is used to store style variables in the database and in the editor settings.
+ * The uncompressed format is used when a variable is used in CSS.
+ */
+
+// Utility to normalize compressed preset var:preset:<type>|<value> variables to --wp--preset--<type>--<value> format
+export function unwrapCompressedPresetStyleVariableName(
+	value: string
+): string | null {
+	if ( typeof value !== 'string' ) return null;
+	const match = value.match(
+		/^var:preset\|([a-zA-Z0-9-]+)\|([a-zA-Z0-9-]+)$/
+	);
+	return match ? `--wp--preset--${ match[ 1 ] }--${ match[ 2 ] }` : null;
+}
+
+// Utility to normalize compressed preset var:preset:<type>|<value> variables to var(--wp--preset--<type>--<value>) format
+export function unwrapCompressedPresetStyleVariable( value: string ): string {
+	const variableName = unwrapCompressedPresetStyleVariableName( value );
+	return variableName ? `var(${ variableName })` : value;
+}
+
+// Get the raw value of a compressed variable read from the root element
+export function getCompressedVariableValue( value: string ): string {
+	const variableName = unwrapCompressedPresetStyleVariableName( value );
+	if ( ! variableName ) return value;
+	const root = document.querySelector( ':root' );
+	if ( ! root ) return value;
+	const computedStyle = getComputedStyle( root );
+	return computedStyle.getPropertyValue( variableName ).trim() || value;
+}

--- a/packages/js/email-editor/src/text-hooks.ts
+++ b/packages/js/email-editor/src/text-hooks.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Replace text in the email editor.
+ * This is used to contextualize some default texts to the email editing context
+ */
+export const initTextHooks = (): void => {
+	const replaceTextMatrix = {
+		'You’ve tried to select a block that is part of a template that may be used elsewhere on your site. Would you like to edit the template?':
+			{
+				domain: 'default',
+				replacementText: __(
+					'You’ve tried to select a block that is part of a template that may be used in other emails. Would you like to edit the template?',
+					'woocommerce'
+				),
+			},
+	};
+
+	addFilter(
+		'i18n.gettext',
+		'woocommerce/email-editor/override-text',
+		( translation, text, domain ) => {
+			if (
+				replaceTextMatrix[ text ] &&
+				replaceTextMatrix[ text ].domain === ( domain || 'default' )
+			) {
+				return replaceTextMatrix[ text ].replacementText;
+			}
+			return translation;
+		}
+	);
+};

--- a/packages/php/email-editor/changelog/wooplug-4200-edtitor-ui-updates
+++ b/packages/php/email-editor/changelog/wooplug-4200-edtitor-ui-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add theme color pallete to base theme and remove the default heading color and use text color as fallback

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -241,9 +241,6 @@
           "fontWeight": "400",
           "fontStyle": "normal",
           "lineHeight": "1.5"
-        },
-        "color": {
-          "text": "#000000"
         }
       },
       "h1": {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -50,9 +50,18 @@ class Text extends Abstract_Block_Renderer {
 			$block_content = $html->get_updated_html();
 		}
 
+		// Add fallback text color when no custom text color or preset text color is set.
+		// Color styles are set on $block_attributes['style']['color'] only when custom values are used.
+		// In case of preset they are set on $block_attributes['textColor'] and $block_attributes['backgroundColor'].
+		$color_styles = $block_attributes['style']['color'] ?? array();
+		if ( empty( $color_styles['text'] ) && empty( $block_attributes['textColor'] ) ) {
+			$email_styles         = $settings_controller->get_email_styles();
+			$color_styles['text'] = $email_styles['color']['text'];
+		}
+
 		$block_styles = $this->get_styles_from_block(
 			array(
-				'color'      => $block_attributes['style']['color'] ?? array(),
+				'color'      => $color_styles,
 				'spacing'    => $block_attributes['style']['spacing'] ?? array(),
 				'typography' => $block_attributes['style']['typography'] ?? array(),
 				'border'     => $block_attributes['style']['border'] ?? array(),

--- a/plugins/woocommerce/changelog/wooplug-4200-edtitor-ui-updates
+++ b/plugins/woocommerce/changelog/wooplug-4200-edtitor-ui-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: We added inline CSS to the block email editor page to ensure preset CSS variables are set globaly
+
+

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -83,6 +83,10 @@ class PageRenderer {
 		// Enqueue media library scripts.
 		wp_enqueue_media();
 
+		// Enqueue CSS containing --wp--preset variables.
+		// They are needed for usage outside of the iframed email canvas (e.g. in the styles preview).
+		wp_enqueue_global_styles_css_custom_properties();
+
 		$this->preload_rest_api_data( $post_id, $post_type );
 
 		require_once ABSPATH . 'wp-admin/admin-header.php';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Updates texts in the modal for sending test emails
- Updates texts in the modal displayed before switching to the template mode and unifies buttons on both modals (the first modal opens when a user clicks on the template block in canvas, the second modal whena  user attempts to switch to template mode from sidebar's template dropdown)
- Fixes the style preview component displayed at the top of the styles panel. The component didn't update when user changed styles
- Fixes that when selecting colors in Style > Colors the theme palette was not present
- Removed hardcoded black heading color. A user can now unset the header color, and headings will use text color instead. This improves alignment with Styles in the site editor

Closes WOOPLUG-4200.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   ![Screenshot 2025-05-16 at 15 42 52](https://github.com/user-attachments/assets/cf5191eb-c043-4de7-943a-0105d39ae585) |  ![Screenshot 2025-05-16 at 15 41 29](https://github.com/user-attachments/assets/b82d38bc-a3ca-4682-8822-413c2e9bfe13)   |
|  ![Screenshot 2025-05-16 at 15 44 40](https://github.com/user-attachments/assets/32412d67-deaf-4741-931d-36a1969a6b92) | ![Screenshot 2025-05-16 at 15 47 35](https://github.com/user-attachments/assets/48d02db4-c2a5-49a5-9539-b0e9d1a7c145) |
| ![Screenshot 2025-05-16 at 15 48 24](https://github.com/user-attachments/assets/1b192111-2faa-471e-8ead-3a9f50c64a38) | ![Screenshot 2025-05-16 at 15 48 11](https://github.com/user-attachments/assets/7043ffbe-56f0-4e52-8de7-cdaccc292d1f) |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block email editor WooCommece > Settings > Advanced > Features
2. Open an email in the editor WooCommece > Settings > Emails
3. Verify the updated features listed in the chnages section work as expected

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
