### PR TITLE
Round individual taxes in fee lines items in orders REST endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-58351
+++ b/plugins/woocommerce/changelog/fix-58351
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Round individual taxes in fee lines items in orders REST endpoint

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -458,7 +458,6 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		// Format decimal values.
-		// Need this for fee_lines['taxes'] to be formatted.
 		foreach ( $format_decimal as $key ) {
 			$data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -252,8 +252,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			foreach ( $data['taxes']['total'] as $tax_rate_id => $tax ) {
 				$taxes[] = array(
 					'id'       => $tax_rate_id,
-					'total'    => $tax,
-					'subtotal' => isset( $data['taxes']['subtotal'][ $tax_rate_id ] ) ? $data['taxes']['subtotal'][ $tax_rate_id ] : '',
+					'total'    => wc_format_decimal( $tax, $this->request['dp'] ),
+					'subtotal' => isset( $data['taxes']['subtotal'][ $tax_rate_id ] ) ? wc_format_decimal( $data['taxes']['subtotal'][ $tax_rate_id ], $this->request['dp'] ) : '',
 				);
 			}
 			$data['taxes'] = $taxes;
@@ -458,6 +458,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		}
 
 		// Format decimal values.
+		// Need this for fee_lines['taxes'] to be formatted.
 		foreach ( $format_decimal as $key ) {
 			$data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR rounds the individual taxes in the order fee line items in the orders REST endpoint.  Providing unrounded numbers means the client must know the number of decimal places and formatting used for currencies in the client and manually calculate them for each line item, which is not ideal.

This also matches the expected values in other areas (various order screens and WC Store API endpoint).

Closes #58351 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="395" alt="Screenshot 2025-06-03 at 6 43 34 AM" src="https://github.com/user-attachments/assets/1163e2e8-d993-4000-a024-92b964668b53" />   |    <img width="421" alt="Screenshot 2025-06-03 at 6 43 17 AM" src="https://github.com/user-attachments/assets/543f8c34-a463-4c98-ad91-a42861f6eea5" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create REST API credentials at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
2. Create two sets of taxes, one at 5% and one at 4%.  Assign them different priorities so that both get used in your order
3. Create an order with a fee of 14.70 that the taxes apply to
4. Make a request with your favorite API app to `/wp-json/wc/v3/orders/{ORDER_ID}` replacing with the order ID just created
5. Check that under `fee_lines`, the individual taxes are rounded to your stores decimal places (e.g., `0.74` and `0.59` if your store uses 2 decimal places).
6. Provide the `dp` argument with a custom value (e.g., `3`).
7. Make sure that the response for individual taxes under fee lines is rounded to the provided number of decimal points

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
