### PR TITLE
Product Gallery: make sure gallery images are not draggable and small images takes all available space

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-small-imgs
+++ b/plugins/woocommerce/changelog/fix-product-gallery-small-imgs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: make sure gallery images are not draggable and small images takes all available space

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -14,8 +14,6 @@ $dialog-padding: 20px;
 		overflow: hidden;
 		scroll-snap-type: x mandatory;
 		scroll-behavior: auto;
-		width: fit-content;
-		height: fit-content;
 		align-items: center;
 		margin: 0;
 		padding: 0;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryLargeImage.php
@@ -144,6 +144,7 @@ class ProductGalleryLargeImage extends AbstractBlock {
 								loading="lazy"
 							<?php endif; ?>
 							tabindex="-1"
+							draggable="false"
 						/>
 					</li>
 				<?php endforeach; ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

During smoke testing I found minor issues and fixing them in this PR:

1. Images in gallery were draggable making it weird especially on Safari:

| Before | After |
| ------ | ----- |
|    https://github.com/user-attachments/assets/ff46bca1-baba-4cc3-9a90-eceb10ea9af9    |   https://github.com/user-attachments/assets/35abbd61-d430-4eaa-9d54-ee84191018bf    |

2. If image is smaller than gallery and it's single image, it doesn't occupy the whole space

| Before | After |
| ------ | ----- |
|    <img width="1130" alt="image" src="https://github.com/user-attachments/assets/1b9e479a-83b4-426b-955c-caf1da4447a8" />    |     <img width="1172" alt="image" src="https://github.com/user-attachments/assets/e6c8e6bb-ef09-4fd1-a5d7-52f0ccab2080" /> |
| <img width="1190" alt="image" src="https://github.com/user-attachments/assets/3c1927d7-3d58-4aee-a6c1-a62da32ed263" /> | <img width="1181" alt="image" src="https://github.com/user-attachments/assets/7a725e4b-9546-4567-be20-9f4cda7428b5" />

3. Weird behavior in Firefox with two small images following (kudos to @Aljullu for reporting it to me! 🙇 )

| Before | After |
| ------ | ----- |
|    https://github.com/user-attachments/assets/473944a6-4e20-4655-943f-135f8f33a60e | https://github.com/user-attachments/assets/0842ff6d-c39a-456d-b47a-053064e36ba8 |



(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create product with 1 SMALL image
2. Go to Editor > Single Product template
3. Replace the Product Image Gallery block with the Product Gallery (beta) block
5. Save and go to frontend
6. **Expected:** Image gets stretched to the available space (preserving aspect ratio)
7. Try dragging the image
8. **Expected:** Make sure nothing happens

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
