### PR TITLE
E2E: retry creating single product template to mitigate network issues

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2988-flaky-test-block-hides-tab-title-in-content-when-toggle-is
+++ b/plugins/woocommerce/changelog/wooplug-2988-flaky-test-block-hides-tab-title-in-content-when-toggle-is
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E: retry creating template to mitigate network issues.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR try to fix the flaky test of single product template test that fails due to network issue (Error: apiRequestContext.fetch: socket hang up) by retrying the request creating template for 3 times. The logic is copied from [here](https://github.com/woocommerce/woocommerce/blob/5db9a9962e0f22bfb0aca9b8cc5985d8a0d61d18/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts#L57).

Closes WOOPLUG-2988.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

See CI passes, the [9/10 one](https://github.com/woocommerce/woocommerce/actions/runs/15386711430/job/43311598855?pr=58457) there is no retry compared to trunk. 