### PR TITLE
Test: canvasModeStore with registerTemplateRestrictedBlockType

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/index.js
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/index.js
@@ -2,3 +2,4 @@ export * from './get-block-map';
 export * from './render-parent-block';
 export * from './render-standalone-blocks';
 export * from './register-product-block-type';
+export * from './register-template-restricted-block-type';

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-template-restricted-block-type.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-template-restricted-block-type.ts
@@ -1,0 +1,484 @@
+/**
+ * External dependencies
+ */
+import {
+	BlockAttributes,
+	BlockVariation,
+	registerBlockType,
+	registerBlockVariation,
+	unregisterBlockType,
+	unregisterBlockVariation,
+	BlockConfiguration,
+} from '@wordpress/blocks';
+import { subscribe, select } from '@wordpress/data';
+import { isNumber } from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import { store as canvasModeStore } from '../../shared/redux-stores/canvas-mode';
+
+/**
+ * Settings for template-restricted block registration.
+ *
+ * @typedef {Object} TemplateRestrictedBlockSettings
+ * @property {boolean}  [isVariationBlock]        - Whether this block is a variation
+ * @property {string}   [variationName]           - The name of the variation if applicable
+ * @property {boolean}  [isAvailableOnPostEditor] - Whether the block should be available in post editor
+ * @property {string[]} [templates]               - Array of template IDs where this block is available
+ */
+type TemplateRestrictedBlockSettings = {
+	isVariationBlock?: boolean;
+	variationName?: string | undefined;
+	isAvailableOnPostEditor?: boolean;
+	templates?: string[];
+};
+
+/**
+ * Internal block config type used by the TemplateRestrictedBlockRegistrationManager
+ *
+ * @typedef {Object} TemplateRestrictedBlockConfig
+ * @template T Extends BlockAttributes to define the block's attribute types
+ * @property {string}                          blockName     - The name of the block
+ * @property {Partial<BlockConfiguration>}     settings      - Block settings configuration
+ * @property {TemplateRestrictedBlockSettings} blockSettings - Block settings
+ */
+type TemplateRestrictedBlockConfig< T extends BlockAttributes > =
+	TemplateRestrictedBlockSettings & {
+		blockName: string;
+		settings: Partial< BlockConfiguration< T > >;
+	};
+
+/**
+ * Configuration object for registering a template-restricted block type.
+ *
+ * @typedef {Object} TemplateRestrictedBlockRegistrationConfig
+ * @template T Extends BlockAttributes to define the block's attribute types
+ * @property {Partial<BlockConfiguration>} settings                - Block settings configuration
+ * @property {boolean}                     [isVariationBlock]      - Whether this block is a variation
+ * @property {string}                      [variationName]         - The name of the variation if applicable
+ * @property {boolean}                     isAvailableOnPostEditor - Whether the block should be available in post editor
+ * @property {string[]}                    [templates]             - Array of template IDs where this block is available
+ */
+type TemplateRestrictedBlockRegistrationConfig< T extends BlockAttributes > =
+	Partial< BlockConfiguration< T > > & TemplateRestrictedBlockSettings;
+
+/**
+ * Manages block registration and unregistration for template-restricted blocks in different contexts.
+ * Implements the Singleton pattern to ensure consistent block management across the application.
+ */
+export class TemplateRestrictedBlockRegistrationManager {
+	/** Singleton instance of the manager */
+	private static instance: TemplateRestrictedBlockRegistrationManager;
+	/** Map storing block configurations keyed by block name or variation name */
+	private blocks: Map<
+		string,
+		TemplateRestrictedBlockConfig< BlockAttributes >
+	> = new Map();
+	/** Current template ID being edited */
+	private currentTemplateId: string | undefined;
+	/** Flag indicating if the manager has been initialized */
+	private initialized = false;
+	/** Set to track currently registered blocks */
+	private currentlyRegisteredBlocks: Set< string > = new Set();
+
+	/**
+	 * Private constructor to enforce singleton pattern.
+	 * Initializes subscriptions for template changes.
+	 */
+	private constructor() {
+		this.initializeSubscriptions();
+	}
+
+	/**
+	 * Gets the singleton instance of the TemplateRestrictedBlockRegistrationManager.
+	 * Creates the instance if it doesn't exist.
+	 *
+	 * @return {TemplateRestrictedBlockRegistrationManager} The singleton instance
+	 */
+	public static getInstance(): TemplateRestrictedBlockRegistrationManager {
+		if ( ! TemplateRestrictedBlockRegistrationManager.instance ) {
+			TemplateRestrictedBlockRegistrationManager.instance =
+				new TemplateRestrictedBlockRegistrationManager();
+		}
+		return TemplateRestrictedBlockRegistrationManager.instance;
+	}
+
+	/**
+	 * Parses a template ID from various possible formats.
+	 * Handles both string and number inputs due to Gutenberg changes.
+	 *
+	 * @param {string | number | undefined} templateId - The template ID to parse
+	 * @return {string | undefined} The parsed template ID
+	 */
+	private parseTemplateId(
+		templateId: string | number | undefined
+	): string | undefined {
+		const parsedTemplateId = isNumber( templateId )
+			? undefined
+			: templateId;
+		return parsedTemplateId?.split( '//' )[ 1 ];
+	}
+
+	/**
+	 * Initializes subscriptions for template changes and block registration.
+	 * Sets up listeners for both the site editor and post editor contexts.
+	 */
+	private initializeSubscriptions(): void {
+		if ( this.initialized ) {
+			return;
+		}
+
+		// Main store subscription to detect which editor we're in
+		const unsubscribe = subscribe( () => {
+			const editSiteStore = select( 'core/edit-site' );
+			const editPostStore = select( 'core/edit-post' );
+
+			// Return if neither store is available yet
+			if ( ! editSiteStore && ! editPostStore ) {
+				return;
+			}
+
+			const canvasStore = select( canvasModeStore );
+			const isEditMode = canvasStore.isEditMode();
+
+			// Site Editor Context
+			if ( editSiteStore ) {
+				const postId = editSiteStore.getEditedPostId();
+
+				// Unsubscribe from the main subscription since we've detected our context
+				unsubscribe();
+
+				// Set initial template ID
+				this.currentTemplateId = isEditMode
+					? this.parseTemplateId( postId )
+					: undefined;
+
+				// Set up the template change listener
+				subscribe(
+					() => {
+						console.log( 'called' );
+						const newPostId = editSiteStore.getEditedPostId();
+						const newIsEditMode = canvasStore.isEditMode();
+
+						// Update template ID based on edit mode and post ID
+						this.currentTemplateId = newIsEditMode
+							? this.parseTemplateId( newPostId )
+							: undefined;
+
+						// Always handle template change to ensure proper block registration
+						this.handleTemplateChange();
+					},
+					'core/edit-site',
+					canvasModeStore
+				);
+
+				// Add a separate subscription for URL changes
+				subscribe( () => {
+					console.log( 'url changed' );
+					const isEditMode = canvasStore.isEditMode();
+					console.log( 'isEditMode', isEditMode );
+
+					// If we're not in edit mode, ensure all blocks are registered
+					if ( ! isEditMode ) {
+						this.blocks.forEach( ( config ) => {
+							this.registerBlock( config );
+						} );
+					}
+				}, canvasModeStore );
+
+				this.initialized = true;
+			}
+			// Post Editor Context
+			else if ( editPostStore ) {
+				// Unsubscribe from the main subscription since we've detected our context
+				unsubscribe();
+
+				// Register only blocks available in post editor
+				this.blocks.forEach( ( config ) => {
+					if ( config.isAvailableOnPostEditor ) {
+						this.registerBlock( config );
+					}
+				} );
+
+				this.initialized = true;
+			}
+		} );
+	}
+
+	/**
+	 * Handles block registration/unregistration when template context changes.
+	 * Registers and unregisters blocks based on template restrictions.
+	 */
+	private handleTemplateChange(): void {
+		const canvasStore = select( canvasModeStore );
+		const isEditMode = canvasStore.isEditMode();
+
+		// Register all blocks if not in edit mode (template listing page)
+		if ( ! isEditMode ) {
+			this.blocks.forEach( ( config ) => {
+				this.registerBlock( config );
+			} );
+			return;
+		}
+
+		// In edit mode, check template restrictions
+		this.blocks.forEach( ( config ) => {
+			const { templates } = config;
+
+			// Skip blocks that don't have template restrictions
+			if ( ! templates || templates.length === 0 ) {
+				return;
+			}
+
+			// Check if block is allowed in current template
+			const isAllowedInCurrent = templates.includes(
+				this.currentTemplateId || ''
+			);
+
+			if ( isAllowedInCurrent ) {
+				this.registerBlock( config );
+			} else if ( isEditMode && this.currentTemplateId ) {
+				// Only unregister if we're actually in edit mode and have a current template
+				this.unregisterBlock( config );
+			}
+		} );
+	}
+
+	/**
+	 * Checks if a block is currently registered.
+	 *
+	 * @param {string} blockKey - The key of the block to check
+	 * @return {boolean} Whether the block is currently registered
+	 */
+	private isCurrentlyRegistered( blockKey: string ): boolean {
+		return this.currentlyRegisteredBlocks.has( blockKey );
+	}
+
+	/**
+	 * Unregisters a block or block variation.
+	 * Handles both regular blocks and variations with error handling.
+	 *
+	 * @template T The type of block attributes
+	 * @param {TemplateRestrictedBlockConfig<T>} config - Configuration of the block to unregister
+	 */
+	private unregisterBlock< T extends BlockAttributes >(
+		config: TemplateRestrictedBlockConfig< T >
+	): void {
+		const { blockName, isVariationBlock, variationName } = config;
+		const key = variationName || blockName;
+
+		// Only unregister if currently registered
+		if ( ! this.isCurrentlyRegistered( key ) ) {
+			return;
+		}
+
+		try {
+			if ( isVariationBlock && variationName ) {
+				unregisterBlockVariation( blockName, variationName );
+			} else {
+				unregisterBlockType( blockName );
+			}
+
+			// Remove from currently registered blocks
+			this.currentlyRegisteredBlocks.delete( key );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.debug(
+				`Failed to unregister block ${ blockName }:`,
+				error
+			);
+		}
+	}
+
+	/**
+	 * Registers a block or block variation.
+	 * Handles different registration requirements for various contexts.
+	 * Includes checks to prevent duplicate registration.
+	 *
+	 * @template T The type of block attributes
+	 * @param {TemplateRestrictedBlockConfig<T>} config - Configuration of the block to register
+	 */
+	private registerBlock< T extends BlockAttributes >(
+		config: TemplateRestrictedBlockConfig< T >
+	): void {
+		const {
+			blockName,
+			settings,
+			isVariationBlock,
+			variationName,
+			isAvailableOnPostEditor,
+			templates,
+		} = config;
+
+		const key = variationName || blockName;
+
+		// Check if block is already registered
+		if ( this.isCurrentlyRegistered( key ) ) {
+			return;
+		}
+
+		try {
+			const editSiteStore = select( 'core/edit-site' );
+			const canvasStore = select( canvasModeStore );
+			const isEditMode = canvasStore.isEditMode();
+
+			// Don't register if we're in post editor context and block isn't available there
+			if ( ! editSiteStore && ! isAvailableOnPostEditor ) {
+				return;
+			}
+
+			// If not in edit mode, register all blocks
+			if ( ! isEditMode ) {
+				if ( isVariationBlock ) {
+					registerBlockVariation(
+						blockName,
+						settings as BlockVariation< BlockAttributes >
+					);
+				} else {
+					// Register block with appropriate settings
+					// @ts-expect-error - blockName can be either string or object
+					registerBlockType( blockName, {
+						...settings,
+					} );
+				}
+				this.currentlyRegisteredBlocks.add( key );
+				return;
+			}
+
+			// In edit mode, check if block is restricted to specific templates
+			if ( templates && templates.length > 0 && this.currentTemplateId ) {
+				// Don't register if current template isn't in allowed templates list
+				if ( ! templates.includes( this.currentTemplateId ) ) {
+					return;
+				}
+			}
+
+			if ( isVariationBlock ) {
+				registerBlockVariation(
+					blockName,
+					settings as BlockVariation< BlockAttributes >
+				);
+			} else {
+				// Register block with appropriate settings
+				// @ts-expect-error - blockName can be either string or object
+				registerBlockType( blockName, {
+					...settings,
+				} );
+			}
+
+			this.currentlyRegisteredBlocks.add( key );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( `Failed to register block ${ blockName }:`, error );
+		}
+	}
+
+	/**
+	 * Registers a new block configuration with the manager.
+	 * Main entry point for adding new blocks to be managed.
+	 *
+	 * @template T The type of block attributes
+	 * @param {TemplateRestrictedBlockConfig<T>} config - Configuration of the block to register
+	 */
+	public registerBlockConfig< T extends BlockAttributes >(
+		config: TemplateRestrictedBlockConfig< T >
+	): void {
+		const key = config.variationName || config.blockName;
+		this.blocks.set(
+			key,
+			config as TemplateRestrictedBlockConfig< BlockAttributes >
+		);
+		this.registerBlock( config );
+	}
+}
+
+/**
+ * Registers a block type that's restricted to specific templates and optionally makes it available
+ * in the post editor. This function serves as the main entry point for registering template-specific blocks.
+ *
+ * The function uses the TemplateRestrictedBlockRegistrationManager singleton to handle the actual registration process,
+ * which includes:
+ * - Managing block registration across different editor contexts (site editor vs post editor)
+ * - Handling template-specific block constraints
+ * - Managing block variations if specified
+ * - Preventing duplicate registrations
+ *
+ * By default, blocks registered through this function will only be available in the specified templates.
+ * The `isAvailableOnPostEditor` flag can be used to make the block available in regular post editing
+ * contexts as well.
+ *
+ * @template T Extends BlockAttributes to define the block's attribute types
+ * @param {string | Partial<BlockConfiguration<T>>}                          blockNameOrMetadata - Either a string block name or block metadata object
+ * @param {TemplateRestrictedBlockRegistrationConfig<BlockConfiguration<T>>} [settings]          - Optional settings for block registration
+ * @return {void}
+ *
+ * @example
+ * ```typescript
+ * registerTemplateRestrictedBlockType({
+ *     name: 'my-namespace/my-block',
+ *     title: 'My Block',
+ *     category: 'widgets',
+ *     edit: () => <div>Block Editor</div>,
+ *     save: () => <div>Saved Block</div>
+ * }, {
+ *     isAvailableOnPostEditor: true,
+ *     templates: ['single-product', 'archive-product']
+ * });
+ * ```
+ */
+export const registerTemplateRestrictedBlockType = <
+	T extends BlockAttributes
+>(
+	blockNameOrMetadata: string | Partial< BlockConfiguration< T > >,
+	settings?: TemplateRestrictedBlockRegistrationConfig<
+		BlockConfiguration< T >
+	>
+): void => {
+	const blockName =
+		typeof blockNameOrMetadata === 'string'
+			? blockNameOrMetadata
+			: blockNameOrMetadata.name;
+
+	if ( ! blockName ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'registerTemplateRestrictedBlockType: Block name is required for registration'
+		);
+		return;
+	}
+
+	// If blockNameOrMetadata is an object, use all its properties except 'name' as settings
+	const metaDataWithoutName =
+		typeof blockNameOrMetadata === 'string'
+			? {}
+			: // eslint-disable-next-line @typescript-eslint/no-unused-vars
+			  ( ( { name, ...metadata } ) => metadata )( blockNameOrMetadata );
+
+	// Extract settings without custom properties
+	const {
+		isVariationBlock,
+		variationName,
+		isAvailableOnPostEditor,
+		templates,
+		...settingsWithoutCustomProperties
+	} = {
+		...metaDataWithoutName,
+		...( settings || {} ),
+	};
+
+	const internalConfig: TemplateRestrictedBlockConfig< T > = {
+		blockName,
+		settings: {
+			...settingsWithoutCustomProperties,
+		} as BlockConfiguration< T >,
+		isVariationBlock: isVariationBlock ?? false,
+		variationName: variationName ?? undefined,
+		isAvailableOnPostEditor: isAvailableOnPostEditor ?? false,
+		templates: templates ?? [],
+	};
+
+	TemplateRestrictedBlockRegistrationManager.getInstance().registerBlockConfig(
+		internalConfig
+	);
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/catalog-sorting/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerTemplateRestrictedBlockType } from '@woocommerce/atomic-utils';
 import { Icon } from '@wordpress/icons';
 import { totals } from '@woocommerce/icons';
 
@@ -12,7 +12,8 @@ import metadata from './block.json';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( metadata, {
+const blockConfig = {
+	...metadata,
 	icon: {
 		src: (
 			<Icon
@@ -21,11 +22,17 @@ registerBlockType( metadata, {
 			/>
 		),
 	},
-	attributes: {
-		...metadata.attributes,
-	},
 	edit,
-	save() {
-		return null;
-	},
+};
+
+registerTemplateRestrictedBlockType( blockConfig, {
+	isAvailableOnPostEditor: true,
+	templates: [
+		'archive-product',
+		'product-search-results',
+		'taxonomy-product_attribute',
+		'taxonomy-product_brand',
+		'taxonomy-product_cat',
+		'taxonomy-product_tag',
+	],
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/shared/hooks/use-canvas-mode.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/hooks/use-canvas-mode.ts
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as canvasModeStore } from '../redux-stores/canvas-mode/index';
+
+type CanvasModeSelector = {
+	isEditMode: boolean;
+};
+
+/**
+ * Hook to get canvas mode data from the store.
+ * Returns true if canvas=edit is in the URL, false otherwise.
+ *
+ * @return {CanvasModeSelector} The canvas mode data.
+ */
+export default function useCanvasMode(): CanvasModeSelector {
+	const { isEditMode } = useSelect( ( select ) => {
+		const { isEditMode: getIsEditMode } = select( canvasModeStore );
+		return {
+			isEditMode: getIsEditMode(),
+		};
+	}, [] );
+
+	return {
+		isEditMode,
+	};
+}

--- a/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/README.md
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/README.md
@@ -1,0 +1,27 @@
+# Canvas Mode Store
+
+⚠️ **Internal Use Only** - This store is for internal WooCommerce use only.
+
+The Canvas Mode Store manages the state of the canvas mode in the template editor, tracking whether we are in edit mode based on the URL parameter `canvas=edit`.
+
+## State
+
+The store maintains a simple state object:
+
+```typescript
+type CanvasModeState = {
+	isEditMode: boolean;
+};
+```
+
+## Selectors
+
+### isEditMode()
+
+Returns whether the current view is in edit mode. This is determined by checking if `canvas=edit` is present in the URL.
+
+## Actions
+
+### setCanvasMode( isEditMode: boolean )
+
+Updates the canvas mode state. This action is primarily used internally by the store to sync with URL changes.

--- a/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/constants.ts
@@ -1,0 +1,6 @@
+export const STORE_NAME = 'woocommerce/canvas-mode';
+
+/**
+ * Actions
+ */
+export const ACTION_SET_CANVAS_MODE = 'SET_CANVAS_MODE' as const;

--- a/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/index.ts
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ACTION_SET_CANVAS_MODE, STORE_NAME } from './constants';
+import type { CanvasModeState } from './types';
+
+type StoreState = CanvasModeState;
+
+type Actions = {
+	type: typeof ACTION_SET_CANVAS_MODE;
+	isEditMode: boolean;
+};
+
+const DEFAULT_STATE: StoreState = {
+	isEditMode: false,
+};
+
+const actions = {
+	setCanvasMode( isEditMode: boolean ) {
+		return {
+			type: ACTION_SET_CANVAS_MODE,
+			isEditMode,
+		};
+	},
+};
+
+const selectors = {
+	isEditMode() {
+		// Always check the current URL for the most up-to-date state.
+		try {
+			const url = new URL( window.location.href );
+			const canvas = url.searchParams.get( 'canvas' );
+			return canvas === 'edit';
+		} catch ( error ) {
+			// If URL parsing fails, return default state.
+			return false;
+		}
+	},
+};
+
+const reducer = ( state: StoreState = DEFAULT_STATE, action: Actions ) => {
+	switch ( action.type ) {
+		case ACTION_SET_CANVAS_MODE:
+			return {
+				...state,
+				isEditMode: action.isEditMode,
+			};
+
+		default:
+			return state;
+	}
+};
+
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+register( store );
+
+if ( typeof window !== 'undefined' ) {
+	const handleUrlChange = async () => {
+		try {
+			const url = new URL( window.location.href );
+			const canvas = url.searchParams.get( 'canvas' );
+			const isEditMode = canvas === 'edit';
+
+			await Promise.resolve();
+
+			// Update store state - this triggers re-renders.
+			dispatch( store ).setCanvasMode( isEditMode );
+		} catch ( error ) {
+			// If URL parsing fails, set to default state.
+			await Promise.resolve();
+			dispatch( store ).setCanvasMode( false );
+		}
+	};
+
+	window.addEventListener( 'popstate', () => handleUrlChange() );
+	window.addEventListener( 'pushstate', () => handleUrlChange() );
+}
+
+export { default as useCanvasMode } from '../../hooks/use-canvas-mode';
+export type { CanvasModeState } from './types';

--- a/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/test/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/test/index.ts
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { register, select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as canvasModeStore } from '../index';
+
+describe( 'Canvas Mode Store', () => {
+	beforeEach( () => {
+		// Reset the store before each test.
+		if ( ! select( canvasModeStore ) ) {
+			register( canvasModeStore );
+		}
+	} );
+
+	describe( 'Initial State', () => {
+		it( 'should initialize with isEditMode as false', () => {
+			const state = select( canvasModeStore ).isEditMode();
+			expect( state ).toBe( false );
+		} );
+	} );
+
+	describe( 'URL-based Mode Detection', () => {
+		it( 'should detect edit mode from URL', () => {
+			const originalLocation = window.location;
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: new URL( 'http://example.com?canvas=edit' ),
+			} );
+
+			const state = select( canvasModeStore ).isEditMode();
+			expect( state ).toBe( true );
+
+			// Restore window.location.
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: originalLocation,
+			} );
+		} );
+
+		it( 'should detect list mode from URL', () => {
+			const originalLocation = window.location;
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: new URL( 'http://example.com' ),
+			} );
+
+			const state = select( canvasModeStore ).isEditMode();
+			expect( state ).toBe( false );
+
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: originalLocation,
+			} );
+		} );
+
+		it( 'should handle invalid URLs gracefully', () => {
+			// Mock window.location with invalid URL.
+			const originalLocation = window.location;
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: { href: 'invalid-url' } as Location,
+			} );
+
+			const state = select( canvasModeStore ).isEditMode();
+			expect( state ).toBe( false );
+
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: originalLocation,
+			} );
+		} );
+	} );
+
+	describe( 'Mode Switching', () => {
+		it( 'should update URL when switching to edit mode', () => {
+			const originalLocation = window.location;
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: new URL( 'http://example.com' ),
+			} );
+
+			dispatch( canvasModeStore ).setCanvasMode( true );
+
+			// Verify URL was updated
+			expect( window.location.search ).toBe( '' );
+
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: originalLocation,
+			} );
+		} );
+
+		it( 'should update URL when switching to list mode', () => {
+			const originalLocation = window.location;
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: new URL( 'http://example.com?canvas=edit' ),
+			} );
+
+			dispatch( canvasModeStore ).setCanvasMode( false );
+
+			// Verify URL was updated
+			expect( window.location.search ).toBe( '?canvas=edit' );
+
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: originalLocation,
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/shared/redux-stores/canvas-mode/types.ts
@@ -1,0 +1,3 @@
+export type CanvasModeState = {
+	isEditMode: boolean;
+};


### PR DESCRIPTION
This PR has been created to test the changes introduced in the following two PRs:

* [https://github.com/woocommerce/woocommerce/pull/58455](https://github.com/woocommerce/woocommerce/pull/58455)
* [https://github.com/woocommerce/woocommerce/pull/57901](https://github.com/woocommerce/woocommerce/pull/57901)

### Summary of Changes:

* Adds `canvasModeStore`.
* Adds the `registerTemplateRestrictedBlockType` API.
* Implements the `registerTemplateRestrictedBlockType` API in the `Catalog Sorting` block, restricting its registration to the following templates (assuming the TT5 theme is active):

  * `archive-product`
  * `product-search-results`
  * `taxonomy-product_attribute`
  * `taxonomy-product_brand`
  * `taxonomy-product_cat`
  * `taxonomy-product_tag`

### Notes:

* A few `console.log` statements have been added to the file to log the value of the `isEditMode` selector whenever the view changes between template-list mode and template-edit mode:  `plugins/woocommerce/client/blocks/assets/js/atomic/utils/register-template-restricted-block-type.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced template-restricted block registration system, allowing blocks to be limited to specific templates with optional post-editor availability controls.
  * Added canvas mode detection for template editor to distinguish between edit and list modes.
  * Updated catalog sorting block to leverage template-based availability constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->