### PR TITLE
Add email usage tracking to WC Tracker

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4527-add-email-usage-tracking
+++ b/plugins/woocommerce/changelog/wooplug-4527-add-email-usage-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add email usage tracking to WC Tracker

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -231,6 +231,9 @@ class WC_Tracker {
 		// Email improvements tracking data.
 		$data['email_improvements'] = self::get_email_improvements_info( $template_overrides );
 
+		// Store email usage.
+		$data['store_emails'] = self::get_store_emails();
+
 		/**
 		 * Filter the data that's sent with the tracker.
 		 *
@@ -1465,6 +1468,28 @@ class WC_Tracker {
 			'core_email_disabled_count'      => $core_email_counts['disabled'],
 			'core_email_overrides_count'     => $core_email_overrides['count'],
 			'core_email_overrides_templates' => array_keys( $core_email_overrides['templates'] ),
+		);
+	}
+
+	/**
+	 * Get store email usage.
+	 *
+	 * @return array Email usage.
+	 */
+	private static function get_store_emails() {
+		$enabled_emails                          = EmailImprovements::get_enabled_emails();
+		$disabled_emails                         = EmailImprovements::get_disabled_emails();
+		$enabled_or_manual_emails_with_cc_or_bcc = EmailImprovements::get_enabled_or_manual_emails_with_cc_or_bcc();
+
+		return array(
+			'enabled_emails'                          => $enabled_emails,
+			'enabled_emails_count'                    => count( $enabled_emails ),
+			'disabled_emails'                         => $disabled_emails,
+			'disabled_emails_count'                   => count( $disabled_emails ),
+			'enabled_or_manual_emails_with_cc'        => $enabled_or_manual_emails_with_cc_or_bcc['ccs'],
+			'enabled_or_manual_emails_with_cc_count'  => count( $enabled_or_manual_emails_with_cc_or_bcc['ccs'] ),
+			'enabled_or_manual_emails_with_bcc'       => $enabled_or_manual_emails_with_cc_or_bcc['bccs'],
+			'enabled_or_manual_emails_with_bcc_count' => count( $enabled_or_manual_emails_with_cc_or_bcc['bccs'] ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
@@ -163,7 +163,7 @@ class EmailImprovements {
 	 */
 	public static function get_core_emails() {
 		return array_filter(
-			WC()->mailer()->get_emails(),
+			self::get_emails(),
 			function ( $email ) {
 				return strpos( get_class( $email ), 'WC_Email_' ) === 0 && is_string( $email->template_html );
 			}
@@ -195,7 +195,7 @@ class EmailImprovements {
 	 */
 	public static function get_enabled_emails() {
 		$enabled_emails = array_filter(
-			WC()->mailer()->get_emails(),
+			self::get_emails(),
 			function ( $email ) {
 				return $email->is_enabled() && ! $email->is_manual();
 			}
@@ -210,7 +210,7 @@ class EmailImprovements {
 	 */
 	public static function get_disabled_emails() {
 		$disabled_emails = array_filter(
-			WC()->mailer()->get_emails(),
+			self::get_emails(),
 			function ( $email ) {
 				return ! $email->is_enabled() && ! $email->is_manual();
 			}
@@ -225,7 +225,7 @@ class EmailImprovements {
 	 */
 	public static function get_enabled_or_manual_emails_with_cc_or_bcc() {
 		$enabled_or_manual_emails = array_filter(
-			WC()->mailer()->get_emails(),
+			self::get_emails(),
 			function ( $email ) {
 				return $email->is_enabled() || $email->is_manual();
 			}
@@ -246,6 +246,19 @@ class EmailImprovements {
 		return array(
 			'ccs'  => $email_ids_with_cc,
 			'bccs' => $email_ids_with_bcc,
+		);
+	}
+
+	/**
+	 * A helper method to filter out non-WC_Email objects.
+	 *
+	 * @return \WC_Email[] All WC_Email objects.
+	 */
+	private static function get_emails() {
+		$emails = WC()->mailer()->get_emails();
+		return array_filter(
+			$emails,
+			fn( $email ) => is_object( $email ) && $email instanceof \WC_Email
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
@@ -187,4 +187,65 @@ class EmailImprovements {
 		$all_email_templates  = array_merge( $core_email_templates, self::EMAIL_TEMPLATE_PARTS );
 		return array_intersect( $all_email_templates, $template_overrides );
 	}
+
+	/**
+	 * Get all enabled email IDs.
+	 *
+	 * @return array Enabled email IDs.
+	 */
+	public static function get_enabled_emails() {
+		$enabled_emails = array_filter(
+			WC()->mailer()->get_emails(),
+			function ( $email ) {
+				return $email->is_enabled() && ! $email->is_manual();
+			}
+		);
+		return array_values( array_map( fn( $email ) => get_class( $email ), $enabled_emails ) );
+	}
+
+	/**
+	 * Get all disabled email IDs.
+	 *
+	 * @return array Enabled email IDs.
+	 */
+	public static function get_disabled_emails() {
+		$disabled_emails = array_filter(
+			WC()->mailer()->get_emails(),
+			function ( $email ) {
+				return ! $email->is_enabled() && ! $email->is_manual();
+			}
+		);
+		return array_values( array_map( fn( $email ) => get_class( $email ), $disabled_emails ) );
+	}
+
+	/**
+	 * Get all enabled or manual emails with Cc or Bcc.
+	 *
+	 * @return array Enabled or manual emails with Cc or Bcc.
+	 */
+	public static function get_enabled_or_manual_emails_with_cc_or_bcc() {
+		$enabled_or_manual_emails = array_filter(
+			WC()->mailer()->get_emails(),
+			function ( $email ) {
+				return $email->is_enabled() || $email->is_manual();
+			}
+		);
+
+		$email_ids_with_cc  = array();
+		$email_ids_with_bcc = array();
+
+		foreach ( $enabled_or_manual_emails as $email ) {
+			if ( $email->get_cc_recipient() ) {
+				$email_ids_with_cc[] = get_class( $email );
+			}
+			if ( $email->get_bcc_recipient() ) {
+				$email_ids_with_bcc[] = get_class( $email );
+			}
+		}
+
+		return array(
+			'ccs'  => $email_ids_with_cc,
+			'bccs' => $email_ids_with_bcc,
+		);
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds email usage tracking to gather data on which emails are used, and which often require Cc or Bcc. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4527, closes #58592.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `var_dump( WC_Tracker::get_tracking_data() );` anywhere.
2. Check that the `store_emails` item is present and the values inside correspond with the **WooCommerce > Settings > Emails**.
3. Disable some emails, add cc or bcc to some and check that the values are correct in the output.
4. Try installing any extension that adds more emails to check, that they are also present in the output.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
