### PR TITLE
Remove support for obsolete Google Web Light

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cache-helper.php
+++ b/plugins/woocommerce/includes/class-wc-cache-helper.php
@@ -51,21 +51,11 @@ class WC_Cache_Helper {
 		$set_cache = false;
 
 		/**
-		 * Allow plugins to enable nocache headers. Enabled for Google weblight.
+		 * Allow plugins to enable nocache headers.
 		 *
 		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: false.
 		 */
 		if ( apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
-			$set_cache = true;
-		}
-
-		/**
-		 * Enabled for Google weblight.
-		 *
-		 * @see https://support.google.com/webmasters/answer/1061943?hl=en
-		 */
-		if ( false !== strpos( $agent, 'googleweblight' ) ) {
-			// no-transform: Opt-out of Google weblight. https://support.google.com/webmasters/answer/6211428?hl=en.
 			$set_cache = true;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This removes support for Google Web Light which was introduced in #26858 and https://github.com/woocommerce/woocommerce/commit/9f6104598ba70425177a058f024cb98724c34e82. The Google Web Light service was shut down in 2022 [per Wikipedia](https://en.wikipedia.org/wiki/Google_Web_Light):

> On December 19, 2022, Google announced that it discontinued the Web Light service by removing the documentation and retiring the Web Light user agent. Increased affordability of more powerful [smartphones](https://en.wikipedia.org/wiki/Smartphones) was cited as the reason for this decision.[[5]](https://en.wikipedia.org/wiki/Google_Web_Light#cite_note-5)

See also [the update from Google Search Central](https://developers.google.com/search/updates#2022):

> December 19: Removed the [Web Light documentation](https://developers.google.com/search/docs/crawling-indexing/mobile/web-light) and retired the [Web Light user agent](https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers#retired). We introduced Web Light to enable us to serve faster, lighter pages to people searching on entry-level devices. While this feature has worked as intended and enabled broader access to the richness of the web, increased affordability of more powerful smartphones has diminished the need for such functionality. We remain committed to evolving and refining the Search experience to meet the changing needs of our users.

So this is removing technical debt.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
