### PR TITLE
Experimental iAPI Mini Cart: Remove item, set item quantity, support min and maximum

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -15,6 +15,7 @@ import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
  * Internal dependencies
  */
 import { triggerAddedToCartEvent } from './legacy-events';
+import { updateCartItemsByKey } from './helpers';
 
 export type OptimisticCartItem = {
 	key?: string;
@@ -33,6 +34,7 @@ export type Store = {
 		};
 	};
 	actions: {
+		removeCartItem: ( key: string ) => void;
 		addCartItem: ( args: OptimisticCartItem ) => void;
 		// Todo: Check why if I switch to an async function here the types of the store stop working.
 		refreshCartItems: () => void;
@@ -82,6 +84,55 @@ const { state, actions } = store< Store >(
 	'woocommerce',
 	{
 		actions: {
+			*removeCartItem( key: string ) {
+				// optimistically update the cart
+				state.cart.items = state.cart.items.filter(
+					( item ) => item.key !== key
+				);
+
+				const previousCart = JSON.stringify( state.cart );
+
+				try {
+					const res: Response = yield fetch(
+						`${ state.restUrl }wc/store/v1/cart/remove-item`,
+						{
+							method: 'POST',
+							headers: {
+								Nonce: state.nonce,
+								'Content-Type': 'application/json',
+							},
+							body: JSON.stringify( { key } ),
+						}
+					);
+
+					const { items, ...rest }: Cart = yield res.json();
+
+					// @ts-ignore
+					updateCartItemsByKey( state.cart.items, items );
+
+					state.cart = {
+						items: state.cart.items,
+						...rest,
+					};
+				} catch ( error ) {
+					const { items: previousItems, ...rest } =
+						JSON.parse( previousCart );
+
+					updateCartItemsByKey(
+						// @ts-ignore
+						state.cart.items,
+						previousItems
+					);
+
+					state.cart = {
+						items: state.cart.items,
+						...rest,
+					};
+
+					// Shows the error notice.
+					actions.showNoticeError( error as Error );
+				}
+			},
 			*addCartItem( { id, quantity, variation }: OptimisticCartItem ) {
 				let item = state.cart.items.find(
 					( { id: productId } ) => id === productId
@@ -125,8 +176,14 @@ const { state, actions } = store< Store >(
 						actions.showNoticeError( error );
 					} );
 
-					// Updates the local cart.
-					state.cart = json;
+					const { items, ...rest } = json;
+					// @ts-ignore
+					updateCartItemsByKey( state.cart.items, items );
+
+					state.cart = {
+						items: state.cart.items,
+						...rest,
+					};
 
 					// Dispatches a legacy event.
 					triggerAddedToCartEvent( {
@@ -138,7 +195,14 @@ const { state, actions } = store< Store >(
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.
-					state.cart = JSON.parse( previousCart );
+					const { items, ...rest } = JSON.parse( previousCart );
+					// @ts-ignore
+					updateCartItemsByKey( state.cart.items, items );
+
+					state.cart = {
+						items: state.cart.items,
+						...rest,
+					};
 
 					// Shows the error notice.
 					actions.showNoticeError( error as Error );
@@ -161,8 +225,15 @@ const { state, actions } = store< Store >(
 					if ( isApiErrorResponse( res, json ) )
 						throw generateError( json );
 
-					// Updates the local cart.
-					state.cart = json;
+					const { items, ...rest } = json;
+
+					// @ts-ignore
+					updateCartItemsByKey( state.cart.items, items );
+
+					state.cart = {
+						items: state.cart.items,
+						...rest,
+					};
 
 					// Resets the timeout.
 					refreshTimeout = 3000;

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -106,8 +106,6 @@ const { state, actions } = store< Store >(
 					);
 
 					const { items, ...rest }: Cart = yield res.json();
-
-					// @ts-ignore
 					updateCartItemsByKey( state.cart.items, items );
 
 					state.cart = {
@@ -117,12 +115,7 @@ const { state, actions } = store< Store >(
 				} catch ( error ) {
 					const { items: previousItems, ...rest } =
 						JSON.parse( previousCart );
-
-					updateCartItemsByKey(
-						// @ts-ignore
-						state.cart.items,
-						previousItems
-					);
+					updateCartItemsByKey( state.cart.items, previousItems );
 
 					state.cart = {
 						items: state.cart.items,
@@ -177,7 +170,6 @@ const { state, actions } = store< Store >(
 					} );
 
 					const { items, ...rest } = json;
-					// @ts-ignore
 					updateCartItemsByKey( state.cart.items, items );
 
 					state.cart = {
@@ -196,7 +188,6 @@ const { state, actions } = store< Store >(
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.
 					const { items, ...rest } = JSON.parse( previousCart );
-					// @ts-ignore
 					updateCartItemsByKey( state.cart.items, items );
 
 					state.cart = {
@@ -226,8 +217,6 @@ const { state, actions } = store< Store >(
 						throw generateError( json );
 
 					const { items, ...rest } = json;
-
-					// @ts-ignore
 					updateCartItemsByKey( state.cart.items, items );
 
 					state.cart = {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/helpers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/helpers.ts
@@ -1,0 +1,54 @@
+import { CartItem } from '../../../types';
+
+function isPrimitive(
+	val: unknown
+): val is string | number | boolean | null | undefined {
+	return (
+		val === null || ( typeof val !== 'object' && typeof val !== 'function' )
+	);
+}
+
+function deepEqual( a: any, b: any ): boolean {
+	// Quick version; replace with fast-deep-equal if needed
+	return JSON.stringify( a ) === JSON.stringify( b );
+}
+
+export function updateCartItemsByKey(
+	currentItems: CartItem[],
+	newItems: CartItem[]
+) {
+	const currentMap = new Map(
+		currentItems.map( ( item ) => [ item.key, item ] )
+	);
+
+	for ( let i = 0; i < newItems.length; i++ ) {
+		const newItem = newItems[ i ];
+		const existing = currentMap.get( newItem.key );
+
+		if ( existing ) {
+			for ( const key of Object.keys(
+				existing
+			) as ( keyof CartItem )[] ) {
+				if (
+					isPrimitive( existing[ key ] ) &&
+					existing[ key ] !== newItem[ key ]
+				) {
+					// @ts-ignore
+					existing[ key ] = newItem[ key ];
+				} else if ( ! deepEqual( existing[ key ], newItem[ key ] ) ) {
+					// @ts-ignore
+					existing[ key ] = newItem[ key ];
+				}
+			}
+		} else {
+			currentItems.push( newItem );
+		}
+	}
+
+	// Optionally prune removed items
+	const newKeys = new Set( newItems.map( ( i ) => i.key ) );
+	const filtered = currentItems.filter( ( i ) => newKeys.has( i.key ) );
+	if ( filtered.length !== currentItems.length ) {
+		currentItems.splice( 0, currentItems.length, ...filtered );
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/helpers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/helpers.ts
@@ -1,4 +1,8 @@
+/**
+ * Internal dependencies
+ */
 import { CartItem } from '../../../types';
+import { OptimisticCartItem } from './cart';
 
 function isPrimitive(
 	val: unknown
@@ -8,14 +12,14 @@ function isPrimitive(
 	);
 }
 
-function deepEqual( a: any, b: any ): boolean {
+function deepEqual( a: unknown, b: unknown ): boolean {
 	// Quick version; replace with fast-deep-equal if needed
 	return JSON.stringify( a ) === JSON.stringify( b );
 }
 
 export function updateCartItemsByKey(
-	currentItems: CartItem[],
-	newItems: CartItem[]
+	currentItems: ( CartItem | OptimisticCartItem )[],
+	newItems: ( CartItem | OptimisticCartItem )[]
 ) {
 	const currentMap = new Map(
 		currentItems.map( ( item ) => [ item.key, item ] )
@@ -30,13 +34,16 @@ export function updateCartItemsByKey(
 				existing
 			) as ( keyof CartItem )[] ) {
 				if (
+					// @ts-expect-error - TODO we need to improve the typing of cart items which is CartItem | OptimisticCartItem making it difficult to type this effectively.
 					isPrimitive( existing[ key ] ) &&
+					// @ts-expect-error - TODO we need to improve the typing of cart items which is CartItem | OptimisticCartItem making it difficult to type this effectively.
 					existing[ key ] !== newItem[ key ]
 				) {
-					// @ts-ignore
+					// @ts-expect-error - TODO we need to improve the typing of cart items which is CartItem | OptimisticCartItem making it difficult to type this effectively.
 					existing[ key ] = newItem[ key ];
+					// @ts-expect-error - TODO we need to improve the typing of cart items which is CartItem | OptimisticCartItem making it difficult to type this effectively.
 				} else if ( ! deepEqual( existing[ key ], newItem[ key ] ) ) {
-					// @ts-ignore
+					// @ts-expect-error - TODO we need to improve the typing of cart items which is CartItem | OptimisticCartItem making it difficult to type this effectively.
 					existing[ key ] = newItem[ key ];
 				}
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -178,6 +178,18 @@ type CartItemContext = {
 store( 'woocommerce/mini-cart-items-block', {
 	state: {
 		// Intended to be used in context of a cart item in wp-each
+		get minimumReached() {
+			const { cartItem } = getContext< CartItemContext >();
+			return cartItem.quantity - 1 < cartItem.quantity_limits.minimum;
+		},
+
+		// Intended to be used in context of a cart item in wp-each
+		get maximumReached() {
+			const { cartItem } = getContext< CartItemContext >();
+			return cartItem.quantity + 1 > cartItem.quantity_limits.maximum;
+		},
+
+		// Intended to be used in context of a cart item in wp-each
 		get reduceQuantityLabel() {
 			const { reduceQuantityLabel } = getConfig(
 				'woocommerce/mini-cart-items-block'
@@ -287,6 +299,49 @@ store( 'woocommerce/mini-cart-items-block', {
 		},
 	},
 	actions: {
+		*changeQuantity( e: InputEvent ): Generator< unknown, void > {
+			const input = e.target as HTMLInputElement;
+			const qty = input.value;
+
+			const { cartItem } = getContext< CartItemContext >();
+			const { actions } = store< WooCommerce >(
+				'woocommerce',
+				{},
+				{ lock: universalLock }
+			);
+			const { minimum, maximum } = cartItem.quantity_limits;
+			const quantity = parseInt( qty );
+
+			let finalQuantity = quantity;
+
+			if ( quantity < minimum ) {
+				input.value = `${ minimum }`;
+				finalQuantity = minimum;
+			} else if ( quantity > maximum ) {
+				input.value = `${ maximum }`;
+				finalQuantity = maximum;
+			} else if ( qty === '' ) {
+				input.value = `${ minimum }`;
+				finalQuantity = minimum;
+			}
+
+			yield actions.addCartItem( {
+				id: cartItem.id,
+				quantity: finalQuantity,
+			} );
+		},
+
+		*removeItemFromCart(): Generator< unknown, void > {
+			const { cartItem } = getContext< CartItemContext >();
+			const { actions } = store< WooCommerce >(
+				'woocommerce',
+				{},
+				{ lock: universalLock }
+			);
+
+			yield actions.removeCartItem( cartItem.key );
+		},
+
 		*incrementQuantity(): Generator< unknown, void > {
 			const { cartItem } = getContext< CartItemContext >();
 			const { actions } = store< WooCommerce >(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -310,7 +310,7 @@ store( 'woocommerce/mini-cart-items-block', {
 				{ lock: universalLock }
 			);
 			const { minimum, maximum } = cartItem.quantity_limits;
-			const quantity = parseInt( qty );
+			const quantity = parseInt( qty, 10 );
 
 			let finalQuantity = quantity;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -178,6 +178,18 @@ type CartItemContext = {
 store( 'woocommerce/mini-cart-items-block', {
 	state: {
 		// Intended to be used in context of a cart item in wp-each
+		get cartItemMinimum() {
+			const { cartItem } = getContext< CartItemContext >();
+			return cartItem.quantity_limits.minimum;
+		},
+
+		// Intended to be used in context of a cart item in wp-each
+		get cartItemMaximum() {
+			const { cartItem } = getContext< CartItemContext >();
+			return cartItem.quantity_limits.maximum;
+		},
+
+		// Intended to be used in context of a cart item in wp-each
 		get minimumReached() {
 			const { cartItem } = getContext< CartItemContext >();
 			return cartItem.quantity - 1 < cartItem.quantity_limits.minimum;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -108,7 +108,16 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 										</div>
 										<div class="wc-block-cart-item__quantity">
 											<div class="wc-block-components-quantity-selector">
-												<input data-wp-on--input="actions.changeQuantity" data-wp-bind--aria-label="state.quantityDescriptionLabel" data-wp-bind--value="context.cartItem.quantity" class="wc-block-components-quantity-selector__input" type="number" step="1" min="state.cartItemMinimum" max="state.cartItemMaximum" >
+												<input 
+													data-wp-on--input="actions.changeQuantity" 
+													data-wp-bind--aria-label="state.quantityDescriptionLabel" 
+													data-wp-bind--min="state.cartItemMinimum" 
+													data-wp-bind--max="state.cartItemMaximum"
+													data-wp-bind--value="context.cartItem.quantity" 
+													class="wc-block-components-quantity-selector__input" 
+													type="number" 
+													step="1"  
+												>
 												<button data-wp-bind--disabled="state.minimumReached" data-wp-on--click="actions.decrementQuantity" data-wp-bind--aria-label="state.reduceQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
 												<button data-wp-bind--disabled="state.maximumReached" data-wp-on--click="actions.incrementQuantity" data-wp-bind--aria-label="state.increaseQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
 											</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -108,11 +108,11 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 										</div>
 										<div class="wc-block-cart-item__quantity">
 											<div class="wc-block-components-quantity-selector">
-												<input data-wp-bind--aria-label="state.quantityDescriptionLabel" data-wp-bind--value="context.cartItem.quantity" class="wc-block-components-quantity-selector__input" type="number" step="1" min="1" max="9999" >
-												<button data-wp-on--click="actions.decrementQuantity" data-wp-bind--aria-label="state.reduceQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
-												<button data-wp-on--click="actions.incrementQuantity" data-wp-bind--aria-label="state.increaseQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
+												<input data-wp-on--input="actions.changeQuantity" data-wp-bind--aria-label="state.quantityDescriptionLabel" data-wp-bind--value="context.cartItem.quantity" class="wc-block-components-quantity-selector__input" type="number" step="1" min="state.cartItemMinimum" max="state.cartItemMaximum" >
+												<button data-wp-bind--disabled="state.minimumReached" data-wp-on--click="actions.decrementQuantity" data-wp-bind--aria-label="state.reduceQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
+												<button data-wp-bind--disabled="state.maximumReached" data-wp-on--click="actions.incrementQuantity" data-wp-bind--aria-label="state.increaseQuantityLabel" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
 											</div>
-											<button data-wp-bind--aria-label="state.removeFromCartLabel" class="wc-block-cart-item__remove-link" >
+											<button data-wp-on--click="actions.removeItemFromCart" data-wp-bind--aria-label="state.removeFromCartLabel" class="wc-block-cart-item__remove-link" >
 												<?php echo esc_html( $remove_item_label ); ?>
 											</button>
 										</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fills out more functionality of the iAPI powered mini cart:

1. When using the stepper buttons, they are disabled when min and max are reached
2. Editing the text of the input updates the quantity (and also respects min and max with same behaviour as the original mini cart)
3. Remove item button works to remove an item entirely
4. Fixes a bug where updating quantities makes the mini cart items flicker

To support removing items I've added another action to the store that uses the `remove-item` endpoint of the store API.

To fix the flickering bug, I've implemented a first attempt at updating the store state without blowing away all the signals. Its a rudimentary implementation and could be improved iteratively in future. It's still (imo) better than blowing away all the signals like we do now with `state.cart = json;`

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/463b39f8-0c31-47fd-842e-7e92e9f33b74




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

TBD
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
