### PR TITLE
[NOX in LYS] Fix “Set up payments” task not marked complete until page refresh after onboarding

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4579-setup-payments-not-complete
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4579-setup-payments-not-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix issue where “Set up payments” task wasn’t marked complete immediately after onboarding in LYS.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
@@ -76,13 +76,14 @@ const LaunchStoreController = () => {
 		);
 
 	const handlePaymentsClose = () => {
-		// Invalidate the task lists to ensure they are refreshed
-		// when the user returns to the main flow.
-		invalidateResolutionForStoreSelector( 'getTaskLists' );
-
 		// Clear session flag to prevent redirect back to payments setup
 		// after exiting the flow and returning to the WC Admin home.
 		window.sessionStorage.setItem( 'lysWaiting', 'no' );
+
+		// Invalidate the task lists to ensure they are refreshed
+		// when the user returns to the main flow.
+		invalidateResolutionForStoreSelector( 'getTaskLists' );
+    	invalidateResolutionForStoreSelector( 'getTaskListsByIds' );
 
 		// Navigate back to the main flow
 		sendToSidebar( { type: 'RETURN_FROM_PAYMENTS' } );

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
@@ -3,6 +3,8 @@
  */
 import { useMachine } from '@xstate5/react';
 import { useEffect } from 'react';
+import { useDispatch } from '@wordpress/data';
+import { onboardingStore } from '@woocommerce/data';
 import clsx from 'clsx';
 
 /**
@@ -43,6 +45,8 @@ const LaunchStoreController = () => {
 		window.sessionStorage.setItem( 'lysWaiting', 'no' );
 	}, [] );
 	const { xstateV5Inspector: inspect } = useXStateInspect( 'V5' );
+	const { invalidateResolutionForStoreSelector } =
+		useDispatch( onboardingStore );
 
 	const [ mainContentState, sendToMainContent, mainContentMachineService ] =
 		useMachine( mainContentMachine, {
@@ -72,6 +76,10 @@ const LaunchStoreController = () => {
 		);
 
 	const handlePaymentsClose = () => {
+		// Invalidate the task lists to ensure they are refreshed
+		// when the user returns to the main flow.
+		invalidateResolutionForStoreSelector( 'getTaskLists' );
+
 		// Clear session flag to prevent redirect back to payments setup
 		// after exiting the flow and returning to the WC Admin home.
 		window.sessionStorage.setItem( 'lysWaiting', 'no' );

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/index.tsx
@@ -83,7 +83,7 @@ const LaunchStoreController = () => {
 		// Invalidate the task lists to ensure they are refreshed
 		// when the user returns to the main flow.
 		invalidateResolutionForStoreSelector( 'getTaskLists' );
-    	invalidateResolutionForStoreSelector( 'getTaskListsByIds' );
+		invalidateResolutionForStoreSelector( 'getTaskListsByIds' );
 
 		// Navigate back to the main flow
 		sendToSidebar( { type: 'RETURN_FROM_PAYMENTS' } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses an issue where the “Set up payments” task in the Launch Your Store (LYS) flow was not marked as complete immediately after successful account onboarding. Previously, the task status would only update after a full page refresh. This fix ensures that the task is marked complete in real-time, improving accuracy and user experience within the onboarding flow.

Closes WOOPLUG-4579

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/a61027a6-a306-42d3-a5d5-67a4ada8ec5e) | ![image](https://github.com/user-attachments/assets/5c1bcdf7-c187-4915-bb94-fa0fddfc46c8) |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
1. Create a new JN store with WooCommerce on this PR's branch, WooPayments and WCPay Dev Tools (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=fix/WOOPLUG-4579-setup-payments-not-complete)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Go to WooCommerce > Home and click on Launch your store task.
<img width="1704" alt="Screenshot 2025-05-30 at 12 14 13" src="https://github.com/user-attachments/assets/98b6edef-7a34-4f84-a371-a65332392bc7" />

5. Click on the Set up payments link.
<img width="1694" alt="Screenshot 2025-05-30 at 12 15 33" src="https://github.com/user-attachments/assets/f4941826-2054-4241-aac1-262077c6dd59" />

7. Verify that a page to install WooPayments is displayed. Click on Install.
<img width="1718" alt="Screenshot 2025-05-30 at 12 16 24" src="https://github.com/user-attachments/assets/55b07c29-e21a-4095-bc09-ea66043e2c50" />

9. Go through the payment methods, WordPress.com connection, and KYC.
10. After successful onboarding, you should be redirected back to the LYS home screen.
11. Verify the "Set up payments" task is completed.
![image](https://github.com/user-attachments/assets/e5e49f3f-d4f6-43b2-b1ea-9e24f5bfff4d)

13. Refresh the page and verify that the "Set up payments" task is still completed.


### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
