### PR TITLE
Blocks - Improve product availability checks for variations

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4337-improve-get-available-variations-blocks
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4337-improve-get-available-variations-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve how available variations are fetched in ProductAvailabilityUtils.

--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4337-improve-get-available-variations-blocks
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4337-improve-get-available-variations-blocks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Improve how available variations are fetched in ProductAvailabilityUtils.
+Improve how available variations are fetched in ProductAvailabilityUtils and introduce has_available_variations function.

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -301,6 +301,8 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
+	 * @hint If the function gets updated, make sure to update has_available_variations too, as they share similar logic.
+	 *
 	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
 	 *
 	 * @return array[]|WC_Product_Variation[]
@@ -339,6 +341,43 @@ class WC_Product_Variable extends WC_Product {
 		}
 
 		return $available_variations;
+	}
+
+	/**
+	 * Check if there are available variations for the current product.
+	 *
+	 * @hint If the function gets updated, make sure to update get_available_variations too, as they share similar logic.
+	 *
+	 * @since  9.9.0
+	 * @return boolean
+	 */
+	public function has_available_variations() {
+		$variation_ids        = $this->get_children();
+
+		if ( is_callable( '_prime_post_caches' ) ) {
+			_prime_post_caches( $variation_ids );
+		}
+
+		foreach ( $variation_ids as $variation_id ) {
+
+			$variation = wc_get_product( $variation_id );
+
+			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
+			if ( ! $variation || ! $variation->exists() || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
+				continue;
+			}
+
+			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
+				continue;
+			}
+
+			// We found at least one available variation, so return true.
+			return true;
+		}
+
+		// There were either no variations, or they were hidden because of the "continues" above.
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -324,7 +324,13 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			/**
+			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			 *
+			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
+			 * @param  int                   $product_id  The ID of the variation.
+			 * @param  WC_Product_Variation  $variation   The variation object.
+			 */
 			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
 				continue;
 			}
@@ -352,7 +358,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function has_available_variations() {
-		$variation_ids        = $this->get_children();
+		$variation_ids = $this->get_children();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -367,7 +373,13 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			/**
+			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			 *
+			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
+			 * @param  int                   $product_id  The ID of the variation.
+			 * @param  WC_Product_Variation  $variation   The variation object.
+			 */
 			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
 				continue;
 			}

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -308,8 +308,9 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array[]|WC_Product_Variation[]
 	 */
 	public function get_available_variations( $return = 'array' ) {
-		$variation_ids        = $this->get_children();
-		$available_variations = array();
+		$variation_ids           = $this->get_children();
+		$hide_out_of_stock_items = ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) );
+		$available_variations    = array();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -320,7 +321,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
+			if ( ! $variation || ! $variation->exists() || ( $hide_out_of_stock_items && ! $variation->is_in_stock() ) ) {
 				continue;
 			}
 
@@ -357,10 +358,11 @@ class WC_Product_Variable extends WC_Product {
 	 * @hint If the function gets updated, make sure to update get_available_variations too, as they share similar logic.
 	 *
 	 * @since  9.9.0
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_available_variations() {
-		$variation_ids = $this->get_children();
+		$variation_ids           = $this->get_children();
+		$hide_out_of_stock_items = ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) );
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -371,7 +373,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
+			if ( ! $variation || ! $variation->exists() || ( $hide_out_of_stock_items && ! $variation->is_in_stock() ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -327,6 +327,8 @@ class WC_Product_Variable extends WC_Product {
 			/**
 			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
 			 *
+			 * @since 2.6.8
+			 *
 			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
 			 * @param  int                   $product_id  The ID of the variation.
 			 * @param  WC_Product_Variation  $variation   The variation object.
@@ -376,6 +378,8 @@ class WC_Product_Variable extends WC_Product {
 			/**
 			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
 			 *
+			 * @since 2.6.8
+			 *
 			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
 			 * @param  int                   $product_id  The ID of the variation.
 			 * @param  WC_Product_Variation  $variation   The variation object.
@@ -405,7 +409,15 @@ class WC_Product_Variable extends WC_Product {
 			return false;
 		}
 
-		// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+		/**
+		 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+		 *
+		 * @since 2.6.8
+		 *
+		 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
+		 * @param  int                   $product_id  The ID of the variation.
+		 * @param  WC_Product_Variation  $variation   The variation object.
+		 */
 		if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -40,7 +40,7 @@ class ProductAvailabilityUtils {
 		/**
 		 * Filters the product availability information.
 		 *
-		 * @since x.x.x
+		 * @since χ.χ.χ
 		 * @param array $product_availability The product availability information.
 		 * @param \WC_Product $product Product object.
 		 */

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -40,7 +40,7 @@ class ProductAvailabilityUtils {
 		/**
 		 * Filters the product availability information.
 		 *
-		 * @since χ.χ.χ
+		 * @since x.x.x
 		 * @param array $product_availability The product availability information.
 		 * @param \WC_Product $product Product object.
 		 */

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -28,7 +28,7 @@ class ProductAvailabilityUtils {
 		// If the product is a variable product, check if it has any available variations.
 		// We will show a custom availability message if it does.
 		if ( $product->get_type() === ProductType::VARIABLE ) {
-			$available_variations = $product->get_available_variations();
+			$available_variations = $product->get_available_variations( 'objects' );
 			if ( empty( $available_variations ) && false !== $available_variations ) {
 				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
@@ -40,9 +40,10 @@ class ProductAvailabilityUtils {
 		/**
 		 * Filters the product availability information.
 		 *
-		 * @since 9.7.0
+		 * @since x.x.x
 		 * @param array $product_availability The product availability information.
+		 * @param \WC_Product $product Product object.
 		 */
-		return apply_filters( 'woocommerce_product_availability', $product_availability );
+		return apply_filters( 'woocommerce_product_availability', $product_availability, $product );
 	}
 }

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -28,8 +28,7 @@ class ProductAvailabilityUtils {
 		// If the product is a variable product, check if it has any available variations.
 		// We will show a custom availability message if it does.
 		if ( $product->get_type() === ProductType::VARIABLE ) {
-			$available_variations = $product->get_available_variations( 'objects' );
-			if ( empty( $available_variations ) && false !== $available_variations ) {
+			if ( ! $product->has_available_variations() ) {
 				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}
@@ -40,7 +39,7 @@ class ProductAvailabilityUtils {
 		/**
 		 * Filters the product availability information.
 		 *
-		 * @since x.x.x
+		 * @since 9.7.0
 		 * @param array $product_availability The product availability information.
 		 * @param \WC_Product $product Product object.
 		 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -39,4 +39,127 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertInstanceOf( WC_Product_Variation::class, $variations[0] );
 		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]->get_sku() );
 	}
+
+	/**
+	 * @testdox 'has_available_variations' should return true when all variations are available.
+	 */
+	public function test_has_available_variations_returns_true_when_all_variations_are_available() {
+
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variations = $product->get_available_variations( 'array' );
+		$this->assertTrue( is_array( $variations[0] ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+
+		$has_available_variations = $product->has_available_variations();
+		$this->assertIsBool( $has_available_variations );
+		$this->assertTrue( $has_available_variations );
+	}
+
+	/**
+	 * @testdox 'has_available_variations' returns true when some variations are available.
+	 */
+	public function test_has_available_variations_returns_true_when_some_variations_are_available() {
+
+		$product = new WC_Product_Variable();
+
+		$product->set_props(
+			array(
+				'name' => 'Dummy Variable Product',
+				'sku'  => 'DUMMY VARIABLE SKU',
+			)
+		);
+
+		$attributes = array();
+
+		$attributes[] = WC_Helper_Product::create_product_attribute_object( 'size', array( 'small', 'large', 'huge' ) );
+
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		$variations = array();
+
+		$variations[] = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE SMALL',
+			10,
+			array( 'pa_size' => 'small' )
+		);
+
+		$variations[] = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE LARGE',
+			'', // Variation is not available.
+			array( 'pa_size' => 'large' )
+		);
+
+		$variation_ids = array_map(
+			function( $variation ) {
+				return $variation->get_id();
+			},
+			$variations
+		);
+		$product->set_children( $variation_ids );
+
+		$variations = $product->get_available_variations( 'array' );
+		$this->assertTrue( is_array( $variations[0] ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+
+		$has_available_variations = $product->has_available_variations();
+		$this->assertIsBool( $has_available_variations );
+		$this->assertTrue( $has_available_variations );
+	}
+
+	/**
+	 * @testdox 'has_available_variations' returns false when all variations are not available.
+	 */
+	public function test_has_available_variations_returns_false_when_all_variations_are_not_available() {
+
+		$product = new WC_Product_Variable();
+
+		$product->set_props(
+			array(
+				'name' => 'Dummy Variable Product',
+				'sku'  => 'DUMMY VARIABLE SKU',
+			)
+		);
+
+		$attributes = array();
+
+		$attributes[] = WC_Helper_Product::create_product_attribute_object( 'size', array( 'small', 'large', 'huge' ) );
+
+		$product->set_attributes( $attributes );
+		$product->save();
+
+		$variations = array();
+
+		$variations[] = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE SMALL',
+			'', // Variation is not available.
+			array( 'pa_size' => 'small' )
+		);
+
+		$variations[] = WC_Helper_Product::create_product_variation_object(
+			$product->get_id(),
+			'DUMMY SKU VARIABLE LARGE',
+			'', // Variation is not available.
+			array( 'pa_size' => 'large' )
+		);
+
+		$variation_ids = array_map(
+			function( $variation ) {
+				return $variation->get_id();
+			},
+			$variations
+		);
+		$product->set_children( $variation_ids );
+
+		$variations = $product->get_available_variations( 'array' );
+		$this->assertTrue( empty( $variations ) );
+
+		$has_available_variations = $product->has_available_variations();
+		$this->assertIsBool( $has_available_variations );
+		$this->assertFalse( $has_available_variations );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -94,7 +94,7 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		);
 
 		$variation_ids = array_map(
-			function( $variation ) {
+			function ( $variation ) {
 				return $variation->get_id();
 			},
 			$variations
@@ -148,7 +148,7 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		);
 
 		$variation_ids = array_map(
-			function( $variation ) {
+			function ( $variation ) {
 				return $variation->get_id();
 			},
 			$variations


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

**Please see this issue before proceeding** 👇 
- https://github.com/woocommerce/woocommerce/issues/58125


### First attempt 2025-05-21 

The first change I made in this PR was to change how we call `$product->get_available_variations`. Instead of calling it without parameters, I passed `objects`.

This prevents calling `get_available_variation` and saves some seconds.

https://github.com/woocommerce/woocommerce/blob/d596e0344d6eb98c860daa36909680d5a75eff35/plugins/woocommerce/includes/class-wc-product-variable.php#L330-L334

**I tried the change on a customer's staging site, where they complained about slow loading times, and pages are 40-45% faster; better but still not acceptable.**

| Page | Before | After |
| ------ | ------ | ----- |
| add to cart          |  9.2      | 4.8      |
| single product          |  8.2      | 4.5      |
| category archive          |  14      | 6.7      |
| cart          |  2.7      | 1.8      |


### Second attempt 2025-05-22 (current version of the PR)

Instead of calling `$product->get_available_variations` and _then_ checking if the variations array is empty (to determine if there is at least 1 available variation), I introduced a new function `$product->has_available_variations` (thanks @mreishus ).

This function bails out early when the first available variation is found and doesn't loop through all of them. That's a significant boost, especially for sites with products with many variations.

_Note that if all variations are not available, we would end up with the exact number of loops._


**I tried the change on a customer's staging site, where they complained about slow loading times, and pages are 80% faster.**

| Page | Before | 2025-05-21 |  2025-05-22 |
| ------ | ------ | ----- | ----- |
| add to cart          |  9.2      | 4.8      | 1.4 |
| single product          |  8.2      | 4.5      | 1.3 |
| category archive          |  14      | 6.7      | 1.6 |
| cart          |  2.7      | 1.8      | 0.9 |

This is a quick improvement, but if I were to recommend anything, it would be to revert 
- https://github.com/woocommerce/woocommerce/pull/54156
and rethink how to solve the initial issue
- https://github.com/woocommerce/woocommerce/issues/53720

Tagging @sunyatasattva @nerrad @Aljullu and @tjcafferkey  (as this function is called in the StoreAPI) to evaluate how to solve the initial issue and investigate why the function is called multiple times
- https://github.com/woocommerce/woocommerce/issues/58125

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### trunk
1. Use a block theme
2. Create a couple of variable products in your store and several variations. (I can share a CSV)
3. Add a product to the cart
4. Visit a category page, single product page and cart and note down the loading times (I used Query Monitor)

#### this branch

1. Use a block theme
2. Create a couple of variable products in your store and several variations. (I can share a CSV)
3. Add a product to the cart
4. Visit a category page, single product page and cart and note down the loading times (I used Query Monitor)
5. See the difference in loading times (40-45% faster)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
