### PR TITLE
Fix the order count cache refresh hook and scheduling

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-cache-refresh
+++ b/plugins/woocommerce/changelog/fix-order-cache-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the order count cache refresh hook and scheduling

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -49,6 +49,9 @@ class OrderCountCacheService {
 		add_action( 'woocommerce_before_delete_order', array( $this, 'update_on_order_deleted' ), 10, 2 );
 		add_action( 'woocommerce_refresh_order_count_cache', array( $this, 'refresh_cache' ) );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'schedule_background_actions' ) );
+		// This is a temporary fix to ensure the background actions are scheduled.
+		// @todo: Remove this once the Action Scheduler package is updated to >= 3.9.3.
+		add_action( 'admin_init', array( $this, 'schedule_background_actions' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -58,7 +58,7 @@ class OrderCountCacheService {
 	 * @return void
 	 */
 	public function refresh_cache( $order_type ) {
-		$this->order_count_cache->remove( $order_type );
+		$this->order_count_cache->flush( $order_type );
 		OrderUtil::get_count_for_type( $order_type );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -150,13 +150,14 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 	 * Test that refresh cache works.
 	 */
 	public function test_refresh_cache() {
-		$pending_count = $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) );
+		$count         = OrderUtil::get_count_for_type( 'shop_order' );
+		$pending_count = $count[ OrderInternalStatus::PENDING ];
 		// Set the pending count to a higher value to ensure it is refreshed.
 		$this->order_cache->set( 'shop_order', OrderInternalStatus::PENDING, $pending_count + 10 );
 
 		$order_count_cache_service = wc_get_container()->get( OrderCountCacheService::class );
 		$order_count_cache_service->refresh_cache( 'shop_order' );
 
-		$this->assertEquals( $pending_count, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
+		$this->assertSame( $pending_count, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -145,4 +145,18 @@ class OrderCountCacheServiceTest extends \WC_Unit_Test_Case {
 		$order_count_cache_service->schedule_background_actions();
 		$this->assertTrue( as_has_scheduled_action( 'woocommerce_refresh_order_count_cache' ) );
 	}
+
+	/**
+	 * Test that refresh cache works.
+	 */
+	public function test_refresh_cache() {
+		$pending_count = $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) );
+		// Set the pending count to a higher value to ensure it is refreshed.
+		$this->order_cache->set( 'shop_order', OrderInternalStatus::PENDING, $pending_count + 10 );
+
+		$order_count_cache_service = wc_get_container()->get( OrderCountCacheService::class );
+		$order_count_cache_service->refresh_cache( 'shop_order' );
+
+		$this->assertEquals( $pending_count, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes an issue with the order count cache calling the incorrect method to flush the cache and temporarily adds the scheduling hooks on `admin_init` since AS has not yet been updated in core to include the `action_scheduler_ensure_recurring_actions` hook.

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="729" alt="Screenshot 2025-06-04 at 7 42 54 AM" src="https://github.com/user-attachments/assets/f7d1bbd0-64f2-47d8-9ed2-72b82ce60281" />    |  <img width="814" alt="Screenshot 2025-06-04 at 7 39 30 AM" src="https://github.com/user-attachments/assets/0cdb930c-b736-428f-b8a2-a0a0f6892795" /><img width="751" alt="Screenshot 2025-06-04 at 7 39 22 AM" src="https://github.com/user-attachments/assets/5a09e00d-f88f-42e6-b145-de2579774edd" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> Scheduled Actions.
2. Check that the `woocommerce_refresh_order_count_cache` is scheduled with any order types (e.g., `shop_order`)
3. Run the action and make sure that it completes
4. Smoke test the order status count numbers under WooCommerce -> Orders to make sure they are accurate.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
