### PR TITLE
Prevent adding items via StoreAPI with 0 quantity 

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4542-store-api-item-is-added-to-cart-even-if-quantity-is-0-within
+++ b/plugins/woocommerce/changelog/wooplug-4542-store-api-item-is-added-to-cart-even-if-quantity-is-0-within
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent items being added to cart with quantity of 0.

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -266,8 +266,8 @@ class CartController {
 				'woocommerce_rest_product_invalid_quantity',
 				sprintf(
 					/* translators: %s: product name */
-					__( 'You cannot add &quot;%s&quot; with a quantity of 0 to the cart.', 'woocommerce' ),
-					$product->get_name()
+					esc_html__( 'You cannot add &quot;%s&quot; with a quantity of 0 to the cart.', 'woocommerce' ),
+					esc_html( $product->get_name() )
 				),
 				400
 			);

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -261,12 +261,12 @@ class CartController {
 			$this->throw_default_product_exception( $product );
 		}
 
-		if ( 0 === (int) $request['quantity'] ) {
+		if ( floatval( $request['quantity'] ) <= 0 ) {
 			throw new RouteException(
 				'woocommerce_rest_product_invalid_quantity',
 				sprintf(
 					/* translators: %s: product name */
-					esc_html__( 'You cannot add &quot;%s&quot; with a quantity of 0 to the cart.', 'woocommerce' ),
+					esc_html__( 'You cannot add &quot;%s&quot; with a quantity less than or equal to 0 to the cart.', 'woocommerce' ),
 					esc_html( $product->get_name() )
 				),
 				400

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -261,6 +261,18 @@ class CartController {
 			$this->throw_default_product_exception( $product );
 		}
 
+		if ( 0 === (int) $request['quantity'] ) {
+			throw new RouteException(
+				'woocommerce_rest_product_invalid_quantity',
+				sprintf(
+					/* translators: %s: product name */
+					__( 'You cannot add &quot;%s&quot; with a quantity of 0 to the cart.', 'woocommerce' ),
+					$product->get_name()
+				),
+				400
+			);
+		}
+
 		if ( ! $product->is_in_stock() ) {
 			throw new RouteException(
 				'woocommerce_rest_product_out_of_stock',

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -112,9 +112,14 @@ class CartController {
 			$request['cart_item_data']
 		);
 
-		$this->validate_add_to_cart( $product, $request );
+		$quantity_limits = new QuantityLimits();
 
-		$quantity_limits  = new QuantityLimits();
+		// If quantity was not passed, it should default to the minimum allowed quantity.
+		if ( null === $request['quantity'] ) {
+			$request['quantity'] = $quantity_limits->get_add_to_cart_limits( $product )['minimum'];
+		}
+
+		$this->validate_add_to_cart( $product, $request );
 		$existing_cart_id = $cart->find_product_in_cart( $cart_id );
 
 		if ( $existing_cart_id ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -918,4 +918,52 @@ class Cart extends ControllerTestCase {
 			)
 		);
 	}
+
+	/**
+	 * Test adding item to cart with negative quantity shows an error.
+	 */
+	public function test_add_item_with_negative_quantity_shows_error() {
+		wc_empty_cart();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => -1,
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			400,
+			array(
+				'code' => 'woocommerce_rest_product_invalid_quantity',
+			)
+		);
+	}
+
+	/**
+	 * Test adding item to cart with negative quantity as string shows an error.
+	 */
+	public function test_add_item_with_string_negative_quantity_shows_error() {
+		wc_empty_cart();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => '-5',
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			400,
+			array(
+				'code' => 'woocommerce_rest_product_invalid_quantity',
+			)
+		);
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -885,8 +885,11 @@ class Cart extends ControllerTestCase {
 			$request,
 			201,
 			array(
-				'items_count' => 1,
+				'items_count' => 1, // Total number of items in cart (quantity sum).
 				'items'       => function ( $value ) {
+					// The callback function checks that:
+					// 1. There is exactly 1 unique product in the cart
+					// 2. The first (and only) product has a quantity of 1.
 					return 1 === count( $value ) && 1 === $value[0]['quantity'];
 				},
 			)
@@ -905,8 +908,11 @@ class Cart extends ControllerTestCase {
 			$request,
 			201,
 			array(
-				'items_count' => 2,
+				'items_count' => 2, // Total quantity of all items (same product added twice).
 				'items'       => function ( $value ) {
+					// The callback function checks that:
+					// 1. There is still only 1 unique product in the cart
+					// 2. That product now has a quantity of 2 (1 + 1 from second add).
 					return 1 === count( $value ) && 2 === $value[0]['quantity'];
 				},
 			)

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -887,7 +887,7 @@ class Cart extends ControllerTestCase {
 			array(
 				'items_count' => 1,
 				'items'       => function ( $value ) {
-					return count( $value ) === 1 && $value[0]['quantity'] === 1;
+					return 1 === count( $value ) && 1 === $value[0]['quantity'];
 				},
 			)
 		);
@@ -907,7 +907,7 @@ class Cart extends ControllerTestCase {
 			array(
 				'items_count' => 2,
 				'items'       => function ( $value ) {
-					return count( $value ) === 1 && $value[0]['quantity'] === 2;
+					return 1 === count( $value ) && 2 === $value[0]['quantity'];
 				},
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/Cart.php
@@ -818,4 +818,98 @@ class Cart extends ControllerTestCase {
 			400
 		);
 	}
+
+	/**
+	 * Test adding item to cart with quantity 0 shows an error.
+	 */
+	public function test_add_item_with_zero_quantity_shows_error() {
+		wc_empty_cart();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => 0,
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			400,
+			array(
+				'code' => 'woocommerce_rest_product_invalid_quantity',
+			)
+		);
+	}
+
+	/**
+	 * Test adding item to cart with quantity "0" as string shows an error.
+	 */
+	public function test_add_item_with_string_zero_quantity_shows_error() {
+		wc_empty_cart();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id'       => $this->products[0]->get_id(),
+				'quantity' => '0',
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			400,
+			array(
+				'code' => 'woocommerce_rest_product_invalid_quantity',
+			)
+		);
+	}
+
+	/**
+	 * Test adding item to cart without quantity adds 1 item.
+	 */
+	public function test_add_item_without_quantity_defaults_to_one() {
+		wc_empty_cart();
+
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id' => $this->products[0]->get_id(),
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			201,
+			array(
+				'items_count' => 1,
+				'items'       => function ( $value ) {
+					return count( $value ) === 1 && $value[0]['quantity'] === 1;
+				},
+			)
+		);
+
+		// Test adding the same item again without quantity to verify it adds another 1.
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/add-item' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'id' => $this->products[0]->get_id(),
+			)
+		);
+
+		$this->assertAPIResponse(
+			$request,
+			201,
+			array(
+				'items_count' => 2,
+				'items'       => function ( $value ) {
+					return count( $value ) === 1 && $value[0]['quantity'] === 2;
+				},
+			)
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- If quantity isn't supplied during add to cart request, it sets quantity to the minimum allowed
- If quantity is supplied, but is 0, no item is added and the API returns an error

Closes WOOPLUG-4542


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using Store API add an item to your cart with no quantity (POST to `/wp-json/wc/store/v1/cart/add-item` with the following body (change id to be a product ID in your store)

 ```json
{
	"id": 15
}
```

2. Repeat this, and expect the item in the returned cart to have a quantity of 2 now (1 item added for each request)
3. Expect the response to show the item to have been added with quantity of 1.
4. POST again, but set quantity to 0

```json
{
	"id": 15,
	"quantity": 0
}
```

5. Expect the API to return an error.
6. Try again with `quantity: "0"` (as a string) ensure the same error is returned.
7. Try with regular, positive integer quantities, expect the items to be added to the cart with the expected quantity.
8. Try with negative integer quantities, arrays, non-numeric strings (e.g. "abc"), etc. expect none of these to work.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
