### PR TITLE
Adds missing verb and improves comments

### DIFF
--- a/plugins/woocommerce/changelog/tweak-WOOPLUG-4343-typo-missing-verb
+++ b/plugins/woocommerce/changelog/tweak-WOOPLUG-4343-typo-missing-verb
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This PR adds a missing verb to a sentence.
+
+

--- a/plugins/woocommerce/changelog/tweak-WOOPLUG-4343-typo-missing-verb
+++ b/plugins/woocommerce/changelog/tweak-WOOPLUG-4343-typo-missing-verb
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: This PR adds a missing verb to a sentence.
-
-

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -62,7 +62,7 @@ class WC_Brands_Admin {
 			}
 		);
 
-		// Hiding setting for future depreciation. Only users who have touched this settings should see it.
+		// Hiding setting for future depreciation. Only users who have touched these settings should see it.
 		$setting_value = get_option( 'wc_brands_show_description' );
 		if ( is_string( $setting_value ) ) {
 
@@ -475,10 +475,10 @@ class WC_Brands_Admin {
 	}
 
 	/**
-	 * Description for brand page.
+	 * Brand taxonomy description.
 	 */
 	public function taxonomy_description() {
-		echo wp_kses_post( wpautop( __( 'Brands be added and managed from this screen. You can optionally upload a brand image to display in brand widgets and on brand archives', 'woocommerce' ) ) );
+		echo wp_kses_post( wpautop( __( 'Brands can be added and managed from this screen. You can optionally upload a brand image to display in brand widgets and on brand archives', 'woocommerce' ) ) );
 	}
 
 	/**
@@ -637,10 +637,10 @@ class WC_Brands_Admin {
 	}
 
 	/**
-	 * Save permalnks settings.
+	 * Save permalink settings.
 	 *
 	 * We need to save the options ourselves;
-	 * settings api does not trigger save for the permalinks page.
+	 * settings api does not trigger save for the permalink page.
 	 */
 	public function save_permalink_settings() {
 		if ( ! is_admin() ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-brands.php
@@ -62,7 +62,7 @@ class WC_Brands_Admin {
 			}
 		);
 
-		// Hiding setting for future depreciation. Only users who have touched these settings should see it.
+		// Hiding setting for future deprecation. Only users who have touched these settings should see it.
 		$setting_value = get_option( 'wc_brands_show_description' );
 		if ( is_string( $setting_value ) ) {
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a missing verb in the Brands taxonomy description.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58146 .
Closes https://linear.app/a8c/issue/WOOPLUG-4343


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/user-attachments/assets/4ca794f4-7c07-4513-b279-dcf6e5d20e20)      |   ![image](https://github.com/user-attachments/assets/fb3dc10d-b050-4914-bd90-469a2ad5097f)    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit `wp-admin/edit-tags.php?taxonomy=product_brand&post_type=product`
2. Description should be `Brands can be added and managed from this screen.`
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR fixes a syntax error in a feature desription.
</details>
