### PR TITLE
Make payment method icons shrinkable to accommodate for longer labels

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4477-fix-afterpay-payment-option-not-fitting-inside-the-container
+++ b/plugins/woocommerce/changelog/wooplug-4477-fix-afterpay-payment-option-not-fitting-inside-the-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make payment method icon images shrinkable by default

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -227,6 +227,7 @@
 		.wc-block-components-radio-control__label img {
 			height: 24px;
 			max-height: 24px;
+			max-width: 100%;
 			object-fit: contain;
 			object-position: left;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR provides a safer default styles for payment method icon images. Adding a `max-width` to them causes them to shrink when the label text (or component) gets too long. This fix targets the editor as all frontend images within `.woocommerce-page` gets this treatment thanks to this stylesheet:
- https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss#L48
- it's enqueued here https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-frontend-scripts.php#L68-L100

Closes https://github.com/woocommerce/woocommerce/issues/58460

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="359" alt="Screenshot 2025-06-03 at 18 12 21" src="https://github.com/user-attachments/assets/948f85b1-2687-44ad-883f-2ff3acc3c1b3" /> | <img width="337" alt="Screenshot 2025-06-03 at 17 40 09" src="https://github.com/user-attachments/assets/7a908319-a531-4019-9b50-d58bb6d52c02" /> |

### How to test the changes in this Pull Request:

To get to the screenshot above, you will need a site with properly setup WooPayments + Afterpay option. The easiest way I found was to do it through jurassic ninja site.

1. Prerequisites: WooPayments + Afterpay installed and active on your site
2. Open the checkout page in the editor
3. Open mobile view in the editor
4. Scroll down to payment options and verify that the label and icon fits within the available space

As an alternative, you can tweak one of the existing payment methods through the dev tools, if you edit the label to be longer, the same sizing constraints for the icon should kick in.

### Testing that has already taken place:

I tested it on jurassic ninja site with properly setup WooPayments Afterpay option. It was synced with my local changes.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
