### PR TITLE
Fix the UI issue with select dropdown on Windows devices

### DIFF
--- a/plugins/woocommerce/changelog/fix-46243
+++ b/plugins/woocommerce/changelog/fix-46243
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the UI issue with select dropdown with dark backgrounds on Windows devices.

--- a/plugins/woocommerce/templates/loop/orderby.php
+++ b/plugins/woocommerce/templates/loop/orderby.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $id_suffix = wp_unique_id();
 
 $background_color = '';
+$text_color       = '';
 
 // Get colors from block theme global styles.
 if ( wp_is_block_theme() && function_exists( 'wp_get_global_styles' ) ) {
@@ -29,9 +30,13 @@ if ( wp_is_block_theme() && function_exists( 'wp_get_global_styles' ) ) {
 	if ( ! empty( $global_styles['color']['background'] ) ) {
 		$background_color = $global_styles['color']['background'];
 	}
+	if ( ! empty( $global_styles['color']['text'] ) ) {
+		$text_color = $global_styles['color']['text'];
+	}
 }
 
-$select_style = $background_color ? 'background-color: ' . esc_attr( $background_color ) . ';' : '';
+$select_style  = $background_color ? 'background-color: ' . esc_attr( $background_color ) . ';' : '';
+$select_style .= $text_color ? ' color: ' . esc_attr( $text_color ) . ';' : '';
 
 ?>
 <form class="woocommerce-ordering" method="get">

--- a/plugins/woocommerce/templates/loop/orderby.php
+++ b/plugins/woocommerce/templates/loop/orderby.php
@@ -21,6 +21,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $id_suffix = wp_unique_id();
 
+$background_color = '';
+
+// Get colors from block theme global styles.
+if ( wp_is_block_theme() && function_exists( 'wp_get_global_styles' ) ) {
+	$global_styles = wp_get_global_styles();
+	if ( ! empty( $global_styles['color']['background'] ) ) {
+		$background_color = $global_styles['color']['background'];
+	}
+}
+
+$select_style = $background_color ? 'background-color: ' . esc_attr( $background_color ) . ';' : '';
+
 ?>
 <form class="woocommerce-ordering" method="get">
 	<?php if ( $use_label ) : ?>
@@ -29,6 +41,7 @@ $id_suffix = wp_unique_id();
 	<select
 		name="orderby"
 		class="orderby"
+		style="<?php echo esc_attr( $select_style ); ?>"
 		<?php if ( $use_label ) : ?>
 			id="woocommerce-orderby-<?php echo esc_attr( $id_suffix ); ?>"
 		<?php else : ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets the global style's background color as the select dropdown's background color and also handles the text color for options. The color only applies for block based themes. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #46243

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/4c1ca7e7-703a-4cab-b037-4f3da8e42d3d

Image comparisons for different browsers on **Windows** devices with Attar Blockbase Theme:

- Firefox

    | Before | After |
    | ------ | ----- |
    | ![Image](https://github.com/user-attachments/assets/39c854ff-a24e-42d4-a527-5d74749cc629) | ![Image](https://github.com/user-attachments/assets/4482b7a5-94ce-4ff5-956f-6583668ef39d) |

- Chrome

    | Before | After |
    | ------ | ----- |
    | ![Image](https://github.com/user-attachments/assets/ff571a96-7144-45d9-8df2-621d78f92fbe) | ![Image](https://github.com/user-attachments/assets/c402685f-7f25-4ac6-aed5-618c33e97ba2) |

Image comparisons for Firefox on **Windows/MacOS** with other themes (these color changes apply to both Windows and MacOS):

- Twenty Twenty Five with dark background and light text color

    | Before | After |
    | ------ | ----- |
    | <img width="400" alt="image" src="https://github.com/user-attachments/assets/736200b6-cfb0-4b46-ae3a-d02e3e77049e" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/769c0dc6-32d7-45f0-b88c-72700176b2d8" /> |

- Twenty Twenty Four with dark background and light text color

    | Before | After |
    | ------ | ----- |
    | <img width="400" alt="image" src="https://github.com/user-attachments/assets/0b2b514a-9f8f-4575-9e14-48631c89fc53" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/a8da2865-5d4f-4441-9d8d-2a1b775b1679" /> |

- Twenty Twenty with dark background and light text color (no change)

    | Before | After |
    | ------ | ----- |
    | <img width="400" alt="image" src="https://github.com/user-attachments/assets/1e2567fb-87d6-48a5-a736-87d9bff67a03" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/67e799f4-1e3b-42ca-bdd1-1425e929da8f" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. On a site with WooCommerce installed, activate Attar theme
2. Go to Appearance > Editor > go to global Styles
3. Select a dark style, or change the site's background color to a dark color, such as black - #000000
4. Save the changes
5. Go to Product Catalog template, and make sure it's using WooCommerce Blocks, and not the Classic product page
6. Make sure there is a Catalog Sorting Block. Or try adding a Product Category List Block, and display it as dropdown
7. Save the changes
8. Check the default Shop page and test the Default Sorting dropdown or the Product Category dropdown using Windows 11
9. Verify that the options are now readable.

<!-- End testing instructions -->

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a visual issue with select dropdowns on dark backgrounds in Windows, improving usability and appearance.

- **Style**
  - Select dropdowns now automatically inherit background and text colors from the site's global theme settings for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->