### PR TITLE
[dev] Clean-up ci and tests on demand workflows - remove unused inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ on:
         required: true
         default: 'default'
         type: string
-      wc-version:
-        description: 'Specific WooCommerce version to install by the test jobs supporting it'
-        required: false
-        type: string
       refName:
         description: 'The ref name to run tests on. It needs to have a corresponding release published.'
         required: false
@@ -246,7 +242,6 @@ jobs:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }} # required by Metrics tests
           LAST_FAILED_RUN: ${{ vars.LAST_FAILED_RUN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          WC_VERSION: ${{ inputs.wc-version }}
           PLUGIN_SLUG: ${{ inputs.refName == 'nightly' && 'woocommerce-trunk-nightly' || '' }} # required by test:plugincheck
         run: |
           lastRunFile="${{ steps.download-last-run-info.outputs.download-path }}/last-run__${{ strategy.job-index }}/.last-run.json"

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -9,21 +9,13 @@ on:
         description: 'Event name: it will be used to filter the jobs to run in ci.yml.'
         required: true
         options:
-          - push
-          - daily-checks
           - pre-release
-          - on-demand
           - custom
-        default: on-demand
+        default: pre-release
       custom-trigger:
         type: string
         description: 'Custom event name: In case the `Event name` choice is `custom`, this field is required.'
         required: false
-      wc-version:
-        type: string
-        description: 'Optional, for `on-demand` or `custom` jobs. Most jobs (wp-env) ignore this. It can be `latest`, `nightly`, or a specific WC version (e.g., `9.7.0-rc.1`).'
-        required: false
-        default: latest
 
 jobs:
   validate-input:
@@ -41,5 +33,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       trigger: ${{ inputs.trigger == 'custom' && inputs.custom-trigger || inputs.trigger }}
-      wc-version: ${{ inputs.wc-version }}
     secrets: inherit


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Clean up some unused input choices in `ci.yml` and `tests-on-demand.yml`.
- `on-demand` trigger is not used anymore in any job config. If added back it can be used via the `custom` event, there's no need for an explicit choice.
- `wc-version` is not used.

### Testing that has already taken place:

CI should pass