### PR TITLE
Provide server architecture message when php_uname is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-58675
+++ b/plugins/woocommerce/changelog/fix-58675
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Provide server architecture message when php_uname is disabled

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -254,7 +254,7 @@ if ( file_exists( $plugin_path ) ) {
 		<tr>
 			<td data-export-label="Server Architecture"><?php esc_html_e( 'Server architecture', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Information about the operating system your server is running.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
-			<td><?php echo esc_html( $environment['server_architecture'] ); ?></td>
+			<td><?php echo ! empty( $environment['server_architecture'] ) ? esc_html( $environment['server_architecture'] ) : esc_html__( 'Unable to determine server architecture.  Please ask your hosting provider for this information.', 'woocommerce' ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="PHP Version"><?php esc_html_e( 'PHP version', 'woocommerce' ); ?>:</td>

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -987,7 +987,9 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		}
 
 		// Operating system.
-		$server_architecture = sprintf( '%s %s %s', php_uname( 's' ), php_uname( 'r' ), php_uname( 'm' ) );
+		$server_architecture = function_exists( 'php_uname' )
+			? sprintf( '%s %s %s', php_uname( 's' ), php_uname( 'r' ), php_uname( 'm' ) )
+			: __( 'Unable to determine server architecture.  Please ask your hosting provider for this information.', 'woocommerce' );
 
 		$database_version = wc_get_server_database_version();
 		$log_directory    = LoggingUtil::get_log_directory( false );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -989,7 +989,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		// Operating system.
 		$server_architecture = function_exists( 'php_uname' )
 			? sprintf( '%s %s %s', php_uname( 's' ), php_uname( 'r' ), php_uname( 'm' ) )
-			: __( 'Unable to determine server architecture.  Please ask your hosting provider for this information.', 'woocommerce' );
+			: '';
 
 		$database_version = wc_get_server_database_version();
 		$log_directory    = LoggingUtil::get_log_directory( false );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some hosts disable `php_uname` for security reasons.  This adds a simple check to see if it's enabled and show the information if so.  If not, it recommends asking the host for the information.

Closes #58675  .

### Screenshots or screen recordings:

<img width="1310" alt="Screenshot 2025-06-10 at 5 25 15 PM" src="https://github.com/user-attachments/assets/546d3785-88b3-4963-acc3-a718c233114c" />
<img width="756" alt="Screenshot 2025-06-10 at 5 23 25 PM" src="https://github.com/user-attachments/assets/72143585-b6ef-4d85-99a5-fc00cf820b67" />



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Navigate to `/wp-admin/admin.php?page=wc-status`
2. Under "Server Architecture" check that the correct information is shown
3. In your `php.ini` file for your server, add the following line or append `,php_uname` to `disable_functions` if it already exists:
```
disable_functions = php_uname
```
4. Restart your server
5. Navigate to `/wp-admin/admin.php?page=wc-status`
6. Under "Server Architecture" check that the error message is shown: "Unable to determine server architecture. Please ask your hosting provider for this information."

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
