### PR TITLE
Fix: updating WooCommerce email properties in editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-subject-and-recipient-update
+++ b/plugins/woocommerce/changelog/fix-subject-and-recipient-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix updating subject, preheader and other WC email data via EmailControllerAPI.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -47,9 +47,8 @@ class EmailApiController {
 	 * @return array - The email data.
 	 */
 	public function get_email_data( $post_data ): array {
-		$email_type  = $this->post_manager->get_email_type_from_post_id( $post_data['id'] );
-		$post_option = get_option( "woocommerce_{$email_type}_settings" );
-		$email       = $this->get_email_by_type( $email_type ?? '' );
+		$email_type = $this->post_manager->get_email_type_from_post_id( $post_data['id'] );
+		$email      = $this->get_email_by_type( $email_type ?? '' );
 
 		// When the email type is not found, it means that the email type is not supported.
 		if ( ! $email ) {
@@ -93,39 +92,37 @@ class EmailApiController {
 		if ( ! array_key_exists( 'subject', $data ) && ! array_key_exists( 'preheader', $data ) ) {
 			return;
 		}
-		$email_type  = $this->post_manager->get_email_type_from_post_id( $post->ID );
-		$option_name = "woocommerce_{$email_type}_settings";
-		$post_option = get_option( $option_name );
+		$email_type = $this->post_manager->get_email_type_from_post_id( $post->ID );
+		$email      = $this->get_email_by_type( $email_type ?? '' );
 
 		// Handle customer_refunded_order email type because it has two different subjects.
 		if ( 'customer_refunded_order' === $email_type ) {
 			if ( array_key_exists( 'subject_full', $data ) ) {
-				$post_option['subject_full'] = $data['subject_full'];
+				$email->update_option( 'subject_full', $data['subject_full'] );
 			}
 			if ( array_key_exists( 'subject_partial', $data ) ) {
-				$post_option['subject_partial'] = $data['subject_partial'];
+				$email->update_option( 'subject_partial', $data['subject_partial'] );
 			}
 		} elseif ( array_key_exists( 'subject', $data ) ) {
-			$post_option['subject'] = $data['subject'];
+			$email->update_option( 'subject', $data['subject'] );
 		}
 
 		if ( array_key_exists( 'preheader', $data ) ) {
-			$post_option['preheader'] = $data['preheader'];
+			$email->update_option( 'preheader', $data['preheader'] );
 		}
 
 		if ( array_key_exists( 'enabled', $data ) ) {
-			$post_option['enabled'] = $data['enabled'] ? 'yes' : 'no';
+			$email->update_option( $data['enabled'] ? 'yes' : 'no' );
 		}
 		if ( array_key_exists( 'recipient', $data ) ) {
-			$post_option['recipient'] = $data['recipient'];
+			$email->update_option( 'recipient', $data['recipient'] );
 		}
 		if ( array_key_exists( 'cc', $data ) ) {
-			$post_option['cc'] = $data['cc'];
+			$email->update_option( 'cc', $data['cc'] );
 		}
 		if ( array_key_exists( 'bcc', $data ) ) {
-			$post_option['bcc'] = $data['bcc'];
+			$email->update_option( 'bcc', $data['bcc'] );
 		}
-		update_option( $option_name, $post_option );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailStub.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailStub.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Automattic\WooCommerce\Tests\Internal\EmailEditor;
+
+// Make sure WC_Email class exists.
+if ( ! class_exists( \WC_Email::class ) ) {
+	require_once WC_ABSPATH . 'includes/emails/class-wc-email.php';
+}
+
+/**
+ * Email class for testing purposes.
+ */
+class EmailStub extends \WC_Email {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id             = 'test_email';
+		$this->title          = 'Test Email';
+		$this->description    = 'This is a test email for unit testing';
+		$this->template_html  = 'emails/test-email.php';
+		$this->template_plain = 'emails/plain/test-email.php';
+		$this->placeholders   = array();
+
+		parent::__construct();
+	}
+
+	/**
+	 * Get form fields.
+	 *
+	 * @return array
+	 */
+	public function get_form_fields(): array {
+		return array(
+			'recipient' => array(),
+		);
+	}
+
+	/**
+	 * Get default subject.
+	 *
+	 * @return string
+	 */
+	public function get_default_subject(): string {
+		return 'Default Subject';
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailStub.php
+++ b/plugins/woocommerce/tests/php/src/Internal/EmailEditor/EmailStub.php
@@ -34,7 +34,9 @@ class EmailStub extends \WC_Email {
 	 */
 	public function get_form_fields(): array {
 		return array(
-			'recipient' => array(),
+			'recipient' => array(
+				'default' => 'test@example.com',
+			),
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4348.

Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57768.

The `EmailApiController` uses the `get_option()` method on the `WC_Email` instance to retrieve WooCommerce email properties (as implemented in the previous PR). However, updating email properties directly via the `post_option()` function did not correctly refresh the attributes within the `WC_Email` instance, leading to stale data issues.

The solution is to use the instance method `update_option()` on the `WC_Email` object. This ensures the attributes are updated consistently across the entire codebase.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| After |
| ----- |
|[Screen Recording at 2025-05-21 at 06-08-27.webm](https://github.com/user-attachments/assets/7f704543-5181-405f-ae77-819cbc06ec0e)|



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the Block Email Editor feature is enabled in **WooCommerce > Settings > Advanced > Features**.
2. Go to **WooCommerce > Settings > Emails**.
3. Edit one of the emails and update values in the recipient and subject fields in the settings sidebar.
4. Make sure that changes are stored and the values are not refreshed after clicking on the save button.
5. Sent email and verify that the new values are used.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
