### PR TITLE
[dev] Disable e2e release checks for pressable and wpcom envs

### DIFF
--- a/plugins/woocommerce/changelog/dev-wooplug-4384-disable-e2e-release-checks-for-pressable-and-wpcom-envs
+++ b/plugins/woocommerce/changelog/dev-wooplug-4384-disable-e2e-release-checks-for-pressable-and-wpcom-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: remove release-checks jobs

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -719,8 +719,6 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"on-demand",
-						"release-checks",
 						"core-e2e-pressable"
 					],
 					"report": {
@@ -736,8 +734,6 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"on-demand",
-						"release-checks",
 						"core-e2e-wpcom"
 					],
 					"report": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPLUG-4384 
Closes #58226

Removed the "release-checks" trigger for the 2 jobs. Also removed the "on-demand" trigger which is not used.

### How to test the changes in this Pull Request:

- CI should pass