### PR TITLE
[dev] Monorepo: drop linting in pre-push hook.

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -28,7 +28,7 @@ matchingRemoteBranches=$(git ls-remote --heads origin refs/heads/$CURRENT_BRANCH
 if [ -n "$matchingRemoteBranches" ]; then
 	commitsToPush=$(git log origin/$CURRENT_BRANCH..$CURRENT_BRANCH)
 	if [ -z "$commitsToPush" ]; then
-		echo 'pre-push: Everything up-to-date, skipping validation and linting'
+		echo 'pre-push: Everything up-to-date, skipping checks'
 		exit 0
 	fi
 fi
@@ -47,44 +47,6 @@ if [ -n "$changedFiles" ]; then
 	echo "[OK]"
 fi
 
-changedFiles=$(git diff $(git merge-base HEAD origin/trunk) --relative --name-only --diff-filter=d -- '*.php' '*.js' '*.jsx' '*.ts' '*.tsx')
-if [ -n "$changedFiles" ]; then
-	echo 'pre-push: linting changes (if unrelated linting occurs, please sync the branch with trunk)'
-
-	# This pre-push check aims to reduce CI load, hence we mimic CI matrix generation and pick linting jobs identical to CI environment.
-	if [ -n "$matchingRemoteBranches" ]; then
-		# The remote branch exists: lint incremental changes only
-		git fetch origin $CURRENT_BRANCH >/dev/null 2>&1
-		ciJobs=$(CI=1 pnpm utils ci-jobs --base-ref origin/$CURRENT_BRANCH --event 'pull_request' 2>&1)
-	else
-		# The remote branch doesn't exists yes: lint all branch changes
-		ciJobs=$(CI=1 pnpm utils ci-jobs --base-ref origin/trunk --event 'pull_request' 2>&1)
-	fi
-
-	# Slightly complicated trailing thru linting jobs provided in JSON-format.
-    lintingJobs=$(echo $ciJobs | sed 's/::set-output/\n::set-output/g' | grep '::set-output name=lint-jobs::' | sed 's/::set-output name=lint-jobs:://g')
-    iteration=1
-    iterations=$( echo $lintingJobs | jq length )
-
-    # Failsafe: running full-scale repo linting might occur occasionally - not clear why, hence this failsafe.
-    if [ $iterations -ge 43 ]; then
-    	echo "-> Looks like we were about to lint the whole monorepo, it might take a while so we are skipping this step [SKIP]"
-    	echo "   Note: that's not necessary related to the changes - possibly we are behind the changes on remote."
-    	exit 0
-	fi
-
-    while read job; do
-		command=$(echo $job | jq --raw-output '( "pnpm --filter=" + .projectName + " " + .command )')
-		echo -n "-> Executing '$command' ($iteration of $iterations) "
-		start=$SECONDS
-		result=$($command 2>&1)
-		code=$?
-		duration=$(( SECONDS - start ))
-		if [ $code -ne 0 ]; then
-			echo "[ERR] (aborting, please run manually to troubleshoot)"
-			exit 1
-		fi
-		echo "($duration sec.) [OK]"
-		iteration=$(expr $iteration + 1)
-	done < <(echo $lintingJobs | jq --compact-output '.[]')
-fi
+# Once upon a time, we added linting here, aiming to reduce pressure on CI (failing lints required pushing new changes and rerunning CI).
+# It added rather more friction for day-to-day development. Hence, note for future reference: there have already been at least two failed iterations.
+# If you consider the next one, please find a more impactful automation task to look into or add extra 'x' in 'xx' to further count attempts.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1748941211084169-slack-C03CPM3UXDJ

Drop pre-push linting.

### How to test the changes in this Pull Request:

- CI-checks shall pass