### PR TITLE
Add $order argument to woocommerce_email_downloads_columns filter

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-1200-enhancement-add-order-object-to
+++ b/plugins/woocommerce/changelog/wooplug-1200-enhancement-add-order-object-to
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add $order argument to woocommerce_email_downloads_columns filter

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -525,7 +525,9 @@ class WC_Emails {
 		 * Filter the columns of the order downloads table.
 		 *
 		 * @since 3.2.0
-		 * @param array $columns Array of columns.
+		 * @since 10.0.0 Added $order parameter.
+		 * @param array    $columns Array of columns.
+		 * @param WC_Order $order  Order object.
 		 */
 		$columns = apply_filters(
 			'woocommerce_email_downloads_columns',
@@ -533,7 +535,8 @@ class WC_Emails {
 				'download-product' => __( 'Product', 'woocommerce' ),
 				'download-expires' => __( 'Expires', 'woocommerce' ),
 				'download-file'    => __( 'Download', 'woocommerce' ),
-			)
+			),
+			$order
 		);
 
 		if ( $plain_text ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a new `$order` argument to  `woocommerce_email_downloads_columns` to allow conditionally add a new column based on the value from order properties. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-1200, closes #37757.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start testing on the `trunk` to check the previous behaviour. 
2. Set up a product with downloadable content.
3. Make an order with this product and mark it as completed. 
4. Install **Code Snippets**.
5. Add this snippet
```php
add_filter( 'woocommerce_email_downloads_columns', 'add_recent_order_downloads_column', 10, 2 );
function add_recent_order_downloads_column( $columns, $order ) {
    $columns['new-column'] = 'Order #' . $order->id;
    return $columns;
}
```
6. Send an order detail to the customer - notice that this throws an error (because the filter expects 2 parameters, but only 1 is passed).
7. Check out this branch.
8. Send an order detail to the customer - notice that the downloads section includes a new column which includes order ID.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
