### PR TITLE
Fix partially refunded action trigger for orders with free items

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-693-order-email-says-partially-refunded-but-remaining-amount-is
+++ b/plugins/woocommerce/changelog/wooplug-693-order-email-says-partially-refunded-but-remaining-amount-is
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix partially refunded action trigger for orders with free items

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -703,7 +703,13 @@ function wc_create_refund( $args = array() ) {
 			 * @param int  $order_id The order id.
 			 * @param int  $refund_id The refund id.
 			 */
-			if ( (bool) apply_filters( 'woocommerce_order_is_partially_refunded', ( $remaining_refund_amount - $args['amount'] ) > 0 || ( $order->has_free_item() && ( $remaining_refund_items - $refund_item_count ) > 0 ), $order->get_id(), $refund->get_id() ) ) {
+			if ( (bool) apply_filters(
+				'woocommerce_order_is_partially_refunded',
+				( $remaining_refund_amount - $args['amount'] ) > 0 ||
+				( ! empty( $args['line_items'] ) && $order->has_free_item() && ( $remaining_refund_items - $refund_item_count ) > 0 ),
+				$order->get_id(),
+				$refund->get_id()
+			) ) {
 				do_action( 'woocommerce_order_partially_refunded', $order->get_id(), $refund->get_id() );
 			} else {
 				do_action( 'woocommerce_order_fully_refunded', $order->get_id(), $refund->get_id() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When creating a full refund for an order containing free items, the order was incorrectly triggering the 'woocommerce_order_partially_refunded' action instead of 'woocommerce_order_fully_refunded'. This was happening because the code was checking remaining refund items even when no line items were being refunded.

Added a check to only evaluate remaining refund items when line items are being refunded.

Closes [WOOPLUG-693: Order email says "partially refunded" but remaining amount is 0](https://linear.app/a8c/issue/WOOPLUG-693/order-email-says-partially-refunded-but-remaining-amount-is-0) (https://github.com/woocommerce/woocommerce/issues/33054).

### Screenshots or screen recordings:

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create two products:
   * One with a price of 0 (free).
   * Another with a non-zero price.
2. Create a new order that includes both products.
3. Edit the order and change its status to **Refunded**.
4. Verify that an email is received indicating the order has been **partially refunded**.
5. Apply the changes from the pull request and repeat steps.
6. Confirm that the refund email no longer refers to the order as "partially refunded".

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix partially refunded action trigger for orders with free items

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
