### PR TITLE
Refactor `useValidation` hook and a deprecation warning will be shown 

### DIFF
--- a/plugins/woocommerce/changelog/58400-refactor-54490
+++ b/plugins/woocommerce/changelog/58400-refactor-54490
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refactor the useValidation hook. A deprecation warning will be shown when any part of the hook is accessed.

--- a/plugins/woocommerce/changelog/refactor-54490
+++ b/plugins/woocommerce/changelog/refactor-54490
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Refactor the useValidation hook. A deprecation warning will be shown when any part of the hook is accessed.

--- a/plugins/woocommerce/changelog/refactor-54490
+++ b/plugins/woocommerce/changelog/refactor-54490
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refactor the useValidation hook. A deprecation warning will be shown when any part of the hook is accessed.

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@wordpress/element';
 import type {
 	ValidationData,
 	ValidationContextError,

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -8,9 +8,24 @@ import type {
 } from '@woocommerce/types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { validationStore } from '@woocommerce/block-data';
+import deprecated from '@wordpress/deprecated';
+
+let warned = false;
+
+const warnDeprecation = () => {
+	if ( ! warned ) {
+		deprecated( 'useValidation()', {
+			alternative: 'validationStore with useSelect/useDispatch',
+			plugin: 'WooCommerce',
+			hint: 'Access the validation store directly in your component. See: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/data-store/validation.md',
+		} );
+		warned = true;
+	}
+};
 
 /**
- * Custom hook for setting for adding errors to the validation system.
+ * @deprecated useValidation is deprecated.
+ * Use validationStore directly with useSelect and useDispatch.
  */
 export const useValidation = (): ValidationData => {
 	const { clearValidationError, hideValidationError, setValidationErrors } =
@@ -19,8 +34,8 @@ export const useValidation = (): ValidationData => {
 	const prefix = 'extensions-errors';
 
 	const { hasValidationErrors, getValidationErrorSelector } = useSelect(
-		( mapSelect ) => {
-			const store = mapSelect( validationStore );
+		( select ) => {
+			const store = select( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
 				getValidationErrorSelector: store.getValidationError,
@@ -29,27 +44,31 @@ export const useValidation = (): ValidationData => {
 		[]
 	);
 
-	const getValidationError = useCallback(
-		( validationErrorId: string ) =>
-			getValidationErrorSelector( `${ prefix }-${ validationErrorId }` ),
-		[ getValidationErrorSelector, prefix ]
-	);
-
 	return {
-		hasValidationErrors,
-		getValidationError,
-		clearValidationError: useCallback(
-			( validationErrorId: string ) =>
-				clearValidationError( `${ prefix }-${ validationErrorId }` ),
-			[ clearValidationError ]
-		),
-		hideValidationError: useCallback(
-			( validationErrorId: string ) =>
-				hideValidationError( `${ prefix }-${ validationErrorId }` ),
-			[ hideValidationError ]
-		),
-		setValidationErrors: useCallback(
-			( errorsObject: Record< string, ValidationContextError > ) =>
+		get hasValidationErrors() {
+			warnDeprecation();
+			return hasValidationErrors;
+		},
+		get getValidationError() {
+			warnDeprecation();
+			return ( validationErrorId: string ) =>
+				getValidationErrorSelector(
+					`${ prefix }-${ validationErrorId }`
+				);
+		},
+		get clearValidationError() {
+			warnDeprecation();
+			return ( validationErrorId: string ) =>
+				clearValidationError( `${ prefix }-${ validationErrorId }` );
+		},
+		get hideValidationError() {
+			warnDeprecation();
+			return ( validationErrorId: string ) =>
+				hideValidationError( `${ prefix }-${ validationErrorId }` );
+		},
+		get setValidationErrors() {
+			warnDeprecation();
+			return ( errorsObject: Record< string, ValidationContextError > ) =>
 				setValidationErrors(
 					Object.fromEntries(
 						Object.entries( errorsObject ).map(
@@ -59,8 +78,7 @@ export const useValidation = (): ValidationData => {
 							]
 						)
 					)
-				),
-			[ setValidationErrors ]
-		),
+				);
+		},
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -14,7 +14,7 @@ let warned = false;
 const warnDeprecation = () => {
 	if ( ! warned ) {
 		deprecated( 'useValidation()', {
-			alternative: 'validationStore with useSelect/useDispatch',
+			alternative: 'validationStore',
 			plugin: 'WooCommerce',
 			hint: 'Access the validation store directly in your component. See: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/data-store/validation.md',
 		} );

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useCallback } from '@wordpress/element';
 import type {
 	ValidationData,
 	ValidationContextError,
@@ -9,16 +10,16 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { validationStore } from '@woocommerce/block-data';
 import deprecated from '@wordpress/deprecated';
 
-let warned = false;
+let deprecationNoticeShown = false;
 
-const warnDeprecation = () => {
-	if ( ! warned ) {
+const showDeprecationNotice = () => {
+	if ( ! deprecationNoticeShown ) {
 		deprecated( 'useValidation()', {
-			alternative: 'validationStore',
+			alternative: 'the validation data store',
 			plugin: 'WooCommerce',
-			hint: 'Access the validation store directly in your component. See: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/data-store/validation.md',
+			hint: 'Access the validation store directly in your component. \nSee: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/data-store/validation.md \nSee: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/',
 		} );
-		warned = true;
+		deprecationNoticeShown = true;
 	}
 };
 
@@ -43,41 +44,59 @@ export const useValidation = (): ValidationData => {
 		[]
 	);
 
+	const getValidationError = useCallback(
+		( validationErrorId: string ) =>
+			getValidationErrorSelector( `${ prefix }-${ validationErrorId }` ),
+		[ getValidationErrorSelector, prefix ]
+	);
+
+	const clearValidationErrorCallback = useCallback(
+		( validationErrorId: string ) =>
+			clearValidationError( `${ prefix }-${ validationErrorId }` ),
+		[ clearValidationError, prefix ]
+	);
+
+	const hideValidationErrorCallback = useCallback(
+		( validationErrorId: string ) =>
+			hideValidationError( `${ prefix }-${ validationErrorId }` ),
+		[ hideValidationError, prefix ]
+	);
+
+	const setValidationErrorsCallback = useCallback(
+		( errorsObject: Record< string, ValidationContextError > ) =>
+			setValidationErrors(
+				Object.fromEntries(
+					Object.entries( errorsObject ).map(
+						( [ validationErrorId, error ] ) => [
+							`${ prefix }-${ validationErrorId }`,
+							error,
+						]
+					)
+				)
+			),
+		[ setValidationErrors, prefix ]
+	);
+
 	return {
 		get hasValidationErrors() {
-			warnDeprecation();
+			showDeprecationNotice();
 			return hasValidationErrors;
 		},
 		get getValidationError() {
-			warnDeprecation();
-			return ( validationErrorId: string ) =>
-				getValidationErrorSelector(
-					`${ prefix }-${ validationErrorId }`
-				);
+			showDeprecationNotice();
+			return getValidationError;
 		},
 		get clearValidationError() {
-			warnDeprecation();
-			return ( validationErrorId: string ) =>
-				clearValidationError( `${ prefix }-${ validationErrorId }` );
+			showDeprecationNotice();
+			return clearValidationErrorCallback;
 		},
 		get hideValidationError() {
-			warnDeprecation();
-			return ( validationErrorId: string ) =>
-				hideValidationError( `${ prefix }-${ validationErrorId }` );
+			showDeprecationNotice();
+			return hideValidationErrorCallback;
 		},
 		get setValidationErrors() {
-			warnDeprecation();
-			return ( errorsObject: Record< string, ValidationContextError > ) =>
-				setValidationErrors(
-					Object.fromEntries(
-						Object.entries( errorsObject ).map(
-							( [ validationErrorId, error ] ) => [
-								`${ prefix }-${ validationErrorId }`,
-								error,
-							]
-						)
-					)
-				);
+			showDeprecationNotice();
+			return setValidationErrorsCallback;
 		},
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -15,6 +15,7 @@ let deprecationNoticeShown = false;
 const showDeprecationNotice = () => {
 	if ( ! deprecationNoticeShown ) {
 		deprecated( 'useValidation()', {
+			since: '10.0',
 			alternative: 'the validation data store',
 			plugin: 'WooCommerce',
 			hint: 'Access the validation store directly in your component. \nSee: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/docs/third-party-developers/extensibility/data-store/validation.md \nSee: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #54490  .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

![Screenshot from 2025-05-31 13-09-21](https://github.com/user-attachments/assets/eb8d406f-5ab6-4e16-be02-bea740959554)



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

I'm not 100% sure if this is the ideal place to test it, but here's how I verified the deprecation warning:

1. Open the file: `plugins/woocommerce/client/blocks/assets/js/blocks/checkout/frontend.tsx` and Add the following import at the top of the file: 
`import { useEffect } from '@wordpress/element';` as external library. 

2. Inside the Wrapper component, right after `const validation = useValidation(); `
insert the following
```
useEffect( () => {
		// Triggering the deprecation warning via actual usage
		if ( validation.hasValidationErrors ) {
			// You can optionally add logic here
		}

		validation.setValidationErrors( {
			'test-id': { message: 'Test error from wrapper', type: 'error' },
		} );

		const error = validation.getValidationError( 'test-id' );

		// Optionally use error somewhere
		validation.hideValidationError( 'test-id' );
		validation.clearValidationError( 'test-id' );
	}, [] );
```
3. Run `pnpm build`
4. Visit the Checkout page on the frontend and check the browser console
5. See the warning on the browser console
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Refactor the useValidation hook. A deprecation warning will be shown when any part of the hook is accessed.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
</details>
