### PR TITLE
Fix Add to Cart + Options block: Item Label block doesn't display product name in the editor

### DIFF
--- a/plugins/woocommerce/changelog/58490-add-product-name-in-grouped-products
+++ b/plugins/woocommerce/changelog/58490-add-product-name-in-grouped-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Item Label block displaying "Product Title" instead of actual product name in editor for grouped products

--- a/plugins/woocommerce/changelog/58490-add-product-name-in-grouped-products
+++ b/plugins/woocommerce/changelog/58490-add-product-name-in-grouped-products
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
+Comment: Fix Item Label block displaying "Product Title" instead of actual product name in editor for grouped products
 
-Fix Item Label block displaying "Product Title" instead of actual product name in editor for grouped products
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
@@ -6,6 +6,8 @@ import { heading } from '@wordpress/icons';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import type { BlockConfiguration } from '@wordpress/blocks';
+import { useProductDataContext } from '@woocommerce/shared-context';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,11 +20,15 @@ if ( shouldBlockifiedAddToCartWithOptionsBeRegistered ) {
 		...metadata,
 		edit: function Edit() {
 			const blockProps = useBlockProps();
+			const { isLoading, product } = useProductDataContext();
 
+			if ( isLoading ) {
+				return <Spinner />;
+			}
 			return (
 				<div { ...blockProps }>
 					<div className="wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector-item-label">
-						{ __( 'Product Title', 'woocommerce' ) }
+						{ product.name }
 					</div>
 				</div>
 			);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-label/index.tsx
@@ -4,7 +4,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { heading } from '@wordpress/icons';
 import { useBlockProps } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 import type { BlockConfiguration } from '@wordpress/blocks';
 import { useProductDataContext } from '@woocommerce/shared-context';
 import { Spinner } from '@wordpress/components';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the Item Label block in the `Add to Cart + Options` block displays "Product Title" placeholder text instead of the actual product name in the editor context for grouped products.

The fix utilizes the `useProductDataContext` hook to properly fetch and display the actual product name in the editor, ensuring consistency between the editor preview and frontend display.

#### Changes made:

- Updated the Item Label block to use `useProductDataContext` hook for proper product name retrieval in editor context
- Ensured the block displays actual product names instead of placeholder text for grouped products

Closes #58463 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/732daeb3-6a34-4788-adb5-671efa2e1753" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/0ea91417-14b1-4e2b-8bbc-ef7485428f4e" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
2. Go to _WooCommerce Admin Test Helper > Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Go to _Appearance > Editor > Templates > Single Product_.
4. Click on the `Add to Cart with Options` block and update to the blockified version.
5. Create a post or page and add the `Single Product` block.
6. Select a grouped product.
7. Update the Add to Cart with Options block to the blockified version.
8. Notice the child products show up with _Product Title_ as the name:

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
