### PR TITLE
Fix `anonymize_refunded_orders` args to ignore anonymized orders

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4325-investigate-potential-loop-in-privacy-cleanup-actions
+++ b/plugins/woocommerce/changelog/wooplug-4325-investigate-potential-loop-in-privacy-cleanup-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix anonymize_refunded_orders args to ignore anonymized orders

--- a/plugins/woocommerce/includes/class-wc-privacy.php
+++ b/plugins/woocommerce/includes/class-wc-privacy.php
@@ -282,6 +282,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 					'limit'        => $limit, // Batches of 20.
 					'status'       => OrderInternalStatus::REFUNDED,
 					'type'         => 'shop_order',
+					'anonymized'   => false,
 				)
 			)
 		);
@@ -301,7 +302,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
 				$order->delete( false );
-				$count ++;
+				++$count;
 			}
 		}
 
@@ -350,7 +351,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
 				WC_Privacy_Erasers::remove_order_personal_data( $order );
-				$count ++;
+				++$count;
 			}
 		}
 
@@ -429,7 +430,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 						$user_id
 					)
 				);
-				$count ++;
+				++$count;
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The query in `anonymize_refunded_orders` was not skipping already anonymized orders, potentially leading to it never completing.

Closes #58094

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WP Crontrol plugin
2. WC > Settings > Accounts and privacy. Choose to Retain refunded orders for only 1 day
3. Edit some orders on your store, or place some new orders and set the created date to the past, and set the status to `refunded`. You can do > 20, or you can change the limits in `anonymize_refunded_orders` and `WC_Privacy_Background_Process::task` to a low number and refund a few more than that.
4. Tools > Cron Events > Run `woocommerce_cleanup_personal_data`
5. See jobs appear under WooCommerce > Status > Scheduled actions > Pending
6. When they are complete go back to orders section
7. Confirm all refunded orders were anonymized

<!-- End testing instructions -->

### Testing that has already taken place:

I set process limit to 2 and refunded 4 orders. All 4 were anonymized.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
