### PR TITLE
Product Filter: Fix group label not associated with its related controls

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4434-group-label-not-associated-with-its-related-controls-missing
+++ b/plugins/woocommerce/changelog/wooplug-4434-group-label-not-associated-with-its-related-controls-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filter: Fix group label not associated with its related controls

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
@@ -53,7 +53,7 @@
 			}
 		}
 	},
-	"usesContext": [ "query", "filterParams" ],
+	"usesContext": [ "query", "filterParams", "headingId" ],
 	"attributes": {
 		"attributeId": {
 			"type": "number",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
@@ -12,6 +12,6 @@
 		"interactivity": true,
 		"html": false
 	},
-	"usesContext": [ "query", "filterParams" ],
+	"usesContext": [ "query", "filterParams", "headingId" ],
 	"viewScriptModule": "woocommerce/product-filter-price"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"ancestor": [ "woocommerce/product-filters" ],
-	"usesContext": [ "query", "filterParams" ],
+	"usesContext": [ "query", "filterParams", "headingId" ],
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
@@ -71,7 +71,7 @@
 			"default": true
 		}
 	},
-	"usesContext": [ "query", "filterParams" ],
+	"usesContext": [ "query", "filterParams", "headingId" ],
 	"example": {
 		"attributes": {
 			"isPreview": true

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
@@ -62,8 +62,11 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 			await page.goto( '/shop' );
 
 			const listItems = page
-				.getByLabel( 'Filter Options' )
-				.getByRole( 'listitem' );
+				.getByRole( 'heading', {
+					name: 'Attribute',
+				} )
+				.locator( '..' )
+				.locator( 'li' );
 
 			await expect( listItems ).toHaveCount( 5 );
 
@@ -171,8 +174,11 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 			await page.goto( '/shop' );
 
 			const listItems = page
-				.getByLabel( 'Filter Options' )
-				.getByRole( 'listitem' );
+				.getByRole( 'heading', {
+					name: 'Attribute',
+				} )
+				.locator( '..' )
+				.locator( 'li' );
 
 			await expect( listItems ).toHaveCount( 5 );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -193,6 +193,10 @@ final class ProductFilterAttribute extends AbstractBlock {
 			'items'      => array(),
 		);
 
+		if ( ! empty( $block->context['headingId'] ) ) {
+			$filter_context['headingId'] = $block->context['headingId'];
+		}
+
 		if ( ! empty( $attribute_counts ) ) {
 			$attribute_options = array_map(
 				function ( $term ) use ( $block_attributes, $attribute_counts, $selected_terms, $product_attribute ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -64,10 +64,15 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 			$wrapper_attributes['style'] = esc_attr( $style ) . ';';
 		}
 
+		$aria_labelledby = '';
+		if ( ! empty( $block_context['headingId'] ) ) {
+			$aria_labelledby = 'aria-labelledby="' . esc_attr( $block_context['headingId'] ) . '"';
+		}
+
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<ul class="wc-block-product-filter-checkbox-list__list" aria-label="<?php echo esc_attr__( 'Filter Options', 'woocommerce' ); ?>">
+			<ul class="wc-block-product-filter-checkbox-list__list" <?php echo $aria_labelledby; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 				<?php foreach ( $items as $item ) { ?>
 					<?php $item_id = $item['type'] . '-' . $item['value']; ?>
 					<li

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -34,6 +34,7 @@ final class ProductFilterChips extends AbstractBlock {
 
 		$items       = $block->context['filterData']['items'] ?? array();
 		$show_counts = $block->context['filterData']['showCounts'] ?? false;
+		$heading_id  = $block->context['filterData']['headingId'] ?? '';
 		$classes     = '';
 		$style       = '';
 
@@ -65,10 +66,15 @@ final class ProductFilterChips extends AbstractBlock {
 			$wrapper_attributes['style'] = esc_attr( $style ) . ';';
 		}
 
+		$aria_labelledby = '';
+		if ( ! empty( $heading_id ) ) {
+			$aria_labelledby = 'role="group" aria-labelledby="' . esc_attr( $heading_id ) . '"';
+		}
+
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<div class="wc-block-product-filter-chips__items" aria-label="<?php echo esc_attr__( 'Filter Options', 'woocommerce' ); ?>">
+			<div class="wc-block-product-filter-chips__items" <?php echo $aria_labelledby; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 				<?php foreach ( $items as $item ) { ?>
 					<?php $item_id = $item['type'] . '-' . $item['value']; ?>
 					<button

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -48,8 +48,8 @@ final class ProductFilterPrice extends AbstractBlock {
 	public function prepare_selected_filters( $items, $params ) {
 		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
 		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
-		$formatted_min_price = $min_price ? html_entity_decode( wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) ) : null;
-		$formatted_max_price = $max_price ? html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) ) : null;
+		$formatted_min_price = $min_price ? html_entity_decode( wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ), ENT_QUOTES, get_bloginfo( 'charset' ) ) : null;
+		$formatted_max_price = $max_price ? html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ), ENT_QUOTES, get_bloginfo( 'charset' ) ) : null;
 
 		if ( ! $formatted_min_price && ! $formatted_max_price ) {
 			return $items;
@@ -129,8 +129,8 @@ final class ProductFilterPrice extends AbstractBlock {
 		$min_price     = intval( $filter_params[ self::MIN_PRICE_QUERY_VAR ] ?? $min_range );
 		$max_price     = intval( $filter_params[ self::MAX_PRICE_QUERY_VAR ] ?? $max_range );
 
-		$formatted_min_price = html_entity_decode( wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) );
-		$formatted_max_price = html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) );
+		$formatted_min_price = html_entity_decode( wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ), ENT_QUOTES, get_bloginfo( 'charset' ) );
+		$formatted_max_price = html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 
 		$filter_context = array(
 			'price' => array(
@@ -140,6 +140,10 @@ final class ProductFilterPrice extends AbstractBlock {
 				'maxRange' => $max_range,
 			),
 		);
+
+		if ( ! empty( $block->context['headingId'] ) ) {
+			$filter_context['headingId'] = $block->context['headingId'];
+		}
 
 		$wrapper_attributes = array(
 			'data-wp-interactive' => 'woocommerce/product-filters',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -144,6 +144,10 @@ final class ProductFilterRating extends AbstractBlock {
 			'showCounts' => $attributes['showCounts'] ?? false,
 		);
 
+		if ( ! empty( $block->context['headingId'] ) ) {
+			$filter_context['headingId'] = $block->context['headingId'];
+		}
+
 		$wrapper_attributes = array(
 			'data-wp-interactive' => 'woocommerce/product-filters',
 			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -146,6 +146,10 @@ final class ProductFilterStatus extends AbstractBlock {
 			'showCounts' => $attributes['showCounts'] ?? false,
 		);
 
+		if ( ! empty( $block->context['headingId'] ) ) {
+			$filter_context['headingId'] = $block->context['headingId'];
+		}
+
 		$wrapper_attributes = array(
 			'data-wp-interactive' => 'woocommerce/product-filters',
 			'data-wp-key'         => wp_unique_prefixed_id( $this->get_full_block_name() ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -79,21 +79,46 @@ class ProductFilters extends AbstractBlock {
 			}
 		);
 
-		$block_context         = array_merge(
+		$block_context = array_merge(
 			$block->context,
 			array(
 				'filterParams'  => $filter_params,
 				'activeFilters' => $active_filters,
 			),
 		);
-		$inner_blocks          = array_reduce(
+		$inner_blocks  = array_reduce(
 			$block->parsed_block['innerBlocks'],
 			function ( $carry, $parsed_block ) use ( $block_context ) {
-				$carry .= ( new \WP_Block( $parsed_block, $block_context ) )->render();
-				return $carry;
+				$heading_id = '';
+
+				if ( 0 === strpos( $parsed_block['blockName'], 'woocommerce/product-filter' ) ) {
+					foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+						if ( 'core/heading' === $inner_block['blockName'] ) {
+							$p = new \WP_HTML_Tag_Processor( $inner_block['innerContent'][0] );
+							if ( $p->next_tag() && $p->get_attribute( 'id' ) ) {
+								$heading_id = $p->get_attribute( 'id' );
+							} else {
+								$heading_id = wp_unique_prefixed_id( $this->block_name . '-heading-' );
+								$p->set_attribute( 'id', $heading_id );
+								$parsed_block['innerBlocks'][ $key ]['innerContent'][0] = $p->get_updated_html();
+							}
+						}
+					}
+				}
+
+				if ( $heading_id ) {
+					$block_context['headingId'] = $heading_id;
+				}
+
+				$output = ( new \WP_Block( $parsed_block, $block_context ) )->render();
+
+				$p = new \WP_HTML_Tag_Processor( $output );
+
+				return $carry . $p->get_updated_html();
 			},
 			''
 		);
+
 		$interactivity_context = array(
 			'params'        => $filter_params,
 			'activeFilters' => $active_filters,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4434

This PR link the filter options with the filter heading by ensure the heading block has the ID and using the `aria-labelledby` to refer it from the list.

You may come across this researching for this topic

> "Don't use aria-label or aria-labelledby on any other non-interactive content such as p, legend, li, or ul, because it is ignored."

But the `ul` has fairly good support across browsers/screen readers. I tested with macOS Voice Over and it announces the group label correctly. See https://html5accessibility.com/stuff/2020/11/07/not-so-short-note-on-aria-label-usage-big-table-edition/

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1512" alt="image" src="https://github.com/user-attachments/assets/9c1baa3f-dd5e-4ed3-a677-c9d0106ea4de" />     |    <img width="1512" alt="image" src="https://github.com/user-attachments/assets/8c7408ef-f1cb-4cec-9514-e45fc83878c1" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template.
2. Visit the Shop page on the frontend.
3. With a screen reader turned on, move the focus by pressing the tab key.
4. When the focus move into the filter option list, see the heading of the list announced.

<!-- End testing instructions -->