### PR TITLE
[Payments Settings NOX] Show tooltips for all suggestion categories

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4481-show-tooltips-for-all-suggestion-categories
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4481-show-tooltips-for-all-suggestion-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show tooltips for all suggestion categories in Settings -> Payments.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -76,7 +76,7 @@ export const OtherPaymentGateways = ( {
 	const [ isExpanded, setIsExpanded ] = useState( initialExpanded );
 	const [ categoryIdWithPopoverVisible, setCategoryIdWithPopoverVisible ] =
 		useState( '' );
-	const buttonRef = useRef< HTMLSpanElement >( null );
+	const buttonRefs = useRef<Record<string, HTMLSpanElement | null>>({});
 
 	const handleInfoIconClick = (
 		event: React.MouseEvent | React.KeyboardEvent,
@@ -87,7 +87,8 @@ export const OtherPaymentGateways = ( {
 			'.other-payment-gateways__content__title__icon-container'
 		);
 
-		if ( buttonRef.current && parentSpan !== buttonRef.current ) {
+		const targetRef = buttonRefs.current[ categoryId ] ?? null;
+		if ( targetRef && parentSpan !== targetRef ) {
 			return;
 		}
 
@@ -216,7 +217,9 @@ export const OtherPaymentGateways = ( {
 									} }
 									tabIndex={ 0 }
 									role="button"
-									ref={ buttonRef }
+									ref={ (el) => {
+										buttonRefs.current[ category.id ] = el;
+									} }
 								>
 									<Gridicon
 										icon="info-outline"

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/other-payment-gateways/other-payment-gateways.tsx
@@ -76,7 +76,7 @@ export const OtherPaymentGateways = ( {
 	const [ isExpanded, setIsExpanded ] = useState( initialExpanded );
 	const [ categoryIdWithPopoverVisible, setCategoryIdWithPopoverVisible ] =
 		useState( '' );
-	const buttonRefs = useRef<Record<string, HTMLSpanElement | null>>({});
+	const buttonRefs = useRef< Record< string, HTMLSpanElement | null > >( {} );
 
 	const handleInfoIconClick = (
 		event: React.MouseEvent | React.KeyboardEvent,
@@ -217,7 +217,7 @@ export const OtherPaymentGateways = ( {
 									} }
 									tabIndex={ 0 }
 									role="button"
-									ref={ (el) => {
+									ref={ ( el ) => {
 										buttonRefs.current[ category.id ] = el;
 									} }
 								>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes WOOPLUG-4481.
Closes #58466.

(For Bug Fixes) Bug introduced in PR #57856.

The reason `buttonRef` stays the same for different icons is because of how React refs work — and specifically how we're applying the ref to elements inside a list/map without isolating the reference per item.

There is this line inside a map() that renders multiple categories:

```
<span
	className="other-payment-gateways__content__title__icon-container"
	...
	ref={ buttonRef }
>
```
Since this is in a loop, this same ref instance (`buttonRef`) is assigned to every icon container, but React only sets `ref.current` to the last one rendered.

So `buttonRef.current` will always point to the last rendered category's icon container.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/user-attachments/assets/d2058fc5-0e62-4827-b749-cca262b956dd) |  ![image](https://github.com/user-attachments/assets/79b92f23-7e5b-4820-8cd9-58e95d7bf56f) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Spin up a new JN site with this PR's branch build (here's [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=fix/WOOPLUG-4481-show-tooltips-for-all-suggestion-categories)).
2. Click on WooCommerce, skip the core profiler, and set your store location to Austria.
3. Install the Stripe plugin from other payment options. 
![image](https://github.com/user-attachments/assets/df9400ef-3822-4537-87e3-39161ff194e6)
4. Click Complete Setup.
![image](https://github.com/user-attachments/assets/ad4bd034-f121-4d97-af1b-1245ee0d2752)
5. Create a test account for Stripe.
![image](https://github.com/user-attachments/assets/43555a5c-9b60-4b00-8a27-a047ad123ea7)
6. Navigate to WooCommerce > Settings > Payments. Verify that tooltips appear for all categories.
![image](https://github.com/user-attachments/assets/1fbe080c-dbba-4f7e-8fc9-eec02c2a1740)

<!-- End testing instructions -->

### Testing that has already taken place:

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
