### PR TITLE
Add a new release workflow to generate the number of commits and contributors list

### DIFF
--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -99,6 +99,9 @@ jobs:
     name: Count commits and contributors between releases
     needs: extract-versions
     runs-on: ubuntu-latest
+    outputs:
+      commit_count: ${{ steps.count-commits.outputs.commit_count }}
+      contributor_count: ${{ steps.count-commits.outputs.contributor_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -106,6 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Count
+        id: count-commits
         run: |
           CURRENT_BRANCH="origin/release/${{ needs.extract-versions.outputs.current_version }}"
           PREVIOUS_BRANCH="origin/release/${{ needs.extract-versions.outputs.previous_version }}"
@@ -120,6 +124,8 @@ jobs:
 
           if [ $COMMIT_EXIT_CODE -eq 0 ] && [ $CONTRIBUTOR_EXIT_CODE -eq 0 ]; then
             echo "Found ${COMMIT_COUNT} commits and ${CONTRIBUTOR_COUNT} contributors in the ${{ needs.extract-versions.outputs.current_version }} release"
+            echo "commit_count=${COMMIT_COUNT}" >> $GITHUB_OUTPUT
+            echo "contributor_count=${CONTRIBUTOR_COUNT}" >> $GITHUB_OUTPUT
           else
             echo "Error counting commits: ${COMMIT_COUNT}"
             exit 1
@@ -129,6 +135,9 @@ jobs:
     name: Generate contributors list
     needs: extract-versions
     runs-on: ubuntu-latest
+    outputs:
+      contributor_list_path: ${{ steps.generate-contributors-list.outputs.filepath }}
+      artifact_url: ${{ steps.output-artifact-url.outputs.artifact_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -171,7 +180,159 @@ jobs:
           echo "filepath=${HTML_FILE_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload contributors HTML
+        id: artifact-upload
         uses: actions/upload-artifact@v4
         with:
           name: contributors-release-${{ needs.extract-versions.outputs.current_version }}
           path: ${{ steps.generate-contributors-list.outputs.filepath }}
+
+      - name: Output artifact URL
+        id: output-artifact-url
+        run: |
+          ARTIFACT_URL=${{ steps.artifact-upload.outputs.artifact-url }}
+          echo "artifact_url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
+
+  db-updates:
+    name: Check for database updates
+    needs: extract-versions
+    runs-on: ubuntu-latest
+    outputs:
+      has_updates: ${{ steps.check-db-updates.outputs.has_updates }}
+      updates_list: ${{ steps.check-db-updates.outputs.updates_list }}
+      formatted_updates: ${{ steps.find-pr.outputs.formatted_updates }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for database updates
+        id: check-db-updates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'plugins/woocommerce/includes/class-wc-install.php';
+            const version = '${{ needs.extract-versions.outputs.current_version }}';
+
+            console.log(`Checking for database updates for version: ${version}`);
+
+            try {
+              const fileContent = fs.readFileSync(path, 'utf8');
+
+              const dbUpdatesMatch = fileContent.match(/\$db_updates\s*=\s*array\s*\((.*?)\);/s);
+
+              if (!dbUpdatesMatch) {
+                console.log('Could not find `$db_updates` array in the file');
+                core.setOutput('has_updates', 'false');
+                return;
+              }
+
+              const dbUpdatesContent = dbUpdatesMatch[1];
+
+              // Check if the version exists as a key in the array
+              // This regex looks for the version as a string key with the format X.Y.Z
+              const escapedVersion = version.replace('.', '\\.');
+              const versionPattern = new RegExp(`['"]${escapedVersion}(?:\\.\\d+)?['"]\\s*=>\\s*array\\s*\\((.*?)\\)`, 's');
+              const versionMatch = dbUpdatesContent.match(versionPattern);
+
+              if (versionMatch) {
+                console.log(`✅ Found database updates for version ${version}`);
+                core.setOutput('has_updates', 'true');
+
+                const updatesContent = versionMatch[1];
+
+                // Split by comma and clean up each update function
+                const updates = updatesContent
+                  .split(',')
+                  .map(update => update.trim().replace(/['"]/g, ''))
+                  .filter(update => update.length > 0);
+
+                // Store updates for the PR finding step
+                core.setOutput('updates_list', updates.join(','));
+
+              } else {
+                console.log(`⛔ No database updates found for version ${version}`);
+                core.setOutput('has_updates', 'false');
+                core.setOutput('updates_list', '');
+              }
+            } catch (error) {
+              console.error(`Error reading file: ${error.message}`);
+              core.setFailed(`Failed to check database updates: ${error.message}`);
+            }
+
+      - name: Find PRs for each database update
+        id: find-pr
+        if: ${{ steps.check-db-updates.outputs.has_updates == 'true' }}
+        run: |
+          FILE_PATH="plugins/woocommerce/includes/class-wc-install.php"
+          UPDATES="${{ steps.check-db-updates.outputs.updates_list }}"
+
+          echo "Searching for PRs that introduced database updates"
+
+          # Create a variable to build the formatted updates list
+          FORMATTED_UPDATES=""
+
+          # Convert comma-separated list to array
+          IFS=',' read -ra UPDATE_ARRAY <<< "$UPDATES"
+
+          for update_function in "${UPDATE_ARRAY[@]}"; do
+            # Clean up the function name (remove any extra whitespace)
+            update_function=$(echo "$update_function" | xargs)
+
+            echo "Searching for: $update_function"
+
+            # Use git blame to find which commit last modified the line with this function
+            commit_hash=$(git blame "$FILE_PATH" | grep "$update_function" | head -1 | cut -d' ' -f1)
+
+            if [ -n "$commit_hash" ] && [ "$commit_hash" != "00000000" ]; then
+              commit_message=$(git log --format="%s" -1 "$commit_hash")
+
+              echo "Found commit: $commit_hash"
+              echo "Commit message: $commit_message"
+
+              # Extract PR number from commit message
+              pr_number=$(echo "$commit_message" | grep -oE '\(#[0-9]+\)|#[0-9]+|PR #[0-9]+' | grep -oE '[0-9]+' | head -1)
+
+              if [ -n "$pr_number" ]; then
+                pr_url="https://github.com/${{ github.repository }}/pull/$pr_number"
+                echo "* \`$update_function\`, $pr_url"
+                FORMATTED_UPDATES="${FORMATTED_UPDATES}• \`$update_function\` (<$pr_url|PR #$pr_number>)\n"
+              else
+                # If no PR number found, link to the commit
+                commit_url="https://github.com/${{ github.repository }}/commit/$commit_hash"
+                echo "* \`$update_function\`, $commit_url"
+                FORMATTED_UPDATES="${FORMATTED_UPDATES}• \`$update_function\` (<$commit_url|Commit>)\n"
+              fi
+            else
+              echo "* \`$update_function\`, No commit or PR found"
+              FORMATTED_UPDATES="${FORMATTED_UPDATES}• \`$update_function\`: No PR information found\n"
+            fi
+            echo ""
+          done
+
+          # Set the formatted updates as output
+          echo "formatted_updates<<EOF" >> $GITHUB_OUTPUT
+          echo "$FORMATTED_UPDATES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  send-slack-notification:
+    name: Send Slack Notification
+    needs: [extract-versions, count-commits-and-contributors, generate-contributors-list, db-updates]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack message
+        uses: archive/github-actions-slack@v2.10.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+          slack-channel: ${{ secrets.WOO_ANNOUNCEMENTS_SLACK_CHANNEL }}
+          slack-text: |
+            :woo: *WooCommerce ${{ needs.extract-versions.outputs.current_version }} Release Summary*
+
+            📊 *Statistics:*
+            • Commits: ${{ needs.count-commits-and-contributors.outputs.commit_count }}
+            • Contributors: ${{ needs.count-commits-and-contributors.outputs.contributor_count }}
+            • <${{ needs.generate-contributors-list.outputs.artifact_url }}|Download Contributors List>
+
+            :database: *Database Updates:*
+            ${{ needs.db-updates.outputs.has_updates == 'true' && needs.db-updates.outputs.formatted_updates || 'This release does not include a database update.' }}

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -1,0 +1,176 @@
+name: 'Release: Generate Number of Commits and Contributors'
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: false
+        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
+
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: false
+        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
+
+jobs:
+  extract-versions:
+    name: Extract release current and previous versions
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.calculate-versions.outputs.current_version }}
+      previous_version: ${{ steps.calculate-versions.outputs.previous_version }}
+    steps:
+      - name: Extract version from the provided input version
+        id: version-from-input
+        if: ${{ github.event.inputs.version != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const currentVersion = '${{ github.event.inputs.version }}';
+            console.log(`Current version from input: ${currentVersion}`);
+
+            const versionMatch = currentVersion.match(/^(\d+)\.(\d+)$/);
+            if (!versionMatch) {
+              core.setFailed(`Version format must be 'x.y', got: ${currentVersion}`);
+              process.exit(1);
+            }
+
+            const major = parseInt(versionMatch[1]);
+            const minor = parseInt(versionMatch[2]);
+            console.log(`Parsed version: major=${major}, minor=${minor}`);
+
+            core.setOutput('major', major);
+            core.setOutput('minor', minor);
+
+      - name: Extract version from the branch name
+        id: version-from-branch
+        if: ${{ github.event.inputs.version == '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = '${{ github.ref_name }}';
+            console.log(`Branch name: ${branchName}`);
+
+            const branchMatch = branchName.match(/^release\/(\d+)\.(\d+)$/);
+            if (!branchMatch) {
+              core.setFailed(`Branch name must be in format 'release/x.y', got: ${branchName}`);
+              process.exit(1);
+            }
+
+            const major = parseInt(branchMatch[1]);
+            const minor = parseInt(branchMatch[2]);
+            const currentVersion = `${major}.${minor}`;
+
+            console.log(`Extracted current version: ${currentVersion}`);
+            console.log(`Parsed version: major=${major}, minor=${minor}`);
+
+            core.setOutput('major', major);
+            core.setOutput('minor', minor);
+
+      - name: Calculate current and previous version
+        id: calculate-versions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let major, minor;
+            if (${{ github.event.inputs.version == '' }}) {
+              major = parseInt('${{ steps.version-from-branch.outputs.major }}');
+              minor = parseInt('${{ steps.version-from-branch.outputs.minor }}');
+            } else {
+              major = parseInt('${{ steps.version-from-input.outputs.major }}');
+              minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
+            }
+
+            let previousVersion;
+            if (minor > 0) {
+              previousVersion = `${major}.${minor - 1}`;
+            } else {
+              previousVersion = `${major - 1}.9`;
+            }
+
+            console.log(`Current version: ${major}.${minor}`);
+            console.log(`Previous version: ${previousVersion}`);
+            core.setOutput('current_version', `${major}.${minor}`);
+            core.setOutput('previous_version', previousVersion);
+
+  count-commits:
+    name: Count commits between releases
+    needs: extract-versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Count commits between releases
+        id: count-commits
+        run: |
+          CURRENT_BRANCH="origin/release/${{ needs.extract-versions.outputs.current_version }}"
+          PREVIOUS_BRANCH="origin/release/${{ needs.extract-versions.outputs.previous_version }}"
+
+          set +e  # Don't exit on error for the git command
+          COMMIT_COUNT=$(git rev-list --count ${CURRENT_BRANCH} ^${PREVIOUS_BRANCH} 2>&1)
+          EXIT_CODE=$?
+          set -e  # Resume exit on error
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "Found ${COMMIT_COUNT} commits between ${PREVIOUS_BRANCH} and ${CURRENT_BRANCH}"
+          else
+            echo "Error counting commits: ${COMMIT_COUNT}"
+            exit 1
+          fi
+
+  generate-contributors-list:
+    name: Generate contributors list
+    needs: extract-versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d
+
+      - name: Setup Node
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install prerequisites
+        working-directory: tools/release-posts
+        run: |
+          pnpm install
+          # pnpm build
+
+      - name: Generate contributors list
+        id: generate-contributors-list
+        working-directory: tools/release-posts
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_BRANCH="release/${{ needs.extract-versions.outputs.current_version }}"
+          PREVIOUS_BRANCH="release/${{ needs.extract-versions.outputs.previous_version }}"
+
+          OUTPUT=$(pnpm run release-post contributors ${CURRENT_BRANCH} ${PREVIOUS_BRANCH})
+          echo "$OUTPUT"
+
+          HTML_FILE_PATH=$(echo "$OUTPUT" | grep "Contributors HTML generated at" | sed 's/.*Contributors HTML generated at //')
+          if [ -z "$HTML_FILE_PATH" ]; then
+            echo "Error: Could not find HTML file path in $OUTPUT"
+            exit 1
+          fi
+
+          echo "filepath=${HTML_FILE_PATH}" >> $GITHUB_OUTPUT
+
+      - name: Upload contributors HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: contributors-release-${{ needs.extract-versions.outputs.current_version }}
+          path: ${{ steps.generate-contributors-list.outputs.filepath }}

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -95,8 +95,8 @@ jobs:
             core.setOutput('current_version', `${major}.${minor}`);
             core.setOutput('previous_version', previousVersion);
 
-  count-commits:
-    name: Count commits between releases
+  count-commits-and-contributors:
+    name: Count commits and contributors between releases
     needs: extract-versions
     runs-on: ubuntu-latest
     steps:
@@ -105,8 +105,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Count commits between releases
-        id: count-commits
+      - name: Count
         run: |
           CURRENT_BRANCH="origin/release/${{ needs.extract-versions.outputs.current_version }}"
           PREVIOUS_BRANCH="origin/release/${{ needs.extract-versions.outputs.previous_version }}"

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -1,18 +1,14 @@
 name: 'Release: Generate Number of Commits and Contributors'
 on:
-  workflow_call:
-    inputs:
-      version:
-        type: string
-        required: false
-        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
-
   workflow_dispatch:
     inputs:
       version:
         type: string
         required: false
         description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
+
+  release:
+    types: [prereleased]
 
 jobs:
   extract-versions:
@@ -22,6 +18,42 @@ jobs:
       current_version: ${{ steps.calculate-versions.outputs.current_version }}
       previous_version: ${{ steps.calculate-versions.outputs.previous_version }}
     steps:
+      - name: Check pre-release and extract RC version
+        id: version-from-prerelease
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tagName = '${{ github.event.release.tag_name }}';
+            const isPrerelease = ${{ github.event.release.prerelease }};
+
+            console.log(`Release tag: ${tagName}, prerelease: ${isPrerelease}`);
+
+            if (!isPrerelease) {
+              core.setFailed(`This workflow only runs for pre-releases`);
+              process.exit(1);
+            }
+
+            // Check if it's an RC format: x.y.z-rc.N
+            const rcPattern = /^v?(\d+)\.(\d+)\.(\d+)-rc\.(\d+)$/;
+            const rcMatch = tagName.match(rcPattern);
+
+            if (!rcMatch) {
+              console.log(`⛔ Not an RC pre-release format: ${tagName}`);
+              console.log(`Expected format: x.y.z-rc.N (e.g., 9.8.0-rc.1)`);
+              core.setFailed(`This workflow only runs for RC pre-releases with format x.y.z-rc.N`);
+              process.exit(1);
+            }
+
+            const major = parseInt(rcMatch[1]);
+            const minor = parseInt(rcMatch[2]);
+
+            console.log(`✅ Valid RC pre-release: ${tagName}`);
+            console.log(`Extracted version: major=${major}, minor=${minor}`);
+
+            core.setOutput('major', major);
+            core.setOutput('minor', minor);
+
       - name: Extract version from the provided input version
         id: version-from-input
         if: ${{ github.event.inputs.version != '' }}
@@ -46,7 +78,7 @@ jobs:
 
       - name: Extract version from the branch name
         id: version-from-branch
-        if: ${{ github.event.inputs.version == '' }}
+        if: ${{ github.event.inputs.version == '' && github.event_name != 'release' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -75,12 +107,22 @@ jobs:
         with:
           script: |
             let major, minor;
-            if (${{ github.event.inputs.version == '' }}) {
-              major = parseInt('${{ steps.version-from-branch.outputs.major }}');
-              minor = parseInt('${{ steps.version-from-branch.outputs.minor }}');
-            } else {
+
+            if ('${{ github.event_name }}' === 'release') {
+              // Pre-release trigger - use RC tag version
+              major = parseInt('${{ steps.version-from-prerelease.outputs.major }}');
+              minor = parseInt('${{ steps.version-from-prerelease.outputs.minor }}');
+              console.log(`Using version from RC pre-release: ${major}.${minor}`);
+            } else if ('${{ github.event.inputs.version }}' !== '') {
+              // Manual trigger with input version
               major = parseInt('${{ steps.version-from-input.outputs.major }}');
               minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
+              console.log(`Using version from input: ${major}.${minor}`);
+            } else {
+              // Manual trigger from branch name
+              major = parseInt('${{ steps.version-from-branch.outputs.major }}');
+              minor = parseInt('${{ steps.version-from-branch.outputs.minor }}');
+              console.log(`Using version from branch: ${major}.${minor}`);
             }
 
             let previousVersion;
@@ -92,6 +134,7 @@ jobs:
 
             console.log(`Current version: ${major}.${minor}`);
             console.log(`Previous version: ${previousVersion}`);
+
             core.setOutput('current_version', `${major}.${minor}`);
             core.setOutput('previous_version', previousVersion);
 
@@ -325,7 +368,7 @@ jobs:
         uses: archive/github-actions-slack@v2.10.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-          slack-channel: ${{ secrets.WOO_ANNOUNCEMENTS_SLACK_CHANNEL }}
+          slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
           slack-text: |
             :woo: *WooCommerce ${{ needs.extract-versions.outputs.current_version }} Release Summary*
 
@@ -336,3 +379,5 @@ jobs:
 
             :database: *Database Updates:*
             ${{ needs.db-updates.outputs.has_updates == 'true' && needs.db-updates.outputs.formatted_updates || 'This release does not include a database update.' }}
+
+            <!subteam^S086N376UTS> you can re-run this workflow <https://github.com/woocommerce/woocommerce/actions/workflows/release-commits-and-contributors.yml|here>

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -149,7 +149,6 @@ jobs:
         working-directory: tools/release-posts
         run: |
           pnpm install
-          # pnpm build
 
       - name: Generate contributors list
         id: generate-contributors-list

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -113,11 +113,14 @@ jobs:
 
           set +e  # Don't exit on error for the git command
           COMMIT_COUNT=$(git rev-list --count ${CURRENT_BRANCH} ^${PREVIOUS_BRANCH} 2>&1)
-          EXIT_CODE=$?
+          COMMIT_EXIT_CODE=$?
+
+          CONTRIBUTOR_COUNT=$(git log --format='%ae' ${PREVIOUS_BRANCH}..${CURRENT_BRANCH} | sort -u | wc -l 2>&1)
+          CONTRIBUTOR_EXIT_CODE=$?
           set -e  # Resume exit on error
 
-          if [ $EXIT_CODE -eq 0 ]; then
-            echo "Found ${COMMIT_COUNT} commits between ${PREVIOUS_BRANCH} and ${CURRENT_BRANCH}"
+          if [ $COMMIT_EXIT_CODE -eq 0 ] && [ $CONTRIBUTOR_EXIT_CODE -eq 0 ]; then
+            echo "Found ${COMMIT_COUNT} commits and ${CONTRIBUTOR_COUNT} contributors in the ${{ needs.extract-versions.outputs.current_version }} release"
           else
             echo "Error counting commits: ${COMMIT_COUNT}"
             exit 1


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces the new `Release: Generate Number of Commits and Contributors` workflow.
Given a release version (X.Y format) or a release branch (`release/X.Y` format), it will:
- Calculate current and previous release versions (from the input format or the branch name).
- Count commits between both releases and output the result.
- Generate the contributors list and upload it as an artifact for the Dev Advocacy team to use to create the release post.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #57934 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

⚠️ If you want to test on your own Slack workspace, follow the instructions from the Steps to set up a Slack app from https://github.com/woocommerce/woocommerce/pull/58417, otherwise follow these 👇

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
3. In the forked repo, create a PR with the branch `57934-automate-contributors-list` and merge it (to get this new workflow into `trunk`).
4. Now go to `Actions`, click on the ` Release: Generate Number of Commits and Contributors`, and manually run the workflow with the `release/9.9` as branch (leave the `version` input empty).
5. Check the flow finishes without error, and that you receive a Slack message similar to the following:
<img width="474" alt="Screenshot 2025-06-12 at 12 47 07" src="https://github.com/user-attachments/assets/91300f65-8a4c-496b-9e6f-0f0813772bc6" />

6. Repeat step 4, but now write the `9.9` version number in the `version` input when manually running the workflow and see that the `Extract release current and previous versions` does not fail (you can cancel the flow at this point, no need to wait for it to finish).
7. Try running the workflow with a random string (not with the `X.Y` format) as a `version` and ensure it fails.
8. Try running the workflow with a random branch (not with the `release/X.Y` format) and empty `version` and ensure it also fails.
9. Create a new release with a random string as a tag, set it as `pre-release`, and save. Ensure the workflow is triggered but fails to validate the version.
10. Create a new release with a version like `9.9.0-rc.2` (should include `rc`), set it as `pre-release`, and save. Ensure the workflow runs and the `Extract release current and previous versions` succeeds (you can cancel the flow at this point, no need to wait for it to finish).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
