### PR TITLE
Add recipient filter to the email listings in block email editor

### DIFF
--- a/plugins/woocommerce/changelog/58255-add-recipient-filter-email-block-editor
+++ b/plugins/woocommerce/changelog/58255-add-recipient-filter-email-block-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add recipient filter to email listing

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-data.ts
@@ -97,6 +97,53 @@ export const useTransactionalEmails = (
 		return statusFilter.value.includes( email.status );
 	} );
 
+	// Apply Recipient Filter.
+	filteredEmails = filteredEmails.filter( ( email ) => {
+		const recipientFilter = view.filters.find(
+			( filter: View.Filter ) => filter.field === 'recipients'
+		);
+
+		if ( ! recipientFilter || ! recipientFilter.value ) {
+			return true;
+		}
+
+		const selectedRecipients = recipientFilter.value as string[];
+
+		// Check for 'Customers' filter.
+		if (
+			selectedRecipients.includes( 'customer' ) &&
+			( ! email.recipients.to || email.recipients.to.length === 0 )
+		) {
+			return true;
+		}
+
+		// Check for specific email recipients.
+		const emailRecipients = [
+			...( email.recipients.to
+				? email.recipients.to
+						.split( ',' )
+						.map( ( r ) => r.trim() )
+						.filter( Boolean )
+				: [] ),
+			...( email.recipients.cc
+				? email.recipients.cc
+						.split( ',' )
+						.map( ( r ) => r.trim() )
+						.filter( Boolean )
+				: [] ),
+			...( email.recipients.bcc
+				? email.recipients.bcc
+						.split( ',' )
+						.map( ( r ) => r.trim() )
+						.filter( Boolean )
+				: [] ),
+		];
+
+		return selectedRecipients.some( ( filterRecipient ) =>
+			emailRecipients.includes( filterRecipient )
+		);
+	} );
+
 	// Apply pagination
 	const startIndex = ( view.page - 1 ) * view.perPage;
 	const endIndex = startIndex + view.perPage;

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -35,8 +35,41 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 		view
 	);
 
-	const fields = useMemo(
-		() => [
+	const fields = useMemo( () => {
+		const recipientElements = Array.from(
+			emailTypes.reduce( ( acc, email ) => {
+				const recipients = [
+					...( email.recipients.to
+						? email.recipients.to
+								.split( ',' )
+								.map( ( r ) => r.trim() )
+								.filter( Boolean )
+						: [] ),
+					...( email.recipients.cc
+						? email.recipients.cc
+								.split( ',' )
+								.map( ( r ) => r.trim() )
+								.filter( Boolean )
+						: [] ),
+					...( email.recipients.bcc
+						? email.recipients.bcc
+								.split( ',' )
+								.map( ( r ) => r.trim() )
+								.filter( Boolean )
+						: [] ),
+				];
+				recipients.forEach( ( recipient ) => acc.add( recipient ) );
+				return acc;
+			}, new Set< string >() )
+		).map( ( recipient ) => ( { value: recipient, label: recipient } ) );
+
+		// // Add "Customers" as a recipient option.
+		// recipientElements.push( {
+		// 	value: 'customer',
+		// 	label: __( 'Customers', 'woocommerce' ),
+		// } );
+
+		return [
 			{
 				id: 'title',
 				label: __( 'Title', 'woocommerce' ),
@@ -56,8 +89,11 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 			{
 				id: 'recipients',
 				label: __( 'Recipient(s)', 'woocommerce' ),
-				enableSorting: false,
-				enableHiding: false,
+				enableHiding: true,
+				filterBy: {
+					operators: [ 'isAny' ],
+				},
+				elements: recipientElements,
 				render: ( row: { item: EmailType } ) => {
 					return (
 						<RecipientsList recipients={ row.item.recipients } />
@@ -76,9 +112,8 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				},
 				elements: EMAIL_STATUSES,
 			},
-		],
-		[]
-	);
+		];
+	}, [ emailTypes ] );
 
 	const actions = useMemo(
 		() => [

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -63,12 +63,6 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 			}, new Set< string >() )
 		).map( ( recipient ) => ( { value: recipient, label: recipient } ) );
 
-		// // Add "Customers" as a recipient option.
-		// recipientElements.push( {
-		// 	value: 'customer',
-		// 	label: __( 'Customers', 'woocommerce' ),
-		// } );
-
 		return [
 			{
 				id: 'title',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new `Recipient` filter to the email listing page to improve merchant experience when managing WooCommerce email templates.

Changes made:

- Added a new `Recipient` filter dropdown to the email notifications interface
- Implemented filter options including "Customers" and all other recipient types used across emails
- Added filtering logic to filter emails by selected recipient
- Maintained consistency with existing filter UI patterns (follows same design as Status filter)

This enhancement allows merchants to quickly filter and find emails based on who receives them, making email management more efficient and user-friendly.

The implementation follows the existing filtering mechanism used for the Status filter to ensure consistency and maintainability.

Closes #58244 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<details> <summary>Click here to see:</summary>

| - | Screenshots |
| ------ | ----- |
| All available flters | ![Screenshot 2025-05-24 at 1 34 43 AM](https://github.com/user-attachments/assets/0a85e729-3316-4eb5-b5e2-3e01d079668c) |
| Single recipient selected | ![Screenshot 2025-05-24 at 1 34 18 AM](https://github.com/user-attachments/assets/35e6a1fa-7057-4018-870c-5f4fc9cdbff8) |
| Multiple recipients selected | ![Screenshot 2025-05-24 at 1 34 28 AM](https://github.com/user-attachments/assets/22b89f51-6332-4d31-b5aa-95587bd1399f) |
| Combined filters applied | ![Screenshot 2025-05-24 at 1 34 36 AM](https://github.com/user-attachments/assets/f196c091-bb69-4d31-bc34-e6ad57d953c2) |

</details>
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)
2. Go to Enable the block-based email editor from WooCommerce → Settings → Email
3. Verify that both "Status" and "Recipient" filter dropdowns are visible in the email listings interface
4. Click on the "Recipient" filter dropdown and verify it shows all available recipient options
5. Select a specific recipient from the dropdown (e.g., "Customers")
6. Verify that the email list updates to show only emails sent to the selected recipient type
7. Test filtering by different recipient types to ensure all work correctly
8. Test combining both Status and Recipient filters to ensure they work together
9. Clear filters and verify the full email list is restored

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
