### PR TITLE
Sanitize address data only once in CartUpdateCustomer

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4557-cartupdate-customer-endpoint-escapes-html-twice-and-leaves
+++ b/plugins/woocommerce/changelog/wooplug-4557-cartupdate-customer-endpoint-escapes-html-twice-and-leaves
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sanitize address data only once in CartUpdateCustomer

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -131,23 +131,9 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		$cart     = $this->cart_controller->get_cart_instance();
 		$customer = wc()->customer;
 
-		// Get data from request object and merge with customer object, then sanitize.
-		$billing  = $this->schema->billing_address_schema->sanitize_callback(
-			wp_parse_args(
-				$request['billing_address'] ?? [],
-				$this->get_customer_billing_address( $customer )
-			),
-			$request,
-			'billing_address'
-		);
-		$shipping = $this->schema->billing_address_schema->sanitize_callback(
-			wp_parse_args(
-				$request['shipping_address'] ?? [],
-				$this->get_customer_shipping_address( $customer )
-			),
-			$request,
-			'shipping_address'
-		);
+		// Get data from request object and merge with customer object.
+		$billing  = wp_parse_args( $request['billing_address'] ?? [], $this->get_customer_billing_address( $customer ) );
+		$shipping = wp_parse_args( $request['shipping_address'] ?? [], $this->get_customer_shipping_address( $customer ) );
 
 		// If the cart does not need shipping, shipping address is forced to match billing address unless defined.
 		if ( ! $cart->needs_shipping() && ! isset( $request['shipping_address'] ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#58679 reported that address data was being sanitized twice which is true and seems to be a mistake. While I was unable to replicate the reported double encoding bug, the sanitization should only run once for other reasons such as performance.

Closes #58679

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

Given this is a minor change this won't require specific testing steps and should be covered by CI tests which post and validate customer address data via Store API and Checkout.

If you do want to test this issue specifically,

1. Go to checkout
2. Enter some address data containing `&`.
3. After placing the order, confirm you still see a single `&` and its not visibly escaped.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
