### PR TITLE
Make Stock Indicator block show the stock status of variable products when stock is managed at the product level

### DIFF
--- a/plugins/woocommerce/changelog/fix-58026-variable-products-stock-indicator
+++ b/plugins/woocommerce/changelog/fix-58026-variable-products-stock-indicator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Make Stock Indicator block show the stock status of variable products when stock is managed at the product level

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -25,15 +25,15 @@ class ProductAvailabilityUtils {
 			return $product_availability;
 		}
 
-		// If the product is a variable product, check if it has any available variations.
-		// We will show a custom availability message if it does.
-		if ( $product->get_type() === ProductType::VARIABLE ) {
+		$product_availability = $product->get_availability();
+		// If the product is a variable product and availability isn't controlled
+		// at the parent product level, check if any of its variations is in stock.
+		// We will show a custom availability message if all variations are out of stock.
+		if ( ! $product_availability && $product->get_type() === ProductType::VARIABLE ) {
 			if ( ! $product->has_available_variations() ) {
 				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}
-		} else {
-			$product_availability = $product->get_availability();
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58026.

(For Bug Fixes) Bug introduced in PR #54156.

This PR makes it so the _Stock Indicator_ block checks `$product->get_availability()` for variable products too and only in the case it's missing it checks for the variations stock status. This fixes the case that stock availability is set at the product-level and not variation-level.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates and edit the _Product Catalog_ and _Single Product_ templates. Add the _Product Stock Indicator_ block in both of them.
2. Set a variable product as out of stock by checking _Track stock quantity for this product_ and setting the _Quantity_ to 0:

![imatge](https://github.com/user-attachments/assets/1930bd7f-a06f-453d-8793-f3d4810b0e23)

3. In the frontend, verify the _Product Stock Indicator_ block displays _Out of stock_ as expected:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/02b1d273-bb4d-4cae-86de-dbd68498d47d) | ![imatge](https://github.com/user-attachments/assets/543dcc61-54c8-4f13-a4b0-1a39fc7ea1ae)
![imatge](https://github.com/user-attachments/assets/9cc65a0b-addd-428c-a158-219a3c42a65c) | ![imatge](https://github.com/user-attachments/assets/afe7343d-85b4-426b-9cf7-bcffb84fb7e4)
