### PR TITLE
Add to Cart + Options block: Fix gallery keyboard navigation

### DIFF
--- a/plugins/woocommerce/changelog/58598-fix-product-gallery-keyboard-nav
+++ b/plugins/woocommerce/changelog/58598-fix-product-gallery-keyboard-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Blockified Add to Cart with Options block: only allow the product gallery to navigate via the keyboard left and right arrows when the gallery is in focus.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -51,15 +51,6 @@ function setAttribute( name: string, value: string | null ) {
 
 function setDefaultSelectedAttribute() {
 	const context = getContext< Context >();
-
-	// Select the first attribute option if no value is selected.
-	if ( ! context.selectedValue && context.options.length > 0 ) {
-		const firstAttribute = context.options[ 0 ];
-		if ( firstAttribute.value ) {
-			context.selectedValue = firstAttribute.value;
-		}
-	}
-
 	setAttribute( context.name, context.selectedValue );
 }
 
@@ -162,8 +153,12 @@ const { state } = store(
 				} );
 			},
 			get pillTabIndex(): number {
-				const { isPillSelected } = state;
-				return isPillSelected ? 0 : -1;
+				const { selectedValue } = getContext< Context >();
+				const { isPillSelected, index } = state;
+				if ( isPillSelected || ( index === 0 && ! selectedValue ) ) {
+					return 0;
+				}
+				return -1;
 			},
 			get index() {
 				const context = getContext< Context >();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -51,6 +51,15 @@ function setAttribute( name: string, value: string | null ) {
 
 function setDefaultSelectedAttribute() {
 	const context = getContext< Context >();
+
+	// Select the first attribute option if no value is selected.
+	if ( ! context.selectedValue && context.options.length > 0 ) {
+		const firstAttribute = context.options[ 0 ];
+		if ( firstAttribute.value ) {
+			context.selectedValue = firstAttribute.value;
+		}
+	}
+
 	setAttribute( context.name, context.selectedValue );
 }
 
@@ -151,6 +160,10 @@ const { state } = store(
 					selectedAttributes,
 					availableVariations,
 				} );
+			},
+			get pillTabIndex(): number {
+				const { isPillSelected } = state;
+				return isPillSelected ? 0 : -1;
 			},
 			get index() {
 				const context = getContext< Context >();

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -1074,7 +1074,7 @@
     nextText: "Next",               //String: Set the text for the "next" directionNav item
 
     // Secondary Navigation
-    keyboard: true,                 //Boolean: Allow slider navigating via keyboard left/right keys
+    keyboard: false,                 //Boolean: Allow slider navigating via keyboard left/right keys
     multipleKeyboard: false,        //{NEW} Boolean: Allow keyboard navigation to affect multiple sliders. Default behavior cuts out keyboard navigation with more than one slider present.
     mousewheel: false,              //{UPDATED} Boolean: Requires jquery.mousewheel.js (https://github.com/brandonaaron/jquery-mousewheel) - Allows slider navigating via mousewheel
     pausePlay: false,               //Boolean: Create pause/play dynamic element

--- a/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/client/legacy/js/flexslider/jquery.flexslider.js
@@ -1074,7 +1074,7 @@
     nextText: "Next",               //String: Set the text for the "next" directionNav item
 
     // Secondary Navigation
-    keyboard: false,                 //Boolean: Allow slider navigating via keyboard left/right keys
+    keyboard: true,                 //Boolean: Allow slider navigating via keyboard left/right keys
     multipleKeyboard: false,        //{NEW} Boolean: Allow keyboard navigation to affect multiple sliders. Default behavior cuts out keyboard navigation with more than one slider present.
     mousewheel: false,              //{UPDATED} Boolean: Requires jquery.mousewheel.js (https://github.com/brandonaaron/jquery-mousewheel) - Allows slider navigating via mousewheel
     pausePlay: false,               //Boolean: Create pause/play dynamic element

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -239,7 +239,9 @@ jQuery( function( $ ) {
 			},
 			after: function( slider ) {
 				gallery.initZoomForTarget( gallery.$images.eq( slider.currentSlide ) );
-			}
+			},
+			// Disable the built-in keyboard navigation and use custom keyboard navigation instead.
+			keyboard: false,
 		}, args );
 
 		$target.flexslider( options );
@@ -264,7 +266,7 @@ jQuery( function( $ ) {
 			}
 		} );
 
-		// Add custom keyboard navigation that applies only to the slider container.
+		// Custom keyboard navigation that applies only when the slider container is focused.
 		$target
 			.on( 'keydown', function ( e ) {
 				if ( e.which === 39 ) {
@@ -279,7 +281,6 @@ jQuery( function( $ ) {
 					e.stopPropagation();
 				}
 			} )
-			// Make the slider focusable.
 			.attr( 'tabindex', '0' );
 	};
 

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -263,6 +263,24 @@ jQuery( function( $ ) {
 				$( this ).trigger( 'load' );
 			}
 		} );
+
+		// Add custom keyboard navigation that applies only to the slider container.
+		$target
+			.on( 'keydown', function ( e ) {
+				if ( e.which === 39 ) {
+					// Right arrow
+					$( this ).flexslider( 'next' );
+					e.preventDefault();
+					e.stopPropagation();
+				} else if ( e.which === 37 ) {
+					// Left arrow
+					$( this ).flexslider( 'prev' );
+					e.preventDefault();
+					e.stopPropagation();
+				}
+			} )
+			// Make the slider focusable.
+			.attr( 'tabindex', '0' );
 	};
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -158,6 +158,8 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 						'data-wp-context'        => array(
 							'option' => $attribute_term,
 						),
+						'data-wp-bind--aria-checked' => 'state.isPillSelected',
+						'data-wp-bind--tabindex'     => 'state.pillTabIndex',
 					),
 				),
 				$attribute_term['label']

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -147,15 +147,15 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'<input type="radio" %s/>',
 				$this->get_normalized_attributes(
 					array(
-						'class'                  => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input',
-						'name'                   => $attribute_slug,
-						'value'                  => $attribute_term['value'],
-						'data-wp-bind--checked'  => 'state.isPillSelected',
-						'data-wp-bind--disabled' => 'state.isPillDisabled',
-						'data-wp-watch'          => 'callbacks.watchSelected',
-						'data-wp-on--click'      => 'actions.toggleSelected',
-						'data-wp-on--keydown'    => 'actions.handleKeyDown',
-						'data-wp-context'        => array(
+						'class'                      => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input',
+						'name'                       => $attribute_slug,
+						'value'                      => $attribute_term['value'],
+						'data-wp-bind--checked'      => 'state.isPillSelected',
+						'data-wp-bind--disabled'     => 'state.isPillDisabled',
+						'data-wp-watch'              => 'callbacks.watchSelected',
+						'data-wp-on--click'          => 'actions.toggleSelected',
+						'data-wp-on--keydown'        => 'actions.handleKeyDown',
+						'data-wp-context'            => array(
 							'option' => $attribute_term,
 						),
 						'data-wp-bind--aria-checked' => 'state.isPillSelected',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/57682.

This attempts to fix the issue described in https://github.com/woocommerce/woocommerce/issues/57682, where the product gallery slider always navigates when the keyboard left and right arrows are pressed, regardless of whether the slider is in focus or not.

The primary fix is updating the FlexSlider implementation in `single-product.js` to disable the default keyboard navigation and use a custom keyboard navigation which only listens to the left and right arrow keys if the gallery is in focus.

I've also updated the variation pills to include `aria-checked` and `tabindex` attributes, which I believe should improve the accessibility of these pills following the guidelines from [this w3 example](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio/). If it's easier, I can create a separate PR for this instead.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/7fe88611-9734-42f3-8a8e-2b59fd54f92b" /> | <video src="https://github.com/user-attachments/assets/2159fd99-b9a6-428c-9a3a-168c4c0b398b" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) plugin.
2. Go to *Tools* > *WCA Test Helper* > *Features* and enable `experimental-blocks` and `blockified-add-to-cart`.
3. Go to *Appearance* > *Editor* > *Templates* > *Single Product* and update the *Add to Cart with Options* block to the blockified version.
4. Make sure in the same template there is the *Product Image Gallery* block.
5. Visit a variable product in the frontend.
6. With the keyboard arrow keys, navigate through the variation options.
7. Ensure that the images from the gallery do not switch at the same time as navigating through the variation options.
8. Use the keyboard to focus the product gallery.
9. Use the left or right arrow keys to navigate the gallery and ensure the gallery images switch correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Blockified Add to Cart with Options block: only allow the product gallery to navigate via the keyboard left and right arrows when the gallery is in focus.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
