### PR TITLE
Only respect quantity limits in cart if manage stock setting is enabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-respect-quantity-limits-when-manage-stock-is-disabled
+++ b/plugins/woocommerce/changelog/fix-respect-quantity-limits-when-manage-stock-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Respect the max qualtity limit of a product in the cart if the manage stock setting is enabled only

--- a/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
@@ -175,7 +175,7 @@ final class QuantityLimits {
 
 		if ( $product->is_sold_individually() ) {
 			$limits[] = 1;
-		} elseif ( $product->managing_stock() && ! $product->backorders_allowed() ) {
+		} elseif ( $product->managing_stock() || ! $product->backorders_allowed() ) {
 			$limits[] = $this->get_remaining_stock( $product );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
@@ -175,7 +175,7 @@ final class QuantityLimits {
 
 		if ( $product->is_sold_individually() ) {
 			$limits[] = 1;
-		} elseif ( ! $product->backorders_allowed() ) {
+		} elseif ( $product->managing_stock() && ! $product->backorders_allowed() ) {
 			$limits[] = $this->get_remaining_stock( $product );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -28,7 +28,7 @@ class QuantityLimitsTests extends TestCase {
 
 		$product->set_manage_stock( true );
 		$product->set_stock_quantity( 10 );
-		$product->set_backorders( 'no' );
+		$product->set_backorders( 'yes' );
 		$product->save();
 
 		$quantity_limits = new QuantityLimits();
@@ -53,7 +53,7 @@ class QuantityLimitsTests extends TestCase {
 		update_option( 'woocommerce_manage_stock', 'yes' );
 
 		$product->set_stock_quantity( 10 );
-		$product->set_backorders( 'no' );
+		$product->set_backorders( 'yes' );
 		$product->save();
 
 		// Disable stock management.
@@ -81,7 +81,7 @@ class QuantityLimitsTests extends TestCase {
 		update_option( 'woocommerce_manage_stock', 'yes' );
 
 		$product->set_stock_quantity( 10 );
-		$product->set_backorders( 'no' );
+		$product->set_backorders( 'yes' );
 		$product->set_sold_individually( true );
 		$product->save();
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -91,4 +91,112 @@ class QuantityLimitsTests extends TestCase {
 
 		$this->assertEquals( 1, $limits['maximum'], 'When stock quantity is sold individually, maximum quantity should be 1' );
 	}
+
+	/**
+	 * Test quantity limit when backorders are allowed.
+	 */
+	public function test_quantity_limit_when_backorders_allowed() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Enable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Set up product with stock management and backorders allowed.
+		$product->set_manage_stock( 'no' );
+		$product->set_stock_quantity( 10 );
+		$product->set_backorders( 'yes' );
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 9999, $limits['maximum'], 'When backorders are allowed, maximum quantity should be 9999' );
+	}
+
+	/**
+	 * Test quantity limit when backorders are not allowed.
+	 */
+	public function test_quantity_limit_when_backorders_not_allowed() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Enable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Set up product with stock management and backorders not allowed.
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_backorders( 'no' );
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 10, $limits['maximum'], 'When backorders are not allowed, maximum quantity should be limited to stock quantity' );
+	}
+
+	/**
+	 * Test quantity limit when product is sold individually with stock management.
+	 */
+	public function test_quantity_limit_when_sold_individually_with_stock() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Enable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Set up product as sold individually with stock management.
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_backorders( 'no' );
+		$product->set_sold_individually( true );
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 1, $limits['maximum'], 'When product is sold individually, maximum quantity should be 1 regardless of stock' );
+	}
+
+	/**
+	 * Test quantity limit when product is sold individually without stock management.
+	 */
+	public function test_quantity_limit_when_sold_individually_without_stock() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Disable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'no' );
+
+		// Set up product as sold individually without stock management.
+		$product->set_manage_stock( false );
+		$product->set_sold_individually( true );
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 1, $limits['maximum'], 'When product is sold individually without stock management, maximum quantity should be 1' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
+
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
+use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * QuantityLimitsTests class.
+ */
+class QuantityLimitsTests extends TestCase {
+	/**
+	 * Test quantity limit when stock management is enabled.
+	 */
+	public function test_quantity_limit_when_stock_management_enabled() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Enable stock management.
+		$product->set_manage_stock( true );
+		// Set stock quantity to 10.
+		$product->set_stock_quantity( 10 );
+		// Save the changes.
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 10, $limits['maximum'], 'When stock management is enabled, maximum quantity should be 10' );
+	}
+
+	/**
+	 * Test quantity limit when stock management is disabled.
+	 */
+	public function test_quantity_limit_when_stock_management_disabled() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Set stock quantity to 10.
+		$product->set_stock_quantity( 10 );
+		// Save the changes.
+		$product->save();
+
+		// Disable stock management.
+		$product->set_manage_stock( false );
+		// Save the changes.
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 9999, $limits['maximum'], 'When stock management is disabled, maximum quantity should be 9999' );
+	}
+
+	/**
+	 * Test quantity limit when stock quantity is sold individually.
+	 */
+	public function test_quantity_limit_when_stock_quantity_is_sold_individually() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Set stock quantity to 10.
+		$product->set_stock_quantity( 10 );
+		// Save the changes.
+		$product->save();
+
+		// Set sold individually to true.
+		$product->set_sold_individually( true );
+		// Save the changes.
+		$product->save();
+
+		$quantity_limits = new QuantityLimits();
+
+		$limits = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 1, $limits['maximum'], 'When stock quantity is sold individually, maximum quantity should be 1' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -23,11 +23,12 @@ class QuantityLimitsTests extends TestCase {
 			)
 		);
 
-		// Enable stock management.
+		// Enable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
 		$product->set_manage_stock( true );
-		// Set stock quantity to 10.
 		$product->set_stock_quantity( 10 );
-		// Save the changes.
+		$product->set_backorders( 'no' );
 		$product->save();
 
 		$quantity_limits = new QuantityLimits();
@@ -48,15 +49,15 @@ class QuantityLimitsTests extends TestCase {
 			)
 		);
 
-		// Set stock quantity to 10.
+		// Enable stock management.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
 		$product->set_stock_quantity( 10 );
-		// Save the changes.
+		$product->set_backorders( 'no' );
 		$product->save();
 
 		// Disable stock management.
-		$product->set_manage_stock( false );
-		// Save the changes.
-		$product->save();
+		update_option( 'woocommerce_manage_stock', 'no' );
 
 		$quantity_limits = new QuantityLimits();
 		$limits          = $quantity_limits->get_add_to_cart_limits( $product );
@@ -76,14 +77,12 @@ class QuantityLimitsTests extends TestCase {
 			)
 		);
 
-		// Set stock quantity to 10.
-		$product->set_stock_quantity( 10 );
-		// Save the changes.
-		$product->save();
+		// Enable stock management globally.
+		update_option( 'woocommerce_manage_stock', 'yes' );
 
-		// Set sold individually to true.
+		$product->set_stock_quantity( 10 );
+		$product->set_backorders( 'no' );
 		$product->set_sold_individually( true );
-		// Save the changes.
 		$product->save();
 
 		$quantity_limits = new QuantityLimits();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Do not respect stock levels in the cart if manage stock setting is disabled in WooCommerce settings

Closes [WOOPLUG-4032](https://linear.app/a8c/issue/WOOPLUG-4032/block-cart-does-not-respect-no-stock-management-for-max-amount)
Closes https://github.com/woocommerce/woocommerce/issues/57452

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable stock management in WooCommerce > Products > Inventory
2. Set stock to 10 for a product
3. Check you cannot add more than 10 of said product to your cart
4. Disable stock management in WooCommerce > Products > Inventory
5. Check you can add more than 10 items of that product to your cart now.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
