### PR TITLE
Wrap checkout validation hook with error handling to prevent fatal errors

### DIFF
--- a/plugins/woocommerce/changelog/enhance-58076
+++ b/plugins/woocommerce/changelog/enhance-58076
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent fatal errors caused by third-party callbacks during checkout validation by wrapping the 'woocommerce_checkout_validate_order_before_payment' action in error handling.

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -216,16 +216,29 @@ class OrderController {
 	protected function perform_custom_order_validation( \WC_Order $order ) {
 		$validation_errors = new \WP_Error();
 
-		/**
-		 * Allow plugins to perform custom validation before payment.
-		 *
-		 * Plugins can add errors to the $validation_errors object.
-		 *
-		 * @param \WC_Order $order             The order object.
-		 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
-		 * @since 9.9.0
-		 */
-		do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
+		try {
+			/**
+			 * Allow plugins to perform custom validation before payment.
+			 *
+			 * Plugins can add errors to the $validation_errors object.
+			 *
+			 * @param \WC_Order $order             The order object.
+			 * @param \WP_Error $validation_errors WP_Error object to add custom errors to.
+			 * @since 9.9.0
+			 */
+			do_action( 'woocommerce_checkout_validate_order_before_payment', $order, $validation_errors );
+		} catch ( \Throwable $e ) {
+			// Log the error, but allow the checkout to proceed.
+			wc_get_logger()->error(
+				sprintf(
+					'Error in checkout validation hook: %s in %s on line %d',
+					$e->getMessage(),
+					$e->getFile(),
+					$e->getLine()
+				),
+				[ 'source' => 'checkout-validation' ]
+			);
+		}
 
 		// Check if there are any errors after custom validation.
 		if ( $validation_errors->has_errors() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58076  .

(For Bug Fixes) Bug introduced in PR # .



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### How to test the changes in this Pull Request:

1. **Simulate a plugin throwing an error during checkout validation:**

   Add the following test code to your site (e.g., `functions.php` of your theme or a custom plugin):

   ```php
   add_action( 'woocommerce_checkout_validate_order_before_payment', function( $order, $validation_errors ) {
       throw new \Exception( 'Simulated error from plugin during validation.' );
   }, 10, 2 );
   ```

2. **Attempt to complete checkout:**
   - Ensure that the checkout process does **not crash** and no fatal error occurs.
   - The order should be placed successfully, assuming there are no actual validation errors.

3. **Check WooCommerce logs:**
   - Go to **WooCommerce → Status → Logs**
   - Locate the log file named `checkout-validation`
   - Confirm that the simulated error is logged correctly.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Prevent fatal errors caused by third-party callbacks during checkout validation by wrapping the 'woocommerce_checkout_validate_order_before_payment' action in error handling.
</details>
