### PR TITLE
Remove unused woocommerce_product_availability filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-woocommerce_product_availability-filter
+++ b/plugins/woocommerce/changelog/fix-remove-woocommerce_product_availability-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove unused woocommerce_product_availability filter

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -36,13 +36,6 @@ class ProductAvailabilityUtils {
 			$product_availability = $product->get_availability();
 		}
 
-		/**
-		 * Filters the product availability information.
-		 *
-		 * @since 9.7.0
-		 * @param array $product_availability The product availability information.
-		 * @param \WC_Product $product Product object.
-		 */
-		return apply_filters( 'woocommerce_product_availability', $product_availability, $product );
+		return $product_availability;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As @jimjasson mentioned in https://github.com/woocommerce/woocommerce/issues/58125, we have a filter in the codebase which is useless: `woocommerce_product_availability`. While it has been improved in #58185 (shipping in WC 9.9), my suggestion is to remove the filter until we see there is demand and valid use cases for it. Otherwise, we will need to support it forever.

This PR will require a CFE for WooCommerce 9.9.

### How to test the changes in this Pull Request:

1. Add the _Product Stock Indicator_ somewhere and verify it still correctly shows the availability text for products which are out of stock or in backorder.
