### PR TITLE
[NOX In-Context] Fix the default country in the business step to match the selected one in NOX

### DIFF
--- a/plugins/woocommerce/changelog/58190-fix-default-country-in-business-step
+++ b/plugins/woocommerce/changelog/58190-fix-default-country-in-business-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix the default country in the business step to match the selected one in NOX

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -30,10 +30,7 @@ export const BusinessVerificationStep: React.FC = () => {
 			location.hostname === 'localhost'
 				? 'https://wcpay.test'
 				: window.wcSettings?.homeUrl + getComingSoonShareKey(),
-		country: (
-			window.wcSettings?.admin?.preloadSettings?.general
-				?.woocommerce_default_country || 'US'
-		).split( ':' )[ 0 ],
+		country: currentStep?.context?.fields?.location,
 		...( currentStep?.context?.self_assessment ?? {} ),
 	};
 	const hasTestAccount = currentStep?.context?.has_test_account ?? false;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -30,7 +30,9 @@ export const BusinessVerificationStep: React.FC = () => {
 			location.hostname === 'localhost'
 				? 'https://wcpay.test'
 				: window.wcSettings?.homeUrl + getComingSoonShareKey(),
-		country: currentStep?.context?.fields?.location,
+		country: ( currentStep?.context?.fields?.location || 'US' ).split(
+			':'
+		)[ 0 ],
 		...( currentStep?.context?.self_assessment ?? {} ),
 	};
 	const hasTestAccount = currentStep?.context?.has_test_account ?? false;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -30,9 +30,7 @@ export const BusinessVerificationStep: React.FC = () => {
 			location.hostname === 'localhost'
 				? 'https://wcpay.test'
 				: window.wcSettings?.homeUrl + getComingSoonShareKey(),
-		country: ( currentStep?.context?.fields?.location || 'US' ).split(
-			':'
-		)[ 0 ],
+		country: currentStep?.context?.fields?.location,
 		...( currentStep?.context?.self_assessment ?? {} ),
 	};
 	const hasTestAccount = currentStep?.context?.has_test_account ?? false;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
@@ -105,6 +105,7 @@ export interface WooPaymentsProviderOnboardingStep {
 			industry_to_mcc: Record< string, string >;
 			mccs_display_tree: MccsDisplayTreeItem;
 			available_countries: Record< string, string >;
+			location: string;
 		};
 		self_assessment: Record< string, string >;
 		sub_steps: Record<

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1504,7 +1504,7 @@ class WooPaymentsService {
 		// This is because WooPayments needs a working WPCOM connection to be able to fetch the fields.
 		if ( $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ) ) {
 			try {
-				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields();
+				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields( $location );
 			} catch ( Exception $e ) {
 				$business_verification_step['errors'][] = array(
 					'code'    => 'fields_error',
@@ -2014,10 +2014,13 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding fields data for the KYC business verification.
 	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
 	 * @return array The onboarding fields data.
 	 * @throws Exception If the onboarding fields data could not be retrieved or there was an error.
 	 */
-	private function get_onboarding_kyc_fields(): array {
+	private function get_onboarding_kyc_fields( string $location ): array {
 		// Call the WooPayments API to get the onboarding fields.
 		$response = $this->proxy->call_static( Utils::class, 'rest_endpoint_get_request', '/wc/v3/payments/onboarding/fields' );
 
@@ -2035,6 +2038,8 @@ class WooPaymentsService {
 		if ( ! isset( $fields['available_countries'] ) && $this->proxy->call_function( 'is_callable', '\WC_Payments_Utils::supported_countries' ) ) {
 			$fields['available_countries'] = $this->proxy->call_static( '\WC_Payments_Utils', 'supported_countries' );
 		}
+
+		$fields['location'] = $location;
 
 		return $fields;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -500,6 +500,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 							'electronics_and_computers' => 'digital_products__other_digital_goods',
 						),
 						'available_countries' => $this->get_woopayments_supported_countries(),
+						'location'            => $location,
 					) : array(),
 					'sub_steps'        => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['sub_steps'] ?? array(),
 					'self_assessment'  => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['self_assessment'] ?? array(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When starting the NOX In-Context, the country selected in the Payments settings doesn't match the one shown inside the business step.

![CleanShot 2025-05-21 at 16 19 17@2x](https://github.com/user-attachments/assets/bb80d866-af00-4b4d-a19b-dd669a308e46)


Closes WOOPLUG-4366
Closes #58186 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR
2. Select a country in Settings > Payments
3. Start the onboarding process using NOX In-Context
4. When you reach the business step, ensure the default selected country matches the one selected before.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix the default country in the business step to match the selected one in NOX
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
