### PR TITLE
Make default attributes selected by default for dropdown mode in Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/58464-make-default-attribute-selected
+++ b/plugins/woocommerce/changelog/58464-make-default-attribute-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix default attribute selection in dropdown mode for Add to Cart + Options block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -213,18 +213,24 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 
 		$options = '';
 		foreach ( $attribute_terms as $attribute_term ) {
+			$option_attributes = array(
+				'value'                  => $attribute_term['value'],
+				'data-wp-bind--disabled' => 'state.isOptionDisabled',
+				'data-wp-context'        => array(
+					'option'  => $attribute_term,
+					'name'    => $attribute_slug,
+					'options' => $attribute_terms,
+				),
+			);
+
+			if ( $attribute_term['isSelected'] ) {
+				$option_attributes['selected'] = 'selected';
+			}
+
 			$options .= sprintf(
 				'<option %s>%s</option>',
 				$this->get_normalized_attributes(
-					array(
-						'value'                  => $attribute_term['value'],
-						'data-wp-bind--disabled' => 'state.isOptionDisabled',
-						'data-wp-context'        => array(
-							'option'  => $attribute_term,
-							'name'    => $attribute_slug,
-							'options' => $attribute_terms,
-						),
-					),
+					$option_attributes
 				),
 				$attribute_term['label']
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the `Add to Cart + Options` block wasn't honoring default attributes of product in dropdown mode. While the pills mode correctly selected default attributes, the dropdown mode was not pre-selecting the default attributes as configured in the product settings.

Closes #58422 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/d79fcd8c-55ef-48a2-ab46-670d549d5567

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
2. Go to _WooCommerce Admin Test Helper > Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Go to _Appearance > Editor > Templates > Single Product_.
4. Click on the `Add to Cart with Options` block and update to the blockified version.
5. Click on the block and change the product type to Variable product
6. Select the `Variation Selector: Attribute Options (Beta)` block and change the style to `Dropdown` and save it
7. Create or edit a variable product and select Default Form Values
8. Visit that product in the frontend.
9.  Notice the options are getting selected by default.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
