### PR TITLE
[NOX in LYS] Fix inconsistent redirection when navigating back from LYS payments setup flow in WooCommerce Home

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4504-redirecting-back-to-lys
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4504-redirecting-back-to-lys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix inconsistent redirection when navigating back from LYS payments setup flow in WooCommerce Home.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
@@ -72,6 +72,10 @@ const LaunchStoreController = () => {
 		);
 
 	const handlePaymentsClose = () => {
+		// Clear session flag to prevent redirect back to payments setup
+		// after exiting the flow and returning to the WC Admin home.
+		window.sessionStorage.setItem( 'lysWaiting', 'no' );
+
 		// Navigate back to the main flow
 		sendToSidebar( { type: 'RETURN_FROM_PAYMENTS' } );
 	};

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/sidebar/components/payments-sidebar.tsx
@@ -72,6 +72,10 @@ export const PaymentsSidebar = ( props: SidebarComponentProps ) => {
 	const sidebarTitle = (
 		<Button
 			onClick={ () => {
+				// Clear session flag to prevent redirect back to payments setup
+				// after exiting the flow and returning to the WC Admin home.
+				window.sessionStorage.setItem( 'lysWaiting', 'no' );
+
 				props.sendEventToSidebar( {
 					type: 'RETURN_FROM_PAYMENTS',
 				} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue where navigating back from the “Set up payments” step in the Launch Your Store (LYS) flow causes a brief and unintended redirect to the WooCommerce Home screen before returning to the LYS hub. This creates a disruptive user experience.

The root cause is the `lysWaiting` session flag not being properly cleared. This flag is used to control navigation by keeping users within the LYS flow until tasks are completed. However, it should be removed when the user cancels or navigates back, rather than forcing a redirect back into LYS.

With this update, the navigation experience is smoother, and users are not forced back into LYS when intentionally exiting or stepping back from the flow.

Closes WOOPLUG-4504

### How to test the changes in this Pull Request:
- Create a new JN store with this PR's branch build (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce-beta-tester&woocommerce&branches.woocommerce=fix/WOOPLUG-4504-redirecting-back-to-lys)).
- Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.

### Testing Set up payment LYS back button
- Go to WooCommerce > Home and click on Launch your store task.
<img width="1704" alt="Screenshot 2025-05-30 at 12 14 13" src="https://github.com/user-attachments/assets/98b6edef-7a34-4f84-a371-a65332392bc7" />

- Click on the Set up payments link.
<img width="1694" alt="Screenshot 2025-05-30 at 12 15 33" src="https://github.com/user-attachments/assets/f4941826-2054-4241-aac1-262077c6dd59" />

- Verify that a page to install WooPayments is displayed. Click on Install.
<img width="1718" alt="Screenshot 2025-05-30 at 12 16 24" src="https://github.com/user-attachments/assets/55b07c29-e21a-4095-bc09-ea66043e2c50" />

- Click on the Set up WooPayments back button.
<img width="1727" alt="Screenshot 2025-06-06 at 11 00 40" src="https://github.com/user-attachments/assets/ebb54e18-5619-442a-b261-72d0ae534684" />


- Click on the Launch Your Store back button.
<img width="1725" alt="Screenshot 2025-06-06 at 10 57 45" src="https://github.com/user-attachments/assets/8b07b004-d5d3-4559-89f9-1d3ce44439e7" />

- Verify you are not redirected back to the Launch Your Store flow.

### Testing Set up payment LYS close button

- Click again on the Launch your store task.
<img width="1704" alt="Screenshot 2025-05-30 at 12 14 13" src="https://github.com/user-attachments/assets/98b6edef-7a34-4f84-a371-a65332392bc7" />

- Click on the Set up payments link.
<img width="1694" alt="Screenshot 2025-05-30 at 12 15 33" src="https://github.com/user-attachments/assets/f4941826-2054-4241-aac1-262077c6dd59" />

- Click on the X icon on the top right corner.
<img width="1727" alt="Screenshot 2025-06-06 at 11 00 40" src="https://github.com/user-attachments/assets/cddf190d-1d5b-4da8-9606-145a1b7b979a" />

- Click on the Launch Your Store back button.
<img width="1725" alt="Screenshot 2025-06-06 at 10 57 45" src="https://github.com/user-attachments/assets/8b07b004-d5d3-4559-89f9-1d3ce44439e7" />

- Verify you are not redirected back to the Launch Your Store flow.

### Testing Set up payment LYS resuming

- Click again on the Launch your store task.
<img width="1704" alt="Screenshot 2025-05-30 at 12 14 13" src="https://github.com/user-attachments/assets/98b6edef-7a34-4f84-a371-a65332392bc7" />

- Click on the Set up payments link.
<img width="1694" alt="Screenshot 2025-05-30 at 12 15 33" src="https://github.com/user-attachments/assets/f4941826-2054-4241-aac1-262077c6dd59" />

- Edit your URL and delete everything after `wp-admin/admin.php?page=wc-admin`, hit enter.
- Verify you are redirected back to the LYS.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
