### PR TITLE
[dev] Release kickoff issue template (Linear only, the PR is only for review)

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -45,7 +45,7 @@ body:
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
-        -    [] Validate version and stable tag in `readme.txt` for the generated zip file
+        -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
 
         #### Release to WordPress.org
 
@@ -84,7 +84,7 @@ body:
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
-        -    [] Validate version and stable tag in `readme.txt` for the generated zip file
+        -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
 
         #### Release to WordPress.org
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -69,7 +69,7 @@ body:
 
         #### Post-release monitoring
 
-        -    [] TBD
+        -    [] Follow post-release monitoring guidelines
 
   - type: markdown
     attributes:
@@ -113,12 +113,7 @@ body:
 
         #### Post-release monitoring
 
-        -    [] TBD
-        
-  - type: markdown
-    attributes:
-      value: |
-        ### After final release
+        -    [] Follow post-release monitoring guidelines
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -40,7 +40,7 @@ body:
       value: |
         ### RC release
         
-        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) is NOT updated 
+        -    [] skip changelog generation
 
   - type: markdown
     attributes:
@@ -52,7 +52,7 @@ body:
       value: |
         ### Final release
         
-        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) IS updated
+        -    [] generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
 
   - type: markdown
     attributes:
@@ -64,4 +64,4 @@ body:
       value: |
         ### Dot-releases
         
-        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) IS updated
+        -    Follow `Final release` checklist

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -35,23 +35,55 @@ body:
       value: |
         ### RC release
         
-        -    [] Ensure all CFEs for the target release version are addressed and merged
+        #### Get release artifact ready
+
+        -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
         -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
         -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Skip changelog generation (?)
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
-        -    [] Review (ensure CI-checks are passing) and merge the PR
+        -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
+        -    [] Build zip-file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
+        -    [] Validate version and stable tag in `readme.txt` for the generated zip-file
+
+        #### Release to WordPress.org
+
+        -    [] TBD
+
+        #### Stage and bump stable tag
+
+        -    [] TBD
+
+        #### Send comms out
+
+        -    [] TBD
 
   - type: markdown
     attributes:
       value: |
         ### Final release
         
+        #### Get release artifact ready
+        
         -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
         -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
-        -    [] Review (ensure CI-checks are passing) and merge the PR
+        -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
+        -    [] Build zip-file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
+        -    [] Validate version and stable tag in `readme.txt` for the generated zip-file
+
+        #### Release to WordPress.org
+
+        -    [] TBD
+
+        #### Stage and bump stable tag
+
+        -    [] TBD
+
+        #### Send comms out
+
+        -    [] TBD
 
   - type: markdown
     attributes:
@@ -63,5 +95,5 @@ body:
       value: |
         ### Dot-releases
         
-        -    [] Ensure all PRRs for the target release version are merged
+        -    [] Ensure all [PRRs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22point%20release%20request%22) for the target release version are merged
         -    [] Follow `Final release` checklist

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -1,11 +1,17 @@
 name: 'WooCommerce: release checklist'
 description: Create a new issue to track the next WooCommerce core release progress.
-title: "WooCommerce VERSION_NUMBER: RC, final and dot-releases progress tracking"
+title: "WooCommerce RELEASE_VERSION: RC, final and dot-releases progress tracking"
 body:
   - type: markdown
     attributes:
       value: |
-        This issue is to provide visibility on the progress of the release process of WooCommerce core VERSION_NUMBER and to 
+        This issue is to provide visibility on the progress of the release process of WooCommerce core RELEASE_VERSION and to 
         centralize any conversations about it. The ultimate goal of this issue is to keep the reference of the steps, 
         resources, work, and conversations about this release so it can be helpful for the next contributors releasing 
         a new WooCommerce core version.
+
+        -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))
+        -   Release Lead: RELEASE_LEAD
+        -   Release Date: RC release on RELEASE_DATE
+        -   Release Date: final release on RELEASE_DATE
+        -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -24,6 +24,7 @@ body:
         -   [Release calendar](https://developer.woocommerce.com/release-calendar/)
         -   [Previous releases](https://developer.woocommerce.com/releases/)
         -   Latest (version 9.9+) [release process changes](https://developer.woocommerce.com/2025/03/05/upcoming-changes-to-the-woocommerce-release-process/)
+        -   Internal reference with more details: Pf59Ax-7F-p2
 
   - type: markdown
     attributes:
@@ -48,15 +49,23 @@ body:
 
         #### Release to WordPress.org
 
-        -    [] TBD
+        -    [] Skip notifying Atomic
+        -    [] Using WooRelease, perform release dry ran with e.g. `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
+        -    [] Using WooRelease, perform release with e.g. `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
+        -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
+        -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
+        -    [] Verify new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/advanced/ page
 
         #### Stage and bump stable tag
 
-        -    [] TBD
+        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip and pick the proper release branch)
+        -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 
-        -    [] TBD
+        -    [] Coordinate with Developer Advocacy team updating pre-release post on developer.woocommerce.com
+        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
+        -    [] Post an update in the internal release P2
 
   - type: markdown
     attributes:
@@ -75,15 +84,28 @@ body:
 
         #### Release to WordPress.org
 
-        -    [] TBD
+        -    [] Notify Atomic (via P2 and Slack) before deploying release
+        -    [] Using WooRelease, perform release dry ran with e.g. `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
+        -    [] Using WooRelease, perform release with e.g. `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
+        -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
+        -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
+        -    [] Verify new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/ page
+        -    [] Update the Atomic comms threads about the release completion        
 
         #### Stage and bump stable tag
 
-        -    [] TBD
+        -    [] For next 4 hours monitor the release staging: monitoring alerts and updates in the Atomic comms threads.
+        -    [] Using WooRelease, perform stable tag bump dry ran with e.g. `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
+        -    [] Using WooRelease, perform stable tag bump with e.g. `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
+        -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag sync with the source code
+        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip and pick the proper release branch)
+        -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 
-        -    [] TBD
+        -    [] Coordinate with Developer Advocacy team posting release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
+        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
+        -    [] Post an update in the internal release P2   
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -98,7 +98,7 @@ body:
 
         #### Stage and bump stable tag
 
-        -    [] For the next 4 hours, monitor the release staging: monitoring alerts and updates in the Atomic comms threads.
+        -    [] For the next 4 hours, monitor the release staging: monitoring alerts (as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC) and updates in the Atomic comms threads.
         -    [] Using WooRelease, perform stable tag bump dry ran with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -44,7 +44,7 @@ body:
         -    [] Skip changelog generation (?)
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
-        -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
+        -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml))
         -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
 
         #### Release to WordPress.org

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -1,0 +1,11 @@
+name: 'WooCommerce: release checklist'
+description: Create a new issue to track the next WooCommerce core release progress.
+title: "WooCommerce VERSION_NUMBER: RC, final and dot-releases progress tracking"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue is to provide visibility on the progress of the release process of WooCommerce core VERSION_NUMBER and to 
+        centralize any conversations about it. The ultimate goal of this issue is to keep the reference of the steps, 
+        resources, work, and conversations about this release so it can be helpful for the next contributors releasing 
+        a new WooCommerce core version.

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -33,26 +33,25 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### Before RC release
-
-  - type: markdown
-    attributes:
-      value: |
         ### RC release
         
-        -    [] skip changelog generation
-
-  - type: markdown
-    attributes:
-      value: |
-        ### Between RC and final releases
+        -    [] Ensure all CFEs for the target release version are addressed and merged
+        -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
+        -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
+        -    [] Skip changelog generation (?)
+        -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
+        -    [] Review (ensure CI-checks are passing) and merge the PR
 
   - type: markdown
     attributes:
       value: |
         ### Final release
         
-        -    [] generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
+        -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
+        -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
+        -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
+        -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
+        -    [] Review (ensure CI-checks are passing) and merge the PR
 
   - type: markdown
     attributes:
@@ -64,4 +63,5 @@ body:
       value: |
         ### Dot-releases
         
-        -    Follow `Final release` checklist
+        -    [] Ensure all PRRs for the target release version are merged
+        -    [] Follow `Final release` checklist

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -24,3 +24,38 @@ body:
         -   [Release calendar](https://developer.woocommerce.com/release-calendar/)
         -   [Previous releases](https://developer.woocommerce.com/releases/)
         -   Latest (version 9.9+) [release process changes](https://developer.woocommerce.com/2025/03/05/upcoming-changes-to-the-woocommerce-release-process/)
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Checklist
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Before RC release
+
+  - type: markdown
+    attributes:
+      value: |
+        ### RC release
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Between RC and final releases
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Final release
+
+  - type: markdown
+    attributes:
+      value: |
+        ### After final release
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Dot-releases

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -101,15 +101,15 @@ body:
         -    [] For the next 4 hours, monitor the release staging: monitoring alerts and updates in the Atomic comms threads.
         -    [] Using WooRelease, perform stable tag bump dry ran with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
-        -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag sync with the source code
+        -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code
         -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 
         -    [] Coordinate with the Developer Advocacy team posting the release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
-        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
-        -    [] Post an update in the internal release P2
+        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the internal release post
+        -    [] Post an update in the internal release post
 
         #### Post-release monitoring
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -15,3 +15,12 @@ body:
         -   Release Date: RC release on RELEASE_DATE
         -   Release Date: final release on RELEASE_DATE
         -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Resources
+
+        -   [Release calendar](https://developer.woocommerce.com/release-calendar/)
+        -   [Previous releases](https://developer.woocommerce.com/releases/)
+        -   Latest (version 9.9+) [release process changes](https://developer.woocommerce.com/2025/03/05/upcoming-changes-to-the-woocommerce-release-process/)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -11,9 +11,9 @@ body:
         a new WooCommerce core version.
 
         -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))
-        -   Release Lead: RELEASE_LEAD
-        -   Release Date: RC release on RELEASE_DATE
-        -   Release Date: final release on RELEASE_DATE
+        -   Release lead: RELEASE_LEAD
+        -   RC release date: RELEASE_DATE
+        -   Final release date: RELEASE_DATE
         -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -5,8 +5,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        This issue is to provide visibility on the progress of the release process of WooCommerce core RELEASE_VERSION and to 
-        centralize any conversations about it. The ultimate goal of this issue is to keep the reference of the steps, 
+        This issue provides visibility on the progress of the release process of WooCommerce core RELEASE_VERSION and 
+        centralizes any conversations about it. The ultimate goal of this issue is to keep a reference of the steps, 
         resources, work, and conversations about this release so it can be helpful for the next contributors releasing 
         a new WooCommerce core version.
 
@@ -44,28 +44,32 @@ body:
         -    [] Skip changelog generation (?)
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
-        -    [] Build zip-file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
-        -    [] Validate version and stable tag in `readme.txt` for the generated zip-file
+        -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
+        -    [] Validate version and stable tag in `readme.txt` for the generated zip file
 
         #### Release to WordPress.org
 
         -    [] Skip notifying Atomic
-        -    [] Using WooRelease, perform release dry ran with e.g. `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
-        -    [] Using WooRelease, perform release with e.g. `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
+        -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
+        -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
         -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
-        -    [] Verify new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/advanced/ page
+        -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/advanced/ page
 
         #### Stage and bump stable tag
 
-        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip and pick the proper release branch)
+        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 
-        -    [] Coordinate with Developer Advocacy team updating pre-release post on developer.woocommerce.com
+        -    [] Coordinate with the Developer Advocacy team updating the pre-release post on developer.woocommerce.com
         -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
         -    [] Post an update in the internal release P2
+
+        #### Post-release monitoring
+
+        -    [] TBD
 
   - type: markdown
     attributes:
@@ -79,34 +83,38 @@ body:
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
-        -    [] Build zip-file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
-        -    [] Validate version and stable tag in `readme.txt` for the generated zip-file
+        -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
+        -    [] Validate version and stable tag in `readme.txt` for the generated zip file
 
         #### Release to WordPress.org
 
         -    [] Notify Atomic (via P2 and Slack) before deploying release
-        -    [] Using WooRelease, perform release dry ran with e.g. `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
-        -    [] Using WooRelease, perform release with e.g. `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
+        -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
+        -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
         -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
-        -    [] Verify new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/ page
+        -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/ page
         -    [] Update the Atomic comms threads about the release completion        
 
         #### Stage and bump stable tag
 
-        -    [] For next 4 hours monitor the release staging: monitoring alerts and updates in the Atomic comms threads.
-        -    [] Using WooRelease, perform stable tag bump dry ran with e.g. `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
-        -    [] Using WooRelease, perform stable tag bump with e.g. `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
+        -    [] For the next 4 hours, monitor the release staging: monitoring alerts and updates in the Atomic comms threads.
+        -    [] Using WooRelease, perform stable tag bump dry ran with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
+        -    [] Using WooRelease, perform stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag sync with the source code
-        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip and pick the proper release branch)
+        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 
-        -    [] Coordinate with Developer Advocacy team posting release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
+        -    [] Coordinate with the Developer Advocacy team posting the release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
         -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
-        -    [] Post an update in the internal release P2   
+        -    [] Post an update in the internal release P2
 
+        #### Post-release monitoring
+
+        -    [] TBD
+        
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -39,6 +39,8 @@ body:
     attributes:
       value: |
         ### RC release
+        
+        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) is NOT updated 
 
   - type: markdown
     attributes:
@@ -49,6 +51,8 @@ body:
     attributes:
       value: |
         ### Final release
+        
+        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) IS updated
 
   - type: markdown
     attributes:
@@ -59,3 +63,5 @@ body:
     attributes:
       value: |
         ### Dot-releases
+        
+        -    [] [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) IS updated

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -24,7 +24,7 @@ body:
         -   [Release calendar](https://developer.woocommerce.com/release-calendar/)
         -   [Previous releases](https://developer.woocommerce.com/releases/)
         -   Latest (version 9.9+) [release process changes](https://developer.woocommerce.com/2025/03/05/upcoming-changes-to-the-woocommerce-release-process/)
-        -   Internal reference with more details: Pf59Ax-7F-p2
+        -   Internal detailed reference to the release process: Pf59Ax-7F-p2
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -59,7 +59,6 @@ body:
         #### Stage and bump stable tag
 
         -    [] Manually create a pre-release entry on https://github.com/woocommerce/woocommerce/releases (use the version as tag, upload the generated zip, and pick the proper release branch)
-        -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -102,7 +102,6 @@ body:
         -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code
         -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
-        -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -38,6 +38,7 @@ body:
         
         #### Get release artifact ready
 
+        -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
         -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
         -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -58,7 +58,7 @@ body:
 
         #### Stage and bump stable tag
 
-        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use the version as tag, upload the generated zip, and pick the proper release branch)
+        -    [] Manually create a pre-release entry on https://github.com/woocommerce/woocommerce/releases (use the version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         This issue provides visibility on the progress of the release process of WooCommerce core RELEASE_VERSION and 
-        centralizes any conversations about it. The ultimate goal of this issue is to keep a reference of the steps, 
+        it centralizes all related discussions and documentation. The ultimate goal of this issue is to keep a reference to the steps,
         resources, work, and conversations associated with this release so it can be helpful for future contributors handling the release of
         a new WooCommerce core version.
 
@@ -46,7 +46,7 @@ body:
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml))
-        -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
+        -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` in the generated zip file
 
         #### Release to WordPress.org
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -55,7 +55,7 @@ body:
         -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
         -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/advanced/ page
 
-        #### Stage and bump stable tag
+        #### Release to GitHub
 
         -    [] Manually create a pre-release entry on https://github.com/woocommerce/woocommerce/releases (use the version as tag, upload the generated zip, and pick the proper release branch)
 
@@ -102,7 +102,7 @@ body:
         -    [] Update the Atomic comms threads about the release completion        
         -    [] For the next 4 hours, monitor the release staging (monitoring as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC and updates in the Atomic comms threads).
         
-        #### Bump stable tag
+        #### Bump stable tag and release to GitHub
 
         -    [] Using WooRelease, perform the stable tag bump dry run with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -34,7 +34,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### RC release
+        ### RC release (reset the list as starting RC 2 ... RC N)
         
         #### Get release artifact ready
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -59,7 +59,7 @@ body:
 
         #### Stage and bump stable tag
 
-        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
+        -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use the version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release
 
         #### Send comms out

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -89,7 +89,7 @@ body:
 
         #### Release to WordPress.org
 
-        -    [] Notify Atomic (via P2 and Slack) before deploying release
+        -    [] Notify Atomic (via P2 and Slack, see  p9o2xV-5y1-p2 and p1747039405416989-slack-C7YPW6K40 for reference) before deploying release
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
         -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -52,7 +52,7 @@ body:
 
         -    [] Skip notifying Atomic
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
-        -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
+        -    [] Using WooRelease, perform the live release with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
         -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
         -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/advanced/ page

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -89,7 +89,7 @@ body:
 
         #### Release to WordPress.org
 
-        -    [] Notify Atomic (via P2 and Slack, see  p9o2xV-5y1-p2 and p1747039405416989-slack-C7YPW6K40 for reference) before deploying release
+        -    [] Notify Atomic that a release is about to be made (via P2 and Slack, see  p9o2xV-5y1-p2 and p1747039405416989-slack-C7YPW6K40 for reference) before deploying release
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
         -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -109,7 +109,7 @@ body:
         #### Send comms out
 
         -    [] Coordinate with the Developer Advocacy team posting the release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
-        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the internal release post
+        -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the internal release post
         -    [] Post an update in the internal release post
 
         #### Post-release monitoring

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -64,7 +64,7 @@ body:
 
         #### Send comms out
 
-        -    [] Coordinate with the Developer Advocacy team updating the pre-release post on developer.woocommerce.com
+        -    [] Coordinate with the Developer Advocacy team to update the pre-release post on developer.woocommerce.com
         -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the release post
         -    [] Post an update in the internal release P2 (see pf59Ax-2Nt-p2 for reference)
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -12,7 +12,8 @@ body:
 
         -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))
         -   Release lead: RELEASE_LEAD
-        -   RC release date: RC1_RELEASE_DATE (RELEASE_VERSION-rc.1)
+        -   RC1 release date: RC1_RELEASE_DATE
+        -   RC2 release date: RC2_RELEASE_DATE
         -   Final release date: RELEASE_DATE
         -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -35,6 +35,8 @@ body:
       value: |
         ### RC release
         
+        <!-- Note: Feel free to duplicate the checklist for new RCs if this is aligned with the current process. -->
+        
         #### Get release artifact ready
 
         -    [] Ensure [GitHub services](https://www.githubstatus.com/) are fully operational
@@ -70,6 +72,8 @@ body:
     attributes:
       value: |
         ### Final and dot-releases
+        
+        <!-- Note: Feel free to duplicate the checklist for new dot-releases if this is aligned with the current process. -->
         
         #### Get release artifact ready
         

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -40,8 +40,7 @@ body:
 
         -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
-        -    [] Validate that the stable tag in `readme.txt` in the release branch matches RELEASE_VERSION or update if necessary
-        -    [] Validate that the stable tag in `readme.txt` in the SVN `trunk` matches RELEASE_VERSION ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
+        -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Skip changelog generation (?)
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
@@ -79,8 +78,7 @@ body:
         
         #### Get release artifact ready
         
-        -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
-        -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
+        -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -93,7 +93,7 @@ body:
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
         -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
-        -    [] Upon receiving email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
+        -    [] Upon receiving the email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
         -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/ page
         -    [] Update the Atomic comms threads about the release completion        
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -64,7 +64,7 @@ body:
         #### Send comms out
 
         -    [] Coordinate with the Developer Advocacy team to update the pre-release post on developer.woocommerce.com
-        -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the release post
+        -    [] Notify #woo-announcements Slack channels of the release with a link to the release post (automation will notify #woo-core-releases)
         -    [] Post an update in the internal release P2 (see pf59Ax-2Nt-p2 for reference)
 
         #### Post-release monitoring
@@ -106,7 +106,7 @@ body:
         #### Send comms out
 
         -    [] Coordinate with the Developer Advocacy team posting the release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
-        -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the internal release post
+        -    [] Notify #woo-announcements Slack channels of the release with a link to the internal release post  (automation will notify #woo-core-releases)
         -    [] Post an update in the internal release post (see pf59Ax-2Nt-p2 for reference)
 
         #### Post-release monitoring

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -42,7 +42,6 @@ body:
         -    [] Ensure [GitHub services](https://www.githubstatus.com/) are fully operational
         -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
-        -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
@@ -78,7 +77,6 @@ body:
         #### Get release artifact ready
         
         -    [] Ensure [GitHub services](https://www.githubstatus.com/) are fully operational
-        -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -40,8 +40,8 @@ body:
 
         -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
-        -    [] Validate stable tag in `readme.txt` for the release branch and update if necessary
-        -    [] Validate stable tag in `readme.txt` for the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
+        -    [] Validate that the stable tag in `readme.txt` in the release branch matches RELEASE_VERSION or update if necessary
+        -    [] Validate that the stable tag in `readme.txt` in the SVN `trunk` matches RELEASE_VERSION ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Skip changelog generation (?)
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -69,7 +69,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### Final release
+        ### Final and dot-releases
         
         #### Get release artifact ready
         
@@ -98,7 +98,7 @@ body:
         #### Staging with Atomic
 
         -    [] Update the Atomic comms threads about the release completion        
-        -    [] For the next 4 hours, monitor the release staging (monitoring as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC and updates in the Atomic comms threads).
+        -    [] For the next 4 hours (2 hours for dot-releases), monitor the release staging (monitoring as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC and updates in the Atomic comms threads).
         
         #### Bump stable tag and release to GitHub
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -101,7 +101,7 @@ body:
 
         -    [] For the next 4 hours, monitor the release staging: monitoring alerts (as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC) and updates in the Atomic comms threads.
         -    [] Using WooRelease, perform stable tag bump dry ran with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
-        -    [] Using WooRelease, perform stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
+        -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code
         -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)
         -    [] Verify new PRs created by `github-actions` and merge ones related to the release

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -12,8 +12,7 @@ body:
 
         -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))
         -   Release lead: RELEASE_LEAD
-        -   RC1 release date: RC1_RELEASE_DATE
-        -   RC2 release date: RC2_RELEASE_DATE
+        -   RC release date: RC1_RELEASE_DATE
         -   Final release date: RELEASE_DATE
         -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
 
@@ -66,10 +65,6 @@ body:
         -    [] Coordinate with the Developer Advocacy team to update the pre-release post on developer.woocommerce.com
         -    [] Notify #woo-announcements Slack channels of the release with a link to the release post (automation will notify #woo-core-releases)
         -    [] Post an update in the internal release P2 (see pf59Ax-2Nt-p2 for reference)
-
-        #### Post-release monitoring
-
-        -    [] Follow post-release monitoring guidelines
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -23,7 +23,6 @@ body:
 
         -   [Release calendar](https://developer.woocommerce.com/release-calendar/)
         -   [Previous releases](https://developer.woocommerce.com/releases/)
-        -   Latest (version 9.9+) [release process changes](https://developer.woocommerce.com/2025/03/05/upcoming-changes-to-the-woocommerce-release-process/)
         -   Internal detailed reference to the release process: Pf59Ax-7F-p2
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -7,7 +7,7 @@ body:
       value: |
         This issue provides visibility on the progress of the release process of WooCommerce core RELEASE_VERSION and 
         centralizes any conversations about it. The ultimate goal of this issue is to keep a reference of the steps, 
-        resources, work, and conversations about this release so it can be helpful for the next contributors releasing 
+        resources, work, and conversations associated with this release so it can be helpful for future contributors handling the release of
         a new WooCommerce core version.
 
         -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -100,7 +100,7 @@ body:
         #### Stage and bump stable tag
 
         -    [] For the next 4 hours, monitor the release staging: monitoring alerts (as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC) and updates in the Atomic comms threads.
-        -    [] Using WooRelease, perform stable tag bump dry ran with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
+        -    [] Using WooRelease, perform the stable tag bump dry run with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code
         -    [] Manually create a release entry on https://github.com/woocommerce/woocommerce/releases (use version as tag, upload the generated zip, and pick the proper release branch)

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -33,14 +33,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### RC release (reset the list as starting RC 2 ... RC N)
+        ### RC release
         
         #### Get release artifact ready
 
         -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
         -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
-        -    [] Skip changelog generation (?)
+        -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml))

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -66,7 +66,7 @@ body:
 
         -    [] Coordinate with the Developer Advocacy team updating the pre-release post on developer.woocommerce.com
         -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
-        -    [] Post an update in the internal release P2
+        -    [] Post an update in the internal release P2 (see pf59Ax-2Nt-p2 for reference)
 
         #### Post-release monitoring
 
@@ -110,7 +110,7 @@ body:
 
         -    [] Coordinate with the Developer Advocacy team posting the release announcement on developer.woocommerce.com (post guidelines outlined here: Pf59Ax-7F-p2)
         -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the internal release post
-        -    [] Post an update in the internal release post
+        -    [] Post an update in the internal release post (see pf59Ax-2Nt-p2 for reference)
 
         #### Post-release monitoring
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -99,7 +99,7 @@ body:
 
         #### Stage and bump stable tag
 
-        -    [] For the next 4 hours, monitor the release staging: monitoring alerts (as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC) and updates in the Atomic comms threads.
+        -    [] For the next 4 hours, monitor the release staging (monitoring as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC and updates in the Atomic comms threads).
         -    [] Using WooRelease, perform the stable tag bump dry run with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -12,7 +12,7 @@ body:
 
         -   WooCommerce core version to release: RELEASE_VERSION ([milestone](https://github.com/woocommerce/woocommerce/milestone/MILESTONE_ID))
         -   Release lead: RELEASE_LEAD
-        -   RC release date: RELEASE_DATE
+        -   RC release date: RC1_RELEASE_DATE (RELEASE_VERSION-rc.1)
         -   Final release date: RELEASE_DATE
         -   WooCommerce core change log: [here](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt)
 

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -48,7 +48,6 @@ body:
 
         #### Release to WordPress.org
 
-        -    [] Skip notifying Atomic
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
         -    [] Using WooRelease, perform the live release with e.g., `php woorelease.php wporg:release --product_version=9.9.0-rc.1 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
@@ -83,19 +82,26 @@ body:
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
         -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
 
+        #### Sync with Atomic on the upcoming release
+        
+        -    [] Ensure releasing to WordPress.org is completed by ~12:00 or ~17:00 UTC (to hit one of the deployment windows)
+        -    [] Notify Atomic that a release is about to be made (via P2 and Slack, see  p9o2xV-5y1-p2 and p1747039405416989-slack-C7YPW6K40 for reference) before deploying release
+
         #### Release to WordPress.org
 
-        -    [] Notify Atomic that a release is about to be made (via P2 and Slack, see  p9o2xV-5y1-p2 and p1747039405416989-slack-C7YPW6K40 for reference) before deploying release
         -    [] Using WooRelease, perform a release dry run with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9`
         -    [] Using WooRelease, perform release with e.g., `php woorelease.php wporg:release --product_version=9.9.0 --zip_file=ZIP_FILE_PATH --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/release/9.9 --release`
         -    [] If the release command reports SVN-related timeouts, validate versions on https://wordpress.org/plugins/woocommerce/advanced/ and https://plugins.svn.wordpress.org/woocommerce/tags/ pages and continue if those are correct
         -    [] Upon receiving the email `[WordPress Plugin Directory] Pending release for WooCommerce`, confirm the release
         -    [] Verify the new version is listed and downloadable on https://wordpress.org/plugins/woocommerce/ page
+
+        #### Staging with Atomic
+
         -    [] Update the Atomic comms threads about the release completion        
-
-        #### Stage and bump stable tag
-
         -    [] For the next 4 hours, monitor the release staging (monitoring as per p1745322404770529/1745322371.115259-slack-C01DT6U03HC and updates in the Atomic comms threads).
+        
+        #### Bump stable tag
+
         -    [] Using WooRelease, perform the stable tag bump dry run with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0`
         -    [] Using WooRelease, perform the stable tag bump with e.g., `php woorelease.php update-stable --product_path=plugins/woocommerce https://github.com/woocommerce/woocommerce/tree/trunk 9.9.0 --update`
         -    [] Review (ensure PR CI-checks are passing) and merge additional PR (ensure merge CI-checks are passing) created on the previous step to sync stable tag with the source code

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -37,6 +37,7 @@ body:
         
         #### Get release artifact ready
 
+        -    [] Ensure [GitHub services](https://www.githubstatus.com/) are fully operational
         -    [] Ensure minimally required WordPress and PHP versions are up-to-date
         -    [] Ensure all [CFEs](https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22code%20freeze%20exception%22) for the target release version are addressed and merged
         -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
@@ -76,6 +77,7 @@ body:
         
         #### Get release artifact ready
         
+        -    [] Ensure [GitHub services](https://www.githubstatus.com/) are fully operational
         -    [] Validate that the stable tag in `readme.txt` in the release branch matches the stable tag in `readme.txt` in the SVN `trunk` ([here](https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt))
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -65,7 +65,7 @@ body:
         #### Send comms out
 
         -    [] Coordinate with the Developer Advocacy team updating the pre-release post on developer.woocommerce.com
-        -    [] Notify #woo-core-releases and #woo-announcements Slack channels with a link to the release post
+        -    [] Notify #woo-core-releases and #woo-announcements Slack channels of the release with a link to the release post
         -    [] Post an update in the internal release P2 (see pf59Ax-2Nt-p2 for reference)
 
         #### Post-release monitoring

--- a/.github/ISSUE_TEMPLATE/4-release.yml
+++ b/.github/ISSUE_TEMPLATE/4-release.yml
@@ -43,6 +43,7 @@ body:
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0-rc.1`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
+        -    [] If CI fails due to E2E tests or infrastructure issues, coordinate with other teams to resolve the failures
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml))
         -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` in the generated zip file
 
@@ -79,6 +80,7 @@ body:
         -    [] Generate [changelog](https://github.com/woocommerce/woocommerce/blob/trunk/changelog.txt) ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/new-cfe-prr-pre-build-compile-changelog-file.yml))
         -    [] Create a PR to bump version in source code with `GITHUB_TOKEN=<your_PAT_token> pnpm utils code-freeze version-bump -b release/9.9 9.9.0`
         -    [] Review (ensure PR CI-checks are passing) and merge the PR (ensure merge CI-checks are passing)
+        -    [] If CI fails due to E2E tests or infrastructure issues, coordinate with other teams to resolve the failures
         -    [] Build zip file ([workflow](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml))
         -    [] Validate version and stable tag in 'woocommerce.php' and `readme.txt` for the generated zip file
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #57897, WOOPLUG-4237

Adds release kickoff issue template with checklists for tracking release progress in the public space and more alignment with other divisions.

### How to test the changes in this Pull Request:

N/A, we aim for the content review only
