### PR TITLE
Add Quantity Selector styles to Grouped Product: Item Selector block

### DIFF
--- a/plugins/woocommerce/changelog/fix-58395-grouped-product-quantity-selector-styles
+++ b/plugins/woocommerce/changelog/fix-58395-grouped-product-quantity-selector-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add Quantity Selector styles to Grouped Product: Item Selector block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-cta/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-cta/style.scss
@@ -1,3 +1,5 @@
+@import "../../../../base/components/quantity-selector/style";
+
 .wc-block-add-to-cart-with-options-grouped-product-selector-item-cta {
 	text-align: center;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58395.
Closes WOOPLUG-4455.

Same as https://github.com/woocommerce/woocommerce/pull/57627, but in that PR I forgot to add the styles to the _Grouped Product: Item Selector_ block. :sweat_smile: 

### How to test the changes in this Pull Request:

1. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
2. Go to *WooCommerce Admin Test Helper* > *Features* and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
4. Click on the *Add to Cart with Options* block and update to the blockified version.

**Other steps:**

5. Make sure you don't have the Mini-Cart block anywhere on the page, header or footer.
6. In the frontend, visit a Grouped Product template.
7. Notice the quantity selector styles are missing:

Before | After
--- | ---
<img src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/049762c9-3d4b-4860-a0ed-b523a56d2799/b3960f35-7a39-4996-8d87-068be1455967?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi8wNDk3NjJjOS0zZDRiLTQ4NjAtYTBlZC1iNTIzYTU2ZDI3OTkvYjM5NjBmMzUtN2EzOS00OTk2LThkODctMDY4YmUxNDU1OTY3IiwiaWF0IjoxNzQ4NTI5MzQ3LCJleHAiOjMzMzE5MDg5MzQ3fQ.sH9RjuRjIrdNwd6sImTzlbFjmLv8e2FRkjWmytSYyP4 " alt="imatge.png" /> | ![Captura de pantalla de 2025-05-29 16-35-09](https://github.com/user-attachments/assets/94106c2d-9ab5-4c2b-be1e-e0eaf272d3ed)
