### PR TITLE
Hide general tab when COGS is disabled in variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-58672
+++ b/plugins/woocommerce/changelog/fix-58672
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide general tab when COGS is disabled in variable products

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -44,7 +44,7 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 		$cogs_controller = wc_get_container()->get( CostOfGoodsSoldController::class );
 		$cogs_is_enabled = $cogs_controller->feature_is_enabled();
 	?>
-	<div class="options_group pricing show_if_simple show_if_external show_if_variable hidden<?php echo $cogs_is_enabled ? ' show_if_variable' : ''; ?>">
+	<div class="options_group pricing show_if_simple show_if_external hidden<?php echo $cogs_is_enabled ? ' show_if_variable' : ''; ?>">
 		<?php if ( $cogs_is_enabled ) : ?>
 			<span class="show_if_simple show_if_external">
 		<?php endif; ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Introduced in [this PR](https://github.com/woocommerce/woocommerce/pull/56103), COGS needs to show the "General" tab for variable products when enabled.  However, when COGS is not enabled, the General tab should be hidden.

Closes #58672  .

(For Bug Fixes) Bug introduced in PR #56103 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="593" alt="Screenshot 2025-06-10 at 4 33 53 PM" src="https://github.com/user-attachments/assets/63636218-ee6f-4841-8a3e-b23612dafe07" />  |  <img width="711" alt="Screenshot 2025-06-10 at 4 28 11 PM" src="https://github.com/user-attachments/assets/b4cfa202-c81a-4f51-b1c9-6db67d2b3397" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the "Cost of Goods Sold" setting is disabled at `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Navigate to Products -> Add new product
3. Select a Variable product from the product type dropdown
4. Note that the "General" tab is not shown
5. Enable the COGS setting by visiting `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
6. Navigate to Products -> Add new product
7. Select a Variable product from the product type dropdown
8. Note that the "General" tab is shown only with COGS inputs

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
