### PR TITLE
[Payments NOX] Allow payment gateway IDs with uppercase characters

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4425-payment-gateway-with-non-standard-ids
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4425-payment-gateway-with-non-standard-ids
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Allow gateway IDs with uppercase characters in the new Payments Settings page UX.
+
+

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
@@ -551,7 +551,18 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 			array( array( WC_Gateway_Paypal::ID => false ) ),
 			array( array( WC_Gateway_Paypal::ID => 'bogus' ) ),
 			array( array( WC_Gateway_Paypal::ID => '1.0' ) ),
-			array( array( '()/paypal%#' => 1 ) ),
+			array( array( 'pay@pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay/pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay(pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay)pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay&pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay$pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'pay#pal' => 1 ) ), // Invalid provider ID with not allowed characters.
+			array( array( 'páypäl' => 1 ) ), // Invalid provider ID with accented characters.
+			array( array( '<script></script>paypal<a></a>' => 1 ) ), // Invalid provider ID with HTML tags.
+			array( array( '&nbsp;paypal&lt;' => 1 ) ), // Invalid provider ID with HTML entities.
+			array( array( 'pay&#60;pal' => 1 ) ), // Invalid provider ID with HTML entities.
+			array( array( '%2Fpay%3Apal' => 1 ) ), // Invalid provider ID with percent encoded characters.
 			array(
 				array(
 					WC_Gateway_Paypal::ID     => '1.1',
@@ -605,7 +616,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body_params(
 			array(
 				'order_map' => array(
-					'provider1' => 1,
+					'Provider_01-1_AHA' => 1, // uppercase characters are allowed.
 				),
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For the payment providers/gateways reordering API endpoint, we now allow uppercase characters in the provider IDs, as there is no enforcement elsewhere, and some payment extensions use IDs with uppercase characters ([example](https://wordpress.org/plugins/zarinpal-woocommerce-payment-gateway/)).

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4425

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Spin up a new JN site with this PR's branch build (here's [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=fix/WOOPLUG-4425-payment-gateway-with-non-standard-ids)).
2. Click on WooCommerce, skip the core profiler, and set your store location to Austria.
3. Go to Plugins > Add plugin and install&activate the [Zarinpal Gateway](https://wordpress.org/plugins/zarinpal-woocommerce-payment-gateway/) extension.
4. Go to WooCommerce > Settings > Payments and the gateway reordering should work with no `/wc-admin/settings/payments/providers/order` API requests returning 500 responses in your browser's Dev Tools > Network tab.
5. Refresh the page and the providers order should remain the same.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
