### PR TITLE
Extend personalization tags for order

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4331-extend-personalization-tags-for-order-and-customer
+++ b/plugins/woocommerce/changelog/wooplug-4331-extend-personalization-tags-for-order-and-customer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add personalization tags for Order Discount, Shipping Cost, Shipping Method, Shipping Address, Billing Address, Transaction Id, Order View URL, Order Admin URL, Order Custom Field.

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -15,6 +15,7 @@ use WC_Order;
 use WC_Product;
 use WC_Product_Variation;
 use WP_User;
+use WC_Order_Item_Shipping;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -343,7 +344,19 @@ class EmailPreview {
 		$order->set_shipping_total( 5 );
 		$order->set_total( 65 );
 		$order->set_payment_method_title( __( 'Direct bank transfer', 'woocommerce' ) );
-		$order->set_customer_note( __( "This is a customer note. Customers can add a note to their order on checkout.\n\nIt can be multiple lines. If there’s no note, this section is hidden.", 'woocommerce' ) );
+		$order->set_transaction_id( '999999999' );
+		$order->set_customer_note( __( "This is a customer note. Customers can add a note to their order on checkout.\n\nIt can be multiple lines. If there's no note, this section is hidden.", 'woocommerce' ) );
+
+		// Add shipping method.
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_props(
+			array(
+				'method_title' => __( 'Flat rate', 'woocommerce' ),
+				'method_id'    => 'flat_rate',
+				'total'        => '5.00',
+			)
+		);
+		$order->add_item( $shipping_item );
 
 		$address = $this->get_dummy_address();
 		$order->set_billing_address( $address );
@@ -477,8 +490,6 @@ class EmailPreview {
 		add_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10, 1 );
 		// Enable email preview mode - this way transient values are fetched for live preview.
 		add_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
-		// Get shipping method without needing to save it in the order.
-		add_filter( 'woocommerce_order_shipping_method', array( $this, 'get_shipping_method' ) );
 		// Use placeholder image included in WooCommerce files.
 		add_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
 	}
@@ -490,17 +501,7 @@ class EmailPreview {
 		remove_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
 		remove_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
-		remove_filter( 'woocommerce_order_shipping_method', array( $this, 'get_shipping_method' ) );
 		remove_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
-	}
-
-	/**
-	 * Get the shipping method for the preview email.
-	 *
-	 * @return string
-	 */
-	public function get_shipping_method() {
-		return __( 'Flat rate', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/OrderTagsProvider.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PersonalizationTags/OrderTagsProvider.php
@@ -104,6 +104,34 @@ class OrderTagsProvider extends AbstractTagProvider {
 
 		$registry->register(
 			new Personalization_Tag(
+				__( 'Order Discount', 'woocommerce' ),
+				'woocommerce/order-discount',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return wc_price( $context['order']->get_discount_total(), array( 'currency' => $context['order']->get_currency() ) );
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Shipping', 'woocommerce' ),
+				'woocommerce/order-shipping',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return wc_price( $context['order']->get_shipping_total(), array( 'currency' => $context['order']->get_currency() ) );
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
 				__( 'Order Total', 'woocommerce' ),
 				'woocommerce/order-total',
 				__( 'Order', 'woocommerce' ),
@@ -141,6 +169,108 @@ class OrderTagsProvider extends AbstractTagProvider {
 					}
 					return $context['order']->get_checkout_payment_url() ?? '';
 				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Transaction ID', 'woocommerce' ),
+				'woocommerce/order-transaction-id',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_transaction_id() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Shipping Method', 'woocommerce' ),
+				'woocommerce/order-shipping-method',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_shipping_method() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Shipping Address', 'woocommerce' ),
+				'woocommerce/order-shipping-address',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_formatted_shipping_address() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Billing Address', 'woocommerce' ),
+				'woocommerce/order-billing-address',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_formatted_billing_address() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order View URL', 'woocommerce' ),
+				'woocommerce/order-view-url',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_view_order_url() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Admin URL', 'woocommerce' ),
+				'woocommerce/order-admin-url',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context ): string {
+					if ( ! isset( $context['order'] ) ) {
+						return '';
+					}
+					return $context['order']->get_edit_order_url() ?? '';
+				},
+			)
+		);
+
+		$registry->register(
+			new Personalization_Tag(
+				__( 'Order Custom Field', 'woocommerce' ),
+				'woocommerce/order-custom-field',
+				__( 'Order', 'woocommerce' ),
+				function ( array $context, array $parameters = array() ): string {
+					if ( ! isset( $context['order'] ) || ! isset( $parameters['key'] ) ) {
+						return '';
+					}
+					$field_key = sanitize_text_field( $parameters['key'] );
+					return $context['order']->get_meta( $field_key ) ?? '';
+				},
+				array(
+					'key' => '',
+				),
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add personalization tags for Order Discount, Shipping Cost, Shipping Address, Billing Address, Transaction Id, Order View URL, Order Admin URL, Order Custom Field. 

Closes [WOOPLUG-4331: Extend personalization tags for order and customer](https://linear.app/a8c/issue/WOOPLUG-4331/extend-personalization-tags-for-order-and-customer) .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Screenshot |
| ------ |
| ![Rf15keHGGb5TXkfH](https://github.com/user-attachments/assets/66d86f80-f105-4184-ab97-a67f3ebda9cb) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**.
2. Open an email in the editor WooCommerce → Settings → **Emails**.
3. Confirm the new personalization tags are present in the "Personalization Tags" pop up (can be opened from the contextual toolbar, refer to the screenshot).
4. Edit the "New order" email and add the new personalization tags.
5. Create a new order to test the email with real data, use **Preview in new tab**, or use the **Send a test email**. Note that we currently don't provide any custom fields in the email preview dummy data.
6. Confirm the personalization tags are replaced with the expected values in the received email.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Add personalization tags for Order Discount, Shipping Cost, Shipping Method, Shipping Address, Billing Address, Transaction Id, Order View URL, Order Admin URL, Order Custom Field. 

</details>
