### PR TITLE
Remove order status validation for order count cache

### DIFF
--- a/plugins/woocommerce/changelog/fix-58556
+++ b/plugins/woocommerce/changelog/fix-58556
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove order status validation for order count cache

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -30,22 +30,6 @@ class OrderCountCache {
 	private $cache_prefix = 'order-count';
 
 	/**
-	 * Validate an object before caching it.
-	 *
-	 * @param string[] $statuses The statuses to validate.
-	 * @throws CacheException If the statuses are not valid.
-	 * @return void
-	 */
-	protected function validate( $statuses ): void {
-		$valid_statuses   = $this->get_valid_statuses();
-		$invalid_statuses = array_diff( $statuses, $valid_statuses );
-
-		if ( ! empty( $invalid_statuses ) ) {
-			throw new \Exception( sprintf( __( '%s is not one of: %s', 'woocommerce' ), implode( ', ', $invalid_statuses ), implode( ', ', $valid_statuses ) ) );
-		}
-	}
-
-	/**
 	 * Get valid statuses.
 	 *
 	 * @return string[]
@@ -101,7 +85,6 @@ class OrderCountCache {
 	 * @return bool True if the value was set, false otherwise.
 	 */
 	public function set( $order_type, $order_status, int $value ): bool {
-		$this->validate( array( $order_status ) );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_set( $cache_key, $value, '', $this->expiration );
 	}
@@ -114,8 +97,6 @@ class OrderCountCache {
 	 * @return int[] The cache value.
 	 */
 	public function get( $order_type, $order_statuses = array() ) {
-		$this->validate( $order_statuses );
-
 		if ( empty( $order_statuses ) ) {
 			$order_statuses = $this->get_default_statuses();
 		}
@@ -149,7 +130,6 @@ class OrderCountCache {
 	 * @return int The new value of the cache.
 	 */
 	public function increment( $order_type, $order_status, $offset = 1 ) {
-		$this->validate( array( $order_status ) );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_incr( $cache_key, $offset );
 	}
@@ -163,7 +143,6 @@ class OrderCountCache {
 	 * @return int The new value of the cache.
 	 */
 	public function decrement( $order_type, $order_status, $offset = 1 ) {
-		$this->validate( array( $order_status ) );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_decr( $cache_key, $offset );
 	}

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
@@ -50,14 +50,6 @@ class OrderCountCacheTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that invalid statuses throw exceptions.
-	 */
-	public function test_invalid_order_status() {
-		$this->expectException( \Exception::class );
-		$this->order_cache->set( 'shop_order', 'bad-status', 1 );
-	}
-
-	/**
 	 * Test that the cache can be flushed.
 	 */
 	public function test_flush_cache() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes validation of order statuses from the order count cache.  While order statuses should be registered, it's possible to add them and later remove them.

While plugins that add these order statuses should also handle clean-up of removed statuses on removal or deactivation, it does not seem like common practice and these orders end up orphaned in the database.

The fix in this PR is simply to allow any key to be set in the order count cache.  While not ideal, the number of sites with orphaned order statuses seems pretty high.

Closes #58556 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1378" alt="Screenshot 2025-06-05 at 3 39 43 PM" src="https://github.com/user-attachments/assets/31c25b50-c178-474f-bcf3-c17f1761172b" />   |    <img width="764" alt="Screenshot 2025-06-05 at 3 28 31 PM" src="https://github.com/user-attachments/assets/5cc2b3a9-f08b-4c3e-92b4-f828bd5823e6" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install an object cache.  [DocketCache](https://wordpress.org/plugins/docket-cache/) is an option that does not require memcached or redis
2. Install a plugin like [Custom Order Status Manager](https://wordpress.org/plugins/bp-custom-order-status-for-woocommerce/)
3. Navigate to WooCommerce -> Order Status
4. Add an order status with a slug of `custom-status` and any name.
5. Create an order and assign it the custom status.
6. Delete the status or deactivate the plugin.
7. Navigate to Tools -> Scheduled actions -> Pending
8. Run the `woocommerce_refresh_order_count_cache` action
9. Note the action completes successfully and that order counts are accurate on the WooCommerce -> Orders screen
10. Optionally, add the following snippet:
```php
add_action( 'plugins_loaded', function() {
	$order_count_cache = new \Automattic\WooCommerce\Caches\OrderCountCache();
	error_log( 'Default counts: ' . print_r( $order_count_cache->get( 'shop_order' ), true ) );
	error_log( 'Custom status count: ' . print_r( $order_count_cache->get( 'shop_order', array( 'wc-custom-status' ) ), true ) );
} );
```
11. Note that the default order counts appear in the first query without the custom status and the custom status count can still be retrieved in the second query.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
