### PR TITLE
Product Gallery: add `alt` to images and improve dialog a11y

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-improvements
+++ b/plugins/woocommerce/changelog/fix-product-gallery-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: improve accessibility

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -249,6 +249,42 @@ const productGallery = {
 			if ( event.code === 'Escape' ) {
 				actions.closeDialog();
 			}
+
+			if ( event.code === 'Tab' ) {
+				const focusableElementsSelectors =
+					'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+				const dialogPopUp = getElement()?.ref as HTMLElement;
+				const focusableElements = dialogPopUp.querySelectorAll(
+					focusableElementsSelectors
+				);
+
+				if ( ! focusableElements.length ) {
+					return;
+				}
+
+				const firstFocusableElement =
+					focusableElements[ 0 ] as HTMLElement;
+				const lastFocusableElement = focusableElements[
+					focusableElements.length - 1
+				] as HTMLElement;
+
+				if (
+					! event.shiftKey &&
+					event.target === lastFocusableElement
+				) {
+					event.preventDefault();
+					firstFocusableElement.focus();
+				}
+
+				if (
+					event.shiftKey &&
+					event.target === firstFocusableElement
+				) {
+					event.preventDefault();
+					lastFocusableElement.focus();
+				}
+			}
 		},
 		openDialog: () => {
 			const context = getContext();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -275,6 +275,7 @@ const productGallery = {
 				) {
 					event.preventDefault();
 					firstFocusableElement.focus();
+					return;
 				}
 
 				if (
@@ -283,6 +284,12 @@ const productGallery = {
 				) {
 					event.preventDefault();
 					lastFocusableElement.focus();
+					return;
+				}
+
+				if ( event.target === dialogPopUp ) {
+					event.preventDefault();
+					firstFocusableElement.focus();
 				}
 			}
 		},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -48,17 +48,15 @@ class ProductGallery extends AbstractBlock {
 		ob_start();
 		?>
 			<dialog
-				data-wp-ref
 				data-wp-bind--open="context.isDialogOpen"
+				data-wp-bind--inert="!context.isDialogOpen"
 				data-wp-on--close="actions.closeDialog"
 				data-wp-on--keydown="actions.onDialogKeyDown"
 				data-wp-watch="callbacks.dialogStateChange"
 				class="wc-block-product-gallery-dialog"
 				role="dialog"
 				aria-modal="true"
-				tabindex="-1"
-				aria-label="Product Gallery"
-				data-wp-bind--inert="!context.isDialogOpen">
+				aria-label="Product Gallery">
 				<div class="wc-block-product-gallery-dialog__content">
 					<button class="wc-block-product-gallery-dialog__close-button" data-wp-on--click="actions.closeDialog" aria-label="<?php echo esc_attr__( 'Close dialog', 'woocommerce' ); ?>">
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -118,8 +118,8 @@ class ProductGallery extends AbstractBlock {
 		$initial_image_id       = count( $image_ids ) > 0 ? $image_ids[0] : -1;
 		$classname_single_image = count( $image_ids ) < 2 ? 'is-single-product-gallery-image' : '';
 		$product_id             = strval( $product->get_id() );
-		$full_image_data        = ProductGalleryUtils::get_image_src_data( $image_ids, 'full' );
-		$gallery_with_dialog    = $this->inject_dialog( $content, $this->render_dialog( $full_image_data ) );
+		$fullsize_image_data    = ProductGalleryUtils::get_image_src_data( $image_ids, 'full', $product->get_title() );
+		$gallery_with_dialog    = $this->inject_dialog( $content, $this->render_dialog( $fullsize_image_data ) );
 		$p                      = new \WP_HTML_Tag_Processor( $gallery_with_dialog );
 
 		if ( $p->next_tag() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -43,7 +43,7 @@ class ProductGallery extends AbstractBlock {
 			$srcset       = $image['srcset'];
 			$sizes        = $image['sizes'];
 			$alt          = $image['alt'];
-			$images_html .= "<img tabindex='0' data-image-id='{$id}' src='{$src}' srcset='{$srcset}' sizes='{$sizes}' loading='lazy' decoding='async' alt='{$alt}' />";
+			$images_html .= "<img data-image-id='{$id}' src='{$src}' srcset='{$srcset}' sizes='{$sizes}' loading='lazy' decoding='async' alt='{$alt}' />";
 		}
 		ob_start();
 		?>
@@ -57,7 +57,8 @@ class ProductGallery extends AbstractBlock {
 				role="dialog"
 				aria-modal="true"
 				tabindex="-1"
-				aria-label="Product Gallery">
+				aria-label="Product Gallery"
+				data-wp-bind--inert="!context.isDialogOpen">
 				<div class="wc-block-product-gallery-dialog__content">
 					<button class="wc-block-product-gallery-dialog__close-button" data-wp-on--click="actions.closeDialog" aria-label="<?php echo esc_attr__( 'Close dialog', 'woocommerce' ); ?>">
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGallery.php
@@ -42,7 +42,8 @@ class ProductGallery extends AbstractBlock {
 			$src          = $image['src'];
 			$srcset       = $image['srcset'];
 			$sizes        = $image['sizes'];
-			$images_html .= "<img tabindex='0' data-image-id='{$id}' src='{$src}' srcset='{$srcset}' sizes='{$sizes}' loading='lazy' decoding='async' />";
+			$alt          = $image['alt'];
+			$images_html .= "<img tabindex='0' data-image-id='{$id}' src='{$src}' srcset='{$srcset}' sizes='{$sizes}' loading='lazy' decoding='async' alt='{$alt}' />";
 		}
 		ob_start();
 		?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -115,8 +115,6 @@ class ProductGalleryLargeImage extends AbstractBlock {
 			$base_classes .= ' wc-block-woocommerce-product-gallery-large-image__image--hoverZoom';
 		}
 
-		do_action('qm/debug', $image_data);
-
 		ob_start();
 		?>
 			<ul

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -115,6 +115,8 @@ class ProductGalleryLargeImage extends AbstractBlock {
 			$base_classes .= ' wc-block-woocommerce-product-gallery-large-image__image--hoverZoom';
 		}
 
+		do_action('qm/debug', $image_data);
+
 		ob_start();
 		?>
 			<ul
@@ -130,6 +132,7 @@ class ProductGalleryLargeImage extends AbstractBlock {
 							srcset="<?php echo esc_attr( $image['srcset'] ); ?>"
 							sizes="<?php echo esc_attr( $image['sizes'] ); ?>"
 							data-image-id="<?php echo esc_attr( $image['id'] ); ?>"
+							alt="<?php echo esc_attr( $image['alt'] ); ?>"
 							data-wp-on--keydown="actions.onSelectedLargeImageKeyDown"
 							data-wp-on--touchstart="actions.onTouchStart"
 							data-wp-on--touchmove="actions.onTouchMove"
@@ -149,7 +152,6 @@ class ProductGalleryLargeImage extends AbstractBlock {
 								loading="lazy"
 							<?php endif; ?>
 							tabindex="0"
-							alt=""
 						/>
 					</li>
 				<?php endforeach; ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -99,6 +99,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 							src="<?php echo esc_attr( $image['src'] ); ?>"
 							srcset="<?php echo esc_attr( $image['srcset'] ); ?>"
 							sizes="<?php echo esc_attr( $image['sizes'] ); ?>"
+							alt="<?php echo esc_attr( $image['alt'] ); ?>"
 							data-wp-on--click="actions.selectCurrentImage"
 							data-wp-on--keydown="actions.onThumbnailKeyDown"
 							data-wp-watch="callbacks.toggleActiveImageAttributes"

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -38,7 +38,7 @@ class ProductGalleryUtils {
 	 */
 	public static function get_product_gallery_image_data( $product, $size ) {
 		$all_image_ids = self::get_all_image_ids( $product );
-		return self::get_image_src_data( $all_image_ids, $size );
+		return self::get_image_src_data( $all_image_ids, $size, $product->get_title() );
 	}
 
 	/**
@@ -57,12 +57,13 @@ class ProductGalleryUtils {
 	 *
 	 * @param array  $image_ids The image IDs to retrieve the source data for.
 	 * @param string $size The size of the image to retrieve.
+	 * @param string $product_title The title of the product used for alt fallback.
 	 * @return array An array of image source data.
 	 */
-	public static function get_image_src_data( $image_ids, $size ) {
+	public static function get_image_src_data( $image_ids, $size, $product_title = '' ) {
 		$image_src_data = array();
 
-		foreach ( $image_ids as $image_id ) {
+		foreach ( $image_ids as $index => $image_id ) {
 			if ( 0 === $image_id ) {
 				// Handle placeholder image.
 				$image_src_data[] = array(
@@ -88,7 +89,7 @@ class ProductGalleryUtils {
 				'src'    => $full_src ? $full_src[0] : '',
 				'srcset' => $srcset ? $srcset : '',
 				'sizes'  => $sizes ? $sizes : '',
-				'alt'    => $alt ? $alt : '',
+				'alt'    => $alt ? $alt : sprintf( '%s - Image %d', $product_title, $index + 1 ),
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -70,6 +70,7 @@ class ProductGalleryUtils {
 					'src'    => wc_placeholder_img_src(),
 					'srcset' => '',
 					'sizes'  => '',
+					'alt'    => '',
 				);
 				continue;
 			}
@@ -80,12 +81,14 @@ class ProductGalleryUtils {
 			// Get srcset and sizes.
 			$srcset = wp_get_attachment_image_srcset( $image_id, $size );
 			$sizes  = wp_get_attachment_image_sizes( $image_id, $size );
+			$alt    = wp_get_attachment_caption( $image_id );
 
 			$image_src_data[] = array(
 				'id'     => $image_id,
 				'src'    => $full_src ? $full_src[0] : '',
 				'srcset' => $srcset ? $srcset : '',
 				'sizes'  => $sizes ? $sizes : '',
+				'alt'    => $alt ? $alt : '',
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -89,7 +89,12 @@ class ProductGalleryUtils {
 				'src'    => $full_src ? $full_src[0] : '',
 				'srcset' => $srcset ? $srcset : '',
 				'sizes'  => $sizes ? $sizes : '',
-				'alt'    => $alt ? $alt : sprintf( '%s - Image %d', $product_title, $index + 1 ),
+				'alt'    => $alt ? $alt : sprintf(
+					/* translators: 1: Product title 2: Image number */
+					__( '%1$s - Image %2$d', 'woocommerce' ),
+					$product_title,
+					$index + 1
+				)
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -82,7 +82,7 @@ class ProductGalleryUtils {
 			// Get srcset and sizes.
 			$srcset = wp_get_attachment_image_srcset( $image_id, $size );
 			$sizes  = wp_get_attachment_image_sizes( $image_id, $size );
-			$alt    = get_post_meta($image_id, '_wp_attachment_image_alt', true);
+			$alt    = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
 
 			$image_src_data[] = array(
 				'id'     => $image_id,
@@ -94,7 +94,7 @@ class ProductGalleryUtils {
 					__( '%1$s - Image %2$d', 'woocommerce' ),
 					$product_title,
 					$index + 1
-				)
+				),
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -82,7 +82,7 @@ class ProductGalleryUtils {
 			// Get srcset and sizes.
 			$srcset = wp_get_attachment_image_srcset( $image_id, $size );
 			$sizes  = wp_get_attachment_image_sizes( $image_id, $size );
-			$alt    = wp_get_attachment_caption( $image_id );
+			$alt    = get_post_meta($image_id, '_wp_attachment_image_alt', true);
 
 			$image_src_data[] = array(
 				'id'     => $image_id,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Product Gallery images miss `alt` attribute. This PR adds `alt` to images and if it's missing for an image, adds a fallback `<<PRODUCT NAME>> - Image <<INDEX>>`, e.g. `Hoodie with Logo - Image 2`. Added to:
- Large Image
- Thumbnails
- Full Page Gallery.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Alt attribute

1. Create product with multiple images and make sure some images have `alt text` some of them not
2. Go to Editor > Single Product template
3. Replace the Product Image Gallery block with the Product Gallery (beta) block
4. Save and go to frontend
5. Inspect images in thumbnails and large images
6. **Expected:** All images have `alt` attribute assign:
  - either their actual `alt`
  - or `<<PRODUCT NAME>> - Image <<INDEX>>`, e.g. `Hoodie with Logo - Image 2` if you didn't set `alt` for this image
7. Open full page gallery by clicking large image
8. Repeat 5 and 6 for them

#### Dialog focus trap

1. On a frontend click on a large image to open full page gallery
2. Use TAB and SHIFT+TAB to navigate trough page
3. **Expected:** Focus stays on "X" closing button (it's the only interactive element on dialog but if there was more, focus would circulate through them but only within dialog)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
