### PR TITLE
Update to marketplace-suggestions/2.0 endpoint

### DIFF
--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -102,7 +102,7 @@ class WC_Marketplace_Updater {
 	public static function add_personalization_data( $data ) {
 		$country_setting = get_option( 'woocommerce_default_country' );
 		// Extract just the country code from the "COUNTRY:STATE" format.
-		$country_code    = explode( ':', $country_setting )[0];
+		$country_code    = sanitize_text_field( explode( ':', $country_setting )[0] );
 		$data['country'] = $country_code;
 
 		return $data;

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -43,7 +43,19 @@ class WC_Marketplace_Updater {
 
 		$data['updated'] = time();
 
-		$url     = 'https://woocommerce.com/wp-json/wccom/marketplace-suggestions/1.0/suggestions.json';
+		$request_data = array();
+
+		if ( class_exists( 'WC_Marketplace_Suggestions' ) && WC_Marketplace_Suggestions::allow_suggestions() ) {
+			$request_data = self::add_personalization_data( $request_data );
+		}
+
+		$url = 'https://woocommerce.com/wp-json/wccom/marketplace-suggestions/2.0/suggestions.json';
+
+		// Add request data as query parameters if it exists.
+		if ( ! empty( $request_data ) ) {
+			$url = add_query_arg( $request_data, $url );
+		}
+
 		$request = wp_safe_remote_get(
 			$url,
 			array(
@@ -79,6 +91,21 @@ class WC_Marketplace_Updater {
 	public static function retry() {
 		WC()->queue()->cancel_all( 'woocommerce_update_marketplace_suggestions' );
 		WC()->queue()->schedule_single( time() + DAY_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+	}
+
+	/**
+	 * Add additional data to the request for personalized suggestions.
+	 *
+	 * @param array $data The data to include in the request.
+	 * @return array
+	 */
+	public static function add_personalization_data( $data ) {
+		$country_setting = get_option( 'woocommerce_default_country' );
+		// Extract just the country code from the "COUNTRY:STATE" format.
+		$country_code    = explode( ':', $country_setting )[0];
+		$data['country'] = $country_code;
+
+		return $data;
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -96,16 +96,16 @@ class WC_Marketplace_Updater {
 	/**
 	 * Add additional data to the request for personalized suggestions.
 	 *
-	 * @param array $data The data to include in the request.
+	 * @param array $request_params The data to include in the request.
 	 * @return array
 	 */
-	public static function add_personalization_data( $data ) {
+	public static function add_personalization_data( $request_params ) {
 		$country_setting = get_option( 'woocommerce_default_country' );
 		// Extract just the country code from the "COUNTRY:STATE" format.
-		$country_code    = sanitize_text_field( explode( ':', $country_setting )[0] );
-		$data['country'] = $country_code;
+		$country_code              = sanitize_text_field( explode( ':', $country_setting )[0] );
+		$request_params['country'] = $country_code;
 
-		return $data;
+		return $request_params;
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -45,7 +45,8 @@ class WC_Marketplace_Updater {
 
 		$request_data = array();
 
-		if ( class_exists( 'WC_Marketplace_Suggestions' ) && WC_Marketplace_Suggestions::allow_suggestions() ) {
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking', 'no' );
+		if ( class_exists( 'WC_Marketplace_Suggestions' ) && WC_Marketplace_Suggestions::allow_suggestions() && $allow_tracking ) {
 			$request_data = self::add_personalization_data( $request_data );
 		}
 
@@ -100,10 +101,7 @@ class WC_Marketplace_Updater {
 	 * @return array
 	 */
 	public static function add_personalization_data( $request_params ) {
-		$country_setting = get_option( 'woocommerce_default_country' );
-		// Extract just the country code from the "COUNTRY:STATE" format.
-		$country_code              = sanitize_text_field( explode( ':', $country_setting )[0] );
-		$request_params['country'] = $country_code;
+		$request_params['country'] = wc_get_base_location()['country'];
 
 		return $request_params;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We're making changes to how product recommendations are generated on WooCommerce.com. This PR updates WooCommerce to call the new version of the endpoint, and to pass the store location to the endpoint so we can return personalized recommendations.
<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WCCOM-1175](https://linear.app/a8c/issue/WCCOM-1175/implement-recommendations-api-helper-in-app)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch and apply [this patch](https://github.com/user-attachments/files/20368694/suggestions.patch) to log some debug data.
2. Navigate to `/plugins/woocommerc`e and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
3. Go to http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com and confirm the Show Suggestions option is enabled
4. Enter a bash session with `pnpm -- wp-env run cli bash`, and tail the logs with `tail -f wp-content/debug.log | grep "Debug URL"`
5. View http://localhost:8888/wp-admin/admin.php?page=wc-orders
6. Wait a minute for the scheduled action to run, or go to http://localhost:8888/wp-admin/tools.php?page=action-scheduler&s=suggestions&action=-1&paged=1&action2=-1 and run the pending `woocommerce_update_marketplace_suggestions` action manually
7. Check the logs and confirm it called v2 of the WCCOM endpoint, and included the country param.
`https://woocommerce.com/wp-json/wccom/marketplace-suggestions/2.0/suggestions.json?country=ZA`
8. Visit that URL and confirm you see data.
9. Refresh the Orders page and confirm it's showing the fake Algolia suggestions from the new endpoint
![Orders_‹_woocommerce_—_WordPress](https://github.com/user-attachments/assets/5d87bea8-ed1f-472e-bd31-4e265d3d14c5)

10. Test around this issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
