### PR TITLE
BlocksUtil: fix the fatal error when dealing with unexpected widget_block data

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4513-blocksutilget_blocks_from_widget_area-fatals-when-returns
+++ b/plugins/woocommerce/changelog/wooplug-4513-blocksutilget_blocks_from_widget_area-fatals-when-returns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+BlocksUtil: fix the fatal error when dealing with unexpected widget_block data.

--- a/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Utilities;
 
@@ -16,7 +17,7 @@ class BlocksUtil {
 	public static function flatten_blocks( $blocks ) {
 		return array_reduce(
 			$blocks,
-			function( $carry, $block ) {
+			function ( $carry, $block ) {
 				array_push( $carry, array_diff_key( $block, array_flip( array( 'innerBlocks' ) ) ) );
 				if ( isset( $block['innerBlocks'] ) ) {
 					$inner_blocks = self::flatten_blocks( $block['innerBlocks'] );
@@ -36,13 +37,18 @@ class BlocksUtil {
 	 * @return array Array of blocks as returned by parse_blocks().
 	 */
 	public static function get_blocks_from_widget_area( $block_name ) {
+		$blocks = get_option( 'widget_block' );
+
+		if ( ! is_array( $blocks ) || empty( $blocks ) ) {
+			return array();
+		}
+
 		return array_reduce(
-			get_option( 'widget_block' ),
+			$blocks,
 			function ( $acc, $block ) use ( $block_name ) {
-				$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
+				$parsed_blocks = ! empty( $block['content'] ) ? parse_blocks( $block['content'] ) : array();
 				if ( ! empty( $parsed_blocks ) && $block_name === $parsed_blocks[0]['blockName'] ) {
 					array_push( $acc, $parsed_blocks[0] );
-					return $acc;
 				}
 				return $acc;
 			},

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/BlocksUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/BlocksUtilTest.php
@@ -1,0 +1,102 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Utilities\BlocksUtil;
+
+/**
+ * Class BlocksUtilTest.
+ *
+ * @package Automattic\WooCommerce\Tests\Internal\Utilities
+ */
+class BlocksUtilTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test get_blocks_from_widget_area with empty widget option.
+	 */
+	public function test_get_blocks_from_widget_area_with_empty_widgets() {
+		// Test with no widgets.
+		update_option( 'widget_block', array() );
+		$result = BlocksUtil::get_blocks_from_widget_area( 'test/block' );
+		$this->assertEmpty( $result );
+
+		// Test with non-array widget option.
+		update_option( 'widget_block', null );
+		$result = BlocksUtil::get_blocks_from_widget_area( 'test/block' );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test get_blocks_from_widget_area with widgets but no matching blocks.
+	 */
+	public function test_get_blocks_from_widget_area_with_no_matching_blocks() {
+		$widgets = array(
+			'2'            => array(
+				'content' => '<!-- wp:test/other-block --><div>Test</div><!-- /wp:test/other-block -->',
+			),
+			'_multiwidget' => 1,
+		);
+
+		update_option( 'widget_block', $widgets );
+		$result = BlocksUtil::get_blocks_from_widget_area( 'test/block' );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test get_blocks_from_widget_area with matching blocks.
+	 */
+	public function test_get_blocks_from_widget_area_with_matching_blocks() {
+		$widgets = array(
+			'2'            => array(
+				'content' => '<!-- wp:test/block --><div>Test 1</div><!-- /wp:test/block -->',
+			),
+			'3'            => array(
+				'content' => '<!-- wp:test/other-block --><div>Test 2</div><!-- /wp:test/other-block -->',
+			),
+			'4'            => array(
+				'content' => '<!-- wp:test/block --><div>Test 3</div><!-- /wp:test/block -->',
+			),
+			'_multiwidget' => 1,
+		);
+
+		update_option( 'widget_block', $widgets );
+		$result = BlocksUtil::get_blocks_from_widget_area( 'test/block' );
+
+		$this->assertCount( 2, $result );
+		$this->assertEquals( 'test/block', $result[0]['blockName'] );
+		$this->assertEquals( 'test/block', $result[1]['blockName'] );
+		$this->assertStringContainsString( 'Test 1', $result[0]['innerHTML'] );
+		$this->assertStringContainsString( 'Test 3', $result[1]['innerHTML'] );
+	}
+
+	/**
+	 * Test get_blocks_from_widget_area with invalid widget data.
+	 */
+	public function test_get_blocks_from_widget_area_with_invalid_data() {
+		$test_cases = array(
+			// Non-array widget item.
+			array( 'invalid' ),
+			// Empty array.
+			array( array() ),
+			// Missing content.
+			array( array( 'something' => 'else' ) ),
+			// Empty content.
+			array( array( 'content' => '' ) ),
+		);
+
+		foreach ( $test_cases as $test_case ) {
+			update_option( 'widget_block', $test_case );
+			$result = BlocksUtil::get_blocks_from_widget_area( 'test/block' );
+			$this->assertEmpty( $result );
+		}
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( 'widget_block' );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes wooplug-4513

This PR add more defensive checks to `BlocksUtil::get_blocks_from_widget_area` function to make it work more reliably. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use this snippet 
```php
<?php
add_filter( 'pre_option_widget_block', function() {
    return 'a string';
});
```
2. Enable tracking in WooCommerce > Settings > Advanced > WooCommerce.com.
3. Make sure error log file is writing (debug.log).
4. See error in debug.log with `trunk` and no error with this PR.

<!-- End testing instructions -->
