### PR TITLE
[NOX in LYS] Multiple design tweaks to the NOX

### DIFF
--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.scss
@@ -9,7 +9,7 @@
 		border: none;
 		width: 100%;
 		height: 100%;
-		border-radius: 20px;
+		border-radius: 10px;
 		box-shadow: 0 15px 20px 0 rgba(0, 0, 0, 0.04), 0 13px 15px 0 rgba(0, 0, 0, 0.03), 0 6px 10px 0 rgba(0, 0, 0, 0.02), 0 0 1px 0 rgba(0, 0, 0, 0.25);
 		overflow-y: auto;
 	}

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -68,11 +68,6 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 		</Button>
 	);
 
-	const sidebarDescription = __(
-		'Set up WooPayments to start accepting payments in your store.',
-		'woocommerce'
-	);
-
 	return (
 		<div
 			className={ clsx(
@@ -92,10 +87,7 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 					className="woocommerce-edit-site-layout__hub"
 				/>
 			</motion.div>
-			<SidebarContainer
-				title={ sidebarTitle }
-				description={ sidebarDescription }
-			>
+			<SidebarContainer title={ sidebarTitle }>
 				{ /* We are using these classes to inherit the styles from the edit your store styling */ }
 				<div className="woocommerce-edit-site-sidebar-navigation-screen-essential-tasks__group-header">
 					<Heading level={ 2 }>

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -34,24 +34,6 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 		isLoading,
 	} = useOnboardingContext();
 
-	// Store the initial uncompleted step IDs on first render
-	const initialUncompletedStepIds = React.useRef< string[] | null >( null );
-
-	// Only set the initial uncompleted step IDs if there are backend steps.
-	if (
-		initialUncompletedStepIds.current === null &&
-		allSteps?.some( ( step ) => step.type === 'backend' )
-	) {
-		initialUncompletedStepIds.current = allSteps
-			.filter( ( step ) => step.status !== 'completed' )
-			.map( ( step ) => step.id );
-	}
-
-	// Only show steps that were uncompleted on first render
-	const stepsToDisplay = allSteps.filter( ( step ) =>
-		initialUncompletedStepIds.current?.includes( step.id )
-	);
-
 	const currentStepIndex = allSteps.findIndex(
 		( step ) => step.id === currentStep?.id
 	);
@@ -106,7 +88,7 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 							animate={ { opacity: 1, y: 0 } }
 							transition={ { duration: 0.7, delay: 0.2 } }
 						>
-							{ stepsToDisplay.map( ( step ) => (
+							{ allSteps.map( ( step ) => (
 								<SidebarNavigationItem
 									key={ step.id }
 									className={ clsx( step.id, {

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -90,32 +90,48 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 			<SidebarContainer title={ sidebarTitle }>
 				{ /* We are using these classes to inherit the styles from the edit your store styling */ }
 				<ItemGroup className="woocommerce-edit-site-sidebar-navigation-screen-essential-tasks__group">
-					{ isLoading && <StepPlaceholder rows={ 3 } /> }
-					{ ! isLoading &&
-						stepsToDisplay.map( ( step ) => (
-							<SidebarNavigationItem
-								key={ step.id }
-								className={ clsx( step.id, {
-									active: currentStep?.id === step.id,
-									'payment-step': true,
-									'payment-step--active':
-										currentStep?.id === step.id,
-									'payment-step--disabled':
-										currentStep?.id !== step.id,
-								} ) }
-								icon={
-									step.id === justCompletedStepId ||
-									step.status === 'completed' ||
-									currentStepIndex === allSteps.length
-										? taskIcons.completedPaymentStep
-										: taskIcons.activePaymentStep
-								}
-								disabled={ true }
-								showChevron={ false }
-							>
-								{ step.label }
-							</SidebarNavigationItem>
-						) ) }
+					{ isLoading && (
+						<motion.div
+							initial={ { opacity: 0 } }
+							animate={ { opacity: 1 } }
+							exit={ { opacity: 0 } }
+							transition={ { duration: 0.3 } }
+						>
+							<StepPlaceholder rows={ 3 } />
+						</motion.div>
+					) }
+					{ ! isLoading && (
+						<motion.div
+							initial={ { opacity: 0, y: 10 } }
+							animate={ { opacity: 1, y: 0 } }
+							transition={ { duration: 0.4, delay: 0.1 } }
+						>
+							{ stepsToDisplay.map( ( step ) => (
+								<SidebarNavigationItem
+									key={ step.id }
+									className={ clsx( step.id, {
+										active: currentStep?.id === step.id,
+										'payment-step': true,
+										'payment-step--active':
+											currentStep?.id === step.id,
+										'payment-step--disabled':
+											currentStep?.id !== step.id,
+									} ) }
+									icon={
+										step.id === justCompletedStepId ||
+										step.status === 'completed' ||
+										currentStepIndex === allSteps.length
+											? taskIcons.completedPaymentStep
+											: taskIcons.activePaymentStep
+									}
+									disabled={ true }
+									showChevron={ false }
+								>
+									{ step.label }
+								</SidebarNavigationItem>
+							) ) }
+						</motion.div>
+					) }
 				</ItemGroup>
 			</SidebarContainer>
 		</div>

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -24,12 +24,14 @@ import type { SidebarComponentProps } from '../xstate';
 import { SidebarContainer } from './sidebar-container';
 import { SiteHub } from '~/customize-store/assembler-hub/site-hub';
 import { taskIcons } from './icons';
+import { StepPlaceholder } from './step-placeholder';
 
 export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 	const {
 		steps: allSteps,
 		currentStep,
 		justCompletedStepId,
+		isLoading,
 	} = useOnboardingContext();
 
 	// Store the initial uncompleted step IDs on first render
@@ -88,30 +90,32 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 			<SidebarContainer title={ sidebarTitle }>
 				{ /* We are using these classes to inherit the styles from the edit your store styling */ }
 				<ItemGroup className="woocommerce-edit-site-sidebar-navigation-screen-essential-tasks__group">
-					{ stepsToDisplay.map( ( step ) => (
-						<SidebarNavigationItem
-							key={ step.id }
-							className={ clsx( step.id, {
-								active: currentStep?.id === step.id,
-								'payment-step': true,
-								'payment-step--active':
-									currentStep?.id === step.id,
-								'payment-step--disabled':
-									currentStep?.id !== step.id,
-							} ) }
-							icon={
-								step.id === justCompletedStepId ||
-								step.status === 'completed' ||
-								currentStepIndex === allSteps.length
-									? taskIcons.completedPaymentStep
-									: taskIcons.activePaymentStep
-							}
-							disabled={ true }
-							showChevron={ false }
-						>
-							{ step.label }
-						</SidebarNavigationItem>
-					) ) }
+					{ isLoading && <StepPlaceholder rows={ 3 } /> }
+					{ ! isLoading &&
+						stepsToDisplay.map( ( step ) => (
+							<SidebarNavigationItem
+								key={ step.id }
+								className={ clsx( step.id, {
+									active: currentStep?.id === step.id,
+									'payment-step': true,
+									'payment-step--active':
+										currentStep?.id === step.id,
+									'payment-step--disabled':
+										currentStep?.id !== step.id,
+								} ) }
+								icon={
+									step.id === justCompletedStepId ||
+									step.status === 'completed' ||
+									currentStepIndex === allSteps.length
+										? taskIcons.completedPaymentStep
+										: taskIcons.activePaymentStep
+								}
+								disabled={ true }
+								showChevron={ false }
+							>
+								{ step.label }
+							</SidebarNavigationItem>
+						) ) }
 				</ItemGroup>
 			</SidebarContainer>
 		</div>

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -102,9 +102,9 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 					) }
 					{ ! isLoading && (
 						<motion.div
-							initial={ { opacity: 0, y: 10 } }
+							initial={ { opacity: 0, y: 0 } }
 							animate={ { opacity: 1, y: 0 } }
-							transition={ { duration: 0.4, delay: 0.1 } }
+							transition={ { duration: 0.7, delay: 0.2 } }
 						>
 							{ stepsToDisplay.map( ( step ) => (
 								<SidebarNavigationItem

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -11,8 +11,6 @@ import clsx from 'clsx';
 import {
 	Button,
 	// @ts-ignore No types for this exist yet.
-	__experimentalHeading as Heading,
-	// @ts-ignore No types for this exist yet.
 	__experimentalItemGroup as ItemGroup,
 	// @ts-ignore No types for this exist yet.
 	__unstableMotion as motion,
@@ -89,11 +87,6 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 			</motion.div>
 			<SidebarContainer title={ sidebarTitle }>
 				{ /* We are using these classes to inherit the styles from the edit your store styling */ }
-				<div className="woocommerce-edit-site-sidebar-navigation-screen-essential-tasks__group-header">
-					<Heading level={ 2 }>
-						{ __( 'Setup your payments', 'woocommerce' ) }
-					</Heading>
-				</div>
 				<ItemGroup className="woocommerce-edit-site-sidebar-navigation-screen-essential-tasks__group">
 					{ stepsToDisplay.map( ( step ) => (
 						<SidebarNavigationItem

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -23,7 +23,7 @@ import { useOnboardingContext } from '~/settings-payments/onboarding/providers/w
 import type { SidebarComponentProps } from '../xstate';
 import { SidebarContainer } from './sidebar-container';
 import { SiteHub } from '~/customize-store/assembler-hub/site-hub';
-import { taskIcons } from './icons';
+import { taskIcons, taskCompleteIcon } from './icons';
 import { StepPlaceholder } from './step-placeholder';
 
 export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
@@ -88,30 +88,35 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 							animate={ { opacity: 1, y: 0 } }
 							transition={ { duration: 0.7, delay: 0.2 } }
 						>
-							{ allSteps.map( ( step ) => (
-								<SidebarNavigationItem
-									key={ step.id }
-									className={ clsx( step.id, {
-										active: currentStep?.id === step.id,
-										'payment-step': true,
-										'payment-step--active':
-											currentStep?.id === step.id,
-										'payment-step--disabled':
-											currentStep?.id !== step.id,
-									} ) }
-									icon={
-										step.id === justCompletedStepId ||
-										step.status === 'completed' ||
-										currentStepIndex === allSteps.length
-											? taskIcons.completedPaymentStep
-											: taskIcons.activePaymentStep
-									}
-									disabled={ true }
-									showChevron={ false }
-								>
-									{ step.label }
-								</SidebarNavigationItem>
-							) ) }
+							{ allSteps.map( ( step ) => {
+								const isStepComplete =
+									step.id === justCompletedStepId ||
+									step.status === 'completed' ||
+									currentStepIndex === allSteps.length;
+								return (
+									<SidebarNavigationItem
+										key={ step.id }
+										className={ clsx( step.id, {
+											active: currentStep?.id === step.id,
+											'payment-step': true,
+											'payment-step--active':
+												currentStep?.id === step.id,
+											'payment-step--disabled':
+												currentStep?.id !== step.id,
+											'is-complete': isStepComplete,
+										} ) }
+										icon={
+											isStepComplete
+												? taskCompleteIcon
+												: taskIcons.activePaymentStep
+										}
+										disabled={ true }
+										showChevron={ false }
+									>
+										{ step.label }
+									</SidebarNavigationItem>
+								);
+							} ) }
 						</motion.div>
 					) }
 				</ItemGroup>

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -64,7 +64,7 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 				} );
 			} }
 		>
-			{ __( 'Get paid', 'woocommerce' ) }
+			{ __( 'Set up WooPayments', 'woocommerce' ) }
 		</Button>
 	);
 

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/index.ts
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/index.ts
@@ -1,0 +1,1 @@
+export { StepPlaceholder } from './step-placeholder';

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
@@ -1,0 +1,36 @@
+.step-placeholder {
+	.step-placeholder__item {
+		display: flex;
+		align-items: center;
+		padding: 12px 16px;
+		border-radius: 2px;
+		margin-bottom: 4px;
+		background-color: transparent;
+		cursor: default;
+		border: 1.5px solid transparent;
+
+		&:hover {
+			background-color: transparent;
+		}
+
+		.step-placeholder__icon {
+			background-color: $gray-100;
+			border-radius: 4px;
+			width: 24px;
+			height: 24px;
+			margin-right: $gap-smaller;
+			flex-shrink: 0;
+		}
+
+		.step-placeholder__content {
+			width: 100%;
+		}
+
+		.step-placeholder__text {
+			background-color: $gray-100;
+			border-radius: 4px;
+			width: 100%;
+			height: 16px;
+		}
+	}
+} 

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
@@ -12,7 +12,7 @@
 	.step-placeholder__item {
 		display: flex;
 		align-items: center;
-		padding: 12px 16px;
+		padding: 8px 8px 8px 16px;
 		border-radius: 2px;
 		margin-bottom: 4px;
 		background-color: transparent;

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
@@ -45,19 +45,10 @@
 
 		// Shimmer effect for loading animation - seamless continuous loop
 		.step-placeholder__shimmer {
-			background: linear-gradient(
-				90deg,
-				$gray-200 0%,
-				$gray-200 20%,
-				$gray-100 40%,
-				$gray-100 50%,
-				$gray-100 60%,
-				$gray-200 80%,
-				$gray-200 100%
-			);
+			background: linear-gradient(90deg, $gray-200 0%, $gray-200 20%, $gray-100 40%, $gray-100 50%, $gray-100 60%, $gray-200 80%, $gray-200 100%);
 			background-size: 400px 100%;
 			animation: shimmer 2s infinite linear;
 			overflow: hidden;
 		}
 	}
-} 
+}

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.scss
@@ -1,3 +1,13 @@
+// Shimmer animation keyframes - seamless loop
+@keyframes shimmer {
+	0% {
+		background-position: -200px 0;
+	}
+	100% {
+		background-position: 200px 0;
+	}
+}
+
 .step-placeholder {
 	.step-placeholder__item {
 		display: flex;
@@ -31,6 +41,23 @@
 			border-radius: 4px;
 			width: 100%;
 			height: 16px;
+		}
+
+		// Shimmer effect for loading animation - seamless continuous loop
+		.step-placeholder__shimmer {
+			background: linear-gradient(
+				90deg,
+				$gray-200 0%,
+				$gray-200 20%,
+				$gray-100 40%,
+				$gray-100 50%,
+				$gray-100 60%,
+				$gray-200 80%,
+				$gray-200 100%
+			);
+			background-size: 400px 100%;
+			animation: shimmer 2s infinite linear;
+			overflow: hidden;
 		}
 	}
 } 

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.tsx
@@ -1,7 +1,12 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /**
  * External dependencies
  */
 import React from 'react';
+import {
+	// @ts-ignore No types for this exist yet.
+	__unstableMotion as motion,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,29 +21,45 @@ interface StepPlaceholderProps {
 }
 
 /**
- * A component that renders placeholder steps that match the structure of SidebarNavigationItem.
- * Each placeholder has an icon on the left and text content on the right.
+ * A component that renders animated placeholder steps that match the structure of SidebarNavigationItem.
+ * Each placeholder has an icon on the left and text content on the right with loading animations.
  * This component is typically used to indicate a loading state for payment steps.
  *
  * @example
- * // Render 3 placeholder steps
+ * // Render 3 animated placeholder steps
  * <StepPlaceholder rows={3} />
  */
 export const StepPlaceholder = ( { rows }: StepPlaceholderProps ) => {
 	// Create an array of placeholder items based on the number of rows.
 	const placeholderItems = Array.from( { length: rows } ).map(
 		( _, index ) => (
-			<div
+			<motion.div
 				key={ index }
 				className="step-placeholder__item payment-step payment-step--disabled"
+				initial={ { opacity: 0, x: -20 } }
+				animate={ { opacity: 1, x: 0 } }
+				transition={ {
+					duration: 0.3,
+					delay: index * 0.1, // Stagger the animation
+					ease: 'easeOut',
+				} }
 			>
-				<div className="step-placeholder__icon" />
+				<div className="step-placeholder__icon step-placeholder__shimmer" />
 				<div className="step-placeholder__content">
-					<div className="step-placeholder__text" />
+					<div className="step-placeholder__text step-placeholder__shimmer" />
 				</div>
-			</div>
+			</motion.div>
 		)
 	);
 
-	return <div className="step-placeholder">{ placeholderItems }</div>;
+	return (
+		<motion.div
+			className="step-placeholder"
+			initial={ { opacity: 0 } }
+			animate={ { opacity: 1 } }
+			transition={ { duration: 0.2 } }
+		>
+			{ placeholderItems }
+		</motion.div>
+	);
 };

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/step-placeholder/step-placeholder.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './step-placeholder.scss';
+
+interface StepPlaceholderProps {
+	/**
+	 * The number of placeholder steps to display.
+	 */
+	rows: number;
+}
+
+/**
+ * A component that renders placeholder steps that match the structure of SidebarNavigationItem.
+ * Each placeholder has an icon on the left and text content on the right.
+ * This component is typically used to indicate a loading state for payment steps.
+ *
+ * @example
+ * // Render 3 placeholder steps
+ * <StepPlaceholder rows={3} />
+ */
+export const StepPlaceholder = ( { rows }: StepPlaceholderProps ) => {
+	// Create an array of placeholder items based on the number of rows.
+	const placeholderItems = Array.from( { length: rows } ).map(
+		( _, index ) => (
+			<div
+				key={ index }
+				className="step-placeholder__item payment-step payment-step--disabled"
+			>
+				<div className="step-placeholder__icon" />
+				<div className="step-placeholder__content">
+					<div className="step-placeholder__text" />
+				</div>
+			</div>
+		)
+	);
+
+	return <div className="step-placeholder">{ placeholderItems }</div>;
+};

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
@@ -79,12 +79,4 @@ export const LYSPaymentsSteps: WooPaymentsProviderOnboardingStep[] = [
 		dependencies: [ 'wpcom_connection' ],
 		content: <BusinessVerificationStep />,
 	},
-	{
-		id: 'finish',
-		order: 5,
-		type: 'frontend',
-		label: 'Submit for verification',
-		dependencies: [ 'business_verification' ],
-		content: <FinishStep />,
-	},
 ];

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
@@ -73,7 +73,7 @@ export const LYSPaymentsSteps: WooPaymentsProviderOnboardingStep[] = [
 	},
 	{
 		id: 'business_verification',
-		order: 4,
+		order: 3,
 		type: 'backend',
 		label: 'Activate Payments',
 		dependencies: [ 'wpcom_connection' ],

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -33,7 +33,7 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Get paid', 'woocommerce' );
+		return __( 'Set up payments', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -33,7 +33,7 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Set up payments', 'woocommerce' );
+		return __( 'Get paid', 'woocommerce' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The following PR introduces multiple small fixes to the NOX inside LYS. Here's a recap of the changes:
- Reduce the border radius for NOX content 0829d529e604539fd96c69713a43fd5a55917120
- Remove the details from the sidebar to match the design 2cef7da7f0d90f2b4ae2b836476340682418e524
- Switch Get Paid with Set up WooPayments in the sidebar 7b6386bc636ed0d47f1d4ffb70784e2865ac9912
- Remove an extra heading from the sidebar to match the design 8b1d6c6cd3be67faa01fac3a38f2a9ff02e4d59c
- Remove an extra step in the NOX given it's not used 125d76fa60780f0e9fcfcc73f7daece005451762
- Add a placeholder to display when sub-steps are loading d4fa1b74d27688eb827d57c8d045cecbfe90e4bd
- Add placeholder animation 75873f87b099b1a7616ffcd27a1d33301bf71c93
- Add sub-steps ease in and placeholder ease out animation ff8affa6e11e615a27bcea35c42b6f059cb53000
- Adapt completed step styling to follow LYS designs 38f483971b7fbe342d6adb3911630103025518b8
- Remove the extra logic to display uncompleted steps only (now we show everything) 07295d771cd5f2d42efd02c2a9dfa6ebd430e875

Closes WOOPLUG-4404
Closes #58277
Closes WOOPLUG-4405
Closes #58278

A few screenshots:
![CleanShot 2025-05-29 at 10 33 25@2x](https://github.com/user-attachments/assets/2e49942c-7104-4c53-b985-3a4c85453441)


https://github.com/user-attachments/assets/df992c8d-8ba8-4c9d-991d-9ee6301f4f75


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get the current branch and build it locally
2. Make sure to apply [this diff](https://github.com/woocommerce/woocommerce/pull/58291#issuecomment-2909982706) to force NOX in LYS
3. Go to `WooCommerce > Home > Launch your store`
4. Click Get Paid
5. Make sure the sidebar matches the design: xO8YdpKfaVoP2d8NvweZ5I-fi-8521_197873
6. Make sure the sidebar steps match the design (ie no extra step is displayed)
7. Reload the page, and pay attention to the sidebar
8. Ensure that a placeholder is displayed while the data is loading. That will be replaced with the actual sub-steps once loaded.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

No changelog is needed for this, given that it will not be merged to trunk

</details>