### PR TITLE
Require opting in to forked iAPI in development to avoid confusion

### DIFF
--- a/plugins/woocommerce/changelog/58101-dev-disable-forked-iapi-runtime-by-default
+++ b/plugins/woocommerce/changelog/58101-dev-disable-forked-iapi-runtime-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Disable the forked iAPI runtime by default in development.

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -5,7 +5,7 @@
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": true,
-		"experimental-iapi-runtime": true,
+		"experimental-iapi-runtime": false,
 		"coming-soon-newsletter-template": false,
 		"coupons": true,
 		"core-profiler": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To avoid any misunderstandings or unintentional bugs when working with the forked iAPI runtime in development we will turn it off by default, and require explicit opt-in in development to test the API.


### Screenshots or screen recordings:

N/A
### How to test the changes in this Pull Request:

CI passing will be sufficient

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Disable the forked iAPI runtime by default in development.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
