### PR TITLE
[Experimental] Add default styles for quantity inputs in Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-options-quantity-styles
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-options-quantity-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add default styles for quantity inputs in Add to Cart + Options block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -1,5 +1,9 @@
-.wc-block-add-to-cart-with-options__quantity-selector,
-.wc-block-add-to-cart-with-options-grouped-product-selector-item-cta {
+.wc-block-add-to-cart-with-options {
+	.quantity {
+		display: inline-flex;
+		align-items: stretch;
+	}
+
 	/**
 	* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
 	*
@@ -9,7 +13,10 @@
 		font-size: var(--wp--preset--font-size--small);
 		padding: 0.9rem 1.1rem;
 	}
+}
 
+.wc-block-add-to-cart-with-options__quantity-selector,
+.wc-block-add-to-cart-with-options-grouped-product-selector-item-cta {
 	// Stepper CSS
 	.wc-block-components-quantity-selector {
 		&::after {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -123,6 +123,17 @@ class AddToCartWithOptions extends AbstractBlock {
 			$template_part_path = apply_filters( '__experimental_woocommerce_' . $product_type . '_add_to_cart_with_options_block_template_part', false, $product_type );
 		}
 
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
+		$classes            = implode(
+			' ',
+			array_filter(
+				array(
+					'wp-block-add-to-cart-with-options wc-block-add-to-cart-with-options',
+					esc_attr( $classes_and_styles['classes'] ),
+				)
+			)
+		);
+
 		if ( is_string( $template_part_path ) && file_exists( $template_part_path ) ) {
 
 			$template_part_contents = '';
@@ -144,18 +155,6 @@ class AddToCartWithOptions extends AbstractBlock {
 			if ( '' === $template_part_contents ) {
 				$template_part_contents = file_get_contents( $template_part_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
-
-			$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
-
-			$classes = implode(
-				' ',
-				array_filter(
-					array(
-						'wp-block-add-to-cart-with-options wc-block-add-to-cart-with-options',
-						esc_attr( $classes_and_styles['classes'] ),
-					)
-				)
-			);
 
 			/**
 			 * Filters the change the quantity to add to cart.
@@ -375,7 +374,13 @@ class AddToCartWithOptions extends AbstractBlock {
 			 */
 			do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
 
+			$wrapper_attributes = array(
+				'class' => $classes,
+				'style' => esc_attr( $classes_and_styles['styles'] ),
+			);
+
 			$form_html = ob_get_clean();
+			$form_html = sprintf( '<div %1$s>%2$s</div>', get_block_wrapper_attributes( $wrapper_attributes ), $form_html );
 		}
 
 		$product = $previous_product;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some extensions rely on themes to style the quantity inputs and the Add to Cart button. In blocks, we try to provide those styles directly in the blocks (like in the [non-blockified _Add to Cart Form_ block](https://github.com/woocommerce/woocommerce/blob/ec4c14247cd6ae89dbf22bdcbaf0fc1d1ceae2f3/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/style.scss#L10-L13)).

This PR adds these styles to the _Add to Cart with Options_ block and makes them available on third-party product types too, by wrapping their template in a `<div>` with the proper class names.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.

#### Testing the PR

1. Install [Product Bundles](https://woocommerce.com/products/product-bundles/).
2. Create a bundle product and view it in the frontend.
3. Verify the input has padding and is aligned with the _Add to Cart_ button.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/3ec048aa-ba4f-44bc-a0a7-6fb69eb6070d) | ![image](https://github.com/user-attachments/assets/276c0259-6fcc-4ce7-b1f5-5bdb7988212c)