### PR TITLE
Product Filters: improve aria label handling

### DIFF
--- a/plugins/woocommerce/changelog/fix-active-filter-label
+++ b/plugins/woocommerce/changelog/fix-active-filter-label
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Product Filters: better aria label handling
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -15,7 +15,7 @@ function selectFilter() {
 		attributeQueryType: context.item.attributeQueryType,
 		activeLabel: context.activeLabelTemplate.replace(
 			'{{label}}',
-			context.item.ariaLabel
+			context.item?.ariaLabel || context.item.label
 		),
 	};
 	const newActiveFilters = context.activeFilters.filter(
@@ -40,7 +40,7 @@ function unselectFilter() {
 
 type FilterItem = {
 	label: string;
-	ariaLabel: string;
+	ariaLabel?: string;
 	value: string;
 	selected: boolean;
 	count: number;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -12,11 +12,9 @@ export type EditProps = BlockEditProps< BlockAttributes >;
 
 export type FilterOptionItem = {
 	label: string;
-	ariaLabel: string;
 	value: string;
 	selected?: boolean;
 	count: number;
-	type: string;
 };
 
 export type FilterBlockContext = {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -198,25 +198,9 @@ final class ProductFilterAttribute extends AbstractBlock {
 				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms, $product_attribute ) {
 					$term          = (array) $term;
 					$term['count'] = $attribute_counts[ $term['term_id'] ] ?? 0;
-					$aria_label    = $term['name'];
-
-					if ( $block_attributes['showCounts'] ) {
-						$aria_label = sprintf(
-							/* translators: %1$s is the term name, %2$d is the term count. */
-							_n(
-								'%1$s (%2$d product)',
-								'%1$s (%2$d products)',
-								$term['count'],
-								'woocommerce'
-							),
-							$term['name'],
-							$term['count']
-						);
-					}
 
 					return array(
 						'label'              => $term['name'],
-						'ariaLabel'          => $aria_label,
 						'value'              => $term['slug'],
 						'selected'           => in_array( $term['slug'], $selected_terms, true ),
 						'count'              => $term['count'],

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -91,7 +91,7 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 									id="<?php echo esc_attr( $item_id ); ?>"
 									class="wc-block-product-filter-checkbox-list__input"
 									type="checkbox"
-									aria-label="<?php echo esc_attr( $item['ariaLabel'] ); ?>"
+									aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
 									data-wp-on--change="actions.toggleFilter"
 									value="<?php echo esc_attr( $item['value'] ); ?>"
 									data-wp-bind--checked="state.isFilterSelected"
@@ -137,5 +137,31 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 	 */
 	protected function get_block_type_style() {
 		return null;
+	}
+
+	/**
+	 * Get aria label for filter item.
+	 *
+	 * @param array $item Filter item.
+	 * @param bool  $show_counts Whether to show counts.
+	 *
+	 * @return string Aria label.
+	 */
+	private function get_aria_label( $item, $show_counts ) {
+		if ( $show_counts ) {
+			return sprintf(
+				/* translators: %1$s: Product filter name, %2$d: Number of products */
+				_n(
+					'%1$s (%2$d product)',
+					'%1$s (%2$d products)',
+					$item['count'],
+					'woocommerce'
+				),
+				$item['ariaLabel'] ?? $item['label'],
+				$item['count']
+			);
+		}
+
+		return $item['ariaLabel'] ?? $item['label'];
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -77,7 +77,7 @@ final class ProductFilterChips extends AbstractBlock {
 						class="wc-block-product-filter-chips__item"
 						type="button"
 						role="checkbox"
-						aria-label="<?php echo esc_attr( $item['ariaLabel'] ); ?>"
+						aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
 						data-wp-on--click="actions.toggleFilter"
 						value="<?php echo esc_attr( $item['value'] ); ?>"
 						data-wp-bind--aria-checked="state.isFilterSelected"
@@ -117,5 +117,31 @@ final class ProductFilterChips extends AbstractBlock {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get aria label for filter item.
+	 *
+	 * @param array $item Filter item.
+	 * @param bool  $show_counts Whether to show counts.
+	 *
+	 * @return string Aria label.
+	 */
+	private function get_aria_label( $item, $show_counts ) {
+		if ( $show_counts ) {
+			return sprintf(
+				/* translators: %1$s: Product filter name, %2$d: Number of products */
+				_n(
+					'%1$s (%2$d product)',
+					'%1$s (%2$d products)',
+					$item['count'],
+					'woocommerce'
+				),
+				$item['ariaLabel'] ?? $item['label'],
+				$item['count']
+			);
+		}
+
+		return $item['ariaLabel'] ?? $item['label'];
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -118,7 +118,7 @@ final class ProductFilterRating extends AbstractBlock {
 		$selected_rating        = array_filter( explode( ',', $rating_query ) );
 
 		$filter_options = array_map(
-			function ( $rating ) use ( $selected_rating, $attributes ) {
+			function ( $rating ) use ( $selected_rating ) {
 				$value = (string) $rating['rating'];
 
 				$aria_label = sprintf(
@@ -126,20 +126,6 @@ final class ProductFilterRating extends AbstractBlock {
 					__( 'Rated %1$d out of 5', 'woocommerce' ),
 					$value,
 				);
-
-				if ( $attributes['showCounts'] ) {
-					$aria_label = sprintf(
-						/* translators: %1$d is referring to rating value, %2$d is the count. */
-						_n(
-							'Rated %1$d out of 5 (%2$d product)',
-							'Rated %1$d out of 5 (%2$d products)',
-							$rating['count'],
-							'woocommerce'
-						),
-						$value,
-						$rating['count']
-					);
-				}
 
 				return array(
 					'label'     => $this->render_rating_label( (int) $value ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -131,11 +131,11 @@ final class ProductFilterStatus extends AbstractBlock {
 		$filter_options = array_map(
 			function ( $item ) use ( $stock_statuses, $selected_stock_statuses ) {
 				return array(
-					'label'     => $stock_statuses[ $item['status'] ],
-					'value'     => $item['status'],
-					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
-					'count'     => $item['count'],
-					'type'      => 'status',
+					'label'    => $stock_statuses[ $item['status'] ],
+					'value'    => $item['status'],
+					'selected' => in_array( $item['status'], $selected_stock_statuses, true ),
+					'count'    => $item['count'],
+					'type'     => 'status',
 				);
 			},
 			$stock_status_data

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -129,21 +129,9 @@ final class ProductFilterStatus extends AbstractBlock {
 		$selected_stock_statuses = array_filter( explode( ',', $query ) );
 
 		$filter_options = array_map(
-			function ( $item ) use ( $stock_statuses, $selected_stock_statuses, $attributes ) {
-				$aria_label = $stock_statuses[ $item['status'] ];
-
-				if ( $attributes['showCounts'] ) {
-					$aria_label = sprintf(
-						/* translators: %1$s is the status, %2$d is the count. */
-						_n( '%1$s (%2$d product)', '%1$s (%2$d products)', $item['count'], 'woocommerce' ),
-						$stock_statuses[ $item['status'] ],
-						$item['count']
-					);
-				}
-
+			function ( $item ) use ( $stock_statuses, $selected_stock_statuses ) {
 				return array(
 					'label'     => $stock_statuses[ $item['status'] ],
-					'ariaLabel' => $aria_label,
 					'value'     => $item['status'],
 					'selected'  => in_array( $item['status'], $selected_stock_statuses, true ),
 					'count'     => $item['count'],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In https://github.com/woocommerce/woocommerce/pull/58405, we added the product count to the aria label. This introduces a regression that the product count leaked into the active filter items. This PR fixes that issue and introduces a better mechanism to handle the product count and A11y.

- We're now append the product count to aria label at the filter display block level (Chips, Checkbox List).
- The `ariaLabel` is now an optional property, only rating use this property. Other filters will fallback to `label`.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58405 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1025" alt="image" src="https://github.com/user-attachments/assets/6055231d-78e7-4f4a-8969-d07cc4c01265" />   |   <img width="1025" alt="image" src="https://github.com/user-attachments/assets/15687392-06cb-4f7b-8bd7-e2c48fe7eef8" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template.
2. Enable product count for Rating, Status, and Attribute blocks.
3. Visit the Shop page on the frontend.
4. Select some filter, see the count doesn't include in the active filter items.
5. Use a screen reader, focusing an filter item with count, see/hear the screen reader announces the item label and count.

<!-- End testing instructions -->
