### PR TITLE
[NOX in LYS] Generate a different Jetpack connection link for LYS

### DIFF
--- a/packages/js/data/src/woopayments-onboarding/resolvers.ts
+++ b/packages/js/data/src/woopayments-onboarding/resolvers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -14,12 +15,19 @@ import {
 	getOnboardingDataError,
 } from './actions';
 
-export function* getOnboardingData() {
+export function* getOnboardingData( source?: string | null ) {
 	yield getOnboardingDataRequest();
 
 	try {
+		let path = `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/onboarding`;
+
+		// Add source parameter if provided
+		if ( source ) {
+			path = addQueryArgs( path, { source } );
+		}
+
 		const response: OnboardingDataResponse = yield apiFetch( {
-			path: `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/onboarding`,
+			path,
 		} );
 
 		yield getOnboardingDataSuccess( response );

--- a/packages/js/data/src/woopayments-onboarding/selectors.ts
+++ b/packages/js/data/src/woopayments-onboarding/selectors.ts
@@ -4,8 +4,13 @@
 import { OnboardingState } from './types';
 import { WPDataSelector, WPDataSelectors } from '../types';
 
-export const getOnboardingData = ( state: OnboardingState ): OnboardingState =>
-	state;
+export const getOnboardingData = (
+	state: OnboardingState,
+	// This is only used to get the onboarding data from the store,
+	// and is not used to determine the current step.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	_source?: string | null
+): OnboardingState => state;
 
 export const isOnboardingDataRequestPending = (
 	state: OnboardingState

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
@@ -107,6 +107,7 @@ const LaunchStoreController = () => {
 				closeModal={ handlePaymentsClose }
 				onboardingSteps={ LYSPaymentsSteps }
 				urlStrategy={ lysUrlStrategy }
+				source="launch-your-store"
 			>
 				<SidebarContainer
 					className={ clsx( {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/data/onboarding-context.tsx
@@ -71,7 +71,8 @@ export const OnboardingProvider: React.FC< {
 	onboardingSteps: WooPaymentsProviderOnboardingStep[];
 	closeModal: () => void;
 	urlStrategy?: URLStrategy;
-} > = ( { children, onboardingSteps, closeModal, urlStrategy } ) => {
+	source?: string | null;
+} > = ( { children, onboardingSteps, closeModal, urlStrategy, source } ) => {
 	const history = getHistory();
 
 	// Use React state to manage steps and loading state
@@ -99,15 +100,17 @@ export const OnboardingProvider: React.FC< {
 	const { invalidateResolutionForStoreSelector: invalidatePaymentProviders } =
 		useDispatch( paymentSettingsStore );
 
-	// Initial data fetch from store
+	// Initial data fetch from store with source parameter
 	const { storeData, isStoreLoading } = useSelect(
 		( select ) => ( {
-			storeData: select( woopaymentsOnboardingStore ).getOnboardingData(),
+			storeData: select( woopaymentsOnboardingStore ).getOnboardingData(
+				source
+			),
 			isStoreLoading: select(
 				woopaymentsOnboardingStore
 			).isOnboardingDataRequestPending(),
 		} ),
-		[]
+		[ source ]
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsRestController.php
@@ -378,8 +378,10 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			$location = $this->payments->get_country();
 		}
 
+		$source = $request->get_param( 'source' );
+
 		try {
-			$onboarding_details = $this->woopayments->get_onboarding_details( $location, $this->get_rest_url_path( 'onboarding' ) );
+			$onboarding_details = $this->woopayments->get_onboarding_details( $location, $this->get_rest_url_path( 'onboarding' ), $source );
 		} catch ( ApiException $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1443,15 +1443,27 @@ class WooPaymentsService {
 		// If the WPCOM connection is already set up, we don't need to add anything more.
 		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $wpcom_step['status'] ) {
 			// Craft the return URL.
-			// By default, we return the user to the onboarding modal.
-			$return_url = $this->proxy->call_static(
-				Utils::class,
-				'wc_payments_settings_url',
-				self::ONBOARDING_PATH_BASE,
-				array(
-					'wpcom_connection_return' => '1', // URL query flag so we can properly identify when the user returns.
-				)
-			);
+			switch($source) {
+				case 'launch-your-store':
+					// If the source is 'launch-your-store', we return the user to the Launch Your Store flow.
+					$return_url = $this->proxy->call_function(
+						'admin_url',
+						'admin.php?page=wc-admin&path=/launch-your-store' . self::ONBOARDING_PATH_BASE . '&sidebar=hub&content=payments&wpcom_connection_return=1'
+					);
+					break;
+				default:
+					// By default, we return the user to the onboarding modal in the Settings > Payments page.
+					$return_url = $this->proxy->call_static(
+						Utils::class,
+						'wc_payments_settings_url',
+						self::ONBOARDING_PATH_BASE,
+						array(
+							'wpcom_connection_return' => '1', // URL query flag so we can properly identify when the user returns.
+						)
+					);
+					break;
+			}
+
 			// Try to generate the authorization URL.
 			$wpcom_connection = $this->get_wpcom_connection_authorization( $return_url );
 			if ( ! $wpcom_connection['success'] ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -1443,7 +1443,7 @@ class WooPaymentsService {
 		// If the WPCOM connection is already set up, we don't need to add anything more.
 		if ( self::ONBOARDING_STEP_STATUS_COMPLETED !== $wpcom_step['status'] ) {
 			// Craft the return URL.
-			switch($source) {
+			switch ( $source ) {
 				case 'launch-your-store':
 					// If the source is 'launch-your-store', we return the user to the Launch Your Store flow.
 					$return_url = $this->proxy->call_function(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentProviders/WooPayments/WooPaymentsService.php
@@ -120,15 +120,16 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding details for the settings page.
 	 *
-	 * @param string $location  The location for which we are onboarding.
-	 *                          This is a ISO 3166-1 alpha-2 country code.
-	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
+	 * @param string      $location  The location for which we are onboarding.
+	 *                               This is a ISO 3166-1 alpha-2 country code.
+	 * @param string      $rest_path The REST API path to use for constructing REST API URLs.
+	 * @param string|null $source    Optional. The source for the onboarding flow.
 	 *
 	 * @return array The onboarding details.
 	 * @throws ApiException If the onboarding action can not be performed due to the current state of the site.
 	 * @throws Exception If there were errors when generating the onboarding details.
 	 */
-	public function get_onboarding_details( string $location, string $rest_path ): array {
+	public function get_onboarding_details( string $location, string $rest_path, ?string $source = null ): array {
 		// Since getting the onboarding details is not idempotent, we will check it as an action.
 		$this->check_if_onboarding_action_is_acceptable();
 
@@ -140,7 +141,7 @@ class WooPaymentsService {
 				'test_mode' => $this->provider->is_in_test_mode_onboarding( $this->get_payment_gateway() ),
 				'dev_mode'  => $this->provider->is_in_dev_mode( $this->get_payment_gateway() ),
 			),
-			'steps'   => $this->get_onboarding_steps( $location, trailingslashit( $rest_path ) . 'step' ),
+			'steps'   => $this->get_onboarding_steps( $location, trailingslashit( $rest_path ) . 'step', $source ),
 			'context' => array(
 				'urls' => array(
 					'overview_page' => $this->get_overview_page_url(),
@@ -1389,14 +1390,15 @@ class WooPaymentsService {
 	/**
 	 * Get the onboarding details for each step.
 	 *
-	 * @param string $location  The location for which we are onboarding.
-	 *                          This is a ISO 3166-1 alpha-2 country code.
-	 * @param string $rest_path The REST API path to use for constructing REST API URLs.
+	 * @param string      $location  The location for which we are onboarding.
+	 *                               This is a ISO 3166-1 alpha-2 country code.
+	 * @param string      $rest_path The REST API path to use for constructing REST API URLs.
+	 * @param string|null $source    Optional. The source for the onboarding flow.
 	 *
 	 * @return array[] The list of onboarding steps details.
 	 * @throws Exception If there was an error generating the onboarding steps details.
 	 */
-	private function get_onboarding_steps( string $location, string $rest_path ): array {
+	private function get_onboarding_steps( string $location, string $rest_path, ?string $source = null ): array {
 		$steps = array();
 
 		// Add the payment methods onboarding step details.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When using NOX, we assumed that the only way to access the flow was through the `Settings > Payments` screen. The return URL we had is for that screen.

For LYS, we want to redirect to the LYS flow to continue the onboarding.

Closes WOOPLUG-4407
Closes #58281 

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new Jurassic Ninja site with WooCommerce Beta on this branch
2. Once ready, skip the onboarding and choose a country with WooPayments (like UK)
3. Go to `Settings > Payments` and click Install on WooPayments to get the latest version. You can skip this step if you have already selected it in JN.
4. **Make sure to override the payment task status**. Go to `Tools > Plugin File Editor`, select WooCommerce, and open this file `src/Admin/Features/OnboardingTasks/Tasks/Payments.php`. Return `false` from `is_complete()` and return `''` from `get_action_url()`.
5. Go to `WooCommerce > Home` and click `Launch your store`
6. Click `Get paid`
7. Click `Continue` on the first step, and you'll reach the WP.com connection step
8. Click on the connect button and go to Jetpack
9. After finishing the login, make sure you're redirected back to the LYS flow instead of the Settings page

Here's a video of the process:

https://github.com/user-attachments/assets/b4bed45e-2f13-4f44-bea0-527d877abf6c

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR will not be merged into trunk. No changelog required

</details>
