### PR TITLE
Product Filters: normalize filter item data structure and update count display in the editor

### DIFF
--- a/plugins/woocommerce/changelog/refactor-normalize-filter-item-data-structure
+++ b/plugins/woocommerce/changelog/refactor-normalize-filter-item-data-structure
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Product Filters: normalize filter item data structure and update count display in the editor.
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -109,12 +109,12 @@ const Edit = ( props: EditProps ) => {
 						}
 					} )
 					.map( ( term, index ) => ( {
-						label: showCounts
-							? `${ term.name } (${ term.count })`
-							: term.name,
+						label: term.name,
+						ariaLabel: term.name,
 						value: term.id.toString(),
 						selected: index === 0,
-						rawData: term,
+						count: term.count,
+						type: `attribute/${ attributeObject?.taxonomy }`,
 					} ) )
 			);
 		}
@@ -217,6 +217,7 @@ const Edit = ( props: EditProps ) => {
 									? attributeOptionsPreview
 									: attributeOptions,
 							isLoading,
+							showCounts,
 						},
 					} }
 				>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -46,7 +46,7 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 		customOptionElement,
 	} = attributes;
 	const { filterData } = context;
-	const { isLoading, items } = filterData;
+	const { isLoading, items, showCounts } = filterData;
 
 	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 	const blockProps = useBlockProps( {
@@ -111,8 +111,15 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 												icon={ checkMark }
 											/>
 										</span>
-										<span className="wc-block-product-filter-checkbox-list__text">
-											{ item.label }
+										<span className="wc-block-product-filter-checkbox-list__text-wrapper">
+											<span className="wc-block-product-filter-checkbox-list__text">
+												{ item.label }
+											</span>
+											{ showCounts && (
+												<span className="wc-block-product-filter-checkbox-list__count">
+													{ ` (${ item.count })` }
+												</span>
+											) }
 										</span>
 									</label>
 								</li>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/block.json
@@ -14,7 +14,7 @@
 	"supports": {
 		"interactivity": true
 	},
-	"usesContext": [ "filterData", "showCounts" ],
+	"usesContext": [ "filterData" ],
 	"attributes": {
 		"chipText": {
 			"type": "string"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -52,7 +52,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 		customSelectedChipBorder,
 	} = attributes;
 	const { filterData } = context;
-	const { isLoading, items } = filterData;
+	const { isLoading, items, showCounts } = filterData;
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'wc-block-product-filter-chips', {
@@ -100,7 +100,14 @@ const Edit = ( props: EditProps ): JSX.Element => {
 								aria-checked={ !! item.selected }
 							>
 								<span className="wc-block-product-filter-chips__label">
-									{ item.label }
+									<span className="wc-block-product-filter-chips__text">
+										{ item.label }
+									</span>
+									{ showCounts && (
+										<span className="wc-block-product-filter-chips__count">
+											{ ` (${ item.count })` }
+										</span>
+									) }
 								</span>
 							</div>
 						) ) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -124,11 +124,12 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 							<Rating
 								key={ rating }
 								rating={ rating }
-								ratedProductsCount={ showCounts ? count : null }
+								ratedProductsCount={ null }
 							/>
 						),
 						value: rating?.toString(),
 						selected: index === 0,
+						count,
 					} ) )
 			: [];
 
@@ -187,6 +188,7 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 								filterData: {
 									items: displayedOptions,
 									isLoading,
+									showCounts,
 								},
 							} }
 						>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/edit.tsx
@@ -64,16 +64,16 @@ const Edit = ( props: EditProps ) => {
 					)?.count ?? 0;
 
 				return {
+					label: value,
+					ariaLabel: value,
 					value: key,
-					label: showCounts
-						? `${ value } (${ count.toString() })`
-						: value,
-					count,
 					selected: index === 0,
+					count,
+					type: 'status',
 				};
 			} )
 			.filter( ( item ) => ! hideEmpty || item.count > 0 );
-	}, [ stockStatusOptions, filteredCounts, showCounts, hideEmpty ] );
+	}, [ stockStatusOptions, filteredCounts, hideEmpty ] );
 
 	return (
 		<div { ...innerBlocksProps }>
@@ -84,6 +84,7 @@ const Edit = ( props: EditProps ) => {
 						filterData: {
 							items,
 							isLoading,
+							showCounts,
 						},
 					} }
 				>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -15,8 +15,8 @@ export type FilterOptionItem = {
 	ariaLabel: string;
 	value: string;
 	selected?: boolean;
+	count: number;
 	type: string;
-	data?: Record< string, unknown >;
 };
 
 export type FilterBlockContext = {
@@ -29,6 +29,7 @@ export type FilterBlockContext = {
 			maxPrice: number;
 			maxRange: number;
 		};
+		showCounts?: boolean;
 	};
 };
 


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR normalizes the data structure of filter items which is passed down from the filter block (Status/Attribute/Rating) to filter options block (Chips/Checkbox List). This PR also updates the count display inside the editor to match with front end behavior for Chips and Checkbox List.

Closes [WOOPLUG-4495](https://linear.app/a8c/issue/WOOPLUG-4495/normalize-filter-item-data-structure-and-update-count-display-in)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The Product Filters block should behave exactly the same as before. No regression should be introduced.

<!-- End testing instructions -->
