### PR TITLE
Show DB update nudge when auto-updates fail to be scheduled

### DIFF
--- a/plugins/woocommerce/changelog/auto-db-update-error-handling
+++ b/plugins/woocommerce/changelog/auto-db-update-error-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show db update nudge when auto updates fail.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Starting 9.9, db updates will be applied automatically but, in the past, we've seen that some sites have missing Action Scheduler tables, which would prevent the actions from being scheduled. This isn't any different from before, with manual updates, but that the nudge wouldn't go away even after clicking **Update WooCommerce Database** would at least be indicative of an issue. With automatic updates, things can fail silently.

Even though we've introduced some logging, it'd be best to make it clear that the updates haven't run. As such, this PR makes sure the "update required" notice is shown when automatic updates have failed for some reason (most likely missing Action Scheduler tables).

**Note:** Our installer needs some work. We've also noticed some issues with it (for example as part of #57256) but for this CFE, I went with a simple approach until we can do some refactoring.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Activate the following snippet (for example by dropping it as a .php in `wp-content/mu-plugins`):
   ```php
   <?php
   add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
   add_action( 'init', fn () => remove_action( ActionScheduler_QueueRunner::WP_CRON_HOOK, [ ActionScheduler_QueueRunner::instance(), 'run' ] ) );
   ```
   This will prevent Action Scheduler from automatically running actions, allowing us to test more easily.

#### Happy path
1. Run the following commands to simulate a db update:
   ```
   wp db query "DELETE FROM $(wp db prefix)wc_admin_notes WHERE name='wc-update-db-reminder'"
   wp transient delete wc_installing
   wp option set woocommerce_db_version 9.8.0 && wp option set woocommerce_version 9.8.0
   ```
1. Go to **Plugins**. No nudge about updates should be shown.
1. Go to **Tools > Scheduled Actions > Pending** and you should see that the db updates for 9.9 should've been enqueued automatically. These have hook name `woocommerce_run_update_callback` and `woocommerce_update_db_to_current_version`.
1. Go to **WC > Status > Logs > wc-updater** and you should see the following entries:
   <img width="491" alt="Screenshot 2025-05-28 at 10 30 54" src="https://github.com/user-attachments/assets/0d02c8d3-8a8a-4efa-a3d2-093df00ad683" />
1. Run `wp action-scheduler run --hooks=woocommerce_run_update_callback,woocommerce_update_db_to_current_version` to execute the actions.


#### Broken Action Scheduler
1. To simulate a "broken" Action-Scheduler without manually removing tables, add the following code to your snippet:
   ```php
   add_filter(
	   'pre_as_schedule_single_action',
	   fn( $pre, $timestamp, $hook ) => in_array( $hook, [ 'woocommerce_run_update_callback', 'woocommerce_update_db_to_current_version' ], true ) ? 0 : $pre,
	   10,
	   3
   );
   ```
1. Run the following commands to simulate a db update:
   ```
   wp db query "DELETE FROM $(wp db prefix)wc_admin_notes WHERE name='wc-update-db-reminder'"
   wp transient delete wc_installing
   wp option set woocommerce_db_version 9.8.0 && wp option set woocommerce_version 9.8.0
   ```
1. Go to **WC > Status > Logs > wc-updater** and you should see the following entry:
   <img width="678" alt="Screenshot 2025-05-28 at 10 35 36" src="https://github.com/user-attachments/assets/f22090ef-2c7e-47d7-81bd-5e36d1900504" />
1. Go to **Plugins**. The database update nudge should now show:
   <img width="727" alt="Screenshot 2025-05-28 at 10 37 45" src="https://github.com/user-attachments/assets/e84adaf1-6375-405d-914c-b82d5ea5e723" />
1. Click **Update WooCommerce database**.
1. Go to **Tools > Scheduled Actions > Pending** and confirm no db updates for 9.9 were enqueued.
1. Remove the snippet from step 1 to simulate A-S having been fixed.
1. Go to **Plugins** and click **Update WooCommerce database**.
1. Go to **Tools > Scheduled Actions > Pending** and confirm db updates were now scheduled. These have hook name `woocommerce_run_update_callback` and `woocommerce_update_db_to_current_version`.
1. Run `wp action-scheduler run --hooks=woocommerce_run_update_callback,woocommerce_update_db_to_current_version` to execute the actions.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
