### PR TITLE
Improve checks for missing context in Variation Selector blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-options-better-context-checks
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-options-better-context-checks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Improve checks for missing context in Variation Selector blocks
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php
@@ -35,8 +35,8 @@ class VariationSelectorAttributeName extends AbstractBlock {
 			return '';
 		}
 
-		$attribute_id   = $block->context['woocommerce/attributeId'];
-		$attribute_name = $block->context['woocommerce/attributeName'];
+		$attribute_id   = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
+		$attribute_name = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
 
 		if ( ! isset( $attribute_id ) || ! isset( $attribute_name ) ) {
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php
@@ -31,16 +31,17 @@ class VariationSelectorAttributeName extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
-		if ( empty( $block->context ) ) {
+		if (
+			! isset(
+				$block->context['woocommerce/attributeId'],
+				$block->context['woocommerce/attributeName']
+			)
+		) {
 			return '';
 		}
 
-		$attribute_id   = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
-		$attribute_name = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
-
-		if ( ! isset( $attribute_id ) || ! isset( $attribute_name ) ) {
-			return '';
-		}
+		$attribute_id   = $block->context['woocommerce/attributeId'];
+		$attribute_name = $block->context['woocommerce/attributeName'];
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -46,12 +46,17 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ): string {
-		if ( empty( $block->context ) ) {
+		if (
+			! isset(
+				$block->context['woocommerce/attributeName'],
+				$block->context['woocommerce/attributeId'],
+				$block->context['woocommerce/attributeTerms']
+			)
+		) {
 			return '';
 		}
 
-		$attribute_name = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
-		$attribute_slug = wc_variation_attribute_name( $attribute_name );
+		$attribute_slug = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
 
 		if ( isset( $attribute_slug ) ) {
 
@@ -138,10 +143,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 * @return string The pills.
 	 */
 	protected function render_pills( $attributes, $content, $block ) {
-		$attribute_id    = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
-		$attribute_name  = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
-		$attribute_slug  = wc_variation_attribute_name( $attribute_name );
-		$attribute_terms = isset( $block->context['woocommerce/attributeTerms'] ) ? $block->context['woocommerce/attributeTerms'] : array();
+		$attribute_id    = $block->context['woocommerce/attributeId'];
+		$attribute_slug  = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
+		$attribute_terms = $block->context['woocommerce/attributeTerms'];
 
 		$pills = '';
 		foreach ( $attribute_terms as $attribute_term ) {
@@ -199,10 +203,9 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 * @return string The dropdown.
 	 */
 	protected function render_dropdown( $attributes, $content, $block ) {
-		$attribute_id    = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
-		$attribute_name  = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
-		$attribute_slug  = wc_variation_attribute_name( $attribute_name );
-		$attribute_terms = isset( $block->context['woocommerce/attributeTerms'] ) ? $block->context['woocommerce/attributeTerms'] : array();
+		$attribute_id    = $block->context['woocommerce/attributeId'];
+		$attribute_slug  = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
+		$attribute_terms = $block->context['woocommerce/attributeTerms'];
 		$default_option  = array(
 			'label'      => esc_html__( 'Choose an option', 'woocommerce' ),
 			'value'      => '',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -50,7 +50,8 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 			return '';
 		}
 
-		$attribute_slug = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
+		$attribute_name = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
+		$attribute_slug = wc_variation_attribute_name( $attribute_name );
 
 		if ( isset( $attribute_slug ) ) {
 
@@ -137,9 +138,10 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 * @return string The pills.
 	 */
 	protected function render_pills( $attributes, $content, $block ) {
-		$attribute_id    = $block->context['woocommerce/attributeId'];
-		$attribute_slug  = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
-		$attribute_terms = $block->context['woocommerce/attributeTerms'];
+		$attribute_id    = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
+		$attribute_name  = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
+		$attribute_slug  = wc_variation_attribute_name( $attribute_name );
+		$attribute_terms = isset( $block->context['woocommerce/attributeTerms'] ) ? $block->context['woocommerce/attributeTerms'] : array();
 
 		$pills = '';
 		foreach ( $attribute_terms as $attribute_term ) {
@@ -197,9 +199,10 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 	 * @return string The dropdown.
 	 */
 	protected function render_dropdown( $attributes, $content, $block ) {
-		$attribute_id    = $block->context['woocommerce/attributeId'];
-		$attribute_slug  = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
-		$attribute_terms = $block->context['woocommerce/attributeTerms'];
+		$attribute_id    = isset( $block->context['woocommerce/attributeId'] ) ? $block->context['woocommerce/attributeId'] : null;
+		$attribute_name  = isset( $block->context['woocommerce/attributeName'] ) ? $block->context['woocommerce/attributeName'] : null;
+		$attribute_slug  = wc_variation_attribute_name( $attribute_name );
+		$attribute_terms = isset( $block->context['woocommerce/attributeTerms'] ) ? $block->context['woocommerce/attributeTerms'] : array();
 		$default_option  = array(
 			'label'      => esc_html__( 'Choose an option', 'woocommerce' ),
 			'value'      => '',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The way blocks are parsed is from the most inner one to the outer ones. In our case, we are passing context from the parent blocks to the children, so there is the chance that we might try to render blocks when context hasn't been set.

We already had some checks that would return early if context wasn't set:

https://github.com/woocommerce/woocommerce/blob/8603154be0d36135d19382c1e915015cd005e3f7/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeName.php#L34-L36

However, there is the case that the Add to Cart + Options block can be added inside a post. In which case all blocks get a `postId` context. In those cases, `empty( $block->context )` is no longer true and we weren't returning early. That caused some warnings to appear in certain cases (see testing steps).

_tl;dr_ this PR strengthens the context checks, so instead of simply checking if `$block->context` is not empty, we make sure the data which is required by blocks actually exists.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.

#### Testing the PR

1. Create a post, add the _Single Product_ block, select a variable product and update the add to cart form to the blockified _Add to Cart + Options_ block.
2. Go to your site's front page or blog page (any page that lists the posts).
3. Verify there are no warnings on the screen.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/3dbcd925-15fa-4285-860f-35c3a72a235e) | ![imatge](https://github.com/user-attachments/assets/ab0aad3b-fe54-47a7-b845-fc649f82ebc9)