### PR TITLE
Update URLs in “please moderate [Product name]” emails

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1139-update-urls-in-please-moderate-product-name-emails
+++ b/plugins/woocommerce/changelog/wooplug-1139-update-urls-in-please-moderate-product-name-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix URLs in “please moderate [Product name]” emails

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -59,6 +59,9 @@ class WC_Comments {
 		// Exclude product reviews from general comments.
 		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 2 );
 
+		// Initialize ReviewsUtil hooks.
+		ReviewsUtil::init();
+
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
 

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -59,7 +59,7 @@ class WC_Comments {
 		// Exclude product reviews from general comments.
 		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 2 );
 
-		//Modifies the moderation URLs in the email notifications for product reviews.
+		// Modifies the moderation URLs in the email notifications for product reviews.
 		add_filter( 'comment_moderation_text', array( ReviewsUtil::class, 'modify_product_review_moderation_urls' ), 10, 2 );
 
 		// Count comments.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -59,8 +59,8 @@ class WC_Comments {
 		// Exclude product reviews from general comments.
 		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 2 );
 
-		// Initialize ReviewsUtil hooks.
-		ReviewsUtil::init();
+		//Modifies the moderation URLs in the email notifications for product reviews.
+		add_filter( 'comment_moderation_text', array( ReviewsUtil::class, 'modify_product_review_moderation_urls' ), 10, 2 );
 
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -17,15 +17,15 @@ class ReviewsUtil {
 	public static function modify_product_review_moderation_urls( $message, $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		// Only modify URLs for product reviews
+		// Only modify URLs for product reviews.
 		if ( ! $comment || get_post_type( $comment->comment_post_ID ) !== 'product' ) {
 			return $message;
 		}
 
-		// Replace the WordPress comment moderation URLs with WooCommerce product review URLs
+		// Replace the WordPress comment moderation URLs with WooCommerce product review URLs.
 		$product_reviews_url = admin_url( 'edit.php?post_type=product&page=product-reviews' );
 
-		// Replace the moderation panel URL (this is the "show all reviews pending" link)
+		// Replace the moderation panel URL (this is the "show all reviews pending" link).
 		$message = str_replace(
 			admin_url( 'edit-comments.php?comment_status=moderated#wpbody-content' ),
 			$product_reviews_url . '&comment_status=moderated',
@@ -35,7 +35,12 @@ class ReviewsUtil {
 		return $message;
 	}
 
-	public static function init() {
+	/**
+	 * Initialize hooks for modifying product review moderation URLs.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 */
+	final public static function init() {
 		add_filter( 'comment_moderation_text', array( __CLASS__, 'modify_product_review_moderation_urls' ), 10, 2 );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -36,15 +36,6 @@ class ReviewsUtil {
 	}
 
 	/**
-	 * Initialize hooks for modifying product review moderation URLs.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 */
-	final public static function init() {
-		add_filter( 'comment_moderation_text', array( __CLASS__, 'modify_product_review_moderation_urls' ), 10, 2 );
-	}
-
-	/**
 	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
 	 *
 	 * @param array|mixed       $clauses A compacted array of comment query clauses.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -8,6 +8,38 @@ namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 class ReviewsUtil {
 
 	/**
+	 * Modifies the moderation URLs in the email notifications for product reviews.
+	 *
+	 * @param string $message The email notification message.
+	 * @param int    $comment_id The comment ID.
+	 * @return string The modified email notification message.
+	 */
+	public static function modify_product_review_moderation_urls( $message, $comment_id ) {
+		$comment = get_comment( $comment_id );
+
+		// Only modify URLs for product reviews
+		if ( ! $comment || get_post_type( $comment->comment_post_ID ) !== 'product' ) {
+			return $message;
+		}
+
+		// Replace the WordPress comment moderation URLs with WooCommerce product review URLs
+		$product_reviews_url = admin_url( 'edit.php?post_type=product&page=product-reviews' );
+
+		// Replace the moderation panel URL (this is the "show all reviews pending" link)
+		$message = str_replace(
+			admin_url( 'edit-comments.php?comment_status=moderated#wpbody-content' ),
+			$product_reviews_url . '&comment_status=moderated',
+			$message
+		);
+
+		return $message;
+	}
+
+	public static function init() {
+		add_filter( 'comment_moderation_text', array( __CLASS__, 'modify_product_review_moderation_urls' ), 10, 2 );
+	}
+
+	/**
 	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
 	 *
 	 * @param array|mixed       $clauses A compacted array of comment query clauses.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This commit resolves an issue where the moderation URLs in email notifications for product reviews incorrectly pointed to the WordPress comment moderation page instead of the WooCommerce product reviews page.

Now, when moderators receive emails about new product reviews, the “show all reviews pending” link correctly points to:
/wp-admin/edit.php?post_type=product&page=product-reviews&comment_status=moderated

Instead of the incorrect:
/wp-admin/edit-comments.php?comment_status=moderated#wpbody-content


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #37270 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1674" alt="Markup 2025-05-27 at 14 44 48" src="https://github.com/user-attachments/assets/feec6493-cc9b-4254-b726-622e7d96293c" />    |    <img width="1874" alt="Markup 2025-05-27 at 14 38 16" src="https://github.com/user-attachments/assets/d8aa2900-3b65-478e-a407-880bf03ec75a" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up Discussion in **Settings → Discussion**
   a. ✔ Allow people to submit comments on new posts
   b. ✔ Anyone posts a comment
   c. ✔ A comment is held for moderation
   d. ✔ Comment must be manually approved
3. Enable Product Reviews in **WooCommerce → Settings → Products**
4. Open any Product detaill in the Shop frontend
5. Go to the review section
6. Submit any review
7. Open the admin email inbox and observe the link at the bottom

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
