### PR TITLE
[NOX In-Context] Animate the progress bar during the test account initialization for better UX

### DIFF
--- a/plugins/woocommerce/changelog/58243-fix-initial-ui-progress-test-account-creation
+++ b/plugins/woocommerce/changelog/58243-fix-initial-ui-progress-test-account-creation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Improve the NOX test account step by animating the progress bar during the initialization phase

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -335,6 +335,32 @@ const TestAccountStep = () => {
 			poll();
 		}
 
+		// -- Progress animation during Initializing Phase --
+		if ( status === 'initializing' ) {
+			// Start progress animation from 10% to 30%, increment by 2% every second
+			if ( initializingTimeoutRef.current === null ) {
+				initializingTimeoutRef.current = window.setInterval( () => {
+					setProgress( ( current ) => {
+						if ( current < INIT_PROGRESS_MAX ) {
+							return Math.min(
+								current + INIT_PROGRESS_INCREMENT,
+								INIT_PROGRESS_MAX
+							);
+						}
+						return current;
+					} );
+				}, 1000 );
+			}
+		}
+		// Clear the initializing timer if not in initializing phase
+		if (
+			status !== 'initializing' &&
+			initializingTimeoutRef.current !== null
+		) {
+			clearTimeout( initializingTimeoutRef.current );
+			initializingTimeoutRef.current = null;
+		}
+
 		// Cleanup function for the effect
 		return () => {
 			clearTimers(); // Clear any pending timeouts

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -174,6 +174,7 @@ const TestAccountStep = () => {
 				currentStep?.status === 'failed'
 			) {
 				setStatus( 'initializing' );
+				setProgress( INIT_PROGRESS_START ); // Start at 10%
 
 				const cleanStepIfNeeded = async () => {
 					// We only need to clean the step if it has been retried or failed.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -62,6 +62,9 @@ const MAX_INITIAL_PROGRESS = 90; // Cap progress at 90% for the initial phase
 const MAX_EXTENDED_PHASE_1_PROGRESS = 96; // Cap progress at 96% for the extended phase 1
 const INITIAL_PHASE_INCREMENT = 5; // Increment progress by 20% for the initial phase
 const EXTENDED_PHASE_1_INCREMENT = 1; // Increment progress by 1% for the extended phase 1
+const INIT_PROGRESS_START = 10; // Start progress at 10% during init
+const INIT_PROGRESS_INCREMENT = 2; // Increment by 2% every second during init
+const INIT_PROGRESS_MAX = 30; // Cap progress at 30% during init
 
 // Status types for the component
 type Status =

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -365,7 +365,13 @@ const TestAccountStep = () => {
 		return () => {
 			clearTimers(); // Clear any pending timeouts
 		};
-	}, [ status, currentStep, retryCounter, pollingPhase ] );
+	}, [
+		status,
+		currentStep,
+		retryCounter,
+		pollingPhase,
+		setJustCompletedStepId,
+	] );
 
 	const getPhaseMessage = ( phase: number ) => {
 		if ( phase === 1 ) {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -95,12 +95,17 @@ const TestAccountStep = () => {
 	// Refs for timers and phase tracking
 	const pollingTimeoutRef = useRef< number | null >( null );
 	const phase1StartTimeRef = useRef< number | null >( null );
+	const initializingTimeoutRef = useRef< number | null >( null );
 
 	// Helper to clear timers
 	const clearTimers = () => {
 		if ( pollingTimeoutRef.current !== null ) {
 			clearTimeout( pollingTimeoutRef.current );
 			pollingTimeoutRef.current = null;
+		}
+		if ( initializingTimeoutRef.current !== null ) {
+			clearTimeout( initializingTimeoutRef.current );
+			initializingTimeoutRef.current = null;
 		}
 	};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When setting up a WooPayments test account, the progress bar would remain static during the initialization phase (while the test account is being created). This phase can take several seconds, making it appear like the process is stuck, even though it works in the background. This could confuse or frustrate users, as there is no visible indication that progress was being made.

The progress bar now animates during the test account initialization phase to provide better feedback to users:
- The progress bar starts at 10% when initialization begins.
- It increases by 2% every second, up to a maximum of 30%.
- Once initialization completes, the progress bar continues as before, reflecting the actual progress of the polling phase.

This change ensures that users always see some movement in the progress bar, making the setup process feel more responsive and reassuring them that progress is being made, even if the initialization takes several seconds.

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/131e7707-9e03-4de9-8ada-33b168076980


### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Settings > Payments
2. Reset any onboarded account and start onboarding again
3. Open the Network tab for reference
4. When the test account step is active, make sure the progress bar is moving even if the init HTTP call is still in progress
5. When the init call responds and the polling begins, make sure the progress bar is moving

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Improve the NOX test account step by animating the progress bar during the initialization phase

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
