### PR TITLE
Revert `unsupported_theme_title_filter` Id parameter typing

### DIFF
--- a/packages/js/components/changelog/58569-fix-58553
+++ b/packages/js/components/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/customer-effort-score/changelog/58569-fix-58553
+++ b/packages/js/customer-effort-score/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/data/changelog/58569-fix-58553
+++ b/packages/js/data/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/email-editor/changelog/58569-fix-58553
+++ b/packages/js/email-editor/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/experimental/changelog/58569-fix-58553
+++ b/packages/js/experimental/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/navigation/changelog/58569-fix-58553
+++ b/packages/js/navigation/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/onboarding/changelog/58569-fix-58553
+++ b/packages/js/onboarding/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/js/product-editor/changelog/58569-fix-58553
+++ b/packages/js/product-editor/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/php/blueprint/changelog/58569-fix-58553
+++ b/packages/php/blueprint/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/packages/php/email-editor/changelog/58569-fix-58553
+++ b/packages/php/email-editor/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/plugins/woocommerce/changelog/58569-fix-58553
+++ b/plugins/woocommerce/changelog/58569-fix-58553
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert "unsupported_theme_title_filter" Id parameter typing.

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -531,7 +531,7 @@ class WC_Template_Loader {
 	 * @param int|null $id ID of the post being filtered.
 	 * @return string
 	 */
-	public static function unsupported_theme_title_filter( $title, ?int $id = null ) {
+	public static function unsupported_theme_title_filter( $title, $id = null ) {
 		if ( is_null( $id ) || self::$theme_support || ! $id !== self::$shop_page_id ) {
 			return $title;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR reverts the typing of the parameter `$id` from the `unsupported_theme_title_filter` function. This was a breaking change since some plugins were passing string IDs instead of ints.

Closes https://github.com/woocommerce/woocommerce/issues/58553

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/56707

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the testing steps from this PR https://github.com/woocommerce/woocommerce/pull/56707 and make sure you don't see the fatal error.
2. Add this snippet to your site (you can do it in the `functions.php` or using `Code Snippets`):
```php
add_filter( 'the_title', array( WC_Template_Loader::class, 'unsupported_theme_title_filter' ), 10, 2 );

add_action(
	'init',
	function () {
		apply_filters( 'the_title', 'Some Title', '123-es' );
	}
);
```
3. Go to you home page and make sure there's no fatal error.
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Revert "unsupported_theme_title_filter" Id parameter typing.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
