### PR TITLE
Fixed stretched images in Inbox notes

### DIFF
--- a/packages/js/experimental/changelog/58131-fix-wooplug-830
+++ b/packages/js/experimental/changelog/58131-fix-wooplug-830
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed stretched images in Inbox notes

--- a/packages/js/experimental/src/inbox-note/style.scss
+++ b/packages/js/experimental/src/inbox-note/style.scss
@@ -17,9 +17,18 @@
 		display: flex;
 		-webkit-flex-direction: row-reverse;
 		flex-direction: row-reverse;
-		img {
-			width: 128px;
-			height: 100%;
+
+		.woocommerce-inbox-message__image {
+			width: 40%;
+			img {
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+			}
+		}
+
+		.woocommerce-inbox-message__wrapper {
+			width: 60%;
 		}
 	}
 	&:hover {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Images inside Inbox notes had a hardcoded width of 128px, which made bigger images appear stretched down, as the height was always maintained at 100%. This PR updates the note section so that the text takes 60% of the available width and the image the 40% of the available width. Inside that area, the `img` element takes 100% of the available height and width and uses the `object-fit: cover;` to be proportionally re-sized. 

Closes #34674 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![Markup on 2025-05-20 at 13:47:29](https://github.com/user-attachments/assets/a2373478-8681-4cc5-9e08-7e9b7a68ee9e) | ![Markup on 2025-05-20 at 14:43:00](https://github.com/user-attachments/assets/ca233238-8c32-4e3b-b287-a202b2d8c658) |



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Start with `trunk`.
1. Go to WooCommerce > Home and scroll down to the Inbox.
2. If you don't have any notes with images, run the following snippet once and then deactivate it:
```
add_action( 'admin_init', 'display_note_with_image' );

function display_note_with_image() {
	$note = Automattic\WooCommerce\Internal\Admin\Notes\MarketingJetpack::get_note();
	$note->save();
}
```
3. Refresh the page and see a note with the Jetpack image stretched down.
4. Check out this branch. 
5. Refresh the page -- the image should show up properly re-sized now. 

Bonus testing! 
1. You may try creating a custom note with your own image to test more edge case scenarios. 
2. Here's an example:

```
$note = new Note();
$note->set_title( __( 'Protect your WooCommerce Store with Jetpack Backup.', 'woocommerce' ) );
$note->set_content( __( 'Store downtime means lost sales. One-click restores get you back online quickly if something goes wrong.', 'woocommerce' ) );
$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
$note->set_name( 'Test' );
$note->set_layout( 'thumbnail' );
$note->set_image( 'your_image_here' );
$note->set_content_data( (object) array() );
$note->set_source( 'woocommerce-admin-notes' );
$note->save();
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixed stretched images in Inbox notes

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
