### PR TITLE
[NOX In-context] Fix KYC data not prefilled in NOX In-Context flow

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4370-nox-in-context-kyc-not-prefilled
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4370-nox-in-context-kyc-not-prefilled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Resolved issue where KYC data was not prefilled in the NOX In-Context onboarding flow.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -18,7 +18,6 @@ import { PaymentMethodListItem } from '~/settings-payments/components/payment-me
 import {
 	combinePaymentMethodsState,
 	combineRequestMethods,
-	decouplePaymentMethodsState,
 	shouldRenderPaymentMethodInMainList,
 } from '~/settings-payments/utils';
 import './style.scss';
@@ -124,7 +123,7 @@ export default function PaymentMethodsSelection() {
 				url: href,
 				method: 'POST',
 				data: {
-					payment_methods: decouplePaymentMethodsState( state ),
+					payment_methods: state,
 				},
 			} );
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -287,25 +287,6 @@ export const combinePaymentMethodsState = (
 };
 
 /**
- * Decouples Apple Pay and Google Pay into two separate states.
- *
- * If an id of `apple_google` exists in the list of payment methods, it is split into two separate states: `apple_pay` and `google_pay`.
- */
-export const decouplePaymentMethodsState = (
-	paymentMethodsState: Record< string, boolean >
-) => {
-	return Object.keys( paymentMethodsState ).reduce( ( acc, key ) => {
-		if ( key === 'apple_google' ) {
-			acc.apple_pay = paymentMethodsState[ key ];
-			acc.google_pay = paymentMethodsState[ key ];
-		} else {
-			acc[ key ] = paymentMethodsState[ key ];
-		}
-		return acc;
-	}, {} as Record< string, boolean > );
-};
-
-/**
  * Checks whether a payment method should be rendered.
  */
 export const shouldRenderPaymentMethodInMainList = (

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1857,14 +1857,25 @@ class WooPaymentsService {
 		$step_pms_data = (array) $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_PAYMENT_METHODS, $location, 'payment_methods' );
 
 		$payment_methods_state = array();
+		$apple_pay_enabled     = false;
+		$google_pay_enabled    = false;
+
 		foreach ( $recommended_pms as $recommended_pm ) {
+			$pm_id = $recommended_pm['id'];
+
 			/**
-			 * Combine Apple Pay and Google Pay into a single entry.
-			 * This is because they are both enabled/disabled together.
-			 * We will use the ID 'apple_google' for this entry.
+			 * We need to handle Apple Pay and Google Pay separately.
+			 * They are not stored in the same way as the other payment methods.
 			 */
-			$pm_id = in_array( $recommended_pm['id'], [ 'apple_pay', 'google_pay' ], true )
-				? 'apple_google' : $recommended_pm['id'];
+			if ( 'apple_pay' === $pm_id ) {
+				$apple_pay_enabled = $recommended_pm['enabled'];
+				continue;
+			}
+
+			if ( 'google_pay' === $pm_id ) {
+				$google_pay_enabled = $recommended_pm['enabled'];
+				continue;
+			}
 
 			// Start with the recommended enabled state.
 			$payment_methods_state[ $pm_id ] = $recommended_pm['enabled'];
@@ -1880,6 +1891,12 @@ class WooPaymentsService {
 				$payment_methods_state[ $pm_id ] = filter_var( $step_pms_data[ $pm_id ], FILTER_VALIDATE_BOOLEAN );
 			}
 		}
+
+		// Combine Apple Pay and Google Pay into a single `apple_google` entry.
+		$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
+
+		// Optionally also respect stored state or forced requirements if needed here
+		$payment_methods_state['apple_google'] = $apple_google_enabled;
 
 		return $payment_methods_state;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1858,7 +1858,13 @@ class WooPaymentsService {
 
 		$payment_methods_state = array();
 		foreach ( $recommended_pms as $recommended_pm ) {
-			$pm_id = $recommended_pm['id'];
+			/**
+			 * Combine Apple Pay and Google Pay into a single entry.
+			 * This is because they are both enabled/disabled together.
+			 * We will use the ID 'apple_google' for this entry.
+			 */
+			$pm_id = in_array( $recommended_pm['id'], [ 'apple_pay', 'google_pay' ], true )
+				? 'apple_google' : $recommended_pm['id'];
 
 			// Start with the recommended enabled state.
 			$payment_methods_state[ $pm_id ] = $recommended_pm['enabled'];

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1895,7 +1895,7 @@ class WooPaymentsService {
 		// Combine Apple Pay and Google Pay into a single `apple_google` entry.
 		$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
 
-		// Optionally also respect stored state or forced requirements if needed here
+		// Optionally also respect stored state or forced requirements if needed here.
 		$payment_methods_state['apple_google'] = $apple_google_enabled;
 
 		return $payment_methods_state;

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -707,9 +707,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 		$expected_pms_state      = array(
-			'card'       => true, // Force enabled because it is required.
-			'apple_pay'  => true,
-			'google_pay' => false,
+			'card'         => true, // Force enabled because it is required.
+			'apple_google' => true,
 		);
 
 		$default_wpcom_connection        = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR resolves an issue where KYC data is not prefilled in the Stripe embedded component after transitioning from a test account to a live account within the NOX In-Context flow.

The root cause was the inclusion of payment method capabilities like `apple_pay` and `google_pay`, which are not valid capabilities to request from Stripe. Instead, these should be grouped under a single placeholder, such as `apple_google`, which is properly excluded and prevents the submission of unsupported capabilities.  

Closes WOOPLUG-4370.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1631" alt="Screenshot 2025-05-22 at 17 57 32" src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/d971d262-ed5c-4142-bcac-fdbb97b6d9bf/c669570e-447b-4199-bcf6-91e04b330e77?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi9kOTcxZDI2Mi1lZDVjLTQxNDItYmNhYy1mZGJiOTdiNmQ5YmYvYzY2OTU3MGUtNDQ3Yi00MTk5LWJjZjYtOTFlMDRiMzMwZTc3IiwiaWF0IjoxNzQ3OTAxMzIwLCJleHAiOjMzMzE4NDYxMzIwfQ.H5mts6M287NouofhAo5OISUqN-3MsBwt-7K27FIpxvg" /> | <img width="1631" alt="Screenshot 2025-05-22 at 17 57 32" src="https://github.com/user-attachments/assets/5aefd7fe-c6d2-47e5-b7e3-09cf7d8c6bd4" /> |

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- Create a new JN store with this PR's branch build (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/WOOPLUG-4370-nox-in-context-kyc-not-prefilled))
- Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
- Go to Plugins > Add plugin and install&activate the [WCPay Dev Tools plugin](https://github.com/Automattic/woocommerce-payments-dev-tools/tree/trunk).
- Navigate to WCPay Dev menu and make sure the `dev mode` is enabled.
<img width="1042" alt="Screenshot 2025-05-22 at 18 13 33" src="https://github.com/user-attachments/assets/e5c593b5-750c-4a00-ab30-3b8f7a2236ce" />

- SFTP or SSH into your JN site and delete the wp-content/object-cache.php file to disable the drop-in cache.
- Click on the "Payments" main menu item, and you should see the Payments Settings page.
- Click the "Install" button next to the WooPayments gateway.
- DO NOT interact with recommended payment methods toggles, directly click the Continue button.
<img width="1634" alt="Screenshot 2025-05-22 at 18 15 40" src="https://github.com/user-attachments/assets/eaeb9cb8-fd4a-4f42-bfcb-97606a49f2f7" />

- Proceed with the Jetpack connection and Test account onboarding.
- Once the test account is connected click the "Activate Payments". On the next step click again on the "Activate Payments" button.
<img width="1635" alt="Screenshot 2025-05-22 at 18 07 15" src="https://github.com/user-attachments/assets/1cdc5bbd-1088-4343-b6ce-197f63cd61c4" />

- Fill in the KYC details.
<img width="1635" alt="Screenshot 2025-05-22 at 18 07 35" src="https://github.com/user-attachments/assets/e0597fa3-f240-4dda-bbf4-a84041c9c5ab" />
- Click the "Continue" button and proceed with Stripe authentication.
- Once the embedded onboarding is loaded ensure the country and MCC Industry is prefilled.
<img width="1631" alt="Screenshot 2025-05-22 at 17 57 32" src="https://github.com/user-attachments/assets/b05b708c-e08e-4153-b923-818f5fa15250" />

- Proceed with the account onboarding.
- Close the modal & reset the account.
<img width="1504" alt="Screenshot 2025-05-22 at 18 26 46" src="https://github.com/user-attachments/assets/9431f5cd-67f3-4791-b7dd-ff92562e921c" />

- Switch the country to the UK.
<img width="1482" alt="Screenshot 2025-05-22 at 19 03 03" src="https://github.com/user-attachments/assets/54bfc856-b964-420b-bc3c-d05e58f472e2" />

- Click the "Continue setup" button next to the WooPayments gateway.
- On the Payment Methods selection screen, disable and enable the Apple / Google Pay toggle, interract with other Payment Methods.
- Proceed with the Test account onboarding.
- - Once the test account is connected, click the "Activate Payments". On the next step click again on the "Activate Payments" button.
<img width="1635" alt="Screenshot 2025-05-22 at 18 07 15" src="https://github.com/user-attachments/assets/1cdc5bbd-1088-4343-b6ce-197f63cd61c4" />

- Fill in the KYC details.
<img width="1635" alt="Screenshot 2025-05-22 at 18 07 35" src="https://github.com/user-attachments/assets/e0597fa3-f240-4dda-bbf4-a84041c9c5ab" />

- Click the "Continue" button and proceed with Stripe authentication.
- Once the embedded onboarding is loaded ensure the country and MCC Industry is prefilled.
<img width="1631" alt="Screenshot 2025-05-22 at 17 57 32" src="https://github.com/user-attachments/assets/b05b708c-e08e-4153-b923-818f5fa15250" />

- Proceed with the account onboarding.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
