### PR TITLE
Add missing CSS class to Add to Cart + Options <form> element

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-add-form-missing-class
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-add-form-missing-class
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add missing CSS class to Add to Cart + Options <form> element
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -410,7 +410,15 @@ class AddToCartWithOptions extends AbstractBlock {
 						$wrapper_attributes,
 						$form_attributes,
 						array(
-							'class' => $wrapper_attributes['class'] . ' ' . $form_attributes['class'],
+							'class' => implode(
+								' ',
+								array_filter(
+									array(
+										isset( $wrapper_attributes['class'] ) ? $wrapper_attributes['class'] : '',
+										isset( $form_attributes['class'] ) ? $form_attributes['class'] : '',
+									)
+								)
+							),
 						)
 					)
 				),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -385,6 +385,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					),
 					'method'  => 'post',
 					'enctype' => 'multipart/form-data',
+					'class'   => 'cart',
 				);
 				if ( ProductType::SIMPLE === $product_type ) {
 					$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
@@ -404,7 +405,15 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			$form_html = sprintf(
 				'<form %1$s>%2$s%3$s%4$s%5$s</form>',
-				get_block_wrapper_attributes( array_merge( $wrapper_attributes, $form_attributes ) ),
+				get_block_wrapper_attributes(
+					array_merge(
+						$wrapper_attributes,
+						$form_attributes,
+						array(
+							'class' => $wrapper_attributes['class'] . ' ' . $form_attributes['class'],
+						)
+					)
+				),
 				$hooks_before,
 				$template_part_blocks,
 				$hooks_after,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Issue originally reported by @tomxygen in https://github.com/woocommerce/woocommerce/issues/58548#issuecomment-2953897086.

WooCommerce Product Add-Ons has some functionality that depends on the Add to Cart `<form>` element having the `cart` CSS class. This PR adds it so PAO script selectors work properly.

### How to test the changes in this Pull Request:

#### Preparation

0. Install and activate the [WooCommerce Beta Tester](https://woocommerce.com/products/woocommerce-beta-tester/) extension.
0. Go to _WooCommerce Admin Test Helper_ > _Features_ and enable `experimental-blocks` and `blockified-add-to-cart`.
1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.

#### Testing the PR

1. Install [WooCommerce Product Add-Ons](https://woocommerce.com/products/product-add-ons/).
2. Edit a product and add a _Multiple Choice_ add-on with _Images_ as the display style.

![imatge](https://github.com/user-attachments/assets/b8c245c2-309d-4384-9eb0-c3243b8c4885)

3. In the frontend, verify that hovering one of the images shows a tooltip, selecting it shows the add-on price and adding to cart correctly adds the product with the add-on.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/9be0352a-0935-424e-8b51-58ccb215948b) | ![imatge](https://github.com/user-attachments/assets/83c87428-0dd3-4b76-ab38-251e43dca29c)