### PR TITLE
Product Filters: fix some A11y issues

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-filters-a11y
+++ b/plugins/woocommerce/changelog/fix-product-filters-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: fix various A11y issues.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
@@ -100,6 +100,15 @@ input[type="checkbox"].wc-block-product-filter-checkbox-list__input:checked {
 	gap: $gap-smallest;
 }
 
+.wc-block-product-filter-checkbox-list__text {
+	display: contents;
+}
+
+.wc-block-product-filter-checkbox-list__count {
+	display: contents;
+	white-space: nowrap;
+}
+
 .wc-block-product-filter-checkbox-list__show-more {
 	text-decoration: underline;
 	appearance: none;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -46,6 +46,15 @@
 	gap: $gap-smallest;
 }
 
+.wc-block-product-filter-chips__text {
+	display: contents;
+}
+
+.wc-block-product-filter-chips__count {
+	display: contents;
+	white-space: nowrap;
+}
+
 .wc-block-product-filter-chips:not(.has-selected-chip-text-color)
 	.wc-block-product-filter-chips__item[aria-checked="true"]
 	> .wc-block-product-filter-chips__label {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -198,9 +198,25 @@ final class ProductFilterAttribute extends AbstractBlock {
 				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms, $product_attribute ) {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
+					$aria_label    = $term['name'];
+
+					if ( $block_attributes['showCounts'] ) {
+						$aria_label = sprintf(
+							/* translators: %1$s is the term name, %2$d is the term count. */
+							_n(
+								'%1$s (%2$d product)',
+								'%1$s (%2$d products)',
+								$term['count'],
+								'woocommerce'
+							),
+							$term['name'],
+							$term['count']
+						);
+					}
+
 					return array(
 						'label'              => $term['name'],
-						'ariaLabel'          => $term['name'],
+						'ariaLabel'          => $aria_label,
 						'value'              => $term['slug'],
 						'selected'           => in_array( $term['slug'], $selected_terms, true ),
 						'count'              => $term['count'],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -72,6 +72,7 @@ final class ProductFilterChips extends AbstractBlock {
 						id="<?php echo esc_attr( $item_id ); ?>"
 						class="wc-block-product-filter-chips__item"
 						type="button"
+						role="checkbox"
 						aria-label="<?php echo esc_attr( $item['ariaLabel'] ); ?>"
 						data-wp-on--click="actions.toggleFilter"
 						value="<?php echo esc_attr( $item['value'] ); ?>"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterClearButton.php
@@ -50,9 +50,6 @@ final class ProductFilterClearButton extends AbstractBlock {
 		if ( $p->next_tag( array( 'class_name' => 'wp-block-button__link' ) ) ) {
 			$p->set_attribute( 'data-wp-on--click', 'actions.removeAllActiveFilters' );
 
-			$style = $p->get_attribute( 'style' );
-			$p->set_attribute( 'style', 'outline:none;' . $style );
-
 			$content = $p->get_updated_html();
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPriceSlider.php
@@ -84,24 +84,37 @@ class ProductFilterPriceSlider extends AbstractBlock {
 			)
 		);
 
+		/**
+		 * Accessibility: Assign the left input to a variable to conditionally
+		 * render it based on the inline input setting. We do this to have the
+		 * correct focus order of the input fields.
+		 */
+		ob_start();
+		?>
+		<div class="wc-block-product-filter-price-slider__left text">
+			<?php if ( $show_input_fields ) : ?>
+				<input
+					class="min"
+					type="text"
+					data-wp-bind--value="state.formattedMinPrice"
+					data-wp-on--focus="actions.selectInputContent"
+					data-wp-on--input="actions.debounceSetMinPrice"
+					aria-label="<?php esc_attr_e( 'Filter products by minimum price', 'woocommerce' ); ?>"
+				/>
+			<?php else : ?>
+				<span data-wp-text="state.formattedMinPrice"></span>
+			<?php endif; ?>
+		</div>
+		<?php
+		$left_input = ob_get_clean();
+
 		ob_start();
 		?>
 		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="<?php echo esc_attr( $content_class ); ?>">
-				<div class="wc-block-product-filter-price-slider__left text">
-					<?php if ( $show_input_fields ) : ?>
-						<input
-							class="min"
-							type="text"
-							data-wp-bind--value="state.formattedMinPrice"
-							data-wp-on--focus="actions.selectInputContent"
-							data-wp-on--input="actions.debounceSetMinPrice"
-							aria-label="<?php esc_attr_e( 'Filter products by minimum price', 'woocommerce' ); ?>"
-						/>
-					<?php else : ?>
-						<span data-wp-text="state.formattedMinPrice"></span>
-					<?php endif; ?>
-				</div>
+				<?php if ( $inline_input ) : ?>
+					<?php echo $left_input; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php endif; ?>
 				<div
 					class="wc-block-product-filter-price-slider__range"
 					data-wp-bind--style="state.rangeStyle"
@@ -132,6 +145,9 @@ class ProductFilterPriceSlider extends AbstractBlock {
 						aria-label="<?php esc_attr_e( 'Filter products by maximum price', 'woocommerce' ); ?>"
 					/>
 				</div>
+				<?php if ( ! $inline_input ) : ?>
+					<?php echo $left_input; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php endif; ?>
 				<div class="wc-block-product-filter-price-slider__right text">
 					<?php if ( $show_input_fields ) : ?>
 						<input

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -122,10 +122,24 @@ final class ProductFilterRating extends AbstractBlock {
 				$value = (string) $rating['rating'];
 
 				$aria_label = sprintf(
-					/* translators: %s is referring to rating value. Example: Rated 4 out of 5. */
-					__( 'Rated %s out of 5', 'woocommerce' ),
+					/* translators: %1$d is referring to rating value. Example: Rated 4 out of 5. */
+					__( 'Rated %1$d out of 5', 'woocommerce' ),
 					$value,
 				);
+
+				if ( $attributes['showCounts'] ) {
+					$aria_label = sprintf(
+						/* translators: %1$d is referring to rating value, %2$d is the count. */
+						_n(
+							'Rated %1$d out of 5 (%2$d product)',
+							'Rated %1$d out of 5 (%2$d products)',
+							$rating['count'],
+							'woocommerce'
+						),
+						$value,
+						$rating['count']
+					);
+				}
 
 				return array(
 					'label'     => $this->render_rating_label( (int) $value ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -130,9 +130,20 @@ final class ProductFilterStatus extends AbstractBlock {
 
 		$filter_options = array_map(
 			function ( $item ) use ( $stock_statuses, $selected_stock_statuses, $attributes ) {
+				$aria_label = $stock_statuses[ $item['status'] ];
+
+				if ( $attributes['showCounts'] ) {
+					$aria_label = sprintf(
+						/* translators: %1$s is the status, %2$d is the count. */
+						_n( '%1$s (%2$d product)', '%1$s (%2$d products)', $item['count'], 'woocommerce' ),
+						$stock_statuses[ $item['status'] ],
+						$item['count']
+					);
+				}
+
 				return array(
 					'label'     => $stock_statuses[ $item['status'] ],
-					'ariaLabel' => $stock_statuses[ $item['status'] ],
+					'ariaLabel' => $aria_label,
 					'value'     => $item['status'],
 					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
 					'count'     => $item['count'],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes some A11y issues for the Product Filters. Due to the size of each issue, I decided to fix multiple issues in on PR to save logistic time.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

- Fixes [WOOPLUG-4432: Incorrect Focus Order](https://linear.app/a8c/issue/WOOPLUG-4432/incorrect-focus-order) by https://github.com/woocommerce/woocommerce/commit/abafe86a4fa94cb5c3e4b23692eea8d9a8326e28
- Fixes [WOOPLUG-4433: ARIA Element Contains Invalid Value](https://linear.app/a8c/issue/WOOPLUG-4433/aria-element-contains-invalid-value) by https://github.com/woocommerce/woocommerce/commit/0d4c9a03ca8c7c6351f9ab3ad3f79a242cccb4a8
- Fixes [WOOPLUG-4435: Focus indicator missing](https://linear.app/a8c/issue/WOOPLUG-4435/focus-indicator-missing) by https://github.com/woocommerce/woocommerce/commit/624365029861c82b24a7f2f998a1ac11c6b400fb
- Fixes [WOOPLUG-4437: Content announced incorrectly](https://linear.app/a8c/issue/WOOPLUG-4437/content-announced-incorrectly) by https://github.com/woocommerce/woocommerce/commit/d9263e4755f1a388768168e214e2a53c361ecd9b
- Fixes [WOOPLUG-4438: Content misaligned when 200% is applied](https://linear.app/a8c/issue/WOOPLUG-4438/content-misaligned-when-200percent-is-applied) by https://github.com/woocommerce/woocommerce/commit/b0037b91e393ca902ab156bf00a12ce08153084c

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Due to the number of issues this PR fixes, please go through each issue to verify this PR fix them, the issue description can be used as testing instruction effectively.