### PR TITLE
Add commit to wporg workflow

### DIFF
--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'Release to upload (can be a draft release).'
+        description: 'Release tag to upload (can be a draft release).'
         required: true
         default: ''
 

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -1,0 +1,216 @@
+name: 'Release: Upload release to WordPress.org'
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Release to upload (can be a draft release).'
+        required: true
+        default: ''
+
+permissions: {}
+
+jobs:
+  get-and-validate-release-asset:
+    name: Get intended release details
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
+    outputs:
+      release_tag: ${{ steps.fetch-release.outputs.release_tag }}
+      release_asset: ${{ steps.fetch-release.outputs.release_asset }}
+      overwrite_trunk: ${{ steps.check-asset.outputs.overwrite_trunk }}
+    steps:
+      - name: Fetch release
+        id: fetch-release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ inputs.release }}';
+            let release = null;
+
+            // Try to get release by tag name.
+            try {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag
+              });
+
+              release = response.data;
+            } catch ( e ) {
+              // Not found, try to find in last 20 releases.
+              const releases = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 20
+              });
+
+              release = releases.data.find( r => r.tag_name === tag );
+            }
+
+            if ( ! release ) {
+              core.setFailed( 'No release found for the given tag.' );
+              return;
+            }
+
+            // Find asset.
+            const asset = release.assets.find( asset => 'woocommerce.zip' === asset.name );
+            if ( ! asset ) {
+              core.setFailed( `No 'woocommerce.zip' asset found for release '${ release.tag_name }'.` );
+              return;
+            }
+
+            console.log( `Tag to be committed: '${ release.tag_name }'` );
+            console.log( `Release asset URL: '${ asset.url }'` );
+
+            core.setOutput( 'release_tag', release.tag_name );
+            core.setOutput( 'release_asset', asset.url );
+      - name: Validate release asset
+        id: check-asset
+        env:
+          RELEASE_TAG: ${{ steps.fetch-release.outputs.release_tag }}
+          SVN_URL: ${{ secrets.wporg_svn_url }}
+          SVN_USERNAME: ${{ secrets.wporg_svn_username }}
+          SVN_PASSWORD: ${{ secrets.wporg_svn_password }}
+
+          # GH CLI.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Install SVN.
+          sudo apt-get -qq install -y subversion
+
+          gh release download "$RELEASE_TAG" --pattern "woocommerce.zip" --output woocommerce.zip
+
+          if [ ! -e "woocommerce.zip" ]; then
+            echo "::error::Could not download 'woocommerce.zip' for release '$RELEASE_TAG'."
+            exit 1
+          fi
+
+          # Unzip asset.
+          unzip -qq woocommerce.zip
+
+          # Check that asset matches the release tag name.
+          version_in_zip=$(cat woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1)
+          if [ "$version_in_zip" != "$RELEASE_TAG" ]; then
+            echo "::error::Version in ZIP ($version_in_zip) does not match release number ($RELEASE_TAG)."
+            exit 1
+          fi
+
+          # Check that tag does not already exist on SVN repo.
+          if svn list "$SVN_URL/tags/$RELEASE_TAG" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" > /dev/null 2>&1; then
+            echo "::error::Tag '$RELEASE_TAG' already exists in SVN."
+            exit 1
+          fi
+
+          # Check whether this release should replace trunk in SVN.
+          svn_plugin_version=$( svn cat "$SVN_URL/trunk/woocommerce.php" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" |  grep -oP '(?<=Version: )(.+)' | head -n1 )
+
+          if php -r "die( version_compare( '$RELEASE_TAG', '$svn_plugin_version', '>' ) ? 0 : 1 );"; then
+            echo "overwrite_trunk=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "overwrite_trunk=0" >> "$GITHUB_OUTPUT"
+          fi
+
+  commit:
+    name: Commit release to WordPress.org
+    runs-on: ubuntu-latest
+    needs: [get-and-validate-release-asset]
+    permissions:
+      contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
+    env:
+      SVN_URL: ${{ secrets.wporg_svn_url }}
+      SVN_USERNAME: ${{ secrets.wporg_svn_username }}
+      SVN_PASSWORD: ${{ secrets.wporg_svn_password }}
+      RELEASE_TAG: ${{ needs.get-and-validate-release-asset.outputs.release_tag }}
+    steps:
+      - name: Download and unzip asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release download "$RELEASE_TAG" --pattern "woocommerce.zip" --output woocommerce.zip
+
+          if [[ ! -e "woocommerce.zip" ]]; then
+            echo "::error::Could not download 'woocommerce.zip' for release '$RELEASE_TAG'."
+            exit 1
+          fi
+
+          # Unzip asset.
+          unzip -qq woocommerce.zip -d release/
+
+          # One last sanity check.
+          if [[ ! -e "release/woocommerce/woocommerce.php" ]]; then
+            echo "::error::Incorrect release asset."
+            exit 1
+          fi
+
+      - name: Install SVN
+        run: |
+          sudo apt-get -qq install -y subversion
+
+      - name: Shallow checkout SVN trunk and tags
+        run: |
+          svn checkout "$SVN_URL" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --depth immediates \
+            svn/
+
+      - name: Commit to trunk and tag
+        if: ${{ needs.get-and-validate-release-asset.outputs.overwrite_trunk == 1 }}
+        working-directory: ./svn
+        run: |
+          # Fetch trunk completely.
+          svn update \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --set-depth infinity \
+            trunk/
+
+          # Remove previous trunk files.
+          rm -rf trunk/*
+          cp -a ../release/woocommerce/. trunk
+
+          # SVN add/delete new or removed files as needed.
+          svn status | grep '^?' | awk '{print $2}' | xargs -r svn add
+          svn status | grep '^!' | awk '{print $2}' | xargs -r svn delete
+
+          # Copy trunk to tag.
+          svn copy trunk "tags/$RELEASE_TAG"
+
+          # Commit.
+          svn commit \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --message "Tagging version $RELEASE_TAG." \
+            --no-auth-cache \
+            --non-interactive \
+            --config-option=servers:global:http-timeout=600
+
+      - name: Commit to tag only
+        if: ${{ needs.get-and-validate-release-asset.outputs.overwrite_trunk != 1 }}
+        working-directory: ./svn
+        run: |
+          # Fetch empty tags.
+          svn update \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --set-depth immediates \
+            tags/
+
+          # Bail out if tag already exists.
+          if [[ -e "tags/$RELEASE_TAG" ]]; then
+            echo "::error::Tag '$RELEASE_TAG' already exists in SVN."
+            exit 1
+          fi
+
+          svn import \
+            ../release/woocommerce \
+            "$SVN_URL/tags/$RELEASE_TAG" \
+            --username "$SVN_USERNAME" \
+            --password "$SVN_PASSWORD" \
+            --message "Tagging version $RELEASE_TAG." \
+            --no-auth-cache \
+            --non-interactive \
+            --config-option=servers:global:http-timeout=600

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -77,9 +77,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # Install SVN.
-          sudo apt-get -qq install -y subversion
-
           gh release download "$RELEASE_TAG" --pattern "woocommerce.zip" --output woocommerce.zip
 
           if [ ! -e "woocommerce.zip" ]; then
@@ -91,13 +88,23 @@ jobs:
           unzip -qq woocommerce.zip
 
           # Check that asset matches the release tag name.
+          if [ ! -e "woocommerce/woocommerce.php" ]; then
+            echo "::error::Asset in release tag '$RELEASE_TAG' is not a valid WooCommerce build."
+            exit 1
+          fi
+
+          # Check that version in ZIP matches tag.
           version_in_zip=$(cat woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1)
           if [ "$version_in_zip" != "$RELEASE_TAG" ]; then
             echo "::error::Version in ZIP ($version_in_zip) does not match release number ($RELEASE_TAG)."
             exit 1
           fi
 
+          # Install SVN.
+          sudo apt-get -qq install -y subversion
+
           # Check that tag does not already exist on SVN repo.
+          # This might return a false negative due to connection errors, but the check is repeated later after checkout.
           if svn list "$SVN_URL/tags/$RELEASE_TAG" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" > /dev/null 2>&1; then
             echo "::error::Tag '$RELEASE_TAG' already exists in SVN."
             exit 1
@@ -105,6 +112,10 @@ jobs:
 
           # Check whether this release should replace trunk in SVN.
           svn_plugin_version=$( svn cat "$SVN_URL/trunk/woocommerce.php" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" |  grep -oP '(?<=Version: )(.+)' | head -n1 )
+          if [ -z "$svn_plugin_version" ]; then
+            echo "::error::Could not determine current version number in SVN."
+            exit 1
+          fi
 
           if php -r "die( version_compare( '$RELEASE_TAG', '$svn_plugin_version', '>' ) ? 0 : 1 );"; then
             echo "overwrite_trunk=1" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR introduces workflow `Release: Upload release to WordPress.org` which, given a GitHub release (draft or published) will use the release asset to commit that release to WordPress.org, overwriting `trunk` only when necessary and tagging the new release in all cases.

With the changes proposed to the `Release: Build ZIP file` workflow (see https://github.com/woocommerce/woocommerce/pull/58657) we will have automations to go from release branch to WordPress.org all directly on GitHub.

<img width="370" alt="Screenshot 2025-06-17 at 19 24 19" src="https://github.com/user-attachments/assets/975acfb3-1c6c-4d03-8cec-6c2f2266a89e" />

Closes #57930.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fork of the WooCommerce repository and ensure that `trunk` is set to this specific branch. You can achieve this using the CLI as follows:

   ```
   git remote add my_fork git@github.com:<GITHUB USERNAME>/woocommerce.git
   git push my_fork enhancement/57930:trunk -f
   ```

   ⚠️ Be careful **not** to push to `origin` but always to `my_fork`.
1. Go to **Settings > Secrets and variables > Actions** and ensure the following secrets are configured: `WPORG_SVN_URL`, `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD`. Use the values from the `Flux SVN test repo` secret in the secret store.
1. Go the SVN URL (`WPORG_SVN_URL`) which emulates a partial checkout of the WordPress.org repository. Confirm that the `woocommerce/` directory is as follows:
   - `trunk/` is `9.9.0-beta.1`.
   - Tags exist in `tags/` for 9.8.0, 9.8.1, 9.8.2, 9.8.3, 9.8.4 and 9.9.0-beta.1.
1. Because the workflow is based on GitHub releases to work, we need to create a few in our fork of the repo to test the various conditions and checks.
   Specifically, we want a mix of draft/published releases with tag names that don't match the contents of the `woocommerce.zip` file or that don't contain a valid file. Similarly, releases that should and shouldn't overwrite `trunk` (this depends on whether the release number is greater than or less than the version in `trunk`).

   I suggest using the following script to populate your fork repo with test releases as above:

   ```shell
   #!/bin/sh
   FORK="YOUR_USER_NAME/woocommerce"
   
   working_dir=`mktemp -d`
   cd ${working_dir}
   
   # Clear previous tags and releases.
   for tag in $(gh release list --limit 50 --repo ${FORK} | awk '{print $1}'); do
	   gh release delete ${tag} --yes --repo ${FORK}
   done
   
   # Download versions.
   wget --quiet https://downloads.wordpress.org/plugin/woocommerce.9.8.5.zip
   wget --quiet https://downloads.wordpress.org/plugin/woocommerce.9.9.0.zip
   
   gh release create '9.8.5-invalid.1' 'woocommerce.9.8.5.zip' --title '9.8.5-invalid.1' --draft --notes '' --latest=false --repo "$FORK"
   gh release create '9.8.5-invalid.2' --title '9.8.5-invalid.2' --draft --notes '' --latest=false --repo "$FORK"
   
   touch noplugin.php && zip -q noplugin.zip noplugin.php && mv noplugin.zip woocommerce.zip
   gh release create '9.8.5-invalid.3' 'woocommerce.zip' --title '9.8.5-invalid.3' --notes '' --latest=false --repo "$FORK"
   
   mv woocommerce.9.8.5.zip woocommerce.zip
   gh release create '9.8.5-invalid.4' 'woocommerce.zip' --title '9.8.5-invalid.4' --notes '' --latest=false --repo "$FORK"
   gh release create '9.8.5' 'woocommerce.zip' --title '9.8.5' --notes '' --latest=false --repo "$FORK"
   
   mv woocommerce.9.9.0.zip woocommerce.zip
   gh release create '9.9.0' 'woocommerce.zip' --draft --title '9.9.0' --notes '' --latest=false --repo "$FORK"
   ```

   ⚠️ Set `FORK` to your forked repo. The script requires `wget` and `gh` to be installed (install via Homebrew if necessary).
1. Go to **Releases** in your fork and confirm that a few releases have been created.
1. Go to **Actions > Release: Upload release to WordPress.org** in your fork.
1. For each of the following releases, click **Run** and enter the corresponding tag as the value for `Release to upload`. Confirm that the results are as indicated.
   
   ℹ️ The test SVN repo is reset every 2 hours to its initial state, so take that into account while testing.

   |**Tag name**|**Description**|**Expected result**|
   |------------|-----------|------------|
   |(empty)||Workflow doesn't run.|
   |`a-random-name`|Release does not exist.|Failure.|
   |`9.8.5-invalid.1`|Release with an attached asset that is not `woocommerce.zip`.|Failure.|
   |`9.8.5-invalid.2`|Release with no attached asset.|Failure.|
   |`9.8.5-invalid.3`|Release with a `woocommerce.zip` that is not a plugin build.|Failure.|
   |`9.8.5-invalid.4`|Release with a tag name that doesn't match the contents in the asset.|Failure.|
   |`9.9.0`|Valid release with a version number that should override `trunk`.|Success. Confirm in SVN that `tags/9.9.0` exists and `trunk/` is now `9.9.0`.|
   |`9.8.5`|Valid release with a version number that should not override `trunk`.|Success. Confirm in SVN that `tags/9.8.5` exists and `trunk/` is still `9.9.0-beta.1`.|
   |`9.8.5` (again)|Already released to SVN.|Failure.|


<!-- End testing instructions -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new workflow to automate uploading WooCommerce releases to the WordPress.org repository. Releases can now be validated and published via a manual trigger, ensuring proper version checks and streamlined deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->