### PR TITLE
[dev] Cherry pick 58227 - Disable e2e release checks for pressable and wpcom envs


### DIFF
--- a/plugins/woocommerce/changelog/dev-wooplug-4384-disable-e2e-release-checks-for-pressable-and-wpcom-envs
+++ b/plugins/woocommerce/changelog/dev-wooplug-4384-disable-e2e-release-checks-for-pressable-and-wpcom-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+CI: remove release-checks jobs

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -683,8 +683,6 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"on-demand",
-						"release-checks",
 						"core-e2e-pressable"
 					],
 					"report": {
@@ -700,8 +698,6 @@
 					"shardingArguments": [],
 					"changes": [],
 					"events": [
-						"on-demand",
-						"release-checks",
 						"core-e2e-wpcom"
 					],
 					"report": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Cherry picks https://github.com/woocommerce/woocommerce/pull/58227 into release/9.9 branch.
Remove the "release-checks" trigger for the 2 jobs. Also removed the "on-demand" trigger which is not used.

### How to test the changes in this Pull Request:

CI should pass
