### PR TITLE
[NOX In-Context] Display completed steps first

### DIFF
--- a/plugins/woocommerce/changelog/58437-fix-change-order-nox-steps
+++ b/plugins/woocommerce/changelog/58437-fix-change-order-nox-steps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Display finished steps first in NOX In-Context

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
@@ -60,6 +60,17 @@ export default function Stepper( {
 		);
 	};
 
+	// Sort steps to show completed ones first
+	const sortedSteps = steps.sort( ( a, b ) => {
+		const aCompleted = isStepCompleted( a );
+		const bCompleted = isStepCompleted( b );
+
+		if ( aCompleted === bCompleted ) {
+			return 0;
+		}
+		return aCompleted ? -1 : 1;
+	} );
+
 	// Renders only the active step based on the current step ID.
 	return (
 		<>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
@@ -91,15 +91,11 @@ export default function Stepper( {
 						</div>
 					</div>
 					<div className="settings-payments-onboarding-modal__sidebar--list">
-						{ steps.map( ( step ) => (
+						{ sortedSteps.map( ( step ) => (
 							<SidebarItem
 								key={ step.id }
 								label={ step.label }
-								isCompleted={
-									step.id === justCompletedStepId ||
-									step.status === 'completed' ||
-									activeStepIndex === steps.length
-								}
+								isCompleted={ isStepCompleted( step ) }
 								isActive={ step.id === active }
 							/>
 						) ) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/components/stepper/index.tsx
@@ -49,6 +49,17 @@ export default function Stepper( {
 	const activeStepIndex =
 		steps.findIndex( ( step ) => step.id === active ) + 1;
 
+	// Helper function to determine if a step is completed
+	const isStepCompleted = (
+		step: WooPaymentsProviderOnboardingStep
+	): boolean => {
+		return (
+			step.id === justCompletedStepId ||
+			step.status === 'completed' ||
+			activeStepIndex === steps.length
+		);
+	};
+
 	// Renders only the active step based on the current step ID.
 	return (
 		<>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change is to display the completed steps first in the NOX. This to avoid showing the merchant that they are on step 1, but 2 is already finished. This happens mainly with WP.com connection step (if the site is already connected)

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

### Screenshots or screen recordings:


https://github.com/user-attachments/assets/e1ea8125-84cf-44a3-9af3-8d88004397cc


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Locally, get this PR and head to Settings > Payments
2. If WP.com is already connected, the step should be the first one (instead of second)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Display finished steps first in NOX In-Context

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
