### PR TITLE
CFE: Multiple fixes for NOX In-Context for WooCommerce 9.9

### DIFF
--- a/plugins/woocommerce/changelog/58189-add-save-form-without-alert
+++ b/plugins/woocommerce/changelog/58189-add-save-form-without-alert
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix browser alert when interacting with offline payment methods settings forms

--- a/plugins/woocommerce/changelog/58190-fix-default-country-in-business-step
+++ b/plugins/woocommerce/changelog/58190-fix-default-country-in-business-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix the default country in the business step to match the selected one in NOX

--- a/plugins/woocommerce/changelog/58243-fix-initial-ui-progress-test-account-creation
+++ b/plugins/woocommerce/changelog/58243-fix-initial-ui-progress-test-account-creation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Improve the NOX test account step by animating the progress bar during the initialization phase

--- a/plugins/woocommerce/changelog/enhance-WOOPLUG-4385-initialize-payment-gateways
+++ b/plugins/woocommerce/changelog/enhance-WOOPLUG-4385-initialize-payment-gateways
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Initialize payment gateway logic for WooPayments API actions.

--- a/plugins/woocommerce/changelog/enhance-WOOPLUG-4390-duplicate-activate-payments-screens
+++ b/plugins/woocommerce/changelog/enhance-WOOPLUG-4390-duplicate-activate-payments-screens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove the duplicate “Activate Payments” screens in NOX In-context flow.

--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4370-nox-in-context-kyc-not-prefilled
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4370-nox-in-context-kyc-not-prefilled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Resolved issue where KYC data was not prefilled in the NOX In-Context onboarding flow.

--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4391-broken-header-styles
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4391-broken-header-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix broken styles on recommended payment methods step on Atomic sites.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
@@ -9,7 +9,10 @@ import { PaymentIncentive } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { getWooPaymentsSetupLiveAccountLink } from '~/settings-payments/utils';
+import {
+	getWooPaymentsSetupLiveAccountLink,
+	disableWooPaymentsTestMode,
+} from '~/settings-payments/utils';
 
 interface ActivatePaymentsButtonProps {
 	/**
@@ -57,16 +60,25 @@ export const ActivatePaymentsButton = ( {
 	const activatePayments = () => {
 		setIsUpdating( true );
 
-		if ( incentive ) {
-			acceptIncentive( incentive.promo_id );
-		}
+		// Disable test mode and redirect to the live account setup link.
+		disableWooPaymentsTestMode()
+			.then( () => {
+				if ( incentive ) {
+					acceptIncentive( incentive.promo_id );
+				}
 
-		if ( onboardingType === 'native_in_context' ) {
-			// Open the onboarding modal.
-			setOnboardingModalOpen( true );
-		} else {
-			window.location.href = getWooPaymentsSetupLiveAccountLink();
-		}
+				if ( onboardingType === 'native_in_context' ) {
+					// Open the onboarding modal.
+					setOnboardingModalOpen( true );
+					setIsUpdating( false );
+				} else {
+					window.location.href = getWooPaymentsSetupLiveAccountLink();
+				}
+			} )
+			.catch( () => {
+				// Handle any errors that occur during the process.
+				setIsUpdating( false );
+			} );
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -30,10 +30,7 @@ export const BusinessVerificationStep: React.FC = () => {
 			location.hostname === 'localhost'
 				? 'https://wcpay.test'
 				: window.wcSettings?.homeUrl + getComingSoonShareKey(),
-		country: (
-			window.wcSettings?.admin?.preloadSettings?.general
-				?.woocommerce_default_country || 'US'
-		).split( ':' )[ 0 ],
+		country: currentStep?.context?.fields?.location,
 		...( currentStep?.context?.self_assessment ?? {} ),
 	};
 	const hasTestAccount = currentStep?.context?.has_test_account ?? false;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -18,7 +18,6 @@ import { PaymentMethodListItem } from '~/settings-payments/components/payment-me
 import {
 	combinePaymentMethodsState,
 	combineRequestMethods,
-	decouplePaymentMethodsState,
 	shouldRenderPaymentMethodInMainList,
 } from '~/settings-payments/utils';
 import './style.scss';
@@ -124,7 +123,7 @@ export default function PaymentMethodsSelection() {
 				url: href,
 				method: 'POST',
 				data: {
-					payment_methods: decouplePaymentMethodsState( state ),
+					payment_methods: state,
 				},
 			} );
 		}

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -125,10 +125,10 @@
 
 	.woocommerce-recommended-payment-methods {
 		// Width to fill available space.
-		width: 100%;
-		width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
-		width: fill-available;
-		width: -moz-available; /* WebKit-based browsers will ignore this. */
+		width: 100% !important;
+		width: -webkit-fill-available !important; /* Mozilla-based browsers will ignore this. */
+		width: fill-available !important;
+		width: -moz-available !important; /* WebKit-based browsers will ignore this. */
 		margin-right: $gap-small + $gap-smallest;
 		display: flex;
 		flex-direction: column;

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -61,6 +61,9 @@ const MAX_INITIAL_PROGRESS = 90; // Cap progress at 90% for the initial phase
 const MAX_EXTENDED_PHASE_1_PROGRESS = 96; // Cap progress at 96% for the extended phase 1
 const INITIAL_PHASE_INCREMENT = 5; // Increment progress by 20% for the initial phase
 const EXTENDED_PHASE_1_INCREMENT = 1; // Increment progress by 1% for the extended phase 1
+const INIT_PROGRESS_START = 10; // Start progress at 10% during init
+const INIT_PROGRESS_INCREMENT = 2; // Increment by 2% every second during init
+const INIT_PROGRESS_MAX = 30; // Cap progress at 30% during init
 
 // Status types for the component
 type Status =
@@ -91,12 +94,17 @@ const TestAccountStep = () => {
 	// Refs for timers and phase tracking
 	const pollingTimeoutRef = useRef< number | null >( null );
 	const phase1StartTimeRef = useRef< number | null >( null );
+	const initializingTimeoutRef = useRef< number | null >( null );
 
 	// Helper to clear timers
 	const clearTimers = () => {
 		if ( pollingTimeoutRef.current !== null ) {
 			clearTimeout( pollingTimeoutRef.current );
 			pollingTimeoutRef.current = null;
+		}
+		if ( initializingTimeoutRef.current !== null ) {
+			clearTimeout( initializingTimeoutRef.current );
+			initializingTimeoutRef.current = null;
 		}
 	};
 
@@ -140,6 +148,7 @@ const TestAccountStep = () => {
 				currentStep?.status === 'failed'
 			) {
 				setStatus( 'initializing' );
+				setProgress( INIT_PROGRESS_START ); // Start at 10%
 
 				const cleanStepIfNeeded = async () => {
 					// We only need to clean the step if it has been retried or failed.
@@ -300,11 +309,43 @@ const TestAccountStep = () => {
 			poll();
 		}
 
+		// -- Progress animation during Initializing Phase --
+		if ( status === 'initializing' ) {
+			// Start progress animation from 10% to 30%, increment by 2% every second
+			if ( initializingTimeoutRef.current === null ) {
+				initializingTimeoutRef.current = window.setInterval( () => {
+					setProgress( ( current ) => {
+						if ( current < INIT_PROGRESS_MAX ) {
+							return Math.min(
+								current + INIT_PROGRESS_INCREMENT,
+								INIT_PROGRESS_MAX
+							);
+						}
+						return current;
+					} );
+				}, 1000 );
+			}
+		}
+		// Clear the initializing timer if not in initializing phase
+		if (
+			status !== 'initializing' &&
+			initializingTimeoutRef.current !== null
+		) {
+			clearTimeout( initializingTimeoutRef.current );
+			initializingTimeoutRef.current = null;
+		}
+
 		// Cleanup function for the effect
 		return () => {
 			clearTimers(); // Clear any pending timeouts
 		};
-	}, [ status, currentStep, retryCounter, pollingPhase ] );
+	}, [
+		status,
+		currentStep,
+		retryCounter,
+		pollingPhase,
+		setJustCompletedStepId,
+	] );
 
 	const getPhaseMessage = ( phase: number ) => {
 		if ( phase === 1 ) {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -16,6 +16,7 @@ import { navigateTo, getNewPath } from '@woocommerce/navigation';
 import WooPaymentsStepHeader from '../../components/header';
 import { useOnboardingContext } from '../../data/onboarding-context';
 import { WC_ASSET_URL } from '~/utils/admin-settings';
+import { disableWooPaymentsTestMode } from '~/settings-payments/utils';
 import './style.scss';
 
 interface StepCheckResponse {
@@ -106,6 +107,31 @@ const TestAccountStep = () => {
 			clearTimeout( initializingTimeoutRef.current );
 			initializingTimeoutRef.current = null;
 		}
+	};
+
+	const [ isContinueButtonLoading, setIsContinueButtonLoading ] =
+		useState( false );
+
+	const handleContinue = () => {
+		// Set the continue button loading state to true.
+		setIsContinueButtonLoading( true );
+
+		// Disable test mode and redirect to the live account setup link.
+		disableWooPaymentsTestMode()
+			.then( () => {
+				// Set the continue button loading state to false.
+				setIsContinueButtonLoading( false );
+
+				// This will refresh the steps and move the modal to the next step
+				navigateToNextStep();
+
+				// Refresh the store data
+				return refreshStoreData();
+			} )
+			.catch( () => {
+				// Handle any errors that occur during the process.
+				setIsContinueButtonLoading( false );
+			} );
 	};
 
 	// Reset state function
@@ -488,13 +514,9 @@ const TestAccountStep = () => {
 
 							<Button
 								variant="secondary"
-								onClick={ () => {
-									// This will refresh the steps and move the modal to the next step
-									navigateToNextStep();
-
-									// Refresh the store data
-									refreshStoreData();
-								} }
+								isBusy={ isContinueButtonLoading }
+								disabled={ isContinueButtonLoading }
+								onClick={ handleContinue }
 							>
 								{ __( 'Activate payments', 'woocommerce' ) }
 							</Button>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
@@ -105,6 +105,7 @@ export interface WooPaymentsProviderOnboardingStep {
 			industry_to_mcc: Record< string, string >;
 			mccs_display_tree: MccsDisplayTreeItem;
 			available_countries: Record< string, string >;
+			location: string;
 		};
 		self_assessment: Record< string, string >;
 		sub_steps: Record<

--- a/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/utils.ts
@@ -287,25 +287,6 @@ export const combinePaymentMethodsState = (
 };
 
 /**
- * Decouples Apple Pay and Google Pay into two separate states.
- *
- * If an id of `apple_google` exists in the list of payment methods, it is split into two separate states: `apple_pay` and `google_pay`.
- */
-export const decouplePaymentMethodsState = (
-	paymentMethodsState: Record< string, boolean >
-) => {
-	return Object.keys( paymentMethodsState ).reduce( ( acc, key ) => {
-		if ( key === 'apple_google' ) {
-			acc.apple_pay = paymentMethodsState[ key ];
-			acc.google_pay = paymentMethodsState[ key ];
-		} else {
-			acc[ key ] = paymentMethodsState[ key ];
-		}
-		return acc;
-	}, {} as Record< string, boolean > );
-};
-
-/**
  * Checks whether a payment method should be rendered.
  */
 export const shouldRenderPaymentMethodInMainList = (

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/settings-embed/index.tsx
@@ -63,9 +63,9 @@ const renderPaymentsSettings = () => {
 	pages.forEach( ( { id, component } ) => {
 		const root = document.getElementById( id );
 		if ( root ) {
-			createRoot(
-				root.insertBefore( document.createElement( 'div' ), null )
-			).render( component );
+			const newDiv = document.createElement( 'div' );
+			newDiv.className = 'wc-settings-prevent-change-event';
+			createRoot( root.insertBefore( newDiv, null ) ).render( component );
 		}
 	} );
 };

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1857,8 +1857,25 @@ class WooPaymentsService {
 		$step_pms_data = (array) $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_PAYMENT_METHODS, $location, 'payment_methods' );
 
 		$payment_methods_state = array();
+		$apple_pay_enabled     = false;
+		$google_pay_enabled    = false;
+
 		foreach ( $recommended_pms as $recommended_pm ) {
 			$pm_id = $recommended_pm['id'];
+
+			/**
+			 * We need to handle Apple Pay and Google Pay separately.
+			 * They are not stored in the same way as the other payment methods.
+			 */
+			if ( 'apple_pay' === $pm_id ) {
+				$apple_pay_enabled = $recommended_pm['enabled'];
+				continue;
+			}
+
+			if ( 'google_pay' === $pm_id ) {
+				$google_pay_enabled = $recommended_pm['enabled'];
+				continue;
+			}
 
 			// Start with the recommended enabled state.
 			$payment_methods_state[ $pm_id ] = $recommended_pm['enabled'];
@@ -1874,6 +1891,12 @@ class WooPaymentsService {
 				$payment_methods_state[ $pm_id ] = filter_var( $step_pms_data[ $pm_id ], FILTER_VALIDATE_BOOLEAN );
 			}
 		}
+
+		// Combine Apple Pay and Google Pay into a single `apple_google` entry.
+		$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
+
+		// Optionally also respect stored state or forced requirements if needed here.
+		$payment_methods_state['apple_google'] = $apple_google_enabled;
 
 		return $payment_methods_state;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -824,6 +824,9 @@ class WooPaymentsService {
 
 		$selected_payment_methods = $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_PAYMENT_METHODS, $location, 'payment_methods', array() );
 
+		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
+		WC()->payment_gateways();
+
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
@@ -922,6 +925,9 @@ class WooPaymentsService {
 
 		// Clear any previous failed status for the step.
 		$this->clear_onboarding_step_failed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
+
+		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
+		WC()->payment_gateways();
 
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
@@ -1027,6 +1033,9 @@ class WooPaymentsService {
 	public function finish_onboarding_kyc_session( string $location, string $source = '' ): array {
 		$this->check_if_onboarding_step_action_is_acceptable( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location );
 
+		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
+		WC()->payment_gateways();
+
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
@@ -1131,6 +1140,9 @@ class WooPaymentsService {
 	public function reset_onboarding( string $from = '', string $source = '' ): array {
 		$this->check_if_onboarding_action_is_acceptable();
 
+		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
+		WC()->payment_gateways();
+
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
@@ -1199,6 +1211,9 @@ class WooPaymentsService {
 	 */
 	public function disable_test_account( string $location, string $from = '', string $source = '' ): array {
 		$this->check_if_onboarding_action_is_acceptable();
+
+		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
+		WC()->payment_gateways();
 
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1504,7 +1504,7 @@ class WooPaymentsService {
 		// This is because WooPayments needs a working WPCOM connection to be able to fetch the fields.
 		if ( $this->check_onboarding_step_requirements( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location ) ) {
 			try {
-				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields();
+				$business_verification_step['context']['fields'] = $this->get_onboarding_kyc_fields( $location );
 			} catch ( Exception $e ) {
 				$business_verification_step['errors'][] = array(
 					'code'    => 'fields_error',
@@ -2014,10 +2014,13 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding fields data for the KYC business verification.
 	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is a ISO 3166-1 alpha-2 country code.
+	 *
 	 * @return array The onboarding fields data.
 	 * @throws Exception If the onboarding fields data could not be retrieved or there was an error.
 	 */
-	private function get_onboarding_kyc_fields(): array {
+	private function get_onboarding_kyc_fields( string $location ): array {
 		// Call the WooPayments API to get the onboarding fields.
 		$response = $this->proxy->call_static( Utils::class, 'rest_endpoint_get_request', '/wc/v3/payments/onboarding/fields' );
 
@@ -2035,6 +2038,8 @@ class WooPaymentsService {
 		if ( ! isset( $fields['available_countries'] ) && $this->proxy->call_function( 'is_callable', '\WC_Payments_Utils::supported_countries' ) ) {
 			$fields['available_countries'] = $this->proxy->call_static( '\WC_Payments_Utils', 'supported_countries' );
 		}
+
+		$fields['location'] = $location;
 
 		return $fields;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -708,9 +708,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 		$expected_pms_state      = array(
-			'card'       => true, // Force enabled because it is required.
-			'apple_pay'  => true,
-			'google_pay' => false,
+			'card'         => true, // Force enabled because it is required.
+			'apple_google' => true,
 		);
 
 		$default_wpcom_connection        = array(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsServiceTest.php
@@ -500,6 +500,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 							'electronics_and_computers' => 'digital_products__other_digital_goods',
 						),
 						'available_countries' => $this->get_woopayments_supported_countries(),
+						'location'            => $location,
 					) : array(),
 					'sub_steps'        => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['sub_steps'] ?? array(),
 					'self_assessment'  => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['self_assessment'] ?? array(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is a CFE with the following PRs cherry-picked:

- [[NOX In-Context] Fix the default country in the business step to match the selected one in NOX](https://github.com/woocommerce/woocommerce/pull/58190)
- [Fix browser alert when interacting with offline payment methods settings forms](https://github.com/woocommerce/woocommerce/pull/58189)
- [[NOX In-context] Fix KYC data not prefilled in NOX In-Context flow](https://github.com/woocommerce/woocommerce/pull/58211/files)
- [[NOX In-Context] Animate the progress bar during the test account initialization for better UX](https://github.com/woocommerce/woocommerce/pull/58243)
- [[NOX In-context] Ensure the Payment Gateways logic is Initialized in WooPayments API actions](https://github.com/woocommerce/woocommerce/pull/58233)
- [[NOX In-context] Remove the duplicate “Activate Payments” screens in NOX In-context flow](https://github.com/woocommerce/woocommerce/pull/58238)
- [[NOX In-context] Fix broken styles on recommended payment method step on Atomic site](https://github.com/woocommerce/woocommerce/pull/58250)

### How to test the changes in this Pull Request:

Testing instructions are included for each PR.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

No changelog is needed; this is a CFE for 9.9

</details>
