### PR TITLE
[Experimental] Display errors in Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-57725-add-to-cart-options-errors
+++ b/plugins/woocommerce/changelog/fix-57725-add-to-cart-options-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Display errors in Add to Cart + Options block

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/store-notices.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/store-notices.ts
@@ -18,6 +18,7 @@ type NoticeWithId = Notice & {
 };
 
 const getStoreNoticeContext = getContextFn< {
+	notices: NoticeWithId[];
 	notice: NoticeWithId;
 } >;
 
@@ -66,7 +67,7 @@ const generateNoticeId = () => {
 };
 
 // Todo: export this store once the store is public.
-store< Store >(
+const { state } = store< Store >(
 	'woocommerce/store-notices',
 	{
 		state: {
@@ -99,13 +100,24 @@ store< Store >(
 				return notice.type === 'notice';
 			},
 			get notices() {
-				const { notices } = getProductCollectionContext();
-				return notices;
+				const productCollectionContext = getProductCollectionContext();
+				if ( productCollectionContext ) {
+					return productCollectionContext?.notices;
+				}
+
+				const context = getStoreNoticeContext();
+
+				if ( context && context.notices ) {
+					return context.notices;
+				}
+
+				return [];
 			},
 		},
 		actions: {
 			addNotice: ( notice: Notice ) => {
-				const { notices } = getProductCollectionContext();
+				const { notices } = state;
+
 				const noticeId = generateNoticeId();
 				const noticeWithId = {
 					...notice,
@@ -117,7 +129,8 @@ store< Store >(
 			},
 
 			removeNotice: ( noticeId: string | PointerEvent ) => {
-				const { notices } = getProductCollectionContext();
+				const { notices } = state;
+
 				noticeId =
 					typeof noticeId === 'string'
 						? noticeId

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -113,7 +113,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( addToCartButton ).toHaveText( '6 in cart' );
 	} );
 
-	test( "'X in cart' text reflects the correct amount in variations", async ( {
+	test( 'allows adding variable products to cart', async ( {
 		page,
 		pageObject,
 		editor,
@@ -135,19 +135,31 @@ test.describe( 'Add to Cart + Options Block', () => {
 		const colorGreenOption = page.locator( 'label:has-text("Green")' );
 		const addToCartButton = page.getByText( 'Add to cart' ).first();
 
-		await logoNoOption.click();
-		await colorGreenOption.click();
-		await addToCartButton.click();
+		await test.step( 'displays an error when attributes are not selected', async () => {
+			await addToCartButton.click();
 
-		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+			await expect(
+				page.getByText( ' No matching variation found.' )
+			).toBeVisible();
+		} );
 
-		await colorBlueOption.click();
+		await test.step( 'successfully adds to cart when attributes are selected', async () => {
+			await logoNoOption.click();
+			await colorGreenOption.click();
+			await addToCartButton.click();
 
-		await expect( page.getByText( '1 in cart' ) ).toBeHidden();
+			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+		} );
 
-		await colorGreenOption.click();
+		await test.step( '"X in cart" text reflects the correct amount in variations', async () => {
+			await colorBlueOption.click();
 
-		await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+			await expect( page.getByText( '1 in cart' ) ).toBeHidden();
+
+			await colorGreenOption.click();
+
+			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+		} );
 	} );
 
 	test( "doesn't allow selecting invalid variations in pills mode", async ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -306,7 +306,8 @@ class AddToCartWithOptions extends AbstractBlock {
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
 			$hidden_input            = '';
-			if ( $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add ) {
+			$legacy_mode             = $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add;
+			if ( $legacy_mode ) {
 				// If an extension is hoooking into the form or we need to redirect to the cart,
 				// we fall back to a regular HTML form.
 				$form_attributes = array(
@@ -380,6 +381,58 @@ class AddToCartWithOptions extends AbstractBlock {
 
 		$product = $previous_product;
 
+		if ( ! $legacy_mode ) {
+			$form_html = $this->render_interactivity_notices_region( $form_html );
+		}
+
 		return $form_html;
+	}
+
+	/**
+	 * Render interactivity API powered notices that can be added client-side. This reuses classes
+	 * from the woocommerce/store-notices block to ensure style consistency.
+	 *
+	 * @param string $form_html The form HTML.
+	 * @return string The rendered store notices HTML.
+	 */
+	protected function render_interactivity_notices_region( $form_html ) {
+		$context = array(
+			'notices' => array(),
+		);
+
+		ob_start();
+		?>
+		<div data-wp-interactive="woocommerce/store-notices" class="wc-block-components-notices alignwide" data-wp-context='<?php echo wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ); ?>'>
+			<template data-wp-each--notice="context.notices" data-wp-each-key="context.notice.id">
+				<div
+					class="wc-block-components-notice-banner"
+					data-wp-class--is-error="state.isError"
+					data-wp-class--is-success ="state.isSuccess"
+					data-wp-class--is-info="state.isInfo"
+					data-wp-class--is-dismissible="context.notice.dismissible"
+					data-wp-bind--role="state.role"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+						<path data-wp-bind--d="state.iconPath"></path>
+					</svg>
+					<div class="wc-block-components-notice-banner__content">
+						<span data-wp-init="callbacks.renderNoticeContent"></span>
+					</div>
+					<button
+						data-wp-bind--hidden="!context.notice.dismissible"
+						class="wc-block-components-button wp-element-button wc-block-components-notice-banner__dismiss contained"
+						aria-label="<?php esc_attr_e( 'Dismiss this notice', 'woocommerce' ); ?>"
+						data-wp-on--click="actions.removeNotice"
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+							<path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z" />
+						</svg>
+					</button>
+				</div>
+			</template>
+			<?php echo $form_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		</div>
+		<?php
+		return ob_get_clean();
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -366,6 +366,10 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			$form_html = $form_html . ob_get_clean();
+
+			if ( ! $legacy_mode ) {
+				$form_html = $this->render_interactivity_notices_region( $form_html );
+			}
 		} else {
 			ob_start();
 
@@ -380,10 +384,6 @@ class AddToCartWithOptions extends AbstractBlock {
 		}
 
 		$product = $previous_product;
-
-		if ( ! $legacy_mode ) {
-			$form_html = $this->render_interactivity_notices_region( $form_html );
-		}
 
 		return $form_html;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #57725.
Closes WOOPLUG-4152.

This PR adds support for displaying errors (and other notices) in the _Add to Cart + Options_ block. Currently, the Store Notices store is tightly coupled to the Product Collection block. Even though there were efforts to update it, we had to revert them (see #57275). In the _Add to Cart + Options_ implementation, I went for what I understand is the approach we want: using the Store Notices store context instead of the specific block context to handle the notices.

#### Next steps

As a next step, we should make it so notices are cleaned up when the user interacts with the form again (changes an attribute, submits again, etc.). However, I would do that in a follow-up issue, as I don't think it's a beta release blocker and this way we don't increase this PR complexity.

* Update: issue opened #58584 (WOOPLUG-4523).

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.

#### Testing the PR

1. Set a product as sold individually.
2. Go to the frontend and try to add the product twice.
3. Verify an error appears.

![image](https://github.com/user-attachments/assets/2fc36d90-c5fe-44dd-83a0-9ced7026fb46)