### PR TITLE
[NOX in LYS] Fix the logic to mark the Set up payments step as finished in LYS

### DIFF
--- a/plugins/woocommerce/changelog/58545-fix-fix-logic-for-marking-step-completed
+++ b/plugins/woocommerce/changelog/58545-fix-fix-logic-for-marking-step-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the logic that was marking a step as incorrectly completed in LYS.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -66,9 +66,25 @@ export const getLysTasklist = async () => {
 	// This is because LYS and the Home screen share the same task list, but the completion logic is different.
 	tasklist[ 0 ].tasks.forEach( ( task: TaskType ) => {
 		if ( task.id === 'payments' ) {
-			task.isComplete =
-				task.additionalData?.wooPaymentsHasOnlineGatewaysEnabled ??
-				false;
+			let isComplete = false;
+
+			// Store has other online gateways enabled.
+			if (
+				task.additionalData?.wooPaymentsHasOnlineGatewaysEnabled &&
+				! task.additionalData?.wooPaymentsIsOnboarded
+			) {
+				isComplete = true;
+			}
+
+			// WooPayments is onboarded and not in test mode.
+			if (
+				task.additionalData?.wooPaymentsIsOnboarded &&
+				! task.additionalData?.wooPaymentsHasTestAccount
+			) {
+				isComplete = true;
+			}
+
+			task.isComplete = isComplete;
 			task.title = __( 'Set up payments', 'woocommerce' );
 		}
 	} );

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -69,7 +69,7 @@ export const getLysTasklist = async () => {
 			let isComplete = false;
 
 			if (
-				// Store has other online gateways enabled.
+				// Store has other online gateways enabled and WooPayments is not onboarded.
 				( task.additionalData?.wooPaymentsHasOnlineGatewaysEnabled &&
 					! task.additionalData?.wooPaymentsIsOnboarded ) ||
 				// WooPayments is onboarded and not in test mode.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/tasklist.tsx
@@ -68,18 +68,13 @@ export const getLysTasklist = async () => {
 		if ( task.id === 'payments' ) {
 			let isComplete = false;
 
-			// Store has other online gateways enabled.
 			if (
-				task.additionalData?.wooPaymentsHasOnlineGatewaysEnabled &&
-				! task.additionalData?.wooPaymentsIsOnboarded
-			) {
-				isComplete = true;
-			}
-
-			// WooPayments is onboarded and not in test mode.
-			if (
-				task.additionalData?.wooPaymentsIsOnboarded &&
-				! task.additionalData?.wooPaymentsHasTestAccount
+				// Store has other online gateways enabled.
+				( task.additionalData?.wooPaymentsHasOnlineGatewaysEnabled &&
+					! task.additionalData?.wooPaymentsIsOnboarded ) ||
+				// WooPayments is onboarded and not in test mode.
+				( task.additionalData?.wooPaymentsIsOnboarded &&
+					! task.additionalData?.wooPaymentsHasTestAccount )
 			) {
 				isComplete = true;
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes the logic that was previously setting the step as completed incorrectly (ie, as soon as WooPayments test account is present)

(For Bug Fixes) Bug introduced in PR #58291

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the logic makes sense.
2. Make sure the code makes sense.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix the logic that was marking a step as incorrectly completed in LYS.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
