### PR TITLE
Allow GH releases to be created from workflow

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -212,29 +212,21 @@ jobs:
 
       - name: Create draft release
         id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.version }}
-          release_name: ${{ steps.get_version.outputs.version }}
-          draft: true
-          prerelease: ${{ contains(steps.get_version.outputs.version, '-rc') }}
-          commitish: ${{ inputs.branch || github.ref }}
-          body: ''
-
-      - name: Upload ZIP to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./woocommerce.zip
-          asset_name: woocommerce.zip
-          asset_content_type: application/zip
-
-      - name: Show link to release.
-        env:
-          RELEASE_URL: ${{ steps.create_release.outputs.html_url }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          IS_PRERELEASE: ${{ contains(steps.get_version.outputs.version, '-rc') }}
         run: |
-          echo "::notice::Draft release available at ${RELEASE_URL}."
+          FLAGS=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            FLAGS="--prerelease=true"
+          fi
+
+          gh release create ${{ steps.get_version.outputs.version }} \
+            './woocommerce.zip' \
+            --title '${{ steps.get_version.outputs.version }}' \
+            --notes '' \
+            --target '${{ inputs.branch || github.ref }}' \
+            --latest=false \
+            --draft \
+            $FLAGS

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: ''
       skip_verify:
-        description: 'Skip the PR verification step.'
+        description: 'Skip verification steps.'
         type: boolean
         required: true
         default: false

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -35,7 +35,7 @@ jobs:
                   let runBuildZipJob = true;
                   const event = context.payload;
 
-                  if (event.inputs.skip_verify !== false) {
+                  if (event.inputs.skip_verify === 'true') {
                     core.setOutput('runBuildZipJob', runBuildZipJob);
                     console.log('Skipping verification step');
                     return;

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -84,7 +84,7 @@ jobs:
                   core.setOutput('runBuildZipJob', runBuildZipJob);
 
         - name: Notify Slack on failure
-          if: ${{ steps.verify-prs.outputs.failureMessage != '' }}
+          if: ${{ steps.verify-prs.outputs.failureMessage != '' && inputs.create_github_release }}
           uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
           with:
               slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
@@ -102,53 +102,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: ${{ ! inputs.skip_verify }}
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          path: checkout-branch
+        if: ${{ inputs.create_github_release && ! inputs.skip_verify }}
 
       - name: 'Pre-build verification'
-        if: ${{ ! inputs.skip_verify }}
+        if: ${{ inputs.create_github_release && ! inputs.skip_verify }}
+        env:
+          BRANCH: ${{ inputs.branch || github.ref }}
         run: |
-            branch_name="${GITHUB_REF#refs/heads/}"
+            # Branch name must be 'release/*'.
+            branch_name="${BRANCH#refs/heads/}"
             if  [[ $branch_name != release/* ]] ; then
-                echo "[ERR] Pre-build verification: the branch name is NOT matching 'release/*' pattern (identified as $branch_name)"
+                echo "::error::Pre-build verification: branch name '$branch_name' is not matching 'release/*' pattern."
                 exit 1
-            else
-                echo "[OK] Pre-build verification: the branch name is matching 'release/*' pattern ($branch_name)"
             fi
+
+            # Version number in branch name and plugin main version must match.
+            branch_plugin_version=$( cat checkout-branch/plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
             version_prefix=${branch_name/"release/"/""}
-
-            # Validate release version related attributions
-            branch_plugin_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
-            svn_plugin_version=$( wget --quiet https://plugins.svn.wordpress.org/woocommerce/trunk/woocommerce.php -O /dev/stdout |  grep -oP '(?<=Version: )(.+)' | head -n1 )
             if [[ $branch_plugin_version != "$version_prefix."* ]] ; then
-                echo "[ERR] Pre-build verification: release version in branch is NOT matching '$version_prefix.*' pattern (identified as $branch_plugin_version)"
+                echo "::error::Pre-build verification: release version in branch ($branch_plugin_version) is not matching '$version_prefix.*' pattern."
                 exit 1
-            else
-                echo "[OK] Pre-build verification: release version in branch is matching '$version_prefix.*' pattern ($branch_plugin_version)"
-            fi
-            if [[ $branch_plugin_version == $svn_plugin_version ]] ; then
-                echo "[ERR] Pre-build verification: release version in branch is matching the one in SVN trunk (identified as $branch_plugin_version)"
-                exit 1
-            else
-                echo "[OK] Pre-build verification: release version in branch is NOT matching the one in SVN trunk ($branch_plugin_version vs $svn_plugin_version)"
             fi
 
-            # Validate stable version attribution
-            branch_stable_version=$( cat plugins/woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
+            # Release should not already exist on wporg.
+            tag_exists=$(curl -s 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=woocommerce' | jq "(.versions | has(\"$branch_plugin_version\"))")
+            if [ "$tag_exists" == "true" ]; then
+              echo "::error::Tag '$branch_plugin_version' already exists on WordPress.org."
+              exit 1
+            fi
+
+            # Stable version in release branch should match wporg.
             svn_stable_version=$( wget --quiet https://plugins.svn.wordpress.org/woocommerce/trunk/readme.txt -O /dev/stdout |  grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
+            branch_stable_version=$( cat checkout-branch/plugins/woocommerce/readme.txt | grep -oP '(?<=Stable tag: )(.+)' | head -n1 )
             if [[ $branch_stable_version != $svn_stable_version ]] ; then
-                echo "[ERR] Pre-build verification: stable version in branch is NOT matching the one in SVN trunk (identified as $branch_stable_version)"
+                echo "::error::Pre-build verification: stable version in release branch ($branch_stable_version) is not matching the one in SVN trunk ($svn_stable_version)."
                 exit 1
-            else
-                echo "[OK] Pre-build verification: stable version in branch is matching the one in SVN trunk ($branch_stable_version vs $svn_stable_version)"
-            fi
-
-            # Validate changelog for the target release version
-            branch_changelog_version=$( cat changelog.txt | grep -oP '\d+\.\d+\.\d+ '| tail -n +1 | head -n1 )
-            if [[ $branch_plugin_version != *'-'* ]] && [[ $branch_plugin_version != $branch_changelog_version ]]; then
-                echo "[ERR] Pre-build verification: changelog for $branch_plugin_version is missing"
-                exit 1
-            else
-                echo "[OK] Pre-build verification: changelog for $branch_plugin_version is present or not required (the last entry is for $branch_changelog_version)"
             fi
 
   build:
@@ -225,7 +216,7 @@ jobs:
           release_name: ${{ steps.get_version.outputs.version }}
           draft: true
           prerelease: ${{ contains(steps.get_version.outputs.version, '-rc') }}
-          commitish: ${{ github.ref }}
+          commitish: ${{ inputs.branch || github.ref }}
           body: ''
 
       - name: Upload ZIP to release

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -2,14 +2,20 @@ name: 'Release: Build ZIP file'
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name or refs/heads/release/x.x). The resulting file will be available as an artifact on the workflow run.'
+      branch:
+        description: 'Source branch to use. Defaults to the branch the workflow is run from.'
         required: false
         default: ''
       skip_verify:
-        description: 'Skip the PR verification step (default: false) pass true to skip'
-        required: false
-        default: 'false'
+        description: 'Skip the PR verification step.'
+        type: boolean
+        required: true
+        default: false
+      create_github_release:
+        description: 'Create a draft GitHub release.'
+        type: boolean
+        required: true
+        default: false
 
 permissions: {}
 
@@ -29,7 +35,7 @@ jobs:
                   let runBuildZipJob = true;
                   const event = context.payload;
 
-                  if (event.inputs.skip_verify !== 'false') {
+                  if (event.inputs.skip_verify !== false) {
                     core.setOutput('runBuildZipJob', runBuildZipJob);
                     console.log('Skipping verification step');
                     return;
@@ -94,11 +100,12 @@ jobs:
   verify-release-versions:
     name: 'Verify release and stable tag versions'
     runs-on: ubuntu-latest
-    if: ${{ inputs.skip_verify == 'false' }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ ! inputs.skip_verify }}
 
       - name: 'Pre-build verification'
+        if: ${{ ! inputs.skip_verify }}
         run: |
             branch_name="${GITHUB_REF#refs/heads/}"
             if  [[ $branch_name != release/* ]] ; then
@@ -134,7 +141,7 @@ jobs:
             else
                 echo "[OK] Pre-build verification: stable version in branch is matching the one in SVN trunk ($branch_stable_version vs $svn_stable_version)"
             fi
-  
+
             # Validate changelog for the target release version
             branch_changelog_version=$( cat changelog.txt | grep -oP '\d+\.\d+\.\d+ '| tail -n +1 | head -n1 )
             if [[ $branch_plugin_version != *'-'* ]] && [[ $branch_plugin_version != $branch_changelog_version ]]; then
@@ -147,12 +154,22 @@ jobs:
   build:
     name: Build release zip file
     runs-on: ubuntu-latest
-    if: ${{ needs.verify-prs.outputs.runBuildZipJob == 'true' }}
     needs: [ verify-prs, verify-release-versions ]
     permissions:
       contents: read
     steps:
+      - name: Verify release branch.
+        env:
+          BRANCH: ${{ inputs.branch || github.ref }}
+        run: |
+          if ! git ls-remote --exit-code --heads  https://github.com/${GITHUB_REPOSITORY} ${BRANCH} > /dev/null; then
+            echo "::error::Source branch '$BRANCH' does not exist."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Setup WooCommerce Monorepo
         uses: ./.github/actions/setup-woocommerce-monorepo
@@ -173,4 +190,56 @@ jobs:
         with:
           name: woocommerce
           path: zipfile
-          retention-days: 7
+          retention-days: 1
+
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ inputs.create_github_release }}
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: woocommerce
+
+      - name: Get version from plugin file
+        id: get_version
+        run: |
+          version=$(cat ./woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1)
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Generate release ZIP file
+        run: |
+          zip -q -9 -r ./woocommerce.zip ./woocommerce/
+
+      - name: Create draft release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          release_name: ${{ steps.get_version.outputs.version }}
+          draft: true
+          prerelease: ${{ contains(steps.get_version.outputs.version, '-rc') }}
+          commitish: ${{ github.ref }}
+          body: ''
+
+      - name: Upload ZIP to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./woocommerce.zip
+          asset_name: woocommerce.zip
+          asset_content_type: application/zip
+
+      - name: Show link to release.
+        env:
+          RELEASE_URL: ${{ steps.create_release.outputs.html_url }}
+        run: |
+          echo "::notice::Draft release available at ${RELEASE_URL}."

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           ref: ${{ inputs.branch || github.ref }}
           path: checkout-branch
+          sparse-checkout: |
+            /plugins/woocommerce/woocommerce.php
+            /plugins/woocommerce/readme.txt
+          sparse-checkout-cone-mode: false
         if: ${{ inputs.create_github_release && ! inputs.skip_verify }}
 
       - name: 'Pre-build verification'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR introduces a few enhancements in the ["build ZIP" workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml). Specifically:

- Simplifies the language for the various options.
- Fixes a workflow failure when the verification step was skipped.
- Adds support for running the workflow from `trunk` while building a specific release branch, so backporting fixes to this workflow to the release branch will no longer be required before building.
- Allows a draft release to be created from while building the ZIP.

<img width="360" alt="Screenshot 2025-06-12 at 11 06 11" src="https://github.com/user-attachments/assets/225b96aa-870a-4ba2-9ee3-35ebec21007c" />


Related to #57898.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fork of the WooCommerce repository and ensure that `trunk` is set to this specific branch and that it has at least the `release/9.9` branch (useful for testing the workflow).
   You can achieve the above using the CLI:

   ```
   git remote add my_fork git@github.com:<GITHUB USERNAME>/woocommerce.git
   git push my_fork enhancement/57898:trunk -f
   git push my_fork release/9.9
   ```

   ⚠️ Be careful **not** to push to `origin` but always to `my_fork`.

1. Go to **Actions > Release: Build ZIP file** in your forked repo and run the workflow with the following configurations.

   Ensure the outcome is as expected and in all cases confirm that the ZIP attached to both the workflow and the release (if any) has the correct version.

   |**Source branch**|**Create a draft GitHub release**|**Expected Result**|
   |-|-|-|
   |`release/9.9`|(checked)|Draft 9.9.4 release in **Releases** with attached file `woocommerce.zip`.|
   |`trunk`|(checked)|Should fail because `trunk` is not a release branch.|
   |`my-super-branch`|(checked)|Build fails due to incorrect source branch name.|
   |(empty)|(unchecked)|ZIP attached to workflow as asset should be 10.0.0-dev.<br>No draft release created.|

   I suggest running with _Skip the PR verification step_ checked off to speed up testing. Do at least one run with it unchecked to make sure the checks are correct. In this case you might need to temporarily bump the version to 9.9.4 in `release/9.9` since the checks prevent releasing a tag that already exists on wporg.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
