### PR TITLE
Unschedule recurring actions when WC is deactivated

### DIFF
--- a/plugins/woocommerce/changelog/fix-37428
+++ b/plugins/woocommerce/changelog/fix-37428
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Unschedule recurring actions when WooCommerce is deactivated.

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -48,6 +48,10 @@ class DraftOrders {
 		add_action( 'woocommerce_my_account_my_orders_query', [ $this, 'delete_draft_order_post_status_from_args' ] );
 		add_action( self::DRAFT_CLEANUP_EVENT_HOOK, [ $this, 'delete_expired_draft_orders' ] );
 		add_action( 'admin_init', [ $this, 'install' ] );
+
+		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
+			add_action( 'deactivate_' . WC_PLUGIN_BASENAME, [ $this, 'unschedule_cronjobs' ] );
+		}
 	}
 
 	/**
@@ -57,6 +61,16 @@ class DraftOrders {
 	 */
 	public function install() {
 		$this->maybe_create_cronjobs();
+	}
+
+	/**
+	 * Unschedule recurring actions when plugin is deactivated.
+	 *
+	 * @since 10.0.0
+	 * @internal
+	 */
+	public function unschedule_cronjobs() {
+		WC()->queue()->cancel_all( self::DRAFT_CLEANUP_EVENT_HOOK );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/DraftOrders.php
@@ -17,6 +17,8 @@ class DraftOrders {
 	const DB_STATUS = 'wc-checkout-draft';
 	const STATUS    = 'checkout-draft';
 
+	const DRAFT_CLEANUP_EVENT_HOOK = 'woocommerce_cleanup_draft_orders';
+
 	/**
 	 * Holds the Package instance
 	 *
@@ -44,7 +46,7 @@ class DraftOrders {
 		add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [ $this, 'append_draft_order_post_status' ], 999 );
 		// Hook into the query to retrieve My Account orders so draft status is excluded.
 		add_action( 'woocommerce_my_account_my_orders_query', [ $this, 'delete_draft_order_post_status_from_args' ] );
-		add_action( 'woocommerce_cleanup_draft_orders', [ $this, 'delete_expired_draft_orders' ] );
+		add_action( self::DRAFT_CLEANUP_EVENT_HOOK, [ $this, 'delete_expired_draft_orders' ] );
 		add_action( 'admin_init', [ $this, 'install' ] );
 	}
 
@@ -62,8 +64,8 @@ class DraftOrders {
 	 */
 	protected function maybe_create_cronjobs() {
 		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
-		if ( false === call_user_func( $has_scheduled_action, 'woocommerce_cleanup_draft_orders' ) ) {
-			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
+		if ( false === call_user_func( $has_scheduled_action, self::DRAFT_CLEANUP_EVENT_HOOK ) ) {
+			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, self::DRAFT_CLEANUP_EVENT_HOOK );
 		}
 	}
 
@@ -179,7 +181,7 @@ class DraftOrders {
 				}
 			}
 			if ( $batch_size === $count && function_exists( 'as_enqueue_async_action' ) ) {
-				as_enqueue_async_action( 'woocommerce_cleanup_draft_orders' );
+				as_enqueue_async_action( self::DRAFT_CLEANUP_EVENT_HOOK );
 			}
 		} catch ( Exception $error ) {
 			wc_caught_exception( $error, __METHOD__ );

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -15,6 +15,8 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
  */
 class OrderCountCacheService {
 
+	const BACKGROUND_EVENT_HOOK = 'woocommerce_refresh_order_count_cache';
+
 	/**
 	 * OrderCountCache instance.
 	 *
@@ -47,7 +49,7 @@ class OrderCountCacheService {
 		add_action( 'woocommerce_order_status_changed', array( $this, 'update_on_order_status_changed' ), 10, 4 );
 		add_action( 'woocommerce_before_trash_order', array( $this, 'update_on_order_trashed' ), 10, 2 );
 		add_action( 'woocommerce_before_delete_order', array( $this, 'update_on_order_deleted' ), 10, 2 );
-		add_action( 'woocommerce_refresh_order_count_cache', array( $this, 'refresh_cache' ) );
+		add_action( self::BACKGROUND_EVENT_HOOK, array( $this, 'refresh_cache' ) );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'schedule_background_actions' ) );
 		// This is a temporary fix to ensure the background actions are scheduled.
 		// @todo: Remove this once the Action Scheduler package is updated to >= 3.9.3.
@@ -74,7 +76,7 @@ class OrderCountCacheService {
 		$order_types = wc_get_order_types( 'order-count' );
 		$frequency   = HOUR_IN_SECONDS * 12;
 		foreach ( $order_types as $order_type ) {
-			as_schedule_recurring_action( time() + $frequency, $frequency, 'woocommerce_refresh_order_count_cache', array( $order_type ), 'count', true );
+			as_schedule_recurring_action( time() + $frequency, $frequency, self::BACKGROUND_EVENT_HOOK, array( $order_type ), 'count', true );
 		}
 	}
 

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -54,6 +54,10 @@ class OrderCountCacheService {
 		// This is a temporary fix to ensure the background actions are scheduled.
 		// @todo: Remove this once the Action Scheduler package is updated to >= 3.9.3.
 		add_action( 'admin_init', array( $this, 'schedule_background_actions' ) );
+
+		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
+			add_action( 'deactivate_' . WC_PLUGIN_BASENAME, array( $this, 'unschedule_background_actions' ) );
+		}
 	}
 
 	/**
@@ -78,6 +82,16 @@ class OrderCountCacheService {
 		foreach ( $order_types as $order_type ) {
 			as_schedule_recurring_action( time() + $frequency, $frequency, self::BACKGROUND_EVENT_HOOK, array( $order_type ), 'count', true );
 		}
+	}
+
+	/**
+	 * Unschedules background actions.
+	 *
+	 * @since 10.0.0
+	 * @internal
+	 */
+	public function unschedule_background_actions() {
+		WC()->queue()->cancel_all( self::BACKGROUND_EVENT_HOOK );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -114,6 +114,15 @@ class DataSynchronizer implements BatchProcessorInterface {
 		if ( self::BACKGROUND_SYNC_MODE_CONTINUOUS === $this->get_background_sync_mode() ) {
 			add_action( 'shutdown', array( $this, 'handle_continuous_background_sync' ) );
 		}
+
+		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
+			add_action(
+				'deactivate_' . WC_PLUGIN_BASENAME,
+				function () {
+					$this->unschedule_background_sync();
+				}
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR makes sure that when the plugin is deactivated, recurring A-S actions that were registered are unscheduled.

Leaving A-S actions registered is not much of a problem when WC is the only plugin using A-S, but in cases where other A-S copies are active on the site (through the A-S plugin itself or other plugins), execution of those actions will continue. This will result in failures (due to no available callback for the action hooks) for both recurring and non-recurring actions, but the later will no longer be attempted after the first failure, while the former recurring will be (unnecessarily) and fail every time.

Closes #37428.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

woocommerce_cleanup_draft_orders
woocommerce_refresh_order_count_cache

1. Go to **Plugins > Add Plugin** on the backend. Search for the **Action Scheduler** plugin and activate it.
2. Go to **Tools > Scheduled Actions > Pending** and confirm that at least the following 2 WC recurring actions are scheduled:
   - `woocommerce_cleanup_draft_orders`
   - `woocommerce_refresh_order_count_cache`
3. Go to **Plugins** and deactivate **WooCommerce**.
4. Go back to **Tools > Scheduled Actions > Pending** and confirm that the actions in step 2 are no longer present.
5. Go back to **Plugins** and re-activate **WooCommerce**.
6. Ensure that the recurring actions in step 2 are again present in **Tools > Scheduled Actions > Pending**.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
