### PR TITLE
Product Button: prepare to detect selected variation when used inside the Add to Cart Form + Options block

### DIFF
--- a/plugins/woocommerce/changelog/feat-prepare-product-button-for-variable-product
+++ b/plugins/woocommerce/changelog/feat-prepare-product-button-for-variable-product
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Product Button: prepare to detect selected variation when used inside the Add to Cart Form + Options block. The Product Button block is a production one, while the Add to Cart + Options block is an experimental block, so the changes to Product Button are split into a separate PR (from https://github.com/woocommerce/woocommerce/pull/57859) for proper testing and history.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -177,6 +177,8 @@ const { state } = store< Store >(
 				}
 			},
 			syncProductId() {
+				// This is intentionally not typed as we don't know if the block
+				// is inside the Add to Cart Form + Options block.
 				const addToCartContext = getContextFn(
 					'woocommerce/add-to-cart-with-options'
 				);

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	store,
-	getContext as getContextFn,
-	useLayoutEffect,
-} from '@wordpress/interactivity';
+import { store, getContext, useLayoutEffect } from '@wordpress/interactivity';
 import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
 
 /**
@@ -55,8 +51,6 @@ interface Store {
 	};
 }
 
-const getContext = () => getContextFn< Context >();
-
 const { state: wooState } = store< WooCommerce >(
 	'woocommerce',
 	{},
@@ -68,23 +62,23 @@ const { state } = store< Store >(
 	{
 		state: {
 			get quantity() {
-				const { productId } = getContext();
+				const { productId } = getContext< Context >();
 				const product = wooState.cart?.items.find(
 					( item ) => item.id === productId
 				);
 				return product?.quantity || 0;
 			},
 			get slideInAnimation() {
-				const { animationStatus } = getContext();
+				const { animationStatus } = getContext< Context >();
 				return animationStatus === AnimationStatus.SLIDE_IN;
 			},
 			get slideOutAnimation() {
-				const { animationStatus } = getContext();
+				const { animationStatus } = getContext< Context >();
 				return animationStatus === AnimationStatus.SLIDE_OUT;
 			},
 			get addToCartText(): string {
 				const { animationStatus, tempQuantity, addToCartText } =
-					getContext();
+					getContext< Context >();
 
 				// We use the temporary quantity when there's no animation, or
 				// when the second part of the animation hasn't started yet.
@@ -103,14 +97,14 @@ const { state } = store< Store >(
 				);
 			},
 			get displayViewCart(): boolean {
-				const { displayViewCart } = getContext();
+				const { displayViewCart } = getContext< Context >();
 				if ( ! displayViewCart ) return false;
 				return state.quantity > 0;
 			},
 		},
 		actions: {
 			*addCartItem() {
-				const context = getContext();
+				const context = getContext< Context >();
 				const { productId, quantityToAdd } = context;
 
 				// Todo: Use the module exports instead of `store()` once the
@@ -142,7 +136,7 @@ const { state } = store< Store >(
 				actions.refreshCartItems();
 			},
 			handleAnimationEnd( event: AnimationEvent ) {
-				const context = getContext();
+				const context = getContext< Context >();
 				if ( event.animationName === 'slideOut' ) {
 					// When the first part of the animation (slide-out) ends, we move
 					// to the second part (slide-in).
@@ -158,7 +152,7 @@ const { state } = store< Store >(
 		},
 		callbacks: {
 			syncTempQuantityOnLoad() {
-				const context = getContext();
+				const context = getContext< Context >();
 				// When we instantiate this element, we sync the temporary
 				// quantity with the quantity in the cart to avoid triggering
 				// the animation. We do this only once, and we use
@@ -170,7 +164,7 @@ const { state } = store< Store >(
 				}, [] );
 			},
 			startAnimation() {
-				const context = getContext();
+				const context = getContext< Context >();
 				// We start the animation if the temporary quantity is out of
 				// sync with the quantity in the cart and the animation hasn't
 				// started yet.
@@ -183,7 +177,7 @@ const { state } = store< Store >(
 			},
 			syncProductId() {
 				const addToCartContext =
-					getContextFn< AddToCartWithOptionsContext >(
+					getContext< AddToCartWithOptionsContext >(
 						'woocommerce/add-to-cart-with-options'
 					) as AddToCartWithOptionsContext | undefined; // Product Button may not be nested inside Add To Cart + Options block.
 
@@ -191,7 +185,7 @@ const { state } = store< Store >(
 					return;
 				}
 
-				const context = getContext();
+				const context = getContext< Context >();
 				const { productId, variationId } = addToCartContext;
 
 				// The `variationId` is only available when the product is a

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -46,6 +46,7 @@ interface Store {
 	callbacks: {
 		startAnimation: () => void;
 		syncTempQuantityOnLoad: () => void;
+		syncProductId: () => void;
 	};
 }
 
@@ -173,6 +174,33 @@ const { state } = store< Store >(
 					context.animationStatus === AnimationStatus.IDLE
 				) {
 					context.animationStatus = AnimationStatus.SLIDE_OUT;
+				}
+			},
+			syncProductId() {
+				const addToCartContext = getContextFn(
+					'woocommerce/add-to-cart-with-options'
+				);
+
+				if (
+					! addToCartContext ||
+					! ( 'productId' in addToCartContext ) ||
+					! ( 'variationId' in addToCartContext ) ||
+					typeof addToCartContext.productId !== 'number' ||
+					typeof addToCartContext.variationId !== 'number' ||
+					! addToCartContext.productId
+				) {
+					return;
+				}
+
+				const context = getContext();
+				const { productId, variationId } = addToCartContext;
+
+				// The `variationId` is only available when the product is a
+				// variable product and the user has selected a variation.
+				if ( variationId > 0 ) {
+					context.productId = variationId;
+				} else {
+					context.productId = productId;
 				}
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -8,6 +8,11 @@ import {
 } from '@wordpress/interactivity';
 import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
 
+/**
+ * Internal dependencies
+ */
+import type { Context as AddToCartWithOptionsContext } from '../../../../blocks/add-to-cart-with-options/frontend';
+
 // Stores are locked to prevent 3PD usage until the API is stable.
 const universalLock =
 	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
@@ -177,20 +182,12 @@ const { state } = store< Store >(
 				}
 			},
 			syncProductId() {
-				// This is intentionally not typed as we don't know if the block
-				// is inside the Add to Cart Form + Options block.
-				const addToCartContext = getContextFn(
-					'woocommerce/add-to-cart-with-options'
-				);
+				const addToCartContext =
+					getContextFn< AddToCartWithOptionsContext >(
+						'woocommerce/add-to-cart-with-options'
+					) as AddToCartWithOptionsContext | undefined; // Product Button may not be nested inside Add To Cart + Options block.
 
-				if (
-					! addToCartContext ||
-					! ( 'productId' in addToCartContext ) ||
-					! ( 'variationId' in addToCartContext ) ||
-					typeof addToCartContext.productId !== 'number' ||
-					typeof addToCartContext.variationId !== 'number' ||
-					! addToCartContext.productId
-				) {
+				if ( ! addToCartContext ) {
 					return;
 				}
 
@@ -199,7 +196,7 @@ const { state } = store< Store >(
 
 				// The `variationId` is only available when the product is a
 				// variable product and the user has selected a variation.
-				if ( variationId > 0 ) {
+				if ( variationId ) {
 					context.productId = variationId;
 				} else {
 					context.productId = productId;

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -31,6 +31,7 @@ enum AnimationStatus {
 interface Store {
 	state: {
 		inTheCartText: string;
+		productId: number;
 		quantity: number;
 		hasCartLoaded: boolean;
 		slideInAnimation: boolean;
@@ -47,7 +48,6 @@ interface Store {
 	callbacks: {
 		startAnimation: () => void;
 		syncTempQuantityOnLoad: () => void;
-		syncProductId: () => void;
 	};
 }
 
@@ -61,10 +61,17 @@ const { state } = store< Store >(
 	'woocommerce/product-button',
 	{
 		state: {
-			get quantity() {
+			get productId() {
 				const { productId } = getContext< Context >();
+				const { variationId } =
+					getContext< AddToCartWithOptionsContext >(
+						'woocommerce/add-to-cart-with-options'
+					);
+				return variationId || productId;
+			},
+			get quantity(): number {
 				const product = wooState.cart?.items.find(
-					( item ) => item.id === productId
+					( item ) => item.id === state.productId
 				);
 				return product?.quantity || 0;
 			},
@@ -105,7 +112,6 @@ const { state } = store< Store >(
 		actions: {
 			*addCartItem() {
 				const context = getContext< Context >();
-				const { productId, quantityToAdd } = context;
 
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.
@@ -118,8 +124,8 @@ const { state } = store< Store >(
 				);
 
 				yield actions.addCartItem( {
-					id: productId,
-					quantity: state.quantity + quantityToAdd,
+					id: state.productId,
+					quantity: state.quantity + context.quantityToAdd,
 				} );
 
 				context.displayViewCart = true;
@@ -173,27 +179,6 @@ const { state } = store< Store >(
 					context.animationStatus === AnimationStatus.IDLE
 				) {
 					context.animationStatus = AnimationStatus.SLIDE_OUT;
-				}
-			},
-			syncProductId() {
-				const addToCartContext =
-					getContext< AddToCartWithOptionsContext >(
-						'woocommerce/add-to-cart-with-options'
-					) as AddToCartWithOptionsContext | undefined; // Product Button may not be nested inside Add To Cart + Options block.
-
-				if ( ! addToCartContext ) {
-					return;
-				}
-
-				const context = getContext< Context >();
-				const { productId, variationId } = addToCartContext;
-
-				// The `variationId` is only available when the product is a
-				// variable product and the user has selected a variation.
-				if ( variationId ) {
-					context.productId = variationId;
-				} else {
-					context.productId = productId;
 				}
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -28,28 +28,13 @@ enum AnimationStatus {
 	SLIDE_IN = 'SLIDE-IN',
 }
 
-interface Store {
+type ServerState = {
 	state: {
 		inTheCartText: string;
-		productId: number;
-		quantity: number;
-		hasCartLoaded: boolean;
-		slideInAnimation: boolean;
-		slideOutAnimation: boolean;
 		addToCartText: string;
-		displayViewCart: boolean;
 		noticeId: string;
 	};
-	actions: {
-		addCartItem: () => void;
-		refreshCartItems: () => void;
-		handleAnimationEnd: ( event: AnimationEvent ) => void;
-	};
-	callbacks: {
-		startAnimation: () => void;
-		syncTempQuantityOnLoad: () => void;
-	};
-}
+};
 
 const { state: wooState } = store< WooCommerce >(
 	'woocommerce',
@@ -57,131 +42,129 @@ const { state: wooState } = store< WooCommerce >(
 	{ lock: universalLock }
 );
 
-const { state } = store< Store >(
-	'woocommerce/product-button',
-	{
-		state: {
-			get productId() {
-				const { productId } = getContext< Context >();
-				const { variationId } =
-					getContext< AddToCartWithOptionsContext >(
-						'woocommerce/add-to-cart-with-options'
-					);
-				return variationId || productId;
-			},
-			get quantity(): number {
-				const product = wooState.cart?.items.find(
-					( item ) => item.id === state.productId
-				);
-				return product?.quantity || 0;
-			},
-			get slideInAnimation() {
-				const { animationStatus } = getContext< Context >();
-				return animationStatus === AnimationStatus.SLIDE_IN;
-			},
-			get slideOutAnimation() {
-				const { animationStatus } = getContext< Context >();
-				return animationStatus === AnimationStatus.SLIDE_OUT;
-			},
-			get addToCartText(): string {
-				const { animationStatus, tempQuantity, addToCartText } =
-					getContext< Context >();
-
-				// We use the temporary quantity when there's no animation, or
-				// when the second part of the animation hasn't started yet.
-				const showTemporaryNumber =
-					animationStatus === AnimationStatus.IDLE ||
-					animationStatus === AnimationStatus.SLIDE_OUT;
-				const quantity = showTemporaryNumber
-					? tempQuantity || 0
-					: state.quantity;
-
-				if ( quantity === 0 ) return addToCartText;
-
-				return state.inTheCartText.replace(
-					'###',
-					quantity.toString()
-				);
-			},
-			get displayViewCart(): boolean {
-				const { displayViewCart } = getContext< Context >();
-				if ( ! displayViewCart ) return false;
-				return state.quantity > 0;
-			},
+const productButtonStore = {
+	state: {
+		get productId() {
+			const { productId } = getContext< Context >();
+			const { variationId } = getContext< AddToCartWithOptionsContext >(
+				'woocommerce/add-to-cart-with-options'
+			);
+			return variationId || productId;
 		},
-		actions: {
-			*addCartItem() {
-				const context = getContext< Context >();
-
-				// Todo: Use the module exports instead of `store()` once the
-				// woocommerce store is public.
-				yield import( '@woocommerce/stores/woocommerce/cart' );
-
-				const { actions } = store< WooCommerce >(
-					'woocommerce',
-					{},
-					{ lock: universalLock }
-				);
-
-				yield actions.addCartItem( {
-					id: state.productId,
-					quantity: state.quantity + context.quantityToAdd,
-				} );
-
-				context.displayViewCart = true;
-			},
-			*refreshCartItems() {
-				// Todo: Use the module exports instead of `store()` once the
-				// woocommerce store is public.
-				yield import( '@woocommerce/stores/woocommerce/cart' );
-				const { actions } = store< WooCommerce >(
-					'woocommerce',
-					{},
-					{ lock: universalLock }
-				);
-				actions.refreshCartItems();
-			},
-			handleAnimationEnd( event: AnimationEvent ) {
-				const context = getContext< Context >();
-				if ( event.animationName === 'slideOut' ) {
-					// When the first part of the animation (slide-out) ends, we move
-					// to the second part (slide-in).
-					context.animationStatus = AnimationStatus.SLIDE_IN;
-				} else if ( event.animationName === 'slideIn' ) {
-					// When the second part of the animation ends, we update the
-					// temporary quantity to sync it with the cart and reset the
-					// animation status so it can be triggered again.
-					context.tempQuantity = state.quantity;
-					context.animationStatus = AnimationStatus.IDLE;
-				}
-			},
+		get quantity(): number {
+			const product = wooState.cart?.items.find(
+				( item ) => item.id === state.productId
+			);
+			return product?.quantity || 0;
 		},
-		callbacks: {
-			syncTempQuantityOnLoad() {
-				const context = getContext< Context >();
-				// When we instantiate this element, we sync the temporary
-				// quantity with the quantity in the cart to avoid triggering
-				// the animation. We do this only once, and we use
-				// useLayoutEffect to avoid the useEffect flickering.
-				// eslint-disable-next-line react-hooks/rules-of-hooks
-				useLayoutEffect( () => {
-					context.tempQuantity = state.quantity;
-					// eslint-disable-next-line react-hooks/exhaustive-deps
-				}, [] );
-			},
-			startAnimation() {
-				const context = getContext< Context >();
-				// We start the animation if the temporary quantity is out of
-				// sync with the quantity in the cart and the animation hasn't
-				// started yet.
-				if (
-					context.tempQuantity !== state.quantity &&
-					context.animationStatus === AnimationStatus.IDLE
-				) {
-					context.animationStatus = AnimationStatus.SLIDE_OUT;
-				}
-			},
+		get slideInAnimation() {
+			const { animationStatus } = getContext< Context >();
+			return animationStatus === AnimationStatus.SLIDE_IN;
+		},
+		get slideOutAnimation() {
+			const { animationStatus } = getContext< Context >();
+			return animationStatus === AnimationStatus.SLIDE_OUT;
+		},
+		get addToCartText(): string {
+			const { animationStatus, tempQuantity, addToCartText } =
+				getContext< Context >();
+
+			// We use the temporary quantity when there's no animation, or
+			// when the second part of the animation hasn't started yet.
+			const showTemporaryNumber =
+				animationStatus === AnimationStatus.IDLE ||
+				animationStatus === AnimationStatus.SLIDE_OUT;
+			const quantity = showTemporaryNumber
+				? tempQuantity || 0
+				: state.quantity;
+
+			if ( quantity === 0 ) return addToCartText;
+
+			return state.inTheCartText.replace( '###', quantity.toString() );
+		},
+		get displayViewCart(): boolean {
+			const { displayViewCart } = getContext< Context >();
+			if ( ! displayViewCart ) return false;
+			return state.quantity > 0;
 		},
 	},
+	actions: {
+		*addCartItem(): Generator< unknown, void > {
+			const context = getContext< Context >();
+
+			// Todo: Use the module exports instead of `store()` once the
+			// woocommerce store is public.
+			yield import( '@woocommerce/stores/woocommerce/cart' );
+
+			const { actions } = store< WooCommerce >(
+				'woocommerce',
+				{},
+				{ lock: universalLock }
+			);
+
+			yield actions.addCartItem( {
+				id: state.productId,
+				quantity: state.quantity + context.quantityToAdd,
+			} );
+
+			context.displayViewCart = true;
+		},
+		*refreshCartItems() {
+			// Todo: Use the module exports instead of `store()` once the
+			// woocommerce store is public.
+			yield import( '@woocommerce/stores/woocommerce/cart' );
+			const { actions } = store< WooCommerce >(
+				'woocommerce',
+				{},
+				{ lock: universalLock }
+			);
+			actions.refreshCartItems();
+		},
+		handleAnimationEnd( event: AnimationEvent ) {
+			const context = getContext< Context >();
+			if ( event.animationName === 'slideOut' ) {
+				// When the first part of the animation (slide-out) ends, we move
+				// to the second part (slide-in).
+				context.animationStatus = AnimationStatus.SLIDE_IN;
+			} else if ( event.animationName === 'slideIn' ) {
+				// When the second part of the animation ends, we update the
+				// temporary quantity to sync it with the cart and reset the
+				// animation status so it can be triggered again.
+				context.tempQuantity = state.quantity;
+				context.animationStatus = AnimationStatus.IDLE;
+			}
+		},
+	},
+	callbacks: {
+		syncTempQuantityOnLoad() {
+			const context = getContext< Context >();
+			// When we instantiate this element, we sync the temporary
+			// quantity with the quantity in the cart to avoid triggering
+			// the animation. We do this only once, and we use
+			// useLayoutEffect to avoid the useEffect flickering.
+			// eslint-disable-next-line react-hooks/rules-of-hooks
+			useLayoutEffect( () => {
+				context.tempQuantity = state.quantity;
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, [] );
+		},
+		startAnimation() {
+			const context = getContext< Context >();
+			// We start the animation if the temporary quantity is out of
+			// sync with the quantity in the cart and the animation hasn't
+			// started yet.
+			if (
+				context.tempQuantity !== state.quantity &&
+				context.animationStatus === AnimationStatus.IDLE
+			) {
+				context.animationStatus = AnimationStatus.SLIDE_OUT;
+			}
+		},
+	},
+};
+
+const { state } = store< typeof productButtonStore & ServerState >(
+	'woocommerce/product-button',
+	productButtonStore,
 	{ lock: true }
 );

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -44,13 +44,6 @@ const { state: wooState } = store< WooCommerce >(
 
 const productButtonStore = {
 	state: {
-		get productId() {
-			const { productId } = getContext< Context >();
-			const { variationId } = getContext< AddToCartWithOptionsContext >(
-				'woocommerce/add-to-cart-with-options'
-			);
-			return variationId || productId;
-		},
 		get quantity(): number {
 			const product = wooState.cart?.items.find(
 				( item ) => item.id === state.productId
@@ -86,6 +79,16 @@ const productButtonStore = {
 			const { displayViewCart } = getContext< Context >();
 			if ( ! displayViewCart ) return false;
 			return state.quantity > 0;
+		},
+		get productId() {
+			const addToCartWithOptionsContext =
+				getContext< AddToCartWithOptionsContext >(
+					'woocommerce/add-to-cart-with-options'
+				);
+			return (
+				addToCartWithOptionsContext?.variationId ||
+				getContext< Context >().productId
+			);
 		},
 	},
 	actions: {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -227,9 +227,8 @@ class ProductButton extends AbstractBlock {
 			data-wp-class--wc-block-slide-in="state.slideInAnimation"
 			data-wp-class--wc-block-slide-out="state.slideOutAnimation"
 			data-wp-on--animationend="actions.handleAnimationEnd"
-			data-wp-watch--start-animation="callbacks.startAnimation"
+			data-wp-watch="callbacks.startAnimation"
 			data-wp-run="callbacks.syncTempQuantityOnLoad"
-			data-wp-watch--sync-product-id="callbacks.syncProductId"
 		';
 
 		$wrapper_attributes = get_block_wrapper_attributes(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -88,9 +88,9 @@ class ProductButton extends AbstractBlock {
 			return '';
 		}
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
+		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 
-		if ( $is_descendent_of_add_to_cart_form && Utils::is_not_purchasable_simple_product( $product ) ) {
+		if ( $is_descendant_of_add_to_cart_form && Utils::is_not_purchasable_simple_product( $product ) ) {
 			$product = $previous_product;
 
 			return '';
@@ -144,11 +144,11 @@ class ProductButton extends AbstractBlock {
 			)
 		);
 
-		$is_descendent_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
+		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 
 		$default_quantity = 1;
 
-		if ( ! $is_descendent_of_add_to_cart_form ) {
+		if ( ! $is_descendant_of_add_to_cart_form ) {
 			/**
 			 * Filters the change the quantity to add to cart.
 			 *
@@ -161,7 +161,7 @@ class ProductButton extends AbstractBlock {
 
 		$add_to_cart_text = null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woocommerce' );
 
-		if ( $is_descendent_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
+		if ( $is_descendant_of_add_to_cart_form && null !== $product->single_add_to_cart_text() ) {
 			$add_to_cart_text = $product->single_add_to_cart_text();
 		}
 
@@ -174,7 +174,7 @@ class ProductButton extends AbstractBlock {
 		);
 
 		$attributes = array(
-			'type' => $is_descendent_of_add_to_cart_form ? 'submit' : 'button',
+			'type' => $is_descendant_of_add_to_cart_form ? 'submit' : 'button',
 		);
 
 		if ( 'a' === $html_element ) {
@@ -219,7 +219,7 @@ class ProductButton extends AbstractBlock {
 			data-wp-init="actions.refreshCartItems"
 		';
 
-		$button_directives = $is_descendent_of_add_to_cart_form ? '' : 'data-wp-on--click="actions.addCartItem"';
+		$button_directives = $is_descendant_of_add_to_cart_form ? '' : 'data-wp-on--click="actions.addCartItem"';
 		$anchor_directive  = 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"';
 
 		$span_button_directives = '
@@ -227,8 +227,9 @@ class ProductButton extends AbstractBlock {
 			data-wp-class--wc-block-slide-in="state.slideInAnimation"
 			data-wp-class--wc-block-slide-out="state.slideOutAnimation"
 			data-wp-on--animationend="actions.handleAnimationEnd"
-			data-wp-watch="callbacks.startAnimation"
+			data-wp-watch--start-animation="callbacks.startAnimation"
 			data-wp-run="callbacks.syncTempQuantityOnLoad"
+			data-wp-watch--sync-product-id="callbacks.syncProductId"
 		';
 
 		$wrapper_attributes = get_block_wrapper_attributes(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The Product Button block is a production block, while the Add to Cart + Options block is an experimental block, so I split the changes to Product Button in https://github.com/woocommerce/woocommerce/pull/57859 into a separate PR for proper testing and history. This also makes it easier to revert if unexpected things happen.

I took this chance to change the implementation of the Product Button to handle selected variation ID. Previously, in https://github.com/woocommerce/woocommerce/pull/57859, we updated the `state.quantity` getter to retrieve the variation ID directly from there. We also needed a new context called `isDescendantOfAddToCartWithOptions` to determine if we were inside the Add to Cart Form + Options block.

```ts
			get quantity() {
				const { productId, isDescendantOfAddToCartWithOptions } =
					getContext();

				const itemId =
					isDescendantOfAddToCartWithOptions &&
					addToCartWithOptionsState?.productOrVariationId
						? addToCartWithOptionsState.productOrVariationId
						: productId;

				const product = wooState.cart?.items.find(
					( item ) => item.id === itemId
				);

				return product?.quantity || 0;
			},
```

In this PR, I took another direction, which does not use that new context but instead uses the result of `getContext('woocommerce/add-to-cart-with-options')` to determine if we are inside the Add to Cart Form with Options block. After that, I modified the `context.productId` of the button according to the selected variation.

Apart from the above change, this PR brings the naming changes as they are from https://github.com/woocommerce/woocommerce/pull/57859.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Smoke testing the Product Button block to verify no regression was introduced.
2. Test https://github.com/woocommerce/woocommerce/pull/57859 which includes change from this PR to verify the logic updating selected variation.