### PR TITLE
Fix test checking you can load the checkout template in the editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-checkout-editor-template-e2e-test
+++ b/plugins/woocommerce/changelog/fix-checkout-editor-template-e2e-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update e2e test to ensure checkout block template is loading

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -16,11 +16,8 @@ test.describe( 'Test the checkout template', () => {
 			postType: templateType,
 			canvas: 'edit',
 		} );
-		await expect(
-			editor.canvas.getByRole( 'button', {
-				name: 'Place Order',
-			} )
-		).toBeVisible();
+		const block = editor.canvas.getByLabel( 'Block: Checkout' );
+		await expect( block ).toBeVisible();
 	} );
 
 	test( 'Template can be accessed from the page editor', async ( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updated the query for the test `Test the checkout template > Template can be opened in the site editor` to check for the checkout blocks existence using `editor.canvas.getByLabel( 'Block: Checkout' )` instead of the Place Order inner block. Its also the most top level block so a more reliable indicator the checkout template has loaded. This is a utility widely used in the E2E tests to check for the existence of blocks.

Closes https://github.com/woocommerce/woocommerce/issues/50731
Closes [WOOPLUG-2504](https://linear.app/a8c/issue/WOOPLUG-2504/flaky-test-template-can-be-opened-in-the-site-editor)

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review new query
2. Make sure CI passes

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
