### PR TITLE
Display country as disabled select if there's a single option

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1961-block-checkout-country-still-presented-as-select-even-if
+++ b/plugins/woocommerce/changelog/wooplug-1961-block-checkout-country-still-presented-as-select-even-if
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+The country select field on Checkout block will not expand idf the store only sells to one country

--- a/plugins/woocommerce/changelog/wooplug-1961-block-checkout-country-still-presented-as-select-even-if
+++ b/plugins/woocommerce/changelog/wooplug-1961-block-checkout-country-still-presented-as-select-even-if
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-The country select field on Checkout block will not expand idf the store only sells to one country
+The country select field on Checkout block will not expand if the store only sells to one country

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -22,7 +22,7 @@ export const CountryInput = ( {
 	value = '',
 	autoComplete = 'off',
 	required = false,
-}: CountryInputWithCountriesProps ): JSX.Element => {
+}: CountryInputWithCountriesProps ) => {
 	const options = useMemo< SelectOption[] >( () => {
 		return Object.entries( countries ).map(
 			( [ countryCode, countryName ] ) => ( {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -43,6 +43,7 @@ export const CountryInput = ( {
 			value={ value }
 			required={ required }
 			autoComplete={ autoComplete }
+			readonly={ options.length === 1 && !! value }
 		/>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/country-input/country-input.tsx
@@ -4,6 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import clsx from 'clsx';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,6 +33,13 @@ export const CountryInput = ( {
 		);
 	}, [ countries ] );
 
+	// Explain the select cannot be changed if there is only one country available, for screen readers.
+	const ariaLabel =
+		options.length === 1
+			? /* translators: %s is the label for the country input on the Checkout page. */
+			  sprintf( __( '%s, cannot be changed', 'woocommerce' ), label )
+			: label;
+
 	return (
 		<Select
 			className={ clsx( className, 'wc-block-components-country-input' ) }
@@ -44,6 +52,7 @@ export const CountryInput = ( {
 			required={ required }
 			autoComplete={ autoComplete }
 			readonly={ options.length === 1 && !! value }
+			aria-label={ ariaLabel }
 		/>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
@@ -28,7 +28,7 @@ export type SelectProps = Omit<
 	options: SelectOption[];
 	label: string;
 	onChange: ( newVal: string ) => void;
-	errorId?: string;
+	errorId?: string | undefined;
 	required?: boolean | undefined;
 	errorMessage?: string | undefined;
 	placeholder?: string | undefined;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
@@ -32,6 +32,7 @@ export type SelectProps = Omit<
 	required?: boolean | undefined;
 	errorMessage?: string | undefined;
 	placeholder?: string | undefined;
+	readonly?: boolean;
 };
 
 export const Select = ( props: SelectProps ) => {
@@ -46,6 +47,7 @@ export const Select = ( props: SelectProps ) => {
 		required,
 		errorMessage = __( 'Please select a valid option', 'woocommerce' ),
 		placeholder,
+		readonly,
 		...restOfProps
 	} = props;
 	const selectOnChange = useCallback(
@@ -134,7 +136,11 @@ export const Select = ( props: SelectProps ) => {
 				'has-error': ! validationError.hidden,
 			} ) }
 		>
-			<div className="wc-blocks-components-select">
+			<div
+				className={ clsx( 'wc-blocks-components-select', {
+					'wc-blocks-components-select--readonly': readonly,
+				} ) }
+			>
 				<div className="wc-blocks-components-select__container">
 					<label
 						htmlFor={ inputId }
@@ -148,6 +154,7 @@ export const Select = ( props: SelectProps ) => {
 						size={ size !== undefined ? size : 1 }
 						onChange={ selectOnChange }
 						value={ value }
+						aria-disabled={ readonly }
 						aria-invalid={
 							error?.message && ! error?.hidden ? true : false
 						}

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -105,3 +105,13 @@
 		}
 	}
 }
+
+.wc-blocks-components-select.wc-blocks-components-select--readonly {
+	.wc-blocks-components-select__select {
+		pointer-events: none;
+	}
+
+	.wc-blocks-components-select__expand {
+		display: none;
+	}
+}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1381,6 +1381,11 @@ function wc_get_customer_default_location() {
 		$default_location = wc_get_customer_geolocation( $default_location );
 	}
 
+	// If only one country is valid, preselect it.
+	if ( 1 === count( $allowed_countries ) ) {
+		$default_location['country'] = key( $allowed_countries );
+	}
+
 	/**
 	 * Filter the customer default location after geolocation.
 	 *

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1367,7 +1367,8 @@ function wc_get_customer_default_location() {
 	);
 
 	// Ensure defaults are valid.
-	$allowed_countries = WC()->countries->get_allowed_countries();
+	$allowed_countries          = WC()->countries->get_allowed_countries();
+	$allowed_shipping_countries = WC()->countries->get_shipping_countries();
 
 	if ( ! in_array( $default_location['country'], array_keys( $allowed_countries ), true ) ) {
 		$default_location = array(
@@ -1381,8 +1382,12 @@ function wc_get_customer_default_location() {
 		$default_location = wc_get_customer_geolocation( $default_location );
 	}
 
-	// If only one country is valid, preselect it.
-	if ( 1 === count( $allowed_countries ) ) {
+	// If only one country is valid for both shipping and billing, preselect it.
+	if (
+		is_array( $allowed_shipping_countries ) &&
+		is_array( $allowed_countries ) &&
+		1 === count( array_merge( $allowed_countries, $allowed_shipping_countries ) )
+	) {
 		$default_location['country'] = key( $allowed_countries );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -181,16 +181,25 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		update_option( 'woocommerce_default_customer_address', 'base' );
 		update_option( 'woocommerce_default_country', 'DE:LS' );
 		update_option( 'woocommerce_allowed_countries', 'specific' );
-		update_option( 'woocommerce_specific_allowed_countries', array( 'GB' ) );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'GB', 'FI' ) );
 		$result = wc_get_customer_default_location();
 		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+
+		// Test with default address, but onyl one specific country set. Address defaults to allowed country.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'GB' ) );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( 'GB', $result['country'] );
 		$this->assertEquals( '', $result['state'] );
 
 		// Test with no default address.
 		update_option( 'woocommerce_default_customer_address', '' );
 		update_option( 'woocommerce_default_country', 'GB' );
 		$result = wc_get_customer_default_location();
-		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( 'GB', $result['country'] );
 		$this->assertEquals( '', $result['state'] );
 
 		// Test with geolocation.

--- a/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-core-functions-test.php
@@ -186,7 +186,7 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( '', $result['country'] );
 		$this->assertEquals( '', $result['state'] );
 
-		// Test with default address, but onyl one specific country set. Address defaults to allowed country.
+		// Test with default address, but only one specific country set. Address defaults to allowed country.
 		update_option( 'woocommerce_default_customer_address', 'base' );
 		update_option( 'woocommerce_default_country', 'DE:LS' );
 		update_option( 'woocommerce_allowed_countries', 'specific' );
@@ -194,6 +194,21 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 		$result = wc_get_customer_default_location();
 		$this->assertEquals( 'GB', $result['country'] );
 		$this->assertEquals( '', $result['state'] );
+
+		// Test with default address, one shipping country and one billing country set. Address defaults to empty.
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_default_country', 'DE:LS' );
+		update_option( 'woocommerce_allowed_countries', 'specific' );
+		update_option( 'woocommerce_specific_allowed_countries', array( 'GB' ) );
+		update_option( 'woocommerce_ship_to_countries', 'specific' );
+		update_option( 'woocommerce_specific_ship_to_countries', array( 'FI' ) );
+		$result = wc_get_customer_default_location();
+		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+
+		// Reset the woocommerce_ship_to_countries countries and woocommerce_specific_ship_to_countries options for the next tests.
+		update_option( 'woocommerce_specific_ship_to_countries', '' );
+		update_option( 'woocommerce_ship_to_countries', '' );
 
 		// Test with no default address.
 		update_option( 'woocommerce_default_customer_address', '' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Update the country select field on the Checkout block to have: no arrow, no interaction, and no disabled state if only one country is available.
- If there is only one country available to sell to and ship to, default the shopper's address to that country.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-1961

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/0003a2254730447eb6d2c1e99f753891 |  https://www.loom.com/share/a1d0f888bd8b4259bfdd329a1ea65b69 |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> General -> Selling location(s). Set it to "Sell to specific countries only" - select one country. Ensure "Shipping location(s)" is set to "Ship to all countries you sell to"
2. Add an item to the cart and go to the Checkout block.
3. Ensure the country in shipping and billing is set and cannot be changed.
4. Use a screen reader and ensure the label for the field is read out and includes 'Country/Region, Cannot be changed'
5. Add this snippet
```php
add_filter('woocommerce_get_country_locale', function( $locale ){
        foreach ( $locale as $country => $value ) {
			$locale[$country]['country'] = [
				'label' => 'Custom country',
			];
	}
	return $locale;
}, 10, 1);
```

6. Repeat step 4 and ensure the correct label (Custom country) is read out.
7. Go to WooCommerce -> Settings -> General -> Selling location(s) and set it to "Sell to all countries".
8. Go to the Checkout block and ensure the country select can be changed. Test billing and shipping.
9. Go to WooCommerce -> Settings -> General -> Selling location(s) and change it to specific countries then choose a country
10. Go to WooCommerce -> Settings -> General -> Shipping location(s) and change it to specific countries, choose a _different_ country.
11. Go to the Checkout block and ensure the country field can be edited. It will include both countries. (Note a follow up issue will be created to take a look into this behaviour)
12. Go to WooCommerce -> Settings -> General -> Selling location(s)/Shipping location(s) and set the same country set in both options
13. Go to the Checkout block and ensure the country select cannot be changed.
14. Try various combinations for these shipping and selling options and ensure the expected behaviour occurs.
15. Test Cart/Checkout Shortcodes and ensure orders can be placed from both Blocks and Shortcodes.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
