### PR TITLE
Fix Product Button block to ignore ajax_add_to_cart when inside Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/58588-product-button-ignore-ajax-add-to-cart
+++ b/plugins/woocommerce/changelog/58588-product-button-ignore-ajax-add-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make the Product Button block ignore ajax_add_to_cart (and assume it's true) when inside the Add to Cart + Options block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -32,31 +32,9 @@ class VariationSelector extends AbstractBlock {
 		global $product;
 
 		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
-			add_filter( 'woocommerce_product_supports', array( $this, 'check_product_supports' ), 10, 3 );
-
 			return $content;
 		}
 
 		return '';
-	}
-
-	/**
-	 * Add 'ajax_add_to_cart' support to a Variable Product.
-	 *
-	 * This is needed so the ProductButton block could add a Variable Product to
-	 * the Cart without a page refresh.
-	 *
-	 * @param  bool        $supports If features are already supported or not.
-	 * @param  string      $feature  The feature to check if is supported.
-	 * @param  \WC_Product $product  The product to check.
-	 * @return bool True if the product supports the feature, false otherwise.
-	 * @since  9.9.0
-	 */
-	public function check_product_supports( $supports, $feature, $product ) {
-		if ( 'ajax_add_to_cart' === $feature ) {
-			return true;
-		}
-
-		return $supports;
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -123,7 +123,7 @@ class ProductButton extends AbstractBlock {
 		$number_of_items_in_cart  = $this->get_cart_item_quantities_by_product_id( $product->get_id() );
 		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
 		$ajax_add_to_cart_enabled = get_option( 'woocommerce_enable_ajax_add_to_cart' ) === 'yes';
-		$is_ajax_button           = $ajax_add_to_cart_enabled && ! $cart_redirect_after_add && $product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock();
+		$is_ajax_button           = $ajax_add_to_cart_enabled && ! $cart_redirect_after_add && ( $is_descendant_of_add_to_cart_form || $product->supports( 'ajax_add_to_cart' ) ) && $product->is_purchasable() && $product->is_in_stock();
 		$html_element             = $is_ajax_button || ( $is_descendant_of_add_to_cart_form && 'external' !== $product->get_type() ) ? 'button' : 'a';
 		$styles_and_classes       = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classname                = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the Product Button block to ignore the `ajax_add_to_cart` support value when it's inside the `Add to Cart + Options` block, eliminating the need for the hacky override approach currently used.

Closes #58559 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
2. Go to _WooCommerce Admin Test Helper > Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Go to _Appearance > Editor > Templates > Single Product_.
4. Click on the `Add to Cart with Options` block and update to the blockified version.
5. Open a variation product and add the product to cart by selecting a variation.
6. Confirm that the product gets added to the cart without page refresh.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
