### PR TITLE
Update the `Notify in Slack when a new (pre)release is published` workflow

### DIFF
--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -15,4 +15,7 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }},${{ secrets.WOO_ANNOUNCEMENTS_SLACK_CHANNEL }}
           slack-optional-unfurl_links: false
-          slack-text: ':woo-bounce: *<${{ github.event.release.html_url }}|WooCommerce ${{ github.event.release.name }}>* has been released! :rocket:'
+          slack-text: |
+            :woo-bounce: *<${{ github.event.release.html_url }}|WooCommerce ${{ github.event.release.name }}>* has been released! :rocket:
+
+            (<@woo-developer-advocacy-team> could you publish the release post? :ty:)

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -9,6 +9,7 @@ jobs:
 
     steps:
       - name: 'Notify to Slack when a new release is published'
+        if: ${{ !contains(github.event.release.name, 'WooCommerce Beta Tester') }}
         uses: archive/github-actions-slack@v2.10.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: 'Notify to Slack when a new release is published'
-        if: ${{ !contains(github.event.release.name, 'WooCommerce Beta Tester') }}
+        if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
         uses: archive/github-actions-slack@v2.10.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes two improvements to the `Release: Notify in Slack when a new (pre)release is published`:
- Skips the release notification for the WooCommerce Beta Tester plugin releases.
- Pings the Dev Adv team to let them know they should update the release post.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Steps to set up a Slack app
1. Create a new Slack app and token from [here](https://href.li/?https://api.slack.com/apps), you can do it on a personal Slack workspace.
2. On that Slack workspace, create two test channels with any names you choose (like #test1 and #test2).
3. Make sure you add the app from step 3 to both Slack channels by mentioning it in the channels @YOUR_APP_NAME.
4. In your app settings, click `OAuth & permissions` in the sidebar and copy the `Bot User OAuth Token`.
5. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN` and paste the copied token from step 6 (I'm using the CODE_FREEZE_BOT_TOKEN secret that we already have defined in the repo to send Slack messages).
- `WOO_RELEASE_SLACK_CHANNEL` with one of the channel names you created in step 4 in plain text without the #.
- `WOO_ANNOUNCEMENTS_SLACK_CHANNEL` with the other channel name.

### Steps to test the notification on release creation
1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In the forked repo, create a PR with the branch `57933-notify-release-published` and merge it (to get these changes into the `trunk` branch).
3. In the forked repo, go to `Releases`, publish a new release with any title, and save.
4. Go to `Actions` and check the `Release: Notify in Slack when a new (pre)release is published` workflow run without errors.
5. Now, go to your Slack workspace and ensure you have received a new message in each of the channels from step 2 in the previous section. They should look like this 👇 but replacing `10.8` with the release title you wrote in step 3, it should also include a mention to the Dev Adv team to update the release post.
<img width="378" alt="Screenshot 2025-05-26 at 16 38 11" src="https://github.com/user-attachments/assets/50984435-2dd0-488f-a5ed-46d1639c842b" />

6. Make sure the link in the notification takes you to the GH release page.
7. Go to `Releases`, publish a new release with a tag cointaing `wc-beta-tester` to simulate releases like https://github.com/woocommerce/woocommerce/releases/tag/wc-beta-tester-3.0.0
8. Go to `Actions` and check the `Release: Notify in Slack when a new (pre)release is published` workflow run and skips sending the notification.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
