### PR TITLE
Add back button to the email editor

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4268-add-back-button-to-the-email-editor
+++ b/packages/js/email-editor/changelog/wooplug-4268-add-back-button-to-the-email-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+This adds a back button to the WooCommerce Email Editor, allowing navigation back to the email listings page from the editor. The back button appears when the editor is in full-screen mode, which is now enforced by default.

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -69,7 +69,7 @@ export function InnerEditor( {
 						? getEditedPostTemplate()
 						: null,
 				post: postObject,
-				isFullscreenEnabled: true,
+				isFullscreenEnabled: settings.fullScreen,
 			};
 		},
 		[ currentPost.postType, currentPost.postId ]

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -54,30 +54,35 @@ export function InnerEditor( {
 		'post-only'
 	);
 
-	const { post, template, isFullScreenForced } = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			const { getEditedPostTemplate } = select( storeName );
-			const postObject = getEntityRecord(
-				'postType',
+	// isFullScreenForced – comes from settings and cannot be changed by the user
+	// isFullscreenEnabled – indicates if a user has enabled fullscreen mode
+	const { post, template, isFullScreenForced, isFullscreenEnabled } =
+		useSelect(
+			( select ) => {
+				const { getEntityRecord } = select( coreStore );
+				const { getEditedPostTemplate } = select( storeName );
+				const postObject = getEntityRecord(
+					'postType',
+					currentPost.postType,
+					currentPost.postId
+				);
+				return {
+					template:
+						currentPost.postType !== 'wp_template'
+							? getEditedPostTemplate()
+							: null,
+					post: postObject,
+					isFullscreenEnabled:
+						select( storeName ).isFeatureActive( 'fullscreenMode' ),
+					isFullScreenForced: settings.isFullScreenForced,
+				};
+			},
+			[
 				currentPost.postType,
-				currentPost.postId
-			);
-			return {
-				template:
-					currentPost.postType !== 'wp_template'
-						? getEditedPostTemplate()
-						: null,
-				post: postObject,
-				isFullScreenForced: settings.isFullScreenForced,
-			};
-		},
-		[
-			currentPost.postType,
-			currentPost.postId,
-			settings.isFullScreenForced,
-		]
-	);
+				currentPost.postId,
+				settings.isFullScreenForced,
+			]
+		);
 
 	// @ts-expect-error Type is missing in @types/wordpress__editor
 	const { removeEditorPanel } = useDispatch( editorStore );
@@ -135,7 +140,9 @@ export function InnerEditor( {
 					<TemplateSelection />
 					<StylesSidebar />
 					<SendPreview />
-					<FullscreenMode isActive={ isFullScreenForced } />
+					<FullscreenMode
+						isActive={ isFullScreenForced || isFullscreenEnabled }
+					/>
 					{ isFullScreenForced && <BackButtonContent /> }
 					{ ! isFullScreenForced && <MoreMenu /> }
 					{ currentPost.postType === 'wp_template' ? (

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -72,7 +72,7 @@ export function InnerEditor( {
 				isFullscreenEnabled: settings.fullScreen,
 			};
 		},
-		[ currentPost.postType, currentPost.postId ]
+		[ currentPost.postType, currentPost.postId, settings.fullScreen ]
 	);
 
 	// @ts-expect-error Type is missing in @types/wordpress__editor

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -54,7 +54,7 @@ export function InnerEditor( {
 		'post-only'
 	);
 
-	const { post, template, isFullscreenEnabled } = useSelect(
+	const { post, template, isFullScreenForced } = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
 			const { getEditedPostTemplate } = select( storeName );
@@ -69,10 +69,14 @@ export function InnerEditor( {
 						? getEditedPostTemplate()
 						: null,
 				post: postObject,
-				isFullscreenEnabled: settings.fullScreen,
+				isFullScreenForced: settings.isFullScreenForced,
 			};
 		},
-		[ currentPost.postType, currentPost.postId, settings.fullScreen ]
+		[
+			currentPost.postType,
+			currentPost.postId,
+			settings.isFullScreenForced,
+		]
 	);
 
 	// @ts-expect-error Type is missing in @types/wordpress__editor
@@ -131,15 +135,15 @@ export function InnerEditor( {
 					<TemplateSelection />
 					<StylesSidebar />
 					<SendPreview />
-					<FullscreenMode isActive={ isFullscreenEnabled } />
-					{ isFullscreenEnabled && <BackButtonContent /> }
-					{ ! isFullscreenEnabled && <MoreMenu /> }
+					<FullscreenMode isActive={ isFullScreenForced } />
+					{ isFullScreenForced && <BackButtonContent /> }
+					{ ! isFullScreenForced && <MoreMenu /> }
 					{ currentPost.postType === 'wp_template' ? (
 						<TemplateSettingsPanel />
 					) : (
 						<SettingsPanel />
 					) }
-					{ ! isFullscreenEnabled && <PublishSave /> }
+					{ ! isFullScreenForced && <PublishSave /> }
 					<EditorNotices />
 					<BlockCompatibilityWarnings />
 				</Editor>

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -132,7 +132,7 @@ export function InnerEditor( {
 					<StylesSidebar />
 					<SendPreview />
 					<FullscreenMode isActive={ isFullscreenEnabled } />
-					<BackButtonContent />
+					{ isFullscreenEnabled && <BackButtonContent /> }
 					<MoreMenu />
 					{ currentPost.postType === 'wp_template' ? (
 						<TemplateSettingsPanel />

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -133,7 +133,7 @@ export function InnerEditor( {
 					<SendPreview />
 					<FullscreenMode isActive={ isFullscreenEnabled } />
 					{ isFullscreenEnabled && <BackButtonContent /> }
-					<MoreMenu />
+					{ ! isFullscreenEnabled && <MoreMenu /> }
 					{ currentPost.postType === 'wp_template' ? (
 						<TemplateSettingsPanel />
 					) : (

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -139,7 +139,7 @@ export function InnerEditor( {
 					) : (
 						<SettingsPanel />
 					) }
-					<PublishSave />
+					{ ! isFullscreenEnabled && <PublishSave /> }
 					<EditorNotices />
 					<BlockCompatibilityWarnings />
 				</Editor>

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -35,6 +35,7 @@ import { TemplateSettingsPanel } from '../sidebar/template-settings-panel';
 import { PublishSave } from '../../hacks/publish-save';
 import { EditorNotices } from '../notices';
 import { BlockCompatibilityWarnings } from '../sidebar';
+import { BackButtonContent } from '../header/back-button-content';
 
 export function InnerEditor( {
 	postId: initialPostId,
@@ -132,6 +133,7 @@ export function InnerEditor( {
 					<StylesSidebar />
 					<SendPreview />
 					<FullscreenMode isActive={ isFullscreenEnabled } />
+					<BackButtonContent />
 					<MoreMenu />
 					{ currentPost.postType === 'wp_template' ? (
 						<TemplateSettingsPanel />

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -69,8 +69,7 @@ export function InnerEditor( {
 						? getEditedPostTemplate()
 						: null,
 				post: postObject,
-				isFullscreenEnabled:
-					select( storeName ).isFeatureActive( 'fullscreenMode' ),
+				isFullscreenEnabled: true,
 			};
 		},
 		[ currentPost.postType, currentPost.postId ]

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -77,7 +77,7 @@ export function InnerEditor( {
 		},
 		[ currentPost.postType, currentPost.postId ]
 	);
-	const { isFullScreenForced } = settings;
+	const { isFullScreenForced, displaySendEmailButton } = settings;
 
 	// @ts-expect-error Type is missing in @types/wordpress__editor
 	const { removeEditorPanel } = useDispatch( editorStore );
@@ -145,7 +145,7 @@ export function InnerEditor( {
 					) : (
 						<SettingsPanel />
 					) }
-					{ ! isFullScreenForced && <PublishSave /> }
+					{ displaySendEmailButton && <PublishSave /> }
 					<EditorNotices />
 					<BlockCompatibilityWarnings />
 				</Editor>

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -56,33 +56,28 @@ export function InnerEditor( {
 
 	// isFullScreenForced – comes from settings and cannot be changed by the user
 	// isFullscreenEnabled – indicates if a user has enabled fullscreen mode
-	const { post, template, isFullScreenForced, isFullscreenEnabled } =
-		useSelect(
-			( select ) => {
-				const { getEntityRecord } = select( coreStore );
-				const { getEditedPostTemplate } = select( storeName );
-				const postObject = getEntityRecord(
-					'postType',
-					currentPost.postType,
-					currentPost.postId
-				);
-				return {
-					template:
-						currentPost.postType !== 'wp_template'
-							? getEditedPostTemplate()
-							: null,
-					post: postObject,
-					isFullscreenEnabled:
-						select( storeName ).isFeatureActive( 'fullscreenMode' ),
-					isFullScreenForced: settings.isFullScreenForced,
-				};
-			},
-			[
+	const { post, template, isFullscreenEnabled } = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			const { getEditedPostTemplate } = select( storeName );
+			const postObject = getEntityRecord(
+				'postType',
 				currentPost.postType,
-				currentPost.postId,
-				settings.isFullScreenForced,
-			]
-		);
+				currentPost.postId
+			);
+			return {
+				template:
+					currentPost.postType !== 'wp_template'
+						? getEditedPostTemplate()
+						: null,
+				post: postObject,
+				isFullscreenEnabled:
+					select( storeName ).isFeatureActive( 'fullscreenMode' ),
+			};
+		},
+		[ currentPost.postType, currentPost.postId ]
+	);
+	const { isFullScreenForced } = settings;
 
 	// @ts-expect-error Type is missing in @types/wordpress__editor
 	const { removeEditorPanel } = useDispatch( editorStore );

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -138,7 +138,9 @@ export function InnerEditor( {
 					<FullscreenMode
 						isActive={ isFullScreenForced || isFullscreenEnabled }
 					/>
-					{ isFullScreenForced && <BackButtonContent /> }
+					{ ( isFullScreenForced || isFullscreenEnabled ) && (
+						<BackButtonContent />
+					) }
 					{ ! isFullScreenForced && <MoreMenu /> }
 					{ currentPost.postType === 'wp_template' ? (
 						<TemplateSettingsPanel />

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -37,7 +37,6 @@ const siteIconVariants = {
 /**
  * TODO: Add on click event
  * TODO: validation on Save
- * TODO: remove the more menu if full screen settings is enabled
  * TODO: remove the save button if full screen settings is enabled
  * TODO: add the close button if full screen settings is disabled, but user toggled full screen
  */

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -36,7 +36,6 @@ const siteIconVariants = {
 
 /**
  * TODO: Add on click event
- * TODO: remove the save button if full screen settings is enabled
  * TODO: add the close button if full screen settings is disabled, but user toggled full screen
  */
 

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -39,10 +39,6 @@ const siteIconVariants = {
 };
 
 /**
- * TODO: add the close button if full screen settings is disabled, but user toggled full screen
- */
-
-/**
  * Back button content component with animation effects.
  */
 export const BackButtonContent = () => {

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { Button, __unstableMotion as motion } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, arrowLeft, wordpress } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { BackButton } from '../../private-apis';
+
+const toggleHomeIconVariants = {
+	edit: {
+		opacity: 0,
+		scale: 0.2,
+	},
+	hover: {
+		opacity: 1,
+		scale: 1,
+		clipPath: 'inset( 22% round 2px )',
+	},
+};
+
+const siteIconVariants = {
+	edit: {
+		clipPath: 'inset(0% round 0px)',
+	},
+	hover: {
+		clipPath: 'inset( 22% round 2px )',
+	},
+	tap: {
+		clipPath: 'inset(0% round 0px)',
+	},
+};
+
+/**
+ * Back button content component with animation effects.
+ */
+export const BackButtonContent = () => {
+	return (
+		<BackButton>
+			{ ( { length } ) =>
+				length <= 1 && (
+					<motion.div
+						className="edit-site-editor__view-mode-toggle"
+						transition={ {
+							duration: 0.2,
+						} }
+						animate="edit"
+						initial="edit"
+						whileHover="hover"
+						whileTap="tap"
+					>
+						<Button
+							__next40pxDefaultSize
+							label={ __( 'Open Navigation', 'woocommerce' ) }
+							showTooltip
+							tooltipPosition="middle right"
+							onClick={ () => {
+								// TODO add action to navigate away from here
+							} }
+						>
+							<motion.div variants={ siteIconVariants }>
+								<div className="edit-site-editor__view-mode-toggle-icon edit-site-site-icon">
+									<Icon
+										className="edit-site-site-icon__icon"
+										icon={ wordpress }
+										size={ 48 }
+									/>
+								</div>
+							</motion.div>
+						</Button>
+						<motion.div
+							className="edit-site-editor__back-icon"
+							variants={ toggleHomeIconVariants }
+						>
+							<Icon icon={ arrowLeft } />
+						</motion.div>
+					</motion.div>
+				)
+			}
+		</BackButton>
+	);
+};

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -36,7 +36,7 @@ const siteIconVariants = {
 
 /**
  * TODO: Add on click event
- * TODO: validation on Save
+ * TODO: validation on Save - move the validation from the send button
  * TODO: remove the save button if full screen settings is enabled
  * TODO: add the close button if full screen settings is disabled, but user toggled full screen
  */

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -35,6 +35,14 @@ const siteIconVariants = {
 };
 
 /**
+ * TODO: Add on click event
+ * TODO: validation on Save
+ * TODO: remove the more menu if full screen settings is enabled
+ * TODO: remove the save button if full screen settings is enabled
+ * TODO: add the close button if full screen settings is disabled, but user toggled full screen
+ */
+
+/**
  * Back button content component with animation effects.
  */
 export const BackButtonContent = () => {

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -43,7 +43,7 @@ export const BackButtonContent = () => {
 			{ ( { length } ) =>
 				length <= 1 && (
 					<motion.div
-						className="edit-site-editor__view-mode-toggle"
+						className="woocommerce-email-editor__view-mode-toggle"
 						transition={ {
 							duration: 0.2,
 						} }
@@ -53,8 +53,7 @@ export const BackButtonContent = () => {
 						whileTap="tap"
 					>
 						<Button
-							__next40pxDefaultSize
-							label={ __( 'Open Navigation', 'woocommerce' ) }
+							label={ __( 'Close editor', 'woocommerce' ) }
 							showTooltip
 							tooltipPosition="middle right"
 							onClick={ () => {
@@ -62,9 +61,9 @@ export const BackButtonContent = () => {
 							} }
 						>
 							<motion.div variants={ siteIconVariants }>
-								<div className="edit-site-editor__view-mode-toggle-icon edit-site-site-icon">
+								<div className="woocommerce-email-editor__view-mode-toggle-icon">
 									<Icon
-										className="edit-site-site-icon__icon"
+										className="woocommerce-email-editor-icon__icon"
 										icon={ wordpress }
 										size={ 48 }
 									/>
@@ -72,7 +71,7 @@ export const BackButtonContent = () => {
 							</motion.div>
 						</Button>
 						<motion.div
-							className="edit-site-editor__back-icon"
+							className="woocommerce-email-editor-icon"
 							variants={ toggleHomeIconVariants }
 						>
 							<Icon icon={ arrowLeft } />

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -36,7 +36,6 @@ const siteIconVariants = {
 
 /**
  * TODO: Add on click event
- * TODO: validation on Save - move the validation from the send button
  * TODO: remove the save button if full screen settings is enabled
  * TODO: add the close button if full screen settings is disabled, but user toggled full screen
  */

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -4,11 +4,15 @@
 import { Button, __unstableMotion as motion } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, arrowLeft, wordpress } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { BackButton } from '../../private-apis';
+import { recordEvent } from '../../events';
+import { storeName } from '../../store';
 
 const toggleHomeIconVariants = {
 	edit: {
@@ -35,7 +39,6 @@ const siteIconVariants = {
 };
 
 /**
- * TODO: Add on click event
  * TODO: add the close button if full screen settings is disabled, but user toggled full screen
  */
 
@@ -43,6 +46,19 @@ const siteIconVariants = {
  * Back button content component with animation effects.
  */
 export const BackButtonContent = () => {
+	const { urls } = useSelect(
+		( select ) => ( {
+			urls: select( storeName ).getUrls(),
+		} ),
+		[]
+	);
+
+	function sendAction() {
+		if ( urls.listings ) {
+			window.location.href = urls.listings;
+		}
+	}
+
 	return (
 		<BackButton>
 			{ ( { length } ) =>
@@ -62,7 +78,12 @@ export const BackButtonContent = () => {
 							showTooltip
 							tooltipPosition="middle right"
 							onClick={ () => {
-								// TODO add action to navigate away from here
+								recordEvent( 'header_close_button_clicked' );
+								const action = applyFilters(
+									'woocommerce_email_editor_close_action_callback',
+									sendAction
+								) as () => void;
+								action();
 							} }
 						>
 							<motion.div variants={ siteIconVariants }>

--- a/packages/js/email-editor/src/components/header/back-button-content.tsx
+++ b/packages/js/email-editor/src/components/header/back-button-content.tsx
@@ -49,9 +49,9 @@ export const BackButtonContent = () => {
 		[]
 	);
 
-	function sendAction() {
+	function backAction() {
 		if ( urls.listings ) {
-			window.location.href = urls.listings;
+			window.location.href = urls.back;
 		}
 	}
 
@@ -77,7 +77,7 @@ export const BackButtonContent = () => {
 								recordEvent( 'header_close_button_clicked' );
 								const action = applyFilters(
 									'woocommerce_email_editor_close_action_callback',
-									sendAction
+									backAction
 								) as () => void;
 								action();
 							} }

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -19,7 +19,7 @@ import { useContentValidation } from '../../hooks/use-content-validation';
 
 export function SendButton() {
 	const { isDirty } = useEntitiesSavedStatesIsDirty();
-	const { validateContent, isInvalid } = useContentValidation();
+	const { isInvalid } = useContentValidation();
 
 	const { hasEmptyContent, isEmailSent, urls } = useSelect(
 		( select ) => ( {
@@ -49,13 +49,11 @@ export function SendButton() {
 			size="compact"
 			onClick={ () => {
 				recordEvent( 'header_send_button_clicked' );
-				if ( validateContent() ) {
-					const action = applyFilters(
-						'woocommerce_email_editor_send_action_callback',
-						sendAction
-					) as () => void;
-					action();
-				}
+				const action = applyFilters(
+					'woocommerce_email_editor_send_action_callback',
+					sendAction
+				) as () => void;
+				action();
 			} }
 			disabled={ isDisabled }
 			data-automation-id="email_editor_send_button"

--- a/packages/js/email-editor/src/components/header/send-button.tsx
+++ b/packages/js/email-editor/src/components/header/send-button.tsx
@@ -15,11 +15,9 @@ import {
  */
 import { storeName } from '../../store';
 import { recordEvent } from '../../events';
-import { useContentValidation } from '../../hooks/use-content-validation';
 
 export function SendButton() {
 	const { isDirty } = useEntitiesSavedStatesIsDirty();
-	const { isInvalid } = useContentValidation();
 
 	const { hasEmptyContent, isEmailSent, urls } = useSelect(
 		( select ) => ( {
@@ -36,7 +34,7 @@ export function SendButton() {
 		}
 	}
 
-	const isDisabled = hasEmptyContent || isEmailSent || isInvalid || isDirty;
+	const isDisabled = hasEmptyContent || isEmailSent || isDirty;
 
 	const label = applyFilters(
 		'woocommerce_email_editor_send_button_label',

--- a/packages/js/email-editor/src/components/header/style.scss
+++ b/packages/js/email-editor/src/components/header/style.scss
@@ -10,3 +10,81 @@
 		display: none;
 	}
 }
+
+.woocommerce-email-editor__view-mode-toggle {
+	view-transition-name: toggle;
+	top: 0;
+	left: 0;
+	height: 60px;
+	width: 60px;
+	z-index: 100;
+
+	.components-button {
+		color: #fff;
+		height: 100%;
+		width: 100%;
+		border-radius: 0;
+		overflow: hidden;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		&:hover,
+		&:active {
+			color: #fff;
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
+
+	.woocommerce-email-editor__view-mode-toggle-icon {
+		svg,
+		img {
+			background: $gray-900;
+			display: block;
+		}
+	}
+}
+
+.woocommerce-email-editor-icon {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 60px;
+	height: 60px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	background-color: hsla(0, 0%, 100%, 0.6);
+	-webkit-backdrop-filter: saturate(180%) blur(15px);
+	backdrop-filter: saturate(180%) blur(15px);
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.woocommerce-email-editor-icon__icon {
+	fill: currentColor;
+	width: 100%;
+	height: 100%;
+	padding: 12px;
+}
+
+.woocommerce-email-editor__view-mode-toggle button:focus {
+	position: relative;
+
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		z-index: 1;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+}

--- a/packages/js/email-editor/src/components/header/style.scss
+++ b/packages/js/email-editor/src/components/header/style.scss
@@ -12,7 +12,9 @@
 }
 
 .woocommerce-email-editor__view-mode-toggle {
+	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 	view-transition-name: toggle;
+	/* stylelint-enable */
 	top: 0;
 	left: 0;
 	height: 60px;

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -16,6 +16,7 @@ import { createStore, storeName, editorCurrentPostType } from './store';
 import { initHooks } from './editor-hooks';
 import { initTextHooks } from './text-hooks';
 import { initEventCollector } from './events';
+import { useContentValidation } from './hooks/use-content-validation';
 import './style.scss';
 
 function Editor() {
@@ -26,6 +27,7 @@ function Editor() {
 		} ),
 		[]
 	);
+	useContentValidation();
 
 	return (
 		<StrictMode>

--- a/packages/js/email-editor/src/private-apis/index.ts
+++ b/packages/js/email-editor/src/private-apis/index.ts
@@ -30,7 +30,7 @@ const { useGlobalStylesOutputWithConfig } = unlock( blockEditorPrivateApis );
 /**
  * The Editor is the main component for the email editor.
  */
-const { Editor, FullscreenMode, ViewMoreMenuGroup } =
+const { Editor, FullscreenMode, ViewMoreMenuGroup, BackButton } =
 	unlock( editorPrivateApis );
 
 export {
@@ -39,4 +39,5 @@ export {
 	Editor,
 	FullscreenMode,
 	ViewMoreMenuGroup,
+	BackButton,
 };

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -54,12 +54,6 @@ function regularizedGetEntityRecord( template ) {
 	};
 }
 
-export const isFeatureActive = createRegistrySelector(
-	( select ) =>
-		( _, feature: Feature ): boolean =>
-			!! select( preferencesStore ).get( storeName, feature )
-);
-
 export const hasEdits = createRegistrySelector( ( select ) => (): boolean => {
 	const postId = select( storeName ).getEmailPostId();
 	return !! select( coreDataStore ).hasEditsForEntityRecord(

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -4,7 +4,6 @@
 import { createRegistrySelector, createSelector } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { serialize, parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { Post } from '@wordpress/core-data/build-types/entity-types/post';
@@ -13,7 +12,7 @@ import { Post } from '@wordpress/core-data/build-types/entity-types/post';
  * Internal dependencies
  */
 import { storeName, editorCurrentPostType } from './constants';
-import { State, Feature, EmailTemplate, EmailEditorPostType } from './types';
+import { State, EmailTemplate, EmailEditorPostType } from './types';
 
 function getContentFromEntity( entity ): string {
 	if ( entity?.content && typeof entity.content === 'function' ) {

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -4,6 +4,7 @@
 import { createRegistrySelector, createSelector } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { serialize, parse } from '@wordpress/blocks';
 import { BlockInstance } from '@wordpress/blocks/index';
 import { Post } from '@wordpress/core-data/build-types/entity-types/post';
@@ -12,7 +13,7 @@ import { Post } from '@wordpress/core-data/build-types/entity-types/post';
  * Internal dependencies
  */
 import { storeName, editorCurrentPostType } from './constants';
-import { State, EmailTemplate, EmailEditorPostType } from './types';
+import { State, EmailTemplate, EmailEditorPostType, Feature } from './types';
 
 function getContentFromEntity( entity ): string {
 	if ( entity?.content && typeof entity.content === 'function' ) {
@@ -52,6 +53,12 @@ function regularizedGetEntityRecord( template ) {
 		content: template?.content?.raw || template?.content || '',
 	};
 }
+
+export const isFeatureActive = createRegistrySelector(
+	( select ) =>
+		( _, feature: Feature ): boolean =>
+			!! select( preferencesStore ).get( storeName, feature )
+);
 
 export const hasEdits = createRegistrySelector( ( select ) => (): boolean => {
 	const postId = select( storeName ).getEmailPostId();

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -171,6 +171,7 @@ export type EmailEditorLayout = {
 };
 
 export type EmailEditorUrls = {
+	back: string;
 	send?: string;
 	listings: string;
 };

--- a/plugins/woocommerce/changelog/wooplug-4268-add-back-button-to-the-email-editor
+++ b/plugins/woocommerce/changelog/wooplug-4268-add-back-button-to-the-email-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Forces the email editor to be run in the full screen mode

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -164,7 +164,10 @@ class PageRenderer {
 				'current_post_type'     => esc_js( $post_type ),
 				'current_post_id'       => $post_id,
 				'current_wp_user_email' => esc_js( $current_user_email ),
-				'editor_settings'       => $this->settings_controller->get_settings(),
+				'editor_settings'       => array(
+					...$this->settings_controller->get_settings(),
+					'fullScreen' => true,
+				),
 				'editor_theme'          => $this->theme_controller->get_base_theme()->get_raw_data(),
 				'user_theme_post_id'    => $this->user_theme->get_user_theme_post()->ID,
 				'urls'                  => array(

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -166,7 +166,7 @@ class PageRenderer {
 				'current_wp_user_email' => esc_js( $current_user_email ),
 				'editor_settings'       => array(
 					...$this->settings_controller->get_settings(),
-					'fullScreen' => true,
+					'isFullScreenForced' => true,
 				),
 				'editor_theme'          => $this->theme_controller->get_base_theme()->get_raw_data(),
 				'user_theme_post_id'    => $this->user_theme->get_user_theme_post()->ID,

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -166,7 +166,8 @@ class PageRenderer {
 				'current_wp_user_email' => esc_js( $current_user_email ),
 				'editor_settings'       => array(
 					...$this->settings_controller->get_settings(),
-					'isFullScreenForced' => true,
+					'isFullScreenForced'     => true,
+					'displaySendEmailButton' => false,
 				),
 				'editor_theme'          => $this->theme_controller->get_base_theme()->get_raw_data(),
 				'user_theme_post_id'    => $this->user_theme->get_user_theme_post()->ID,

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -174,6 +174,7 @@ class PageRenderer {
 				'urls'                  => array(
 					'listings' => admin_url( 'admin.php?page=wc-settings&tab=email' ),
 					'send'     => admin_url( 'admin.php?page=wc-settings&tab=email' ),
+					'back'     => admin_url( 'admin.php?page=wc-settings&tab=email' ),
 				),
 				'email_types'           => $email_types,
 				'block_preview_url'     => esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail_editor_content=true' ), 'preview-mail' ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds a back button to the WooCommerce Email Editor, allowing navigation back to the email listings page from the editor. The back button appears when the editor is in full-screen mode, which is now enforced by default.

- Added a new `BackButtonContent` component that renders a back button
- Updated the editor component to conditionally render the back button when in full-screen mode
- Modified `PageRenderer.php` to force full-screen mode by adding the isFullScreenForced setting

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4268 #57959.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    ![Screenshot 2025-05-21 at 10 14 41](https://github.com/user-attachments/assets/a717f3e0-f0a9-4523-950b-c3d2dd747f24)   |   ![Screenshot 2025-05-21 at 10 15 01](https://github.com/user-attachments/assets/ec14c2b4-75df-42fc-8e6b-dd67c4be712c)    |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to the WooCommerce Email Editor
2. Verify that the editor opens in full-screen mode
3. Check that the back button appears in the top-left corner
4. Hover over the back button to see the animation effect
5. Click the back button to confirm it navigates back to the email listings page

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
