### PR TITLE
[NOX In-context] Fix broken styles on recommended payment method step on Atomic site

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4391-broken-header-styles
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4391-broken-header-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix broken styles on recommended payment methods step on Atomic sites.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -125,7 +125,7 @@
 
 	.woocommerce-recommended-payment-methods {
 		// Width to fill available space.
-		width: 100% !important;;
+		width: 100% !important;
 		width: -webkit-fill-available !important; /* Mozilla-based browsers will ignore this. */
 		width: fill-available !important;
 		width: -moz-available !important; /* WebKit-based browsers will ignore this. */

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -125,10 +125,10 @@
 
 	.woocommerce-recommended-payment-methods {
 		// Width to fill available space.
-		width: 100%;
-		width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
-		width: fill-available;
-		width: -moz-available; /* WebKit-based browsers will ignore this. */
+		width: 100% !important;;
+		width: -webkit-fill-available !important; /* Mozilla-based browsers will ignore this. */
+		width: fill-available !important;
+		width: -moz-available !important; /* WebKit-based browsers will ignore this. */
 		margin-right: $gap-small + $gap-smallest;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses a UI alignment issue on Atomic (WPCOM) sites affecting the “Payment Methods Selection” step in the NOX In-Context onboarding modal.

On Atomic sites, the “Close”, “Toggle”, and “Continue” buttons within this step are misaligned due to conflicting Jetpack styles that override the expected layout. This results in a broken or inconsistent button alignment that impacts the overall user experience.

Closes WOOPLUG-4391

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1723" alt="Screenshot 2025-05-23 at 18 46 22" src="https://github.com/user-attachments/assets/ee79cd8d-e7b0-4cfd-bc21-4b61b20f96e0" /> | <img width="1720" alt="Screenshot 2025-05-23 at 18 45 06" src="https://github.com/user-attachments/assets/7ac46875-8399-4c4c-a14b-56ff54faa71e" /> |

### How to test the changes in this Pull Request:
- Check out the `trunk `branch locally.
- Extract and add the [following](https://github.com/user-attachments/files/20413905/admin-styles-fix.php.zip) following MU plugin to your `mu-plugins` directory.
- Navigate to Settings > Payments and start the NOX In-context onboarding flow.
- Observe that the "Close", "Toggle", and "Continue" buttons are misaligned.
- Check out this PR branch, reload the page, and start the NOX In-context onboarding flow again.
- Ensure the buttons are aligned properly.

### Testing that has already taken place:
Check above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
