### PR TITLE
Prevent extra space rendering under local pickup options in Checkout Block

### DIFF
--- a/plugins/woocommerce/changelog/fix-local-pickup-gaps
+++ b/plugins/woocommerce/changelog/fix-local-pickup-gaps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix spacing on local pickup select component

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -47,7 +47,11 @@ export const LocalPickupSelect = ( {
 				highlightChecked={ true }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
-					renderPickupLocation( location, packageCount )
+					renderPickupLocation(
+						location,
+						packageCount,
+						selectedOption
+					)
 				) }
 			/>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -47,11 +47,7 @@ export const LocalPickupSelect = ( {
 				highlightChecked={ true }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
-					renderPickupLocation(
-						location,
-						packageCount,
-						selectedOption
-					)
+					renderPickupLocation( location, packageCount )
 				) }
 			/>
 		</div>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -70,7 +70,8 @@ const getPickupDetails = (
 
 const renderPickupLocation = (
 	option: CartShippingPackageShippingRate,
-	packageCount: number
+	packageCount: number,
+	selectedOption: string
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -80,6 +80,8 @@ const renderPickupLocation = (
 	const address = getPickupAddress( option );
 	const details = getPickupDetails( option );
 
+	const isSelected = selectedOption === option.rate_id;
+
 	// Default to showing "free" as the secondary label. Price checks below will update it if needed.
 	let secondaryLabel = <em>{ __( 'free', 'woocommerce' ) }</em>;
 
@@ -130,9 +132,12 @@ const renderPickupLocation = (
 				{ decodeEntities( address ) }
 			</>
 		) : undefined,
-		secondaryDescription: details ? (
-			<ReadMore maxLines={ 2 }>{ decodeEntities( details ) }</ReadMore>
-		) : undefined,
+		secondaryDescription:
+			isSelected && details ? (
+				<ReadMore maxLines={ 2 }>
+					{ decodeEntities( details ) }
+				</ReadMore>
+			) : undefined,
 	};
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -70,8 +70,7 @@ const getPickupDetails = (
 
 const renderPickupLocation = (
 	option: CartShippingPackageShippingRate,
-	packageCount: number,
-	selectedOption: string
+	packageCount: number
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
@@ -80,7 +79,7 @@ const renderPickupLocation = (
 	const address = getPickupAddress( option );
 	const details = getPickupDetails( option );
 
-	const isSelected = selectedOption === option.rate_id;
+	const isSelected = option?.selected;
 
 	// Default to showing "free" as the secondary label. Price checks below will update it if needed.
 	let secondaryLabel = <em>{ __( 'free', 'woocommerce' ) }</em>;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/test/block.tsx
@@ -212,3 +212,43 @@ test( 'upstream rate selection updates are properly reflected in local state', a
 	expect( firstRate ).toBeChecked();
 	expect( secondRate ).not.toBeChecked();
 } );
+
+test( 'description is not shown if rate is not selected', async () => {
+	const packageData = generateShippingPackage( {
+		packageId: 0,
+		shippingRates: [
+			generateShippingRate( {
+				rateId: 'pickup_location:1',
+				name: 'Pickup New York City',
+				methodID: 'pickup_nyc',
+				price: '0',
+				instanceID: 0,
+				selected: false,
+				meta_data: [
+					{ key: 'pickup_details', value: 'Store 1 details.' },
+				],
+			} ),
+			generateShippingRate( {
+				rateId: 'pickup_location:2',
+				name: 'Pickup Los Angeles',
+				methodID: 'pickup_la',
+				price: '0',
+				instanceID: 1,
+				selected: true,
+				meta_data: [
+					{ key: 'pickup_details', value: 'Store 2 details.' },
+				],
+			} ),
+		],
+	} );
+	( useShippingData as jest.Mock ).mockImplementation( () => {
+		return {
+			selectShippingRate: jest.fn(),
+			isSelectingRate: false,
+			shippingRates: [ packageData ],
+		};
+	} );
+	render( <CheckoutPickupOptionsBlock /> );
+	expect( screen.queryByText( 'Store 1 details.' ) ).not.toBeInTheDocument();
+	expect( screen.getByText( 'Store 2 details.' ) ).toBeInTheDocument();
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/mocks/shipping-package.ts
@@ -13,6 +13,8 @@ export const generateShippingRate = ( {
 	instanceID,
 	methodID = name.toLowerCase().split( ' ' ).join( '_' ),
 	selected = false,
+	// eslint-disable-next-line @typescript-eslint/naming-convention -- meta_data comes from the API response.
+	meta_data = [],
 }: {
 	rateId: string;
 	name: string;
@@ -20,6 +22,7 @@ export const generateShippingRate = ( {
 	instanceID: number;
 	methodID?: string;
 	selected?: boolean;
+	meta_data?: { key: string; value: string }[];
 } ): CartShippingPackageShippingRate => {
 	return {
 		rate_id: rateId,
@@ -30,7 +33,7 @@ export const generateShippingRate = ( {
 		taxes: '0',
 		instance_id: instanceID,
 		method_id: methodID,
-		meta_data: [],
+		meta_data,
 		selected,
 		currency_code: 'USD',
 		currency_symbol: '$',

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/option.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/option.tsx
@@ -17,7 +17,7 @@ const Option = ( {
 	disabled = false,
 	highlightChecked = false,
 	descriptionStackingDirection,
-}: RadioControlOptionProps ): JSX.Element => {
+}: RadioControlOptionProps ) => {
 	const {
 		value,
 		label,

--- a/plugins/woocommerce/client/blocks/packages/components/radio-control/types.ts
+++ b/plugins/woocommerce/client/blocks/packages/components/radio-control/types.ts
@@ -31,7 +31,7 @@ export interface RadioControlOptionProps {
 	disabled?: boolean;
 	// Should the selected option be highlighted with a border?
 	highlightChecked?: boolean;
-	descriptionStackingDirection?: 'column' | 'row';
+	descriptionStackingDirection?: 'column' | 'row' | undefined;
 }
 
 interface RadioControlOptionContent {
@@ -49,5 +49,5 @@ export interface RadioControlOption extends RadioControlOptionContent {
 
 export interface RadioControlOptionLayout extends RadioControlOptionContent {
 	id?: string;
-	descriptionStackingDirection?: 'column' | 'row';
+	descriptionStackingDirection?: 'column' | 'row' | undefined;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add a new `selectedOption` arg for the `renderPickupLocation` method. We use to generate the react components that show the pickup instructions, however these instructions only show when the method is selected. If the method is not selected, the `ReadMore` component is still rendered, but it is empty, however there is spacing applied to it with CSS, even when empty.
- The method will skip rendering the component if it's not selected.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="601" alt="image" src="https://github.com/user-attachments/assets/99fc8745-cddb-40c3-825f-3aea57bf6f27" /> |  <img width="609" alt="image" src="https://github.com/user-attachments/assets/f421d939-a529-41a3-b1c2-353363076358" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC -> Settings -> Shipping -> Local Pickup and add multiple methods, some of these methods should have an empty "Pickup details" option.
<img width="565" alt="image" src="https://github.com/user-attachments/assets/724a947e-ccd6-4a80-b9da-1b6669802d5f" />

2. Add an item to your cart and go to the Checkout block.
3. Select Local Pickup and select different methods, ensure they show correctly.
4. Ensure other components on the page using Radio buttons work OK (Shipping, Payment).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
