### PR TITLE
Fix setting pickup location causing too many state updates

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4075-incorrect-rate-when-toggling-between-shipping-and-local-follow-up
+++ b/plugins/woocommerce/changelog/wooplug-4075-incorrect-rate-when-toggling-between-shipping-and-local-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/package-rates.tsx
@@ -4,7 +4,6 @@
 import { useState, useEffect } from '@wordpress/element';
 import { RadioControl } from '@woocommerce/blocks-components';
 import type { CartShippingPackageShippingRate } from '@woocommerce/types';
-import { usePrevious } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -35,7 +34,6 @@ const PackageRates = ( {
 	highlightChecked = false,
 }: PackageRates ): JSX.Element => {
 	const selectedRateId = selectedRate?.rate_id;
-	const previousSelectedRateId = usePrevious( selectedRateId );
 
 	// Store selected rate ID in local state so shipping rates changes are shown in the UI instantly.
 	const [ selectedOption, setSelectedOption ] = useState<
@@ -58,14 +56,13 @@ const PackageRates = ( {
 
 	// Update the selected option if cart state changes in the data store.
 	useEffect( () => {
-		if (
-			selectedRateId &&
-			selectedRateId !== previousSelectedRateId &&
-			selectedRateId !== selectedOption
-		) {
+		if ( selectedRateId && selectedRateId !== selectedOption ) {
 			setSelectedOption( selectedRateId );
 		}
-	}, [ selectedRateId, selectedOption, previousSelectedRateId ] );
+		// We want to explicitly react to changes in the data store only here, local state is managed
+		// through different code path.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ selectedRateId ] );
 
 	if ( rates.length === 0 ) {
 		return noResultsMessage;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -74,7 +74,7 @@ const renderPickupLocation = (
 ): RadioControlOptionType => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
-		: option.price;
+		: parseInt( option.price, 10 );
 	const location = getPickupLocation( option );
 	const address = getPickupAddress( option );
 	const details = getPickupDetails( option );
@@ -85,7 +85,7 @@ const renderPickupLocation = (
 	let secondaryLabel = <em>{ __( 'free', 'woocommerce' ) }</em>;
 
 	// If there is a cost for local pickup, show the cost per package.
-	if ( parseInt( priceWithTaxes, 10 ) > 0 ) {
+	if ( priceWithTaxes > 0 ) {
 		// If only one package, show the price and not the package count.
 		if ( packageCount === 1 ) {
 			secondaryLabel = (
@@ -144,7 +144,7 @@ const Block = () => {
 	const { shippingRates, selectShippingRate } = useShippingData();
 
 	// Memoize pickup locations to prevent re-rendering when the shipping rates change.
-	const pickupLocations = useMemo( () => {
+	const pickupLocations: CartShippingPackageShippingRate[] = useMemo( () => {
 		return ( shippingRates[ 0 ]?.shipping_rates || [] ).filter(
 			isPackageRateCollectable
 		);
@@ -188,7 +188,10 @@ const Block = () => {
 		if ( selectedRateId && selectedRateId !== selectedOption ) {
 			setSelectedOption( selectedRateId );
 		}
-	}, [ pickupLocations, selectedOption ] );
+		// We want to explicitly react to changes in the data store only here, local state is managed
+		// through different code path.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ pickupLocations ] );
 
 	// Prepare props to pass to the ExperimentalOrderLocalPickupPackages slot fill.
 	// We need to pluck out receiveCart.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57675
Original issue https://github.com/woocommerce/woocommerce/issues/57542

`useEffect` that was supposed to react only to data store changes was fired for local state changes too, caused too many updates to fire that resulted in bad visual flicker, especially on slower connections.

### Screenshots or screen recordings:

Both recorder with network throttling set to Slow 4G

#### Before

https://github.com/user-attachments/assets/050e5365-2a80-4009-bf49-1ac898f4c635

#### After

https://github.com/user-attachments/assets/db3f84e8-94c8-4ae6-97bf-a058b0448e7c

### How to test the changes in this Pull Request:

1. Go to WC → Settings → Shipping → Local pickup.
2. Enable Local Pickup and set up at least two locations.
3. Add an item to your cart and go to the Checkout block.
4. Go to Local Pickup and switch between the locations and verify that the location is properly picked (and that the experience is smooth).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is a follow-up fix to a fix that is already in `trunk` and will target the same release. The other fix has a changelog entry.

</details>
