### PR TITLE
Try: Add test coverage for Product Details Block Hooks Extensibility Point

### DIFF
--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -196,13 +196,17 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		add_filter( 'hooked_block_types', array( $hooked_block_types_introspection, 'filter' ), 20, 4 );
 
 		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
-		// This will apply the `woocommerce_product_details_hooked_blocks` filter defined above.
+		// This will add the `woocommerce_product_details_hooked_blocks` filter defined above.
 		$block_instance = new Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
 			$this->asset_api,
 			$this->registry,
 			$this->integration_registry,
 			'blockified-product-details-mock'
 		);
+
+		// Next, we apply the `hooked_block_types` filter. We pretend that we're in the `last_child` position
+		// of the `woocommerce/accordion-group` block.
+		apply_filters( 'hooked_block_types', array(), 'woocommerce/accordion-group', 'last_child' );
 
 		$this->assertSame( 1, $hooked_block_types_introspection->get_call_count() );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -175,20 +175,22 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 	}
 
 	public function test_hooked_block() {
-		$test_block = [
-			"slug" => "custom-info",
-			"title" => "Custom Info",
-			"content" =>
-				"<!-- wp:paragraph --><p>This is the content for the custom info tab.</p><!-- /wp:paragraph -->"
-		];
+		$test_block = array(
+			'slug'    => 'custom-info',
+			'title'   => 'Custom Info',
+			'content' => '<!-- wp:paragraph --><p>This is the content for the custom info tab.</p><!-- /wp:paragraph -->',
+		);
 
 		remove_all_filters( 'hooked_block_types' );
 		remove_all_filters( 'hooked_block_' . $test_block['slug'] );
 
-		add_filter( 'woocommerce_product_details_hooked_blocks', function ( $hooked_blocks ) use ( $test_block ) {
-			$hooked_blocks[] = $test_block;
-			return $hooked_blocks;
-		} );
+		add_filter(
+			'woocommerce_product_details_hooked_blocks',
+			function ( $hooked_blocks ) use ( $test_block ) {
+				$hooked_blocks[] = $test_block;
+				return $hooked_blocks;
+			}
+		);
 
 		$hooked_block_types_introspection = new \MockAction();
 		add_filter( 'hooked_block_types', array( $hooked_block_types_introspection, 'filter' ), 20, 4 );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\BlockifiedProductDetails;
 
 use WC_Helper_Product;
-
-use Automattic\WooCommerce\Blocks\Assets\Api;
-use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\BlockifiedProductDetailsMock;
 
 /**
  * Tests for the BlockifiedProductDetails block type
@@ -28,28 +24,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 	 * @var @WC_Product
 	 */
 	private static $product;
-
-	/**
-	 * @var AssetDataRegistryMock The asset data registry mock.
-	 */
-	private $registry;
-
-	/**
-	 * @var IntegrationRegistry The integration registry, not used, but required to set up a BlockifiedProductDetails block.
-	 */
-	private $integration_registry;
-
-	/**
-	 * @var Api The asset API, not used, but required to set up a BlockifiedProductDetails block.
-	 */
-	private $asset_api;
-
-	/**
-	 * Mock logger instance.
-	 *
-	 * @var \WC_Logger_Interface $mock_logger
-	 */
-	private $mock_logger;
 
 	/**
 	 * Create Simple Product and Page
@@ -82,15 +56,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		setup_postdata( $post );
 		$product            = self::$product;
 		$GLOBALS['product'] = $product;
-
-		$this->asset_api            = Package::container()->get( API::class );
-		$this->registry             = new AssetDataRegistryMock( $this->asset_api );
-		$this->integration_registry = new IntegrationRegistry();
-		$this->mock_logger          = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
-		add_filter(
-			'woocommerce_logging_class',
-			array( $this, 'override_wc_logger' )
-		);
 	}
 
 	/**
@@ -194,14 +159,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 			}
 		);
 
-		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
-		// This will add the `woocommerce_product_details_hooked_blocks` filter defined above.
-		$block_instance = new \Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
-			$this->asset_api,
-			$this->registry,
-			$this->integration_registry,
-			'blockified-product-details-mock'
-		);
+		new BlockifiedProductDetailsMock();
 
 		// Next, we apply the `hooked_block_types` and `hooked_block_{$slug}` filters.
 		// We pretend that we're in the `last_child` position of the `woocommerce/accordion-group` block.
@@ -241,14 +199,5 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		$this->assertSame( 'woocommerce/accordion-panel', $hooked_block_custom_info['innerBlocks'][1]['blockName'] );
 		$this->assertSame( parse_blocks( $test_block['content'] ), $hooked_block_custom_info['innerBlocks'][1]['innerBlocks'] );
-	}
-
-	/**
-	 * Overrides the WC logger.
-	 *
-	 * @return mixed
-	 */
-	public function override_wc_logger() {
-		return $this->mock_logger;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -5,6 +5,11 @@ namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes\BlockifiedProductDetail
 
 use WC_Helper_Product;
 
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AssetDataRegistryMock;
+
 /**
  * Tests for the BlockifiedProductDetails block type
  */
@@ -25,6 +30,28 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 	private static $product;
 
 	/**
+	 * @var AssetDataRegistryMock The asset data registry mock.
+	 */
+	private $registry;
+
+	/**
+	 * @var IntegrationRegistry The integration registry, not used, but required to set up a BlockifiedProductDetails block.
+	 */
+	private $integration_registry;
+
+	/**
+	 * @var Api The asset API, not used, but required to set up a BlockifiedProductDetails block.
+	 */
+	private $asset_api;
+
+	/**
+	 * Mock logger instance.
+	 *
+	 * @var \WC_Logger_Interface $mock_logger
+	 */
+	private $mock_logger;
+
+	/**
 	 * Create Simple Product and Page
 	 */
 	public static function setUpBeforeClass(): void {
@@ -43,7 +70,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		);
 	}
 	/**
-	 * Set up product and page for each test
+	 * Set up product and page for each test, and create an AssetDataRegistryMock.
 	 *
 	 * @return void
 	 */
@@ -55,6 +82,15 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		setup_postdata( $post );
 		$product            = self::$product;
 		$GLOBALS['product'] = $product;
+
+		$this->asset_api            = Package::container()->get( API::class );
+		$this->registry             = new AssetDataRegistryMock( $this->asset_api );
+		$this->integration_registry = new IntegrationRegistry();
+		$this->mock_logger          = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
+		add_filter(
+			'woocommerce_logging_class',
+			array( $this, 'override_wc_logger' )
+		);
 	}
 
 	/**
@@ -136,5 +172,48 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		$expected_serialized_blocks_without_whitespace = wp_strip_all_tags( $expected_serialized_blocks, true );
 
 		$this->assertEquals( $serialized_blocks_without_whitespace, $expected_serialized_blocks_without_whitespace, '' );
+	}
+
+	public function test_hooked_block() {
+		$test_block = [
+			"slug" => "custom-info",
+			"title" => "Custom Info",
+			"content" =>
+				"<!-- wp:paragraph --><p>This is the content for the custom info tab.</p><!-- /wp:paragraph -->"
+		];
+
+		remove_all_filters( 'hooked_block_types' );
+		remove_all_filters( 'hooked_block_' . $test_block['slug'] );
+
+		add_filter( 'woocommerce_product_details_hooked_blocks', function ( $hooked_blocks ) use ( $test_block ) {
+			$hooked_blocks[] = $test_block;
+			return $hooked_blocks;
+		} );
+
+		$hooked_block_types_introspection = new MockAction();
+		add_filter( 'hooked_block_types', array( $hooked_block_types_introspection, 'filter' ), 20, 4 );
+
+		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
+		// This will apply the `woocommerce_product_details_hooked_blocks` filter defined above.
+		$block_instance = new BlockifiedProductDetails(
+			$this->asset_api,
+			$this->registry,
+			$this->integration_registry,
+			'blockified-product-details-mock'
+		);
+
+		$this->assertSame( 1, $hooked_block_types_introspection->get_call_count() );
+
+		$args = $hooked_block_types_introspection->get_args();
+		$this->assertSame( array( $test_block['slug'] ), $args[0][1] );
+	}
+
+	/**
+	 * Overrides the WC logger.
+	 *
+	 * @return mixed
+	 */
+	public function override_wc_logger() {
+		return $this->mock_logger;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -207,7 +207,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		// We pretend that we're in the `last_child` position of the `woocommerce/accordion-group` block.
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
-		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
+		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group', null );
 		$this->assertSame( array( $test_block['slug'] ), $hooked_block_types );
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
@@ -230,7 +230,8 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 				),
 				'innerBlocks'  => array(),
 				'innerContent' => array(),
-			) // $parsed_anchor_block
+			), // $parsed_anchor_block
+			null
 		);
 		$this->assertSame( 'woocommerce/accordion-item', $hooked_block_custom_info['blockName'] );
 		$this->assertCount( 2, $hooked_block_custom_info['innerBlocks'] );

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -190,7 +190,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 			return $hooked_blocks;
 		} );
 
-		$hooked_block_types_introspection = new MockAction();
+		$hooked_block_types_introspection = new \MockAction();
 		add_filter( 'hooked_block_types', array( $hooked_block_types_introspection, 'filter' ), 20, 4 );
 
 		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -174,7 +174,12 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		$this->assertEquals( $serialized_blocks_without_whitespace, $expected_serialized_blocks_without_whitespace, '' );
 	}
 
-	public function test_hooked_block() {
+	/**
+	 * Test the `woocommerce_product_details_hooked_blocks` hook. This hook allows developers to
+	 * specify a title and block markup that will be automatically wrapped in the required
+	 * Accordion Item block and appended to the Product Details' Accordion Group block.
+	 */
+	public function test_hooked_blocks() {
 		$test_block = array(
 			'slug'    => 'custom-info',
 			'title'   => 'Custom Info',
@@ -203,9 +208,12 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		// Next, we apply the `hooked_block_types` and `hooked_block_{$slug}` filters.
 		// We pretend that we're in the `last_child` position of the `woocommerce/accordion-group` block.
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
 		$this->assertSame( array( $test_block['slug'] ), $hooked_block_types );
 
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
 		$hooked_block_custom_info = apply_filters(
 			'hooked_block_' . $test_block['slug'],
 			array(
@@ -221,7 +229,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 				'attrs'        => array(
 					'metadata' => array(
 						'isDescendantOfProductDetails' => true,
-					)
+					),
 				),
 				'innerBlocks'  => array(),
 				'innerContent' => array(),

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -186,9 +186,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 			'content' => '<!-- wp:paragraph --><p>This is the content for the custom info tab.</p><!-- /wp:paragraph -->',
 		);
 
-		remove_all_filters( 'hooked_block_types' );
-		remove_all_filters( 'hooked_block_' . $test_block['slug'] );
-
 		add_filter(
 			'woocommerce_product_details_hooked_blocks',
 			function ( $hooked_blocks ) use ( $test_block ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -206,7 +206,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		// Next, we apply the `hooked_block_types` filter. We pretend that we're in the `last_child` position
 		// of the `woocommerce/accordion-group` block.
-		apply_filters( 'hooked_block_types', array(), 'woocommerce/accordion-group', 'last_child' );
+		apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
 
 		$this->assertSame( 1, $hooked_block_types_introspection->get_call_count() );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -45,6 +45,13 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 	private $asset_api;
 
 	/**
+	 * Mock logger instance.
+	 *
+	 * @var \WC_Logger_Interface $mock_logger
+	 */
+	private $mock_logger;
+
+	/**
 	 * Create Simple Product and Page
 	 */
 	public static function setUpBeforeClass(): void {
@@ -79,6 +86,11 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		$this->asset_api            = Package::container()->get( API::class );
 		$this->registry             = new AssetDataRegistryMock( $this->asset_api );
 		$this->integration_registry = new IntegrationRegistry();
+		$this->mock_logger          = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
+		add_filter(
+			'woocommerce_logging_class',
+			array( $this, 'override_wc_logger' )
+		);
 	}
 
 	/**
@@ -229,5 +241,14 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		$this->assertSame( 'woocommerce/accordion-panel', $hooked_block_custom_info['innerBlocks'][1]['blockName'] );
 		$this->assertSame( parse_blocks( $test_block['content'] ), $hooked_block_custom_info['innerBlocks'][1]['innerBlocks'] );
+	}
+
+	/**
+	 * Overrides the WC logger.
+	 *
+	 * @return mixed
+	 */
+	public function override_wc_logger() {
+		return $this->mock_logger;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -197,7 +197,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
 		// This will add the `woocommerce_product_details_hooked_blocks` filter defined above.
-		$block_instance = new Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
+		$block_instance = new \Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
 			$this->asset_api,
 			$this->registry,
 			$this->integration_registry,

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -192,9 +192,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 			}
 		);
 
-		$hooked_block_types_introspection = new \MockAction();
-		add_filter( 'hooked_block_types', array( $hooked_block_types_introspection, 'filter' ), 20, 4 );
-
 		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
 		// This will add the `woocommerce_product_details_hooked_blocks` filter defined above.
 		$block_instance = new \Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
@@ -206,12 +203,9 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		// Next, we apply the `hooked_block_types` filter. We pretend that we're in the `last_child` position
 		// of the `woocommerce/accordion-group` block.
-		apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
+		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
 
-		$this->assertSame( 1, $hooked_block_types_introspection->get_call_count() );
-
-		$args = $hooked_block_types_introspection->get_args();
-		$this->assertSame( array( $test_block['slug'] ), $args[0][0] );
+		$this->assertSame( array( $test_block['slug'] ), $hooked_block_types );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -197,7 +197,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		// Create a new BlockifiedProductDetails block class with the mocked AssetDataRegistry.
 		// This will apply the `woocommerce_product_details_hooked_blocks` filter defined above.
-		$block_instance = new BlockifiedProductDetails(
+		$block_instance = new Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails(
 			$this->asset_api,
 			$this->registry,
 			$this->integration_registry,

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -201,11 +201,40 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 			'blockified-product-details-mock'
 		);
 
-		// Next, we apply the `hooked_block_types` filter. We pretend that we're in the `last_child` position
-		// of the `woocommerce/accordion-group` block.
+		// Next, we apply the `hooked_block_types` and `hooked_block_{$slug}` filters.
+		// We pretend that we're in the `last_child` position of the `woocommerce/accordion-group` block.
 		$hooked_block_types = apply_filters( 'hooked_block_types', array(), 'last_child', 'woocommerce/accordion-group' );
-
 		$this->assertSame( array( $test_block['slug'] ), $hooked_block_types );
+
+		$hooked_block_custom_info = apply_filters(
+			'hooked_block_' . $test_block['slug'],
+			array(
+				'blockName'    => $test_block['slug'],
+				'attrs'        => array(),
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			), // $parsed_hooked_block
+			$test_block['slug'],
+			'last_child',
+			array(
+				'blockName'    => 'woocommerce/accordion-group',
+				'attrs'        => array(
+					'metadata' => array(
+						'isDescendantOfProductDetails' => true,
+					)
+				),
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			) // $parsed_anchor_block
+		);
+		$this->assertSame( 'woocommerce/accordion-item', $hooked_block_custom_info['blockName'] );
+		$this->assertCount( 2, $hooked_block_custom_info['innerBlocks'] );
+
+		$this->assertSame( 'woocommerce/accordion-header', $hooked_block_custom_info['innerBlocks'][0]['blockName'] );
+		$this->assertStringContainsString( $test_block['title'], $hooked_block_custom_info['innerBlocks'][0]['innerHTML'] );
+
+		$this->assertSame( 'woocommerce/accordion-panel', $hooked_block_custom_info['innerBlocks'][1]['blockName'] );
+		$this->assertSame( parse_blocks( $test_block['content'] ), $hooked_block_custom_info['innerBlocks'][1]['innerBlocks'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -211,7 +211,7 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		$this->assertSame( 1, $hooked_block_types_introspection->get_call_count() );
 
 		$args = $hooked_block_types_introspection->get_args();
-		$this->assertSame( array( $test_block['slug'] ), $args[0][1] );
+		$this->assertSame( array( $test_block['slug'] ), $args[0][0] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/BlockifiedProductDetails/BlockifiedProductDetails.php
@@ -45,13 +45,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 	private $asset_api;
 
 	/**
-	 * Mock logger instance.
-	 *
-	 * @var \WC_Logger_Interface $mock_logger
-	 */
-	private $mock_logger;
-
-	/**
 	 * Create Simple Product and Page
 	 */
 	public static function setUpBeforeClass(): void {
@@ -86,11 +79,6 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 		$this->asset_api            = Package::container()->get( API::class );
 		$this->registry             = new AssetDataRegistryMock( $this->asset_api );
 		$this->integration_registry = new IntegrationRegistry();
-		$this->mock_logger          = $this->getMockBuilder( \WC_Logger_Interface::class )->getMock();
-		add_filter(
-			'woocommerce_logging_class',
-			array( $this, 'override_wc_logger' )
-		);
 	}
 
 	/**
@@ -241,14 +229,5 @@ class BlockifiedProductDetails extends \WP_UnitTestCase {
 
 		$this->assertSame( 'woocommerce/accordion-panel', $hooked_block_custom_info['innerBlocks'][1]['blockName'] );
 		$this->assertSame( parse_blocks( $test_block['content'] ), $hooked_block_custom_info['innerBlocks'][1]['innerBlocks'] );
-	}
-
-	/**
-	 * Overrides the WC logger.
-	 *
-	 * @return mixed
-	 */
-	public function override_wc_logger() {
-		return $this->mock_logger;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockifiedProductDetailsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockifiedProductDetailsMock.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\BlockifiedProductDetails;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+
+/**
+ * BlockifiedProductDetailsMock used to test BlockifiedProductDetails block functions.
+ */
+class BlockifiedProductDetailsMock extends BlockifiedProductDetails {
+
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+
+	/**
+	 * Mock implementation of register_block_type method.
+	 *
+	 * @return void
+	 */
+	protected function register_block_type() {}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add test coverage for Product Details Block Hooks Extensibility Point (introduced by https://github.com/woocommerce/woocommerce/pull/57893). Alternative approach to https://github.com/woocommerce/woocommerce/pull/58309. See this discussion: https://github.com/woocommerce/woocommerce/pull/58309#issuecomment-2912753744.

The underlying idea is that it’s sufficient to only cover the functionality of the `woocommerce_product_details_hooked_blocks` hook, namely that its filters are applied upon construction of a `BlockifiedProductDetails` class instance, and that they should result in the `hooked_block_types` and `hooked_block_{$slug}` filters being added for the hooked block (wrapped in an Accordion Item block, in case of the second filter). Arguably, we don't have to verify that applying Block Hooks with those hooked blocks to a given piece of block markup will actually insert them; the latter is covered (and thus, guaranteed) by WordPress Core's unit test coverage of Block Hooks.