### PR TITLE
[Experimental] Add to Cart + Options: support missing hooks in variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-58358-add-missing-hooks-to-variable-product
+++ b/plugins/woocommerce/changelog/fix-58358-add-missing-hooks-to-variable-product
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add to Cart + Options: Add support for missing hooks in variable products
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -245,18 +245,6 @@ class AddToCartWithOptions extends AbstractBlock {
 					 */
 					do_action( 'woocommerce_before_variations_form' );
 					/**
-					 * Hook: woocommerce_before_add_to_cart_quantity.
-					 *
-					 * @since 2.7.0
-					 */
-					do_action( 'woocommerce_before_add_to_cart_quantity' );
-					/**
-					 * Hook: woocommerce_before_add_to_cart_button.
-					 *
-					 * @since 10.0.0
-					 */
-					do_action( 'woocommerce_before_add_to_cart_button' );
-					/**
 					 * Hook: woocommerce_after_variations_table.
 					 *
 					 * @since 10.0.0
@@ -283,6 +271,18 @@ class AddToCartWithOptions extends AbstractBlock {
 					if ( function_exists( 'woocommerce_single_variation_add_to_cart_button' ) ) {
 						add_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
 					}
+					/**
+					 * Hook: woocommerce_before_add_to_cart_button.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_button' );
+					/**
+					 * Hook: woocommerce_before_add_to_cart_quantity.
+					 *
+					 * @since 2.7.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_quantity' );
 				}
 				$hooks_before = ob_get_clean();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -220,30 +220,69 @@ class AddToCartWithOptions extends AbstractBlock {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_button' );
 				} elseif ( ProductType::EXTERNAL === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_button' );
 				} elseif ( ProductType::GROUPED === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_variations_form.
 					 *
-					 * @since 2.4.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_variations_form' );
+					/**
+					 * Hook: woocommerce_before_add_to_cart_quantity.
+					 *
+					 * @since 2.7.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_quantity' );
+					/**
+					 * Hook: woocommerce_before_add_to_cart_button.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_before_add_to_cart_button' );
+					/**
+					 * Hook: woocommerce_after_variations_table.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_after_variations_table' );
+					/**
+					 * Hook: woocommerce_before_single_variation.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_before_single_variation' );
+
+					remove_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 );
+					remove_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
+					/**
+					 * Hook: woocommerce_single_variation.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_single_variation' );
+					if ( function_exists( 'woocommerce_single_variation' ) ) {
+						add_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 );
+					}
+					if ( function_exists( 'woocommerce_single_variation_add_to_cart_button' ) ) {
+						add_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
+					}
 				}
 				$hooks_before = ob_get_clean();
 
@@ -252,34 +291,52 @@ class AddToCartWithOptions extends AbstractBlock {
 					/**
 					 * Hook: woocommerce_after_add_to_cart_quantity.
 					 *
-					 * @since 2.7.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_quantity' );
 					/**
 					 * Hook: woocommerce_after_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_button' );
 				} elseif ( ProductType::EXTERNAL === $product_type ) {
 					/**
 					 * Hook: woocommerce_after_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_button' );
 				} elseif ( ProductType::GROUPED === $product_type ) {
 					/**
 					 * Hook: woocommerce_after_add_to_cart_button.
 					 *
-					 * @since 1.5.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_after_add_to_cart_button' );
 				} elseif ( ProductType::VARIABLE === $product_type ) {
 					/**
+					 * Hook: woocommerce_after_add_to_cart_quantity.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_after_add_to_cart_quantity' );
+					/**
+					 * Hook: woocommerce_after_add_to_cart_button.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_after_add_to_cart_button' );
+					/**
+					 * Hook: woocommerce_after_single_variation.
+					 *
+					 * @since 10.0.0
+					 */
+					do_action( 'woocommerce_after_single_variation' );
+					/**
 					 * Hook: woocommerce_after_variations_form.
 					 *
-					 * @since 2.4.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_after_variations_form' );
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -257,6 +257,12 @@ class AddToCartWithOptions extends AbstractBlock {
 					 */
 					do_action( 'woocommerce_before_single_variation' );
 
+					// WooCommerce uses `woocommerce_single_variation` to render
+					// some UI elements like the Add to Cart button for
+					// variations. We need to remove them to avoid those UI
+					// elements being duplicate with the blocks.
+					// We later add these actions back to avoid affecting other
+					// blocks or templates.
 					remove_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 );
 					remove_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
 					/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58358.

This PR adds some extra PHP actions to the Add to Cart + Options compatibility layer when displaying variable products. I also updated the `@since` version of all of them to 10.0.0, which is when the block is planned to be released.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.

#### Testing the PR

##### Testing a real extension

3. Install [Product Add-Ons](https://woocommerce.com/products/product-add-ons/).
4. Edit a variable product and add some add-ons to it.
5. In the frontend, add that product to the cart (while selecting some of the add-ons).
6. Verify the product was added correctly to cart, including the add-ons.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/51037a17-5e6d-4363-93a6-1128ff3592d8) | ![image](https://github.com/user-attachments/assets/d906e258-5f8d-47c3-b6ef-bc65f3c5bf63)

##### Testing PHP hooks

6. Add this PHP code snippet to your store (you can use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin):
```PHP
$actions = [
	'woocommerce_before_variations_form',
	'woocommerce_before_add_to_cart_quantity',
	'woocommerce_after_add_to_cart_quantity',
	'woocommerce_before_add_to_cart_button',
	'woocommerce_after_add_to_cart_button',
	'woocommerce_before_single_variation',
	'woocommerce_single_variation',
	'woocommerce_after_single_variation',
	'woocommerce_after_variations_table',
];

foreach ( $actions as $action ) {
	add_action( $action, function() use ( $action ) {
		echo '<p>' . $action . ' run</p>';
	} );
}
```

7. In the frontend, visit the template of a variable product.
8. Verify hooks are rendered correctly.