### PR TITLE
Fix email status toggle in the email editor integration to ensure proper functionality.

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4476-email-status-update-on-the-email-editor-stopped-working
+++ b/plugins/woocommerce/changelog/wooplug-4476-email-status-update-on-the-email-editor-stopped-working
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix email status toggle in the email editor integration

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailApiController.php
@@ -67,8 +67,9 @@ class EmailApiController {
 		}
 
 		$form_fields = $email->get_form_fields();
+		$enabled     = $email->get_option( 'enabled' );
 		return array(
-			'enabled'         => $email->is_enabled(),
+			'enabled'         => is_null( $enabled ) ? $email->is_enabled() : 'yes' === $enabled,
 			'is_manual'       => $email->is_manual(),
 			'subject'         => $email->get_option( 'subject' ),
 			'subject_full'    => $email->get_option( 'subject_full' ), // For customer_refunded_order email type because it has two different subjects.
@@ -102,6 +103,10 @@ class EmailApiController {
 		$email_type = $this->post_manager->get_email_type_from_post_id( $post->ID );
 		$email      = $this->get_email_by_type( $email_type ?? '' );
 
+		if ( ! $email ) {
+			return null; // not saving of type wc_email. Allow process to continue.
+		}
+
 		// Handle customer_refunded_order email type because it has two different subjects.
 		if ( 'customer_refunded_order' === $email_type ) {
 			if ( array_key_exists( 'subject_full', $data ) ) {
@@ -119,7 +124,7 @@ class EmailApiController {
 		}
 
 		if ( array_key_exists( 'enabled', $data ) ) {
-			$email->update_option( $data['enabled'] ? 'yes' : 'no' );
+			$email->update_option( 'enabled', $data['enabled'] ? 'yes' : 'no' );
 		}
 		if ( array_key_exists( 'recipient', $data ) ) {
 			$email->update_option( 'recipient', $data['recipient'] );


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<img width="334" alt="Screenshot 2025-06-02 at 6 07 32 PM" src="https://github.com/user-attachments/assets/a15f765b-af92-4a99-b5b8-3cfe90c5864f" />


Update the EmailApiController to correctly handle the 'enabled' option and prevent null email types from causing issues.

Closes #58456 WOOPLUG-4476

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   ![Screen Recording at 2025-06-02 at 06-17-44](https://github.com/user-attachments/assets/18ef6a18-8572-479d-bef7-75ad8c63c72a) |    ![Screen Recording at 2025-06-02 at 06-13-52](https://github.com/user-attachments/assets/ff9459cc-700b-4e9a-a396-8cc6cee5ed82) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open any email from the listing page
2. Click on email status from the settings sidebar
3. Switch the status
4. Click on save.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
