### PR TITLE
Add to Cart + Options block: Use woocommerce_quantity_input_min for default quantity

### DIFF
--- a/plugins/woocommerce/changelog/58729-update-atcwo-default-quantity
+++ b/plugins/woocommerce/changelog/58729-update-atcwo-default-quantity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Blockified Add to Cart with Options block: set $default_quantity to use the woocommerce_quantity_input_min filter

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -237,7 +237,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						/**
 						 * Filter the minimum quantity for a child product in a grouped product.
 						 *
-						 * @since 10.9.0
+						 * @since 10.0.0
 						 * @param int $min_quantity The minimum quantity.
 						 * @param WC_Product $child_product The child product object.
 						 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -233,7 +233,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				// Set default quantity for each child product.
 				foreach ( $context['groupedProductIds'] as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
-					if ( $child_product && $this->is_child_product_purchasable( $child_product ) ) {
+					if ( $child_product ) {
 						$default_child_quantity = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
 						$context['quantity'][ $child_product_id ] = $default_child_quantity;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -234,7 +234,14 @@ class AddToCartWithOptions extends AbstractBlock {
 				foreach ( $context['groupedProductIds'] as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
 					if ( $child_product ) {
-						$default_child_quantity = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
+						/**
+						 * Filter the minimum quantity for a child product in a grouped product.
+						 *
+						 * @since 10.9.0
+						 * @param int $min_quantity The minimum quantity.
+						 * @param WC_Product $child_product The child product object.
+						 */
+						$default_child_quantity                   = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
 						$context['quantity'][ $child_product_id ] = $default_child_quantity;
 
 						// Check for any "sold individually" products and set their default quantity to 0.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -183,7 +183,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			 * @param number $default_quantity The default quantity.
 			 * @param number $product_id The product id.
 			 */
-			$default_quantity = apply_filters( 'woocommerce_add_to_cart_quantity', 1, $product->get_id() );
+			$default_quantity = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
 
 			wp_interactivity_state(
 				'woocommerce/add-to-cart-with-options',
@@ -230,11 +230,17 @@ class AddToCartWithOptions extends AbstractBlock {
 					$default_quantity
 				);
 
-				// Check for any "sold individually" products and set their default quantity to 0.
+				// Set default quantity for each child product.
 				foreach ( $context['groupedProductIds'] as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
-					if ( $child_product && $child_product->is_sold_individually() ) {
-						$context['quantity'][ $child_product_id ] = 0;
+					if ( $child_product && $this->is_child_product_purchasable( $child_product ) ) {
+						$default_child_quantity = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
+						$context['quantity'][ $child_product_id ] = $default_child_quantity;
+
+						// Check for any "sold individually" products and set their default quantity to 0.
+						if ( $child_product->is_sold_individually() ) {
+							$context['quantity'][ $child_product_id ] = 0;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

As a follow-up from https://github.com/woocommerce/woocommerce/pull/58002 and to address [this comment](https://github.com/woocommerce/woocommerce/pull/58002#discussion_r2135302391), this changes `$default_quantity` to use the `woocommerce_quantity_input_min` filter rather than `woocommerce_add_to_cart_quantity`.

There should be no change to any behaviour and the block should work the same as before. You should still be able to add grouped products to the cart.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the WooCommerce Beta Tester plugin.
2. Go to WooCommerce Admin Test Helper -> Features and enable experimental-blocks and blockified-add-to-cart.
3. Go to `/wp-admin/site-editor.php?canvas=edit&p=%2Fwp_template%2Fwoocommerce%2Fwoocommerce%2F%2Fsingle-product`
4. Select the Add to cart block 
5. Then click on `Upgrade to the blockified Add to Cart with Options block` link from the inspector.
6. Then click `Save` to publish the changes.
7. Go to the store and click on any grouped product or create a new one.
8. Change some of the quantities of the child products.
9. Click add to cart.
10. Check that the correct products and quantities are added to the cart, and that the page does not reload.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Blockified Add to Cart with Options block: set $default_quantity to use the woocommerce_quantity_input_min filter

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
