### PR TITLE
Fix fatal error when WC_Email child class doesn't set template_html

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4488-fatal-error-when-wc_email-child-class-doesnt-set
+++ b/plugins/woocommerce/changelog/wooplug-4488-fatal-error-when-wc_email-child-class-doesnt-set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when WC_Email child class doesn't set template_html

--- a/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
@@ -165,7 +165,7 @@ class EmailImprovements {
 		return array_filter(
 			WC()->mailer()->get_emails(),
 			function ( $email ) {
-				return strpos( get_class( $email ), 'WC_Email_' ) === 0;
+				return strpos( get_class( $email ), 'WC_Email_' ) === 0 && is_string( $email->template_html );
 			}
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

==== **Don't merge this PR unless https://github.com/woocommerce/woocommerce/issues/58489 is approved.** ====

In WC Tracker, we track usage of core WC emails, which are detected by checking for `WC_Email_` prefix in the registered emails class name. In all core emails, the `template_html` is properly set, but some 3rd-party extension use the same prefix and don't set `template_html`, which ends up in fatal error, because the `template_html` is later used and is expected to be a string (but is `null`). 

This PR adds one more check for `template_html` property to pass `is_string()`.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4488, closes #58486.

(For Bug Fixes) Bug introduced in PR #58286.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. This isn't easily replicable in the UI, so some code needs to be changed to test this.
2. Before checking out this branch, add `var_dump( WC_Tracker::get_tracking_data() );` anywhere, which will indicate if the error is present.
3. Update any of the `includes/emails/class-wc-email-*` classes and remove `$this->template_html =` file from construct.
4. Reload the page to observe the fatal error.
5. Check out this branch. 
6. Reload the page to see there is no error.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

The above.