### PR TITLE
Fix:ensure wp_is_block_theme() is called after theme directories registration 

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4444-function-wp_is_block_theme-was-called-incorrectly-notice
+++ b/plugins/woocommerce/changelog/wooplug-4444-function-wp_is_block_theme-was-called-incorrectly-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: ensure wp_is_block_theme() is called after theme directories registration.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -285,6 +285,7 @@ final class WooCommerce {
 		register_shutdown_function( array( $this, 'log_errors' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ), -1 );
+		add_action( 'plugins_loaded', array( $this, 'init_customizer' ) );
 		add_action( 'plugins_loaded', array( $this, 'init_jetpack_connection_config' ), 1 );
 		add_action( 'admin_notices', array( $this, 'build_dependencies_notice' ) );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
@@ -1380,5 +1381,24 @@ final class WooCommerce {
 
 		// Always update the last change.
 		update_option( 'woocommerce_allow_tracking_last_modified', time() );
+	}
+
+	/**
+	 * Initialize the customizer on the plugins_loaded action.
+	 * If WooCommerce is network activated, wp_is_block_theme() will be called too early,
+	 * which cause the warning in #58364. By initializing the customizer on plugins_loaded,
+	 * we ensure that wp_is_block_theme() is called after theme directories registration.
+	 *
+	 * See https://github.com/woocommerce/woocommerce/issues/58364
+	 */
+	public function init_customizer() {
+		global $pagenow;
+		if (
+			'customize.php' === $pagenow ||
+			isset( $_REQUEST['customize_theme'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! wp_is_block_theme()
+		) {
+			new WC_Shop_Customizer();
+		}
 	}
 }

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1389,7 +1389,8 @@ final class WooCommerce {
 	 * which cause the warning in #58364. By initializing the customizer on plugins_loaded,
 	 * we ensure that wp_is_block_theme() is called after theme directories registration.
 	 *
-	 * See https://github.com/woocommerce/woocommerce/issues/58364
+	 * @internal
+	 * @see https://github.com/woocommerce/woocommerce/issues/58364
 	 */
 	public function init_customizer() {
 		global $pagenow;

--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -949,12 +949,3 @@ class WC_Shop_Customizer {
 		return strpos( $post->post_content, '<!-- wp:woocommerce/checkout' ) !== false;
 	}
 }
-
-global $pagenow;
-if (
-	'customize.php' === $pagenow ||
-	isset( $_REQUEST['customize_theme'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	! wp_is_block_theme()
-) {
-	new WC_Shop_Customizer();
-}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes wooplug-4444.

This PR ensures that we don't call `wp_is_block_theme()` too early which throw the warning as pointed out in https://github.com/woocommerce/woocommerce/issues/58364. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Smoke test the Customizer in the follow case:
- Directly access the customizer when using block theme.
- Using Customizer with classic theme.

<!-- End testing instructions -->

