### PR TITLE
Update non-marketplace recommendations placements

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
@@ -349,6 +349,12 @@
 		function displaySuggestions( marketplaceSuggestionsApiData ) {
 			var usedSuggestionsContexts = [];
 
+			// Extract recommendations count from the first element if it exists
+			var recommendationsCount = 5; // default fallback
+			if ( marketplace_suggestions.suggestions_data && marketplace_suggestions.suggestions_data[0]['recommendations-count'] ) {
+				recommendationsCount = marketplace_suggestions.suggestions_data[0]['recommendations-count'];
+			}
+
 			// iterate over all suggestions containers, rendering promos
 			$( '.marketplace-suggestions-container' ).each( function() {
 				// determine the context / placement we're populating
@@ -357,8 +363,8 @@
 				// find promotions that target this context
 				var promos = getRelevantPromotions( marketplaceSuggestionsApiData, context );
 
-				// shuffle/randomly select five suggestions to display
-				var suggestionsToDisplay = _.sample( promos, 5 );
+				// shuffle/randomly select suggestions to display based on API count
+				var suggestionsToDisplay = _.sample( promos, recommendationsCount );
 
 				// render the promo content
 				for ( var i in suggestionsToDisplay ) {

--- a/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
@@ -352,7 +352,11 @@
 			// Extract recommendations count from the first element if it exists
 			var recommendationsCount = 5; // default fallback
 			if ( marketplace_suggestions.suggestions_data && marketplace_suggestions.suggestions_data[0]['recommendations-count'] ) {
-				recommendationsCount = marketplace_suggestions.suggestions_data[0]['recommendations-count'];
+				var apiCount = marketplace_suggestions.suggestions_data[0]['recommendations-count'];
+				// Validate that it's a positive number and within reasonable bounds
+				if ( typeof apiCount === 'number' && apiCount > 0 && apiCount <= 50 ) {
+					recommendationsCount = Math.floor( apiCount );
+				}
 			}
 
 			// iterate over all suggestions containers, rendering promos

--- a/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
@@ -351,7 +351,11 @@
 
 			// Extract recommendations count from the first element if it exists
 			var recommendationsCount = 5; // default fallback
-			if ( marketplace_suggestions.suggestions_data && marketplace_suggestions.suggestions_data[0]['recommendations-count'] ) {
+			if (
+				marketplace_suggestions.suggestions_data &&
+				marketplace_suggestions.suggestions_data[0] &&
+				marketplace_suggestions.suggestions_data[0]['recommendations-count']
+			) {
 				var apiCount = marketplace_suggestions.suggestions_data[0]['recommendations-count'];
 				// Validate that it's a positive number and within reasonable bounds
 				if ( typeof apiCount === 'number' && apiCount > 0 && apiCount <= 50 ) {

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -79,8 +79,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 
 		echo '</div>';
 
-		do_action( 'wc_marketplace_suggestions_products_empty_state' );
-
 		echo '</div>';
 	}
 

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -31,7 +31,6 @@ class WC_Marketplace_Suggestions {
 		add_action( 'wp_ajax_woocommerce_add_dismissed_marketplace_suggestion', array( __CLASS__, 'post_add_dismissed_suggestion_handler' ) );
 
 		// Register hooks for rendering suggestions container markup.
-		add_action( 'wc_marketplace_suggestions_products_empty_state', array( __CLASS__, 'render_products_list_empty_state' ) );
 		add_action( 'wc_marketplace_suggestions_orders_empty_state', array( __CLASS__, 'render_orders_list_empty_state' ) );
 	}
 
@@ -107,15 +106,6 @@ class WC_Marketplace_Suggestions {
 		);
 
 		wp_die();
-	}
-
-	/**
-	 * Render suggestions containers in products list empty state.
-	 */
-	public static function render_products_list_empty_state() {
-		self::render_suggestions_container( 'products-list-empty-header' );
-		self::render_suggestions_container( 'products-list-empty-body' );
-		self::render_suggestions_container( 'products-list-empty-footer' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR further enhances the new endpoint we've switched to in #58187 to allow the number of recommendations shown to be set remotely. We're also removing some recommendations that are no longer needed.

Related changes to the API in https://github.com/Automattic/woocommerce.com/pull/23982

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- Remove recommendations on the empty products list page - as of 9.8 that page is redirected to the onboarding checklist, so it's no longer reachable.
- Get number of recommendations to display from the API instead of using a hard-coded value
<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WCCOM-1177](https://linear.app/a8c/issue/WCCOM-1177/update-non-marketplace-placements-to-use-api#comment-348a9b5e)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Navigate to `/plugins/woocommerce` and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`.
3. Make sure your local WCCOM is running on the `update/WCCOM-1177-recommendations-non-marketplace-placements` branch, and connect your Core env to your local WCCOM using `docker network connect woocommerce.test <container id>` (container-id for the `wordpress` container in the Core wp-env).
4. Change the endpoint URL here to woocommerce.test:
https://github.com/woocommerce/woocommerce/blob/23182138e0ada04d34f8b2aa9406e06b6a1f079f/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php#L53
5. Update this condition to always be true:
https://github.com/woocommerce/woocommerce/blob/23182138e0ada04d34f8b2aa9406e06b6a1f079f/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php#L189
6. Visit http://localhost:8888/wp-admin/admin.php?page=wc-orders, then go to http://localhost:8888/wp-admin/tools.php?page=action-scheduler&s=woocommerce_update_marketplace_suggestions&bulk_action=Apply&paged=1 and run the pending action
7. Refresh the Orders page and confirm you now see suggestions returned from Algolia instead of the hard-coded ones from the JSON file on WCCOM.
![Orders_‹_woocommerce_—_WordPress](https://github.com/user-attachments/assets/9f9f4454-77e6-4e4c-a323-083f5b901c78)

8. Create a new product, and view the Get more options tab of Product Data section. It should also show Algolia recommendations.
![Add_new_product_‹_woocommerce_—_WordPress](https://github.com/user-attachments/assets/ddce107c-282d-42eb-94d3-346b3fc7203e)

9. On WCCOM, increase the `RECOMMENDATIONS_COUNT` value (see testing instructions for https://github.com/Automattic/woocommerce.com/pull/23982) and clear the cache. Then refresh the Orders page and run the scheduled action again to fetch new recommendations.
10. On both the empty Order screen and the product editor you should now see more than five recommendations returned, depending on the number you set in step 9, as well as other conditions included in the data (some of the hard-coded recommendations for the product editor only show if particular plugins are already active on the site)
11. Change the endpoint you modified in step 4 to the 1.0 endpoint. Repeat the steps to trigger the action and re-fetch recommendations
12. Confirm you now see the five hard-coded recommendations in each location.
![Orders_‹_WP_Test_Site_—_WordPress](https://github.com/user-attachments/assets/98fdc255-ae6b-4c47-8ebb-38d5e96ea8ee)

13. Please test around this issue


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
