### PR TITLE
[NOX In-Context] Fix typo on test account onboarding success screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4519-typo-after-test-account-onboarding
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4519-typo-after-test-account-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix typo on test onboarding confirmation screen in NOX In-Context.

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -482,7 +482,7 @@ const TestAccountStep = () => {
 											<p>
 												{ interpolateComponents( {
 													mixedString: __(
-														'Provide some additional details about your business so you can being accepting real payments. {{link}}Learn more{{/link}}',
+														'Provide some additional details about your business so you can begin accepting real payments. {{link}}Learn more{{/link}}',
 														'woocommerce'
 													),
 													components: {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a typo in the success confirmation screen displayed after completing the test account onboarding in the NOX In-Context flow.

The current message incorrectly states:
“Provide some additional details about your business so you can being accepting real payments.”

This PR corrects the wording to:
“Provide some additional details about your business so you can begin accepting real payments.”

Closes WOOPLUG-4519

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="680" alt="Screenshot 2025-06-05 at 13 43 57" src="https://github.com/user-attachments/assets/df5e50b7-7931-4d99-96e7-a8695ca07199" />  |  <img width="683" alt="Screenshot 2025-06-05 at 13 43 41" src="https://github.com/user-attachments/assets/13e13f0b-8e0a-4f84-af2c-aef4c7aca58b" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- Create a new JN store with this PR's branch build (here's a [direct create link](fix/WOOPLUG-4519-typo-after-test-account-onboarding)).
- Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
- Click on the "Payments" main menu item, and you should see the Payments Settings page.
- Click the "Install" button next to the WooPayments gateway.
- Proceed through the onboarding steps until a test account is successfully onboarded and the success screen is displayed.
- Verify the description under Activate payments section is `Provide some additional details about your business so you can begin accepting real payments`.

<img width="1639" alt="Screenshot 2025-06-05 at 13 47 42" src="https://github.com/user-attachments/assets/59e99585-4662-41b3-ae6f-90eef48fd579" />

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
