### PR TITLE
Product Filters: Fix warning when processing canonical URL

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4505-warning-when-using-product-filters-on-a-page
+++ b/plugins/woocommerce/changelog/wooplug-4505-warning-when-using-product-filters-on-a-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Product Filters: fix warning when processing canonical URL.
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -283,12 +283,12 @@ class ProductFilters extends AbstractBlock {
 	 */
 	private function get_canonical_url_no_pagination( $filter_params ) {
 		$canonical_url_no_pagination = is_singular() ? get_permalink() : get_pagenum_link( 1 );
+		$parsed_url = wp_parse_url( html_entity_decode( $canonical_url_no_pagination ) );
 
-		if ( empty( $filter_params ) ) {
+		// If there are active filters, $parsed_url['query'] is empty for page or post but not empty for archives.
+		if ( empty( $filter_params ) || empty( $parsed_url['query'] ) ) {
 			return $canonical_url_no_pagination;
 		}
-
-		$parsed_url = wp_parse_url( html_entity_decode( $canonical_url_no_pagination ) );
 
 		foreach ( array_keys( $filter_params ) as $key ) {
 			$parsed_url['query'] = remove_query_arg( $key, $parsed_url['query'] );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -283,7 +283,7 @@ class ProductFilters extends AbstractBlock {
 	 */
 	private function get_canonical_url_no_pagination( $filter_params ) {
 		$canonical_url_no_pagination = is_singular() ? get_permalink() : get_pagenum_link( 1 );
-		$parsed_url = wp_parse_url( html_entity_decode( $canonical_url_no_pagination ) );
+		$parsed_url                  = wp_parse_url( html_entity_decode( $canonical_url_no_pagination, ENT_QUOTES, get_bloginfo( 'charset' ) ) );
 
 		// If there are active filters, $parsed_url['query'] is empty for page or post but not empty for archives.
 		if ( empty( $filter_params ) || empty( $parsed_url['query'] ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4505
This PR fix issue with canonical URL that throws a warning when using Product Filters on a page.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a new page, add Product Collection block.
2. Add Product Filters block inside the Product Collection.
3. On the frontend, apply a filter.
4. Reload a page.
5. Verify there is no PHP warning mentioned in the connected issue.

<!-- End testing instructions -->

