### PR TITLE
Hardening for HPOS manual sync in settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-55187
+++ b/plugins/woocommerce/changelog/fix-55187
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure HPOS tables are created when running sync manually from settings.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -273,7 +273,7 @@ class CustomOrdersTableController {
 		$tools_array = array_merge( $tools_array, $this->data_cleanup->get_tools_entries() );
 
 		// Delete HPOS tables tool.
-		if ( $this->custom_orders_table_usage_is_enabled() || $this->data_synchronizer->data_sync_is_enabled() ) {
+		if ( $this->custom_orders_table_usage_is_enabled() || $this->data_synchronizer->data_sync_is_enabled() || $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) ) ) {
 			$disabled = true;
 			$message  = __( 'This will delete the custom orders tables. The tables can be deleted only if the "High-Performance order storage" is not authoritative and sync is disabled (via Settings > Advanced > Features).', 'woocommerce' );
 		} else {
@@ -289,7 +289,11 @@ class CustomOrdersTableController {
 				$message
 			),
 			'requires_refresh' => true,
-			'callback'         => function () {
+			'callback'         => function () use ( $disabled ) {
+				if ( $disabled ) {
+					return;
+				}
+
 				$this->features_controller->change_feature_enable( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, false );
 				$this->delete_custom_orders_tables();
 				return __( 'Custom orders tables have been deleted.', 'woocommerce' );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -500,6 +500,13 @@ class CustomOrdersTableController {
 		$this->data_cleanup->toggle_flag( false );
 
 		if ( 'sync-now' === $action ) {
+			if ( ! $this->data_synchronizer->check_orders_table_exists() && ! $this->data_synchronizer->create_database_tables() ) {
+				WC_Admin_Settings::add_error(
+					__( 'Unable to create HPOS tables for synchronization.', 'woocommerce' )
+				);
+				return;
+			}
+
 			$this->batch_processing_controller->enqueue_processor( DataSynchronizer::class );
 		} else {
 			$this->batch_processing_controller->remove_processor( DataSynchronizer::class );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR ensures that HPOS tables are always created when a manual sync is triggered via the settings, even if HPOS is not the authoritative table.

It also adds some checks to prevent the **Delete the custom orders tables** from running when a sync is in progress.

Closes #55187.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the following snippet on your site (for example, by dropping it as a `.php` file in `wp-content/mu-plugins`):
   ```php
   <?php
   add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
   add_action( 'init', fn () => remove_action( ActionScheduler_QueueRunner::WP_CRON_HOOK, [ ActionScheduler_QueueRunner::instance(), 'run' ] ) );
   ```

   This will prevent A-S from running jobs automatically, allowing us to test via CLI instead.
1. Go to WC > Settings > Advanced > Features and make sure **WordPress posts storage (legacy)** is set as **Order data storage** and compatibility mode is **disabled**.
   If you can't change the data storage option, run `wp wc hpos sync` in the CLI to sync all orders first.
1. Go to WC > Status > Tools and trigger the **Delete the custom orders tables** tool by clicking the **Delete** button.
1. Confirm that the HPOS tables have been removed. For example, by running `wp db tables '*wc_orders' --all-tables-with-prefix`.
1. Go back to WC > Settings > Advanced > Features and click the **Sync orders now** link.
1. While the sync is "in progress", go back to WC > Status > Tools and confirm that the **Delete the custom orders tables** tool is not available.
1. Confirm that the HPOS tables have been created by running `wp db tables '*wc_orders' --all-tables-with-prefix`.
1. Run `wp wc hpos sync` to sync all your orders.
1. Make changes to settings in WC > Settings > Advanced > Features as necessary and confirm that the **Delete the custom orders tables** in WC > Status > Tools is only enabled when both **WordPress posts storage (legacy)** is the chosen datastore **and** compatibility mode is disabled. Any other choice in order storage or compatibility mode should result in the tool being disabled.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
