### PR TITLE
Fix flaky emails tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-flaky-email-tests
+++ b/plugins/woocommerce/changelog/fix-flaky-email-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a fix for a flaky e2e test
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/account-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/account-emails.spec.js
@@ -1,8 +1,4 @@
 /* eslint-disable playwright/expect-expect */
-/**
- * External dependencies
- */
-import { request } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -11,8 +7,8 @@ import { getFakeCustomer } from '../../utils/data';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { expectEmail, expectEmailContent } from '../../utils/email';
-import { setOption, deleteOption } from '../../utils/options';
 import { WC_API_PATH } from '../../utils/api-client';
+import { setFeatureEmailImprovementsFlag } from './helpers/set-email-improvements-feature-flag';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -31,17 +27,7 @@ const test = baseTest.extend( {
 } );
 
 test.beforeEach( async ( { baseURL } ) => {
-	await setOption(
-		request,
-		baseURL,
-		'woocommerce_feature_email_improvements_enabled',
-		'no'
-	);
-	await deleteOption(
-		request,
-		baseURL,
-		'_transient_wc_settings_email_improvements_reverted'
-	);
+	await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 } );
 
 test.skip(

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/account-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/account-emails.spec.js
@@ -11,7 +11,7 @@ import { getFakeCustomer } from '../../utils/data';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { expectEmail, expectEmailContent } from '../../utils/email';
-import { setOption } from '../../utils/options';
+import { setOption, deleteOption } from '../../utils/options';
 import { WC_API_PATH } from '../../utils/api-client';
 
 const test = baseTest.extend( {
@@ -36,6 +36,11 @@ test.beforeEach( async ( { baseURL } ) => {
 		baseURL,
 		'woocommerce_feature_email_improvements_enabled',
 		'no'
+	);
+	await deleteOption(
+		request,
+		baseURL,
+		'_transient_wc_settings_email_improvements_reverted'
 	);
 } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/helpers/set-email-improvements-feature-flag.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/helpers/set-email-improvements-feature-flag.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { request } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { setOption, deleteOption } from '../../../utils/options';
+
+/**
+ * Set the feature flag for email improvements feature.
+ *
+ * @param {string} baseURL The base URL.
+ * @param {string} value   The value to set ('yes' or 'no').
+ * @return {Promise<void>}
+ */
+export const setFeatureEmailImprovementsFlag = async ( baseURL, value ) => {
+	await setOption(
+		request,
+		baseURL,
+		'woocommerce_feature_email_improvements_enabled',
+		value
+	);
+	// We need to delete the transient to prevent unwanted popups.
+	await deleteOption(
+		request,
+		baseURL,
+		'_transient_wc_settings_email_improvements_reverted'
+	);
+};

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { faker } from '@faker-js/faker';
-import { request } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -12,8 +11,8 @@ import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { admin } from '../../test-data/data';
 import { expectEmail, expectEmailContent } from '../../utils/email';
-import { setOption, deleteOption } from '../../utils/options';
 import { WC_API_PATH } from '../../utils/api-client';
+import { setFeatureEmailImprovementsFlag } from './helpers/set-email-improvements-feature-flag';
 
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
@@ -41,17 +40,7 @@ const test = baseTest.extend( {
 } );
 
 test.beforeEach( async ( { baseURL } ) => {
-	await setOption(
-		request,
-		baseURL,
-		'woocommerce_feature_email_improvements_enabled',
-		'no'
-	);
-	await deleteOption(
-		request,
-		baseURL,
-		'_transient_wc_settings_email_improvements_reverted'
-	);
+	await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 } );
 
 [

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/order-emails.spec.js
@@ -12,7 +12,7 @@ import { ADMIN_STATE_PATH } from '../../playwright.config';
 import { expect, test as baseTest } from '../../fixtures/fixtures';
 import { admin } from '../../test-data/data';
 import { expectEmail, expectEmailContent } from '../../utils/email';
-import { setOption } from '../../utils/options';
+import { setOption, deleteOption } from '../../utils/options';
 import { WC_API_PATH } from '../../utils/api-client';
 
 const test = baseTest.extend( {
@@ -46,6 +46,11 @@ test.beforeEach( async ( { baseURL } ) => {
 		baseURL,
 		'woocommerce_feature_email_improvements_enabled',
 		'no'
+	);
+	await deleteOption(
+		request,
+		baseURL,
+		'_transient_wc_settings_email_improvements_reverted'
 	);
 } );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -6,29 +6,9 @@ const { test, expect, request } = require( '@playwright/test' );
 /**
  * Internal dependencies
  */
-import { setOption, deleteOption } from '../../utils/options';
+import { setOption } from '../../utils/options';
+import { setFeatureEmailImprovementsFlag } from './helpers/set-email-improvements-feature-flag';
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
-
-/**
- * Set the email improvements feature flag.
- *
- * @param {string} baseURL The base URL.
- * @param {string} value   The value to set ('yes' or 'no').
- * @return {Promise<void>}
- */
-const setFeatureFlag = async ( baseURL, value ) => {
-	await setOption(
-		request,
-		baseURL,
-		'woocommerce_feature_email_improvements_enabled',
-		value
-	);
-	await deleteOption(
-		request,
-		baseURL,
-		'_transient_wc_settings_email_improvements_reverted'
-	);
-};
 
 /**
  * Set the email auto-sync feature flag.
@@ -50,7 +30,7 @@ test.describe( 'Email Style Sync', () => {
 
 	test.beforeEach( async ( { baseURL } ) => {
 		// Enable email improvements feature
-		await setFeatureFlag( baseURL, 'yes' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'yes' );
 		// Ensure auto-sync is enabled by default
 		await setAutoSyncFlag( baseURL, 'yes' );
 		// Ensure color palette is not synced with theme
@@ -64,7 +44,7 @@ test.describe( 'Email Style Sync', () => {
 
 	test.afterAll( async ( { baseURL } ) => {
 		// Reset feature flags after tests
-		await setFeatureFlag( baseURL, 'no' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 		await setAutoSyncFlag( baseURL, 'no' );
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
 const { test, expect, request } = require( '@playwright/test' );
-const { setOption } = require( '../../utils/options' );
+
+/**
+ * Internal dependencies
+ */
+import { setOption, deleteOption } from '../../utils/options';
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 
 /**
@@ -9,13 +16,19 @@ const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
  * @param {string} value   The value to set ('yes' or 'no').
  * @return {Promise<void>}
  */
-const setFeatureFlag = async ( baseURL, value ) =>
+const setFeatureFlag = async ( baseURL, value ) => {
 	await setOption(
 		request,
 		baseURL,
 		'woocommerce_feature_email_improvements_enabled',
 		value
 	);
+	await deleteOption(
+		request,
+		baseURL,
+		'_transient_wc_settings_email_improvements_reverted'
+	);
+};
 
 /**
  * Set the email auto-sync feature flag.

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
@@ -1,21 +1,11 @@
-const { test, expect, request } = require( '@playwright/test' );
-const { setOption, deleteOption } = require( '../../utils/options' );
+/**
+ * Internal dependencies
+ */
+import { setFeatureEmailImprovementsFlag } from './helpers/set-email-improvements-feature-flag';
+
+const { test, expect } = require( '@playwright/test' );
 const { tags } = require( '../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
-
-const setFeatureFlag = async ( baseURL, value ) => {
-	await setOption(
-		request,
-		baseURL,
-		'woocommerce_feature_email_improvements_enabled',
-		value
-	);
-	await deleteOption(
-		request,
-		baseURL,
-		'_transient_wc_settings_email_improvements_reverted'
-	);
-};
 
 const pickImageFromLibrary = async ( page, imageName ) => {
 	await page.getByRole( 'tab', { name: 'Media Library' } ).click();
@@ -29,11 +19,11 @@ test.describe( 'WooCommerce Email Settings', () => {
 	const storeName = 'WooCommerce Core E2E Test Suite';
 
 	test.afterAll( async ( { baseURL } ) => {
-		await setFeatureFlag( baseURL, 'no' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 	} );
 
 	test( 'See email preview', async ( { page, baseURL } ) => {
-		await setFeatureFlag( baseURL, 'no' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 		const emailPreviewElement =
 			'#wc_settings_email_preview_slotfill iframe';
 		const emailSubjectElement = '.wc-settings-email-preview-header-subject';
@@ -78,7 +68,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 		'Email sender options live change in email preview',
 		{ tag: [ tags.COULD_BE_LOWER_LEVEL_TEST ] },
 		async ( { page, baseURL } ) => {
-			await setFeatureFlag( baseURL, 'no' );
+			await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 			await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 			const fromNameElement = '#woocommerce_email_from_name';
@@ -122,7 +112,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 		'Live preview when changing email settings',
 		{ tag: tags.SKIP_ON_EXTERNAL_ENV },
 		async ( { page, baseURL } ) => {
-			await setFeatureFlag( baseURL, 'no' );
+			await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 			await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 			// Wait for the iframe content to load
@@ -183,7 +173,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 	);
 
 	test( 'Send email preview', async ( { page, baseURL } ) => {
-		await setFeatureFlag( baseURL, 'no' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'no' );
 		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 		// Click the "Send a test email" button
@@ -404,7 +394,7 @@ test.describe( 'WooCommerce Email Settings', () => {
 	} ) => {
 		const resetButtonElement = '.wc-settings-email-color-palette-buttons';
 
-		await setFeatureFlag( baseURL, 'yes' );
+		await setFeatureEmailImprovementsFlag( baseURL, 'yes' );
 		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=email' );
 
 		await expect( page.locator( resetButtonElement ) ).toBeVisible();

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email.spec.js
@@ -1,15 +1,21 @@
 const { test, expect, request } = require( '@playwright/test' );
-const { setOption } = require( '../../utils/options' );
+const { setOption, deleteOption } = require( '../../utils/options' );
 const { tags } = require( '../../fixtures/fixtures' );
 const { ADMIN_STATE_PATH } = require( '../../playwright.config' );
 
-const setFeatureFlag = async ( baseURL, value ) =>
+const setFeatureFlag = async ( baseURL, value ) => {
 	await setOption(
 		request,
 		baseURL,
 		'woocommerce_feature_email_improvements_enabled',
 		value
 	);
+	await deleteOption(
+		request,
+		baseURL,
+		'_transient_wc_settings_email_improvements_reverted'
+	);
+};
 
 const pickImageFromLibrary = async ( page, imageName ) => {
 	await page.getByRole( 'tab', { name: 'Media Library' } ).click();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes flaky e2e tests:
- tests/e2e-pw/tests/email/settings-email-style-sync.spec.js
- tests/e2e-pw/tests/email/settings-email.spec.js

There was an issue caused by a modal with a questionnaire. In this PR, we delete the transient triggering the modal before each test


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

N/A

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
