### PR TITLE
Product Filters A11y: make group label associates with its related controls

### DIFF
--- a/plugins/woocommerce/changelog/fix-filter-checkbox-list-a11y
+++ b/plugins/woocommerce/changelog/fix-filter-checkbox-list-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters A11y: use fieldset for checkbox list and chips blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -85,14 +85,14 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 		<>
 			<div { ...blockProps }>
 				<Disabled>
-					<ul className="wc-block-product-filter-checkbox-list__list">
+					<div className="wc-block-product-filter-checkbox-list__items">
 						{ isLoading && loadingState }
 						{ ! isLoading &&
 							( isLongList
 								? items.slice( 0, threshold )
 								: items
 							).map( ( item, index ) => (
-								<li
+								<div
 									key={ index }
 									className="wc-block-product-filter-checkbox-list__item"
 								>
@@ -125,9 +125,9 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 											) }
 										</span>
 									</label>
-								</li>
+								</div>
 							) ) }
-					</ul>
+					</div>
 					{ ! isLoading && isLongList && (
 						<button className="wc-block-product-filter-checkbox-list__show-more">
 							{ __( 'Show more…', 'woocommerce' ) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/style.scss
@@ -1,7 +1,5 @@
-.wc-block-product-filter-checkbox-list__list {
-	list-style: none outside;
-	margin: 0;
-	padding: 0;
+.wc-block-product-filter-checkbox-list fieldset {
+	display: contents;
 }
 
 .wc-block-product-filter-checkbox-list__label {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/style.scss
@@ -1,3 +1,7 @@
+.wc-block-product-filter-chips fieldset {
+	display: contents;
+}
+
 :where(.wc-block-product-filter-chips__items) {
 	display: flex;
 	flex-wrap: wrap;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
@@ -62,8 +62,11 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 			await page.goto( '/shop' );
 
 			const listItems = page
-				.getByLabel( 'Filter Options' )
-				.getByRole( 'listitem' );
+				.getByRole( 'heading', {
+					name: 'Attribute',
+				} )
+				.locator( '..' )
+				.locator( 'label' );
 
 			await expect( listItems ).toHaveCount( 5 );
 
@@ -171,8 +174,11 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 			await page.goto( '/shop' );
 
 			const listItems = page
-				.getByLabel( 'Filter Options' )
-				.getByRole( 'listitem' );
+				.getByRole( 'heading', {
+					name: 'Attribute',
+				} )
+				.locator( '..' )
+				.locator( 'label' );
 
 			await expect( listItems ).toHaveCount( 5 );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -191,6 +191,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 		$filter_context = array(
 			'showCounts' => $block_attributes['showCounts'] ?? false,
 			'items'      => array(),
+			'groupLabel' => $product_attribute->name,
 		);
 
 		if ( ! empty( $attribute_counts ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -68,11 +68,13 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<fieldset>
-				<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
-				<ul class="wc-block-product-filter-checkbox-list__list">
+				<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
+					<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
+				<?php endif; ?>
+				<div class="wc-block-product-filter-checkbox-list__item">
 					<?php foreach ( $items as $item ) { ?>
 						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
-						<li
+						<div
 							data-wp-key="<?php echo esc_attr( $item_id ); ?>"
 							class="wc-block-product-filter-checkbox-list__item"
 							<?php if ( ! $item['selected'] ) : ?>
@@ -114,9 +116,9 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 									<?php endif; ?>
 								</span>
 							</label>
-						</li>
+						</div>
 					<?php } ?>
-				</ul>
+				</div>
 				<?php if ( count( $items ) > $show_initially ) : ?>
 					<button
 						class="wc-block-product-filter-checkbox-list__show-more"
@@ -124,7 +126,7 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 						data-wp-on--click="actions.showAllListItems"
 						hidden
 					>
-						<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
+						<?php echo esc_html__( 'Show more…', 'woocommerce' ); ?>
 					</button>
 				<?php endif; ?>
 			</fieldset>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -67,64 +67,67 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<ul class="wc-block-product-filter-checkbox-list__list" aria-label="<?php echo esc_attr__( 'Filter Options', 'woocommerce' ); ?>">
-				<?php foreach ( $items as $item ) { ?>
-					<?php $item_id = $item['type'] . '-' . $item['value']; ?>
-					<li
-						data-wp-key="<?php echo esc_attr( $item_id ); ?>"
-						class="wc-block-product-filter-checkbox-list__item"
-						<?php if ( ! $item['selected'] ) : ?>
-							<?php if ( $count >= $remaining_initial_unchecked ) : ?>
-								data-wp-bind--hidden="!context.showAll"
-								hidden
-							<?php else : ?>
-								<?php ++$count; ?>
-							<?php endif; ?>
-						<?php endif; ?>
-					>
-						<label
-							class="wc-block-product-filter-checkbox-list__label"
-							for="<?php echo esc_attr( $item_id ); ?>"
-						>
-							<span class="wc-block-product-filter-checkbox-list__input-wrapper">
-								<input
-									id="<?php echo esc_attr( $item_id ); ?>"
-									class="wc-block-product-filter-checkbox-list__input"
-									type="checkbox"
-									aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
-									data-wp-on--change="actions.toggleFilter"
-									value="<?php echo esc_attr( $item['value'] ); ?>"
-									data-wp-bind--checked="state.isFilterSelected"
-									<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-								>
-								<svg class="wc-block-product-filter-checkbox-list__mark" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-									<path d="M9.25 1.19922L3.75 6.69922L1 3.94922" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-								</svg>
-							</span>
-							<span class="wc-block-product-filter-checkbox-list__text-wrapper">
-								<span class="wc-block-product-filter-checkbox-list__text">
-									<?php echo $item['label']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-								</span>
-								<?php if ( $show_counts ) : ?>
-									<span class="wc-block-product-filter-checkbox-list__count">
-										(<?php echo esc_html( $item['count'] ); ?>)
-									</span>
+			<fieldset>
+				<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
+				<ul class="wc-block-product-filter-checkbox-list__list">
+					<?php foreach ( $items as $item ) { ?>
+						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
+						<li
+							data-wp-key="<?php echo esc_attr( $item_id ); ?>"
+							class="wc-block-product-filter-checkbox-list__item"
+							<?php if ( ! $item['selected'] ) : ?>
+								<?php if ( $count >= $remaining_initial_unchecked ) : ?>
+									data-wp-bind--hidden="!context.showAll"
+									hidden
+								<?php else : ?>
+									<?php ++$count; ?>
 								<?php endif; ?>
-							</span>
-						</label>
-					</li>
-				<?php } ?>
-			</ul>
-			<?php if ( count( $items ) > $show_initially ) : ?>
-				<button
-					class="wc-block-product-filter-checkbox-list__show-more"
-					data-wp-bind--hidden="context.showAll"
-					data-wp-on--click="actions.showAllListItems"
-					hidden
-				>
-					<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
-				</button>
-			<?php endif; ?>
+							<?php endif; ?>
+						>
+							<label
+								class="wc-block-product-filter-checkbox-list__label"
+								for="<?php echo esc_attr( $item_id ); ?>"
+							>
+								<span class="wc-block-product-filter-checkbox-list__input-wrapper">
+									<input
+										id="<?php echo esc_attr( $item_id ); ?>"
+										class="wc-block-product-filter-checkbox-list__input"
+										type="checkbox"
+										aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
+										data-wp-on--change="actions.toggleFilter"
+										value="<?php echo esc_attr( $item['value'] ); ?>"
+										data-wp-bind--checked="state.isFilterSelected"
+										<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+									>
+									<svg class="wc-block-product-filter-checkbox-list__mark" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+										<path d="M9.25 1.19922L3.75 6.69922L1 3.94922" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+									</svg>
+								</span>
+								<span class="wc-block-product-filter-checkbox-list__text-wrapper">
+									<span class="wc-block-product-filter-checkbox-list__text">
+										<?php echo $item['label']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+									</span>
+									<?php if ( $show_counts ) : ?>
+										<span class="wc-block-product-filter-checkbox-list__count">
+											(<?php echo esc_html( $item['count'] ); ?>)
+										</span>
+									<?php endif; ?>
+								</span>
+							</label>
+						</li>
+					<?php } ?>
+				</ul>
+				<?php if ( count( $items ) > $show_initially ) : ?>
+					<button
+						class="wc-block-product-filter-checkbox-list__show-more"
+						data-wp-bind--hidden="context.showAll"
+						data-wp-on--click="actions.showAllListItems"
+						hidden
+					>
+						<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
+					</button>
+				<?php endif; ?>
+			</fieldset>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -69,7 +69,9 @@ final class ProductFilterChips extends AbstractBlock {
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<fieldset>
-				<legend class="screen-reader-text"><?php echo esc_html( $block->context['filterData']['groupLabel'] ); ?></legend>
+				<?php if ( ! empty( $block->context['filterData']['groupLabel'] ) ) : ?>
+					<legend class="screen-reader-text"><?php echo esc_html( $block->context['filterData']['groupLabel'] ); ?></legend>
+				<?php endif; ?>
 				<div class="wc-block-product-filter-chips__items">
 					<?php foreach ( $items as $item ) { ?>
 						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
@@ -113,7 +115,7 @@ final class ProductFilterChips extends AbstractBlock {
 						data-wp-bind--hidden="context.showAll"
 						hidden
 					>
-						<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
+						<?php echo esc_html__( 'Show more…', 'woocommerce' ); ?>
 					</button>
 				<?php endif; ?>
 			</fieldset>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterChips.php
@@ -68,52 +68,55 @@ final class ProductFilterChips extends AbstractBlock {
 		ob_start();
 		?>
 		<div <?php echo get_block_wrapper_attributes( $wrapper_attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<div class="wc-block-product-filter-chips__items" aria-label="<?php echo esc_attr__( 'Filter Options', 'woocommerce' ); ?>">
-				<?php foreach ( $items as $item ) { ?>
-					<?php $item_id = $item['type'] . '-' . $item['value']; ?>
-					<button
-						data-wp-key="<?php echo esc_attr( $item_id ); ?>"
-						id="<?php echo esc_attr( $item_id ); ?>"
-						class="wc-block-product-filter-chips__item"
-						type="button"
-						role="checkbox"
-						aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
-						data-wp-on--click="actions.toggleFilter"
-						value="<?php echo esc_attr( $item['value'] ); ?>"
-						data-wp-bind--aria-checked="state.isFilterSelected"
-						<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						<?php if ( ! $item['selected'] ) : ?>
-							<?php if ( $count >= $remaining_initial_unchecked ) : ?>
-								data-wp-bind--hidden="!context.showAll"
-								hidden
-							<?php else : ?>
-								<?php ++$count; ?>
+			<fieldset>
+				<legend class="screen-reader-text"><?php echo esc_html( $block->context['filterData']['groupLabel'] ); ?></legend>
+				<div class="wc-block-product-filter-chips__items">
+					<?php foreach ( $items as $item ) { ?>
+						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
+						<button
+							data-wp-key="<?php echo esc_attr( $item_id ); ?>"
+							id="<?php echo esc_attr( $item_id ); ?>"
+							class="wc-block-product-filter-chips__item"
+							type="button"
+							role="checkbox"
+							aria-label="<?php echo esc_attr( $this->get_aria_label( $item, $show_counts ) ); ?>"
+							data-wp-on--click="actions.toggleFilter"
+							value="<?php echo esc_attr( $item['value'] ); ?>"
+							data-wp-bind--aria-checked="state.isFilterSelected"
+							<?php echo wp_interactivity_data_wp_context( array( 'item' => $item ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							<?php if ( ! $item['selected'] ) : ?>
+								<?php if ( $count >= $remaining_initial_unchecked ) : ?>
+									data-wp-bind--hidden="!context.showAll"
+									hidden
+								<?php else : ?>
+									<?php ++$count; ?>
+								<?php endif; ?>
 							<?php endif; ?>
-						<?php endif; ?>
-					>
-						<span class="wc-block-product-filter-chips__label">
-							<span class="wc-block-product-filter-chips__text">
-								<?php echo $item['label']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-							</span>
-							<?php if ( $show_counts ) : ?>
-								<span class="wc-block-product-filter-chips__count">
-									(<?php echo esc_html( $item['count'] ); ?>)
+						>
+							<span class="wc-block-product-filter-chips__label">
+								<span class="wc-block-product-filter-chips__text">
+									<?php echo $item['label']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								</span>
-							<?php endif; ?>
-						</span>
+								<?php if ( $show_counts ) : ?>
+									<span class="wc-block-product-filter-chips__count">
+										(<?php echo esc_html( $item['count'] ); ?>)
+									</span>
+								<?php endif; ?>
+							</span>
+						</button>
+					<?php } ?>
+				</div>
+				<?php if ( count( $items ) > $show_initially ) : ?>
+					<button
+						class="wc-block-product-filter-chips__show-more"
+						data-wp-on--click="actions.showAllChips"
+						data-wp-bind--hidden="context.showAll"
+						hidden
+					>
+						<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
 					</button>
-				<?php } ?>
-			</div>
-			<?php if ( count( $items ) > $show_initially ) : ?>
-				<button
-					class="wc-block-product-filter-chips__show-more"
-					data-wp-on--click="actions.showAllChips"
-					data-wp-bind--hidden="context.showAll"
-					hidden
-				>
-					<?php echo esc_html__( 'Show more...', 'woocommerce' ); ?>
-				</button>
-			<?php endif; ?>
+				<?php endif; ?>
+			</fieldset>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -133,12 +133,13 @@ final class ProductFilterPrice extends AbstractBlock {
 		$formatted_max_price = html_entity_decode( wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) );
 
 		$filter_context = array(
-			'price' => array(
+			'price'      => array(
 				'minPrice' => $min_price,
 				'maxPrice' => $max_price,
 				'minRange' => $min_range,
 				'maxRange' => $max_range,
 			),
+			'groupLabel' => __( 'Price', 'woocommerce' ),
 		);
 
 		$wrapper_attributes = array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -142,6 +142,7 @@ final class ProductFilterRating extends AbstractBlock {
 		$filter_context = array(
 			'items'      => $filter_options,
 			'showCounts' => $attributes['showCounts'] ?? false,
+			'groupLabel' => __( 'Rating', 'woocommerce' ),
 		);
 
 		$wrapper_attributes = array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -144,6 +144,7 @@ final class ProductFilterStatus extends AbstractBlock {
 		$filter_context = array(
 			'items'      => array_values( $filter_options ),
 			'showCounts' => $attributes['showCounts'] ?? false,
+			'groupLabel' => __( 'Status', 'woocommerce' ),
 		);
 
 		$wrapper_attributes = array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PRs fix the issue that Group label not associated with its related controls following @amberhinds recommendation to use `fieldset` and remove `ul` from Checkbox List block. Thank you, Amber!

Closes https://github.com/woocommerce/woocommerce/issues/58343

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="1512" alt="image" src="https://github.com/user-attachments/assets/082f8ed2-ad0c-4a96-8da2-a481c508ccff" />    |   <img width="1512" alt="image" src="https://github.com/user-attachments/assets/0dda9ed6-e1ed-44d1-bda7-c3a52a11d6ae" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template.
2. Visit the Shop page on the frontend.
3. With a screen reader turned on, move the focus by pressing the tab key.
4. When the focus move into the filter option list, see the heading of the list announced.

<!-- End testing instructions -->
