### PR TITLE
Prevent showing welcome guide on template tests

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2504-flaky-test-template-can-be-opened-in-the-site-editor
+++ b/plugins/woocommerce/changelog/wooplug-2504-flaky-test-template-can-be-opened-in-the-site-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Test changes only
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -15,6 +15,7 @@ test.describe( 'Test the cart template', () => {
 			postId: templatePath,
 			postType: templateType,
 			canvas: 'edit',
+			showWelcomeGuide: false,
 		} );
 		await expect(
 			editor.canvas.getByLabel( 'Block: Title' )

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -15,6 +15,7 @@ test.describe( 'Test the checkout template', () => {
 			postId: templatePath,
 			postType: templateType,
 			canvas: 'edit',
+			showWelcomeGuide: false,
 		} );
 		const block = editor.canvas.getByLabel( 'Block: Checkout' );
 		await expect( block ).toBeVisible();
@@ -25,7 +26,10 @@ test.describe( 'Test the checkout template', () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor( { postType: 'page' } );
+		await admin.visitSiteEditor( {
+			postType: 'page',
+			showWelcomeGuide: false,
+		} );
 		await editor.page
 			.getByRole( 'button', { name: 'Checkout', exact: true } )
 			.click();


### PR DESCRIPTION

### Changes proposed in this Pull Request:

- When navigating to site editor, pass `showWelcomeGuide: false` in the options. The welcome guide seems to be a fairly frequent source of flakiness, so disabling it makes sense.

Closes WOOPLUG-2504

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check CI passes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
