### PR TITLE
Prevent fatals while uninstalling with `WC_REMOVE_ALL_DATA`

### DIFF
--- a/plugins/woocommerce/changelog/fix-39881
+++ b/plugins/woocommerce/changelog/fix-39881
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors in uninstall routine.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -317,6 +317,10 @@ class WC_Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
+		if ( defined( 'WC_UNINSTALLING_PLUGIN' ) ) {
+			return;
+		}
+
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
 		add_action( 'woocommerce_newly_installed', array( __CLASS__, 'maybe_enable_hpos' ), 20 );
@@ -2017,7 +2021,7 @@ $hpos_table_schema;
 			"{$wpdb->prefix}woocommerce_tax_rates",
 			"{$wpdb->prefix}wc_reserved_stock",
 			"{$wpdb->prefix}wc_rate_limits",
-			wc_get_container()->get( DataRegenerator::class )->get_lookup_table_name(),
+			"{$wpdb->prefix}wc_product_attributes_lookup",
 
 			// WCA Tables.
 			"{$wpdb->prefix}wc_order_stats",

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -2028,6 +2028,12 @@ $hpos_table_schema;
 			"{$wpdb->prefix}wc_admin_note_actions",
 			"{$wpdb->prefix}wc_customer_lookup",
 			"{$wpdb->prefix}wc_category_lookup",
+
+			// HPOS.
+			"{$wpdb->prefix}wc_orders",
+			"{$wpdb->prefix}wc_order_addresses",
+			"{$wpdb->prefix}wc_order_operational_data",
+			"{$wpdb->prefix}wc_orders_meta",
 		);
 
 		/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -317,7 +317,7 @@ class WC_Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
-		if ( defined( 'WC_UNINSTALLING_PLUGIN' ) ) {
+		if ( ! empty( $GLOBALS['wc_uninstalling_plugin'] ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -134,7 +134,8 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		// Make WC_Install::get_schema() accessible.
 		$wc_install = new \ReflectionClass( WC_Install::class );
 		$get_schema = $wc_install->getMethod( 'get_schema' );
-		$schema     = $get_schema->invoke( null );
+		$get_schema->setAccessible( true );
+		$schema = $get_schema->invoke( null );
 		preg_match_all( '/CREATE TABLE (.*?)\s*\(/i', $schema, $matches, PREG_PATTERN_ORDER );
 
 		$this->assertNotEmpty( $matches );

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -131,19 +131,23 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 	 * @group core-only
 	 */
 	public function test_get_tables() {
-		global $wpdb;
+		// Make WC_Install::get_schema() accessible.
+		$wc_install = new \ReflectionClass( WC_Install::class );
+		$get_schema = $wc_install->getMethod( 'get_schema' );
+		$schema     = $get_schema->invoke( null );
+		preg_match_all( '/CREATE TABLE (.*?)\s*\(/i', $schema, $matches, PREG_PATTERN_ORDER );
 
-		$tables = $wpdb->get_col(
-			"SHOW TABLES WHERE `Tables_in_{$wpdb->dbname}` LIKE '{$wpdb->prefix}woocommerce\_%'
-			OR `Tables_in_{$wpdb->dbname}` LIKE '{$wpdb->prefix}wc\_%'"
-		);
-		$result = WC_Install::get_tables();
-		$diff   = array_diff( $result, $tables );
+		$this->assertNotEmpty( $matches );
+		$this->assertNotEmpty( $matches[1] );
+
+		$tables_from_schema = $matches[1];
+		$tables_to_remove   = WC_Install::get_tables();
+		$diff               = array_diff( $tables_from_schema, $tables_to_remove );
 
 		$this->assertEmpty(
 			$diff,
 			sprintf(
-				'The following table(s) were returned from WC_Install::get_tables() but do not exist: %s',
+				'The following table(s) were returned from WC_Install::get_schema() but are not listed in WC_Install::get_tables(): %s',
 				implode( ', ', $diff )
 			)
 		);

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -8,13 +8,11 @@
  * @version 2.3.0
  */
 
-use Automattic\WooCommerce\Admin\Notes\Notes;
-use Automattic\WooCommerce\Admin\ReportsSync;
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
-
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 global $wpdb, $wp_version;
+
+define( 'WC_UNINSTALLING_PLUGIN', true );
 
 wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
@@ -35,7 +33,7 @@ wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
  */
 if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Load WooCommerce so we can access the container, install routines, etc, during uninstall.
-	require_once __DIR__ . '/woocommerce.php';
+	require_once __DIR__ . '/includes/class-wc-install.php';
 
 	// Roles + caps.
 	WC_Install::remove_roles();
@@ -72,11 +70,6 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 
 	$wpdb->query( "DELETE FROM {$wpdb->comments} WHERE comment_type IN ( 'order_note' );" );
 	$wpdb->query( "DELETE meta FROM {$wpdb->commentmeta} meta LEFT JOIN {$wpdb->comments} comments ON comments.comment_ID = meta.comment_id WHERE comments.comment_ID IS NULL;" );
-
-	foreach ( wc_get_container()->get( OrdersTableDataStore::class )->get_all_table_names() as $cot_table ) {
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$wpdb->query( "DROP TABLE IF EXISTS {$cot_table}" );
-	}
 
 	// Delete terms if > WP 4.2 (term splitting was added in 4.2).
 	if ( version_compare( $wp_version, '4.2', '>=' ) ) {

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -10,11 +10,9 @@
 
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
-global $wpdb, $wp_version;
+global $wpdb, $wp_version, $wc_uninstalling_plugin;
 
-if ( ! defined( 'WC_UNINSTALLING_PLUGIN' ) ) {
-	define( 'WC_UNINSTALLING_PLUGIN', true );
-}
+$wc_uninstalling_plugin = true;
 
 wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
@@ -110,3 +108,5 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Clear any cached data that has been removed.
 	wp_cache_flush();
 }
+
+unset( $wc_uninstalling_plugin );

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -12,7 +12,9 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 global $wpdb, $wp_version;
 
-define( 'WC_UNINSTALLING_PLUGIN', true );
+if ( ! defined( 'WC_UNINSTALLING_PLUGIN' ) ) {
+	define( 'WC_UNINSTALLING_PLUGIN', true );
+}
 
 wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR makes sure that fully uninstalling WooCommerce doesn't trigger any fatal errors.

The reason for these fatals is that in #34469 we changed the uninstall routine from requiring only `WC_Install` to requiring the full WooCommerce plugin. This allowed us to gain access to the container and some constants (which was used to remove HPOS tables) but at the same time resulted in all callbacks being connected to hooks that might run as part or after the uninstall process. This is problematic because some code is hooked to `shutdown` or later hooks and might attempt to run after the files had been removed by the uninstall process producing autoloader errors.

Ideally, a fully initialized WC shouldn't fatal when uninstalled but ensuring functionality and hooks are all "uninstall aware" is much more difficult and error prone than keeping the uninstall process as simple as possible, which is what this PR does.

Closes #39881.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build a ZIP from this branch for easier testing.
   ```
   cd plugins/woocommerce
   pnpm build:zip
   ```

   This will give you a `woocommerce.zip` inside `plugins/woocommerce` which you can upload to a test site.
1. Edit the `wp-config.php` file on your test site to include the following line:
   ```php
   define( 'WC_REMOVE_ALL_DATA', true );
   ```
1. Upload `woocommerce.zip` from step 1 to your test site and activate it.
1. Go to **Plugins**:
   1. Click **Deactivate** for the **WooCommerce** plugin.
   2. Click **Delete** for the **WooCommerce** plugin.
   3. The process should end successfully with message
      > WooCommerce was successfully deleted. 
   4. No fatal errors should be logged in your log files.
   5. Ensure WC tables have been removed from your site:
      ```
      wp db tables '*wc_*' --all-tables
      ```
1. Install and activate the latest version of WooCommerce on your test site by searching for WooCommerce in **Plugins > Add Plugin**.
1. Go to **Plugins** and click **Deactivate** followed by **Delete**.
1. The process will likely fail with message "Deletion failed: There has been a critical error on this website.Learn more about troubleshooting WordPress." and you'll find some errors in your logs:
   ```
   PHP Fatal error:  Uncaught Error: Class "WC_Plugin_Updates" not found in [...]/plugins/woocommerce/includes/wc-core-functions.php:2401
   PHP Fatal error:  Uncaught Error: Class "ActionScheduler_Lock" not found in [...]/plugins/woocommerce/packages/action-scheduler/classes/abstracts/ActionScheduler.php:55
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
