### PR TITLE
Product Details: running description through the_content filter

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4475-wrap-product-description-in-p-element-in-accordion-block
+++ b/plugins/woocommerce/changelog/wooplug-4475-wrap-product-description-in-p-element-in-accordion-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Description: running content through the_content filter.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
@@ -57,6 +57,8 @@ class ProductDescription extends AbstractBlock {
 
 		// Get the description content.
 		$description = $product->get_description();
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		$description = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $description ) );
 		if ( empty( $description ) ) {
 			unset( self::$seen_ids[ $product_id ] );
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductDescription.php
@@ -57,6 +57,10 @@ class ProductDescription extends AbstractBlock {
 
 		// Get the description content.
 		$description = $product->get_description();
+		/**
+		 * This filter is documented in wp-includes/post-template.php.
+		 * We follow core/content block to replace ]]> with ]&gt;
+		 */
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$description = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $description ) );
 		if ( empty( $description ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fix the issue that product description isn't wrapped in paragraph tags event though it's rich text. The issue is fixed by applying `the_content` filter like the `core/content` block.

Closes WOOPLUG-4475

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the Single Product template is using Blockified Product Details (use WooCommerce Beta Tester to enable experimental blocks).
2. Visit a product on the frontend.
3. See the product description is wrapped by `<p>` tags.
4. Check with product that has multiple paragraph and image, see the HTML semantic is properly output.
<!-- End testing instructions -->
