### PR TITLE
Prevent bug in All Products block by hardening type checking on `defaultFields`

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4572-all-products-block-is-broken-in-993-on-wordpresscom
+++ b/plugins/woocommerce/changelog/wooplug-4572-all-products-block-is-broken-in-993-on-wordpresscom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent All Products block breaking when mini cart is not present in site header

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -100,9 +100,13 @@ const prepareFormFields = (
 	return fieldKeys
 		.map( ( field ) => {
 			const defaultConfig =
-				field in defaultFields ? defaultFields[ field ] : {};
+				defaultFields && field in defaultFields
+					? defaultFields[ field ]
+					: {};
 			const localeConfig =
-				field in localeConfigs ? localeConfigs[ field ] : {};
+				localeConfigs && field in localeConfigs
+					? localeConfigs[ field ]
+					: {};
 
 			return {
 				key: field,

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
@@ -139,7 +139,9 @@ export type CountryAddressFields = Record< string, FormFields >;
 /**
  * Default field properties.
  */
-export const defaultFields: FormFields =
-	getSetting< FormFields >( 'defaultFields' );
+export const defaultFields: FormFields = getSetting< FormFields >(
+	'defaultFields',
+	{}
+);
 
 export default defaultFields;

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
@@ -9,7 +9,8 @@ import type { AllHTMLAttributes, AriaAttributes } from 'react';
  * Internal dependencies
  */
 import { SelectOption } from '../../base/components';
-import { getSetting } from './utils';
+import { getSettingWithCoercion } from './utils';
+import { isFormFields } from '../../types/type-guards';
 
 // A list of attributes that can be added to a custom field when registering it.
 type CustomFieldAttributes = Pick<
@@ -137,11 +138,130 @@ export interface BillingAddress extends AddressFormValues {
 export type CountryAddressFields = Record< string, FormFields >;
 
 /**
+ * Fallback FormFields object matching the server-side structure exactly.
+ * Based on CheckoutFields::get_core_fields() in PHP.
+ */
+const fallbackFormFields: FormFields = {
+	email: {
+		label: 'Email address',
+		optionalLabel: 'Email address (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'email',
+		autocapitalize: 'none',
+		type: 'email',
+		index: 0,
+		validation: [],
+	},
+	country: {
+		label: 'Country/Region',
+		optionalLabel: 'Country/Region (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'country',
+		index: 1,
+		validation: [],
+	},
+	first_name: {
+		label: 'First name',
+		optionalLabel: 'First name (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'given-name',
+		autocapitalize: 'sentences',
+		index: 10,
+		validation: [],
+	},
+	last_name: {
+		label: 'Last name',
+		optionalLabel: 'Last name (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'family-name',
+		autocapitalize: 'sentences',
+		index: 20,
+		validation: [],
+	},
+	company: {
+		label: 'Company',
+		optionalLabel: 'Company (optional)',
+		required: false,
+		hidden: true,
+		autocomplete: 'organization',
+		autocapitalize: 'sentences',
+		index: 30,
+		validation: [],
+	},
+	address_1: {
+		label: 'Address',
+		optionalLabel: 'Address (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'address-line1',
+		autocapitalize: 'sentences',
+		index: 40,
+		validation: [],
+	},
+	address_2: {
+		label: 'Apartment, suite, etc.',
+		optionalLabel: 'Apartment, suite, etc. (optional)',
+		required: false,
+		hidden: false,
+		autocomplete: 'address-line2',
+		autocapitalize: 'sentences',
+		index: 50,
+		validation: [],
+	},
+	city: {
+		label: 'City',
+		optionalLabel: 'City (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'address-level2',
+		autocapitalize: 'sentences',
+		index: 70,
+		validation: [],
+	},
+	state: {
+		label: 'State/County',
+		optionalLabel: 'State/County (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'address-level1',
+		autocapitalize: 'sentences',
+		index: 80,
+		validation: [],
+	},
+	postcode: {
+		label: 'Postal code',
+		optionalLabel: 'Postal code (optional)',
+		required: true,
+		hidden: false,
+		autocomplete: 'postal-code',
+		autocapitalize: 'characters',
+		index: 90,
+		validation: [],
+	},
+	phone: {
+		label: 'Phone',
+		optionalLabel: 'Phone (optional)',
+		required: true,
+		hidden: false,
+		type: 'tel',
+		autocomplete: 'tel',
+		autocapitalize: 'characters',
+		index: 100,
+		validation: [],
+	},
+};
+
+/**
  * Default field properties.
  */
-export const defaultFields: FormFields = getSetting< FormFields >(
+export const defaultFields: FormFields = getSettingWithCoercion< FormFields >(
 	'defaultFields',
-	{}
+	fallbackFormFields,
+	isFormFields
 );
 
 export default defaultFields;

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts
@@ -4,13 +4,13 @@
 import type { DocumentObject } from '@woocommerce/base-hooks';
 import type { JSONSchemaType } from 'ajv';
 import type { AllHTMLAttributes, AriaAttributes } from 'react';
+import { isFormFields } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
 import { SelectOption } from '../../base/components';
 import { getSettingWithCoercion } from './utils';
-import { isFormFields } from '../../types/type-guards';
 
 // A list of attributes that can be added to a custom field when registering it.
 type CustomFieldAttributes = Pick<

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-guards/form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-guards/form-fields.ts
@@ -28,42 +28,6 @@ const isField = ( value: unknown ): value is Field => {
 		return false;
 	}
 
-	// Optional properties - validate type if present
-	if ( field.autocomplete !== undefined && typeof field.autocomplete !== 'string' ) {
-		return false;
-	}
-
-	if ( field.autocapitalize !== undefined && typeof field.autocapitalize !== 'string' ) {
-		return false;
-	}
-
-	if ( field.type !== undefined && typeof field.type !== 'string' ) {
-		return false;
-	}
-
-	// Validation can be boolean, array, or JSON schema object
-	if ( field.validation !== undefined && 
-		 typeof field.validation !== 'boolean' &&
-		 ! Array.isArray( field.validation ) &&
-		 typeof field.validation !== 'object' ) {
-		return false;
-	}
-
-	// For select fields
-	if ( field.options !== undefined && ! Array.isArray( field.options ) ) {
-		return false;
-	}
-
-	if ( field.placeholder !== undefined && typeof field.placeholder !== 'string' ) {
-		return false;
-	}
-
-	// Attributes should be an object if present
-	if ( field.attributes !== undefined && 
-		 ( typeof field.attributes !== 'object' || field.attributes === null || Array.isArray( field.attributes ) ) ) {
-		return false;
-	}
-
 	return true;
 };
 
@@ -90,7 +54,7 @@ export const isFormFields = ( value: unknown ): value is FormFields => {
 	// These are the fields that should always be present
 	const coreFields = [
 		'email',
-		'country', 
+		'country',
 		'first_name',
 		'last_name',
 		'company',
@@ -99,36 +63,21 @@ export const isFormFields = ( value: unknown ): value is FormFields => {
 		'city',
 		'state',
 		'postcode',
-		'phone'
+		'phone',
 	];
 
-	// We'll check for a minimum subset to allow flexibility
-	// but still ensure it's a valid checkout form structure
-	const minimumRequiredFields = [ 'first_name', 'last_name', 'email' ];
-	
-	if ( ! minimumRequiredFields.every( ( field ) => field in fields ) ) {
+	if ( ! coreFields.every( ( field ) => field in fields ) ) {
 		return false;
 	}
 
 	// Validate each field has the proper Field structure
-	for ( const [ fieldKey, fieldValue ] of Object.entries( fields ) ) {
+	for ( const [ fieldId, fieldValue ] of Object.entries( fields ) ) {
+		// If not included in core fields, it's an additional field we don't need to consider.
+		if ( ! coreFields.includes( fieldId ) ) {
+			continue;
+		}
 		if ( ! isField( fieldValue ) ) {
 			return false;
-		}
-
-		// Additional validation for specific core fields
-		if ( fieldKey === 'email' ) {
-			const emailField = fieldValue as Record< string, unknown >;
-			if ( emailField.type !== undefined && emailField.type !== 'email' ) {
-				return false;
-			}
-		}
-
-		if ( fieldKey === 'phone' ) {
-			const phoneField = fieldValue as Record< string, unknown >;
-			if ( phoneField.type !== undefined && phoneField.type !== 'tel' ) {
-				return false;
-			}
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-guards/form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-guards/form-fields.ts
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import type { FormFields, Field } from '@woocommerce/settings';
+
+/**
+ * Type guard to check if a value is a valid Field object.
+ * Based on the Field interface and CheckoutFields::get_core_fields() in PHP.
+ *
+ * @param value - The value to check.
+ * @return Whether the value is a valid Field object.
+ */
+const isField = ( value: unknown ): value is Field => {
+	if ( typeof value !== 'object' || value === null ) {
+		return false;
+	}
+
+	const field = value as Record< string, unknown >;
+
+	// Required properties that must always be present
+	if (
+		typeof field.label !== 'string' ||
+		typeof field.optionalLabel !== 'string' ||
+		typeof field.required !== 'boolean' ||
+		typeof field.hidden !== 'boolean' ||
+		typeof field.index !== 'number'
+	) {
+		return false;
+	}
+
+	// Optional properties - validate type if present
+	if ( field.autocomplete !== undefined && typeof field.autocomplete !== 'string' ) {
+		return false;
+	}
+
+	if ( field.autocapitalize !== undefined && typeof field.autocapitalize !== 'string' ) {
+		return false;
+	}
+
+	if ( field.type !== undefined && typeof field.type !== 'string' ) {
+		return false;
+	}
+
+	// Validation can be boolean, array, or JSON schema object
+	if ( field.validation !== undefined && 
+		 typeof field.validation !== 'boolean' &&
+		 ! Array.isArray( field.validation ) &&
+		 typeof field.validation !== 'object' ) {
+		return false;
+	}
+
+	// For select fields
+	if ( field.options !== undefined && ! Array.isArray( field.options ) ) {
+		return false;
+	}
+
+	if ( field.placeholder !== undefined && typeof field.placeholder !== 'string' ) {
+		return false;
+	}
+
+	// Attributes should be an object if present
+	if ( field.attributes !== undefined && 
+		 ( typeof field.attributes !== 'object' || field.attributes === null || Array.isArray( field.attributes ) ) ) {
+		return false;
+	}
+
+	return true;
+};
+
+/**
+ * Type guard to check if a value is a valid FormFields object.
+ * Validates that the object has the expected structure with proper field definitions.
+ * Based on CheckoutFields::get_core_fields() which defines the core checkout fields.
+ *
+ * @param value - The value to check.
+ * @return Whether the value is a valid FormFields object.
+ */
+export const isFormFields = ( value: unknown ): value is FormFields => {
+	if (
+		typeof value !== 'object' ||
+		value === null ||
+		Array.isArray( value )
+	) {
+		return false;
+	}
+
+	const fields = value as Record< string, unknown >;
+
+	// Check if it has all core fields from CheckoutFields::get_core_fields()
+	// These are the fields that should always be present
+	const coreFields = [
+		'email',
+		'country', 
+		'first_name',
+		'last_name',
+		'company',
+		'address_1',
+		'address_2',
+		'city',
+		'state',
+		'postcode',
+		'phone'
+	];
+
+	// We'll check for a minimum subset to allow flexibility
+	// but still ensure it's a valid checkout form structure
+	const minimumRequiredFields = [ 'first_name', 'last_name', 'email' ];
+	
+	if ( ! minimumRequiredFields.every( ( field ) => field in fields ) ) {
+		return false;
+	}
+
+	// Validate each field has the proper Field structure
+	for ( const [ fieldKey, fieldValue ] of Object.entries( fields ) ) {
+		if ( ! isField( fieldValue ) ) {
+			return false;
+		}
+
+		// Additional validation for specific core fields
+		if ( fieldKey === 'email' ) {
+			const emailField = fieldValue as Record< string, unknown >;
+			if ( emailField.type !== undefined && emailField.type !== 'email' ) {
+				return false;
+			}
+		}
+
+		if ( fieldKey === 'phone' ) {
+			const phoneField = fieldValue as Record< string, unknown >;
+			if ( phoneField.type !== undefined && phoneField.type !== 'tel' ) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+};

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-guards/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-guards/index.ts
@@ -1,6 +1,7 @@
 export * from './boolean';
 export * from './cart-response-totals';
 export * from './error';
+export * from './form-fields';
 export * from './function';
 export * from './null';
 export * from './number';

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-guards/test/form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-guards/test/form-fields.ts
@@ -1,0 +1,531 @@
+/**
+ * Internal dependencies
+ */
+import { isFormFields } from '../form-fields';
+
+describe( 'isFormFields', () => {
+	it( 'should return true for valid FormFields object', () => {
+		const validFormFields = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+
+		expect( isFormFields( validFormFields ) ).toBe( true );
+	} );
+
+	it( 'should return true for FormFields with additional optional properties', () => {
+		const formFieldsWithExtras = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				type: 'email',
+				autocomplete: 'email',
+				validation: [],
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+				autocomplete: 'given-name',
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: true,
+				index: 30,
+			},
+		};
+
+		expect( isFormFields( formFieldsWithExtras ) ).toBe( true );
+	} );
+
+	it( 'should return false for null', () => {
+		expect( isFormFields( null ) ).toBe( false );
+	} );
+
+	it( 'should return false for undefined', () => {
+		expect( isFormFields( undefined ) ).toBe( false );
+	} );
+
+	it( 'should return false for false (the original bug case)', () => {
+		expect( isFormFields( false ) ).toBe( false );
+	} );
+
+	it( 'should return false for arrays', () => {
+		expect( isFormFields( [] ) ).toBe( false );
+		expect( isFormFields( [ 'test' ] ) ).toBe( false );
+	} );
+
+	it( 'should return false for primitives', () => {
+		expect( isFormFields( 'string' ) ).toBe( false );
+		expect( isFormFields( 123 ) ).toBe( false );
+		expect( isFormFields( true ) ).toBe( false );
+	} );
+
+	it( 'should return false for empty object', () => {
+		expect( isFormFields( {} ) ).toBe( false );
+	} );
+
+	it( 'should return false when missing required fields', () => {
+		// Missing first_name
+		const missingFirstName = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( missingFirstName ) ).toBe( false );
+
+		// Missing email
+		const missingEmail = {
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( missingEmail ) ).toBe( false );
+	} );
+
+	it( 'should return false when field values are not objects', () => {
+		const invalidFieldValue = {
+			email: 'invalid string instead of object',
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( invalidFieldValue ) ).toBe( false );
+	} );
+
+	it( 'should return false when field has invalid property types', () => {
+		// Invalid label type
+		const invalidLabel = {
+			email: {
+				label: 123, // should be string
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( invalidLabel ) ).toBe( false );
+
+		// Invalid required type
+		const invalidRequired = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: 'true', // should be boolean
+				hidden: false,
+				index: 0,
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( invalidRequired ) ).toBe( false );
+
+		// Invalid index type
+		const invalidIndex = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: '0', // should be number
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( invalidIndex ) ).toBe( false );
+	} );
+
+	it( 'should return false when field has null values', () => {
+		const nullFieldValue = {
+			email: null,
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( nullFieldValue ) ).toBe( false );
+	} );
+
+	it( 'should validate optional field properties when present', () => {
+		const fieldsWithOptionalProps = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				type: 'email',
+				autocomplete: 'email',
+				autocapitalize: 'none',
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+				autocomplete: 'given-name',
+				autocapitalize: 'sentences',
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( fieldsWithOptionalProps ) ).toBe( true );
+	} );
+
+	it( 'should reject fields with wrong optional property types', () => {
+		const invalidAutocomplete = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				autocomplete: 123, // should be string
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( invalidAutocomplete ) ).toBe( false );
+	} );
+
+	it( 'should validate email field type if present', () => {
+		const wrongEmailType = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				type: 'text', // should be 'email' when specified
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+		};
+		expect( isFormFields( wrongEmailType ) ).toBe( false );
+	} );
+
+	it( 'should validate phone field type if present', () => {
+		const validWithPhone = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: false,
+				hidden: false,
+				index: 100,
+				type: 'tel',
+			},
+		};
+		expect( isFormFields( validWithPhone ) ).toBe( true );
+
+		const wrongPhoneType = {
+			...validWithPhone,
+			phone: {
+				...validWithPhone.phone,
+				type: 'text', // should be 'tel'
+			},
+		};
+		expect( isFormFields( wrongPhoneType ) ).toBe( false );
+	} );
+
+	it( 'should accept fields with validation arrays', () => {
+		const fieldsWithValidation = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				validation: [],
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+				validation: [ { type: 'string', minLength: 1 } ],
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+				validation: false,
+			},
+		};
+		expect( isFormFields( fieldsWithValidation ) ).toBe( true );
+	} );
+
+	it( 'should accept complete core fields structure matching PHP', () => {
+		// This matches exactly what CheckoutFields::get_core_fields() returns
+		const completeCoreFields = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'email',
+				autocapitalize: 'none',
+				type: 'email',
+				index: 0,
+			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'country',
+				index: 1,
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'given-name',
+				autocapitalize: 'sentences',
+				index: 10,
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'family-name',
+				autocapitalize: 'sentences',
+				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: true,
+				autocomplete: 'organization',
+				autocapitalize: 'sentences',
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'address-line1',
+				autocapitalize: 'sentences',
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				autocomplete: 'address-line2',
+				autocapitalize: 'sentences',
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'address-level2',
+				autocapitalize: 'sentences',
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'address-level1',
+				autocapitalize: 'sentences',
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				autocomplete: 'postal-code',
+				autocapitalize: 'characters',
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				type: 'tel',
+				autocomplete: 'tel',
+				autocapitalize: 'characters',
+				index: 100,
+			},
+		};
+		expect( isFormFields( completeCoreFields ) ).toBe( true );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-guards/test/form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-guards/test/form-fields.ts
@@ -4,7 +4,7 @@
 import { isFormFields } from '../form-fields';
 
 describe( 'isFormFields', () => {
-	it( 'should return true for valid FormFields object', () => {
+	it( 'should return true for valid FormFields object with all core fields', () => {
 		const validFormFields = {
 			email: {
 				label: 'Email address',
@@ -12,6 +12,13 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 0,
+			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
 			},
 			first_name: {
 				label: 'First name',
@@ -26,6 +33,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 
@@ -43,6 +99,14 @@ describe( 'isFormFields', () => {
 				type: 'email',
 				autocomplete: 'email',
 				validation: [],
+			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+				autocomplete: 'country',
 			},
 			first_name: {
 				label: 'First name',
@@ -66,6 +130,153 @@ describe( 'isFormFields', () => {
 				hidden: true,
 				index: 30,
 			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
+				type: 'tel',
+			},
+		};
+
+		expect( isFormFields( formFieldsWithExtras ) ).toBe( true );
+	} );
+
+	it( 'should return true for FormFields with additional optional fields', () => {
+		const formFieldsWithExtras = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+				type: 'email',
+				autocomplete: 'email',
+				validation: [],
+			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+				autocomplete: 'country',
+			},
+			first_name: {
+				label: 'First name',
+				optionalLabel: 'First name (optional)',
+				required: true,
+				hidden: false,
+				index: 10,
+				autocomplete: 'given-name',
+			},
+			last_name: {
+				label: 'Last name',
+				optionalLabel: 'Last name (optional)',
+				required: true,
+				hidden: false,
+				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: true,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
+				type: 'tel',
+			},
+			'switch-shipping-methods/custom-checkbox': {
+				label: 'Check this box to see a custom field on the order.',
+				optionalLabel:
+					'Check this box to see a custom field on the order. (optional)',
+				location: 'contact',
+				type: 'checkbox',
+				hidden: false,
+				required: false,
+				attributes: [],
+				show_in_order_confirmation: true,
+				sanitize_callback: [ {}, 'default_sanitize_callback' ],
+				validate_callback: [ {}, 'default_validate_callback' ],
+				validation: [],
+			},
 		};
 
 		expect( isFormFields( formFieldsWithExtras ) ).toBe( true );
@@ -79,7 +290,7 @@ describe( 'isFormFields', () => {
 		expect( isFormFields( undefined ) ).toBe( false );
 	} );
 
-	it( 'should return false for false (the original bug case)', () => {
+	it( 'should return false for false', () => {
 		expect( isFormFields( false ) ).toBe( false );
 	} );
 
@@ -98,8 +309,8 @@ describe( 'isFormFields', () => {
 		expect( isFormFields( {} ) ).toBe( false );
 	} );
 
-	it( 'should return false when missing required fields', () => {
-		// Missing first_name
+	it( 'should return false when missing any required core fields', () => {
+		// Missing first_name (and other core fields)
 		const missingFirstName = {
 			email: {
 				label: 'Email address',
@@ -108,6 +319,13 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: 0,
 			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			last_name: {
 				label: 'Last name',
 				optionalLabel: 'Last name (optional)',
@@ -115,11 +333,67 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: 20,
 			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
+			},
 		};
 		expect( isFormFields( missingFirstName ) ).toBe( false );
 
-		// Missing email
-		const missingEmail = {
+		// Missing multiple core fields
+		const missingMultiple = {
+			email: {
+				label: 'Email address',
+				optionalLabel: 'Email address (optional)',
+				required: true,
+				hidden: false,
+				index: 0,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -135,12 +409,19 @@ describe( 'isFormFields', () => {
 				index: 20,
 			},
 		};
-		expect( isFormFields( missingEmail ) ).toBe( false );
+		expect( isFormFields( missingMultiple ) ).toBe( false );
 	} );
 
 	it( 'should return false when field values are not objects', () => {
 		const invalidFieldValue = {
 			email: 'invalid string instead of object',
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -154,6 +435,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 		expect( isFormFields( invalidFieldValue ) ).toBe( false );
@@ -169,6 +499,13 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: 0,
 			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -182,6 +519,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 		expect( isFormFields( invalidLabel ) ).toBe( false );
@@ -195,6 +581,13 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: 0,
 			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -208,6 +601,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 		expect( isFormFields( invalidRequired ) ).toBe( false );
@@ -221,6 +663,13 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: '0', // should be number
 			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -234,6 +683,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 		expect( isFormFields( invalidIndex ) ).toBe( false );
@@ -242,6 +740,13 @@ describe( 'isFormFields', () => {
 	it( 'should return false when field has null values', () => {
 		const nullFieldValue = {
 			email: null,
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -255,6 +760,55 @@ describe( 'isFormFields', () => {
 				required: true,
 				hidden: false,
 				index: 20,
+			},
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
+				hidden: false,
+				index: 30,
+			},
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
+				required: true,
+				hidden: false,
+				index: 40,
+			},
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
+				hidden: false,
+				index: 50,
+			},
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
+				required: true,
+				hidden: false,
+				index: 70,
+			},
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
+				required: true,
+				hidden: false,
+				index: 80,
+			},
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
+				required: true,
+				hidden: false,
+				index: 90,
+			},
+			phone: {
+				label: 'Phone',
+				optionalLabel: 'Phone (optional)',
+				required: true,
+				hidden: false,
+				index: 100,
 			},
 		};
 		expect( isFormFields( nullFieldValue ) ).toBe( false );
@@ -272,6 +826,13 @@ describe( 'isFormFields', () => {
 				autocomplete: 'email',
 				autocapitalize: 'none',
 			},
+			country: {
+				label: 'Country/Region',
+				optionalLabel: 'Country/Region (optional)',
+				required: true,
+				hidden: false,
+				index: 1,
+			},
 			first_name: {
 				label: 'First name',
 				optionalLabel: 'First name (optional)',
@@ -288,138 +849,57 @@ describe( 'isFormFields', () => {
 				hidden: false,
 				index: 20,
 			},
-		};
-		expect( isFormFields( fieldsWithOptionalProps ) ).toBe( true );
-	} );
-
-	it( 'should reject fields with wrong optional property types', () => {
-		const invalidAutocomplete = {
-			email: {
-				label: 'Email address',
-				optionalLabel: 'Email address (optional)',
-				required: true,
+			company: {
+				label: 'Company',
+				optionalLabel: 'Company (optional)',
+				required: false,
 				hidden: false,
-				index: 0,
-				autocomplete: 123, // should be string
+				index: 30,
 			},
-			first_name: {
-				label: 'First name',
-				optionalLabel: 'First name (optional)',
+			address_1: {
+				label: 'Address',
+				optionalLabel: 'Address (optional)',
 				required: true,
 				hidden: false,
-				index: 10,
+				index: 40,
 			},
-			last_name: {
-				label: 'Last name',
-				optionalLabel: 'Last name (optional)',
-				required: true,
+			address_2: {
+				label: 'Apartment, suite, etc.',
+				optionalLabel: 'Apartment, suite, etc. (optional)',
+				required: false,
 				hidden: false,
-				index: 20,
+				index: 50,
 			},
-		};
-		expect( isFormFields( invalidAutocomplete ) ).toBe( false );
-	} );
-
-	it( 'should validate email field type if present', () => {
-		const wrongEmailType = {
-			email: {
-				label: 'Email address',
-				optionalLabel: 'Email address (optional)',
+			city: {
+				label: 'City',
+				optionalLabel: 'City (optional)',
 				required: true,
 				hidden: false,
-				index: 0,
-				type: 'text', // should be 'email' when specified
+				index: 70,
 			},
-			first_name: {
-				label: 'First name',
-				optionalLabel: 'First name (optional)',
+			state: {
+				label: 'State/County',
+				optionalLabel: 'State/County (optional)',
 				required: true,
 				hidden: false,
-				index: 10,
+				index: 80,
 			},
-			last_name: {
-				label: 'Last name',
-				optionalLabel: 'Last name (optional)',
+			postcode: {
+				label: 'Postal code',
+				optionalLabel: 'Postal code (optional)',
 				required: true,
 				hidden: false,
-				index: 20,
-			},
-		};
-		expect( isFormFields( wrongEmailType ) ).toBe( false );
-	} );
-
-	it( 'should validate phone field type if present', () => {
-		const validWithPhone = {
-			email: {
-				label: 'Email address',
-				optionalLabel: 'Email address (optional)',
-				required: true,
-				hidden: false,
-				index: 0,
-			},
-			first_name: {
-				label: 'First name',
-				optionalLabel: 'First name (optional)',
-				required: true,
-				hidden: false,
-				index: 10,
-			},
-			last_name: {
-				label: 'Last name',
-				optionalLabel: 'Last name (optional)',
-				required: true,
-				hidden: false,
-				index: 20,
+				index: 90,
 			},
 			phone: {
 				label: 'Phone',
 				optionalLabel: 'Phone (optional)',
-				required: false,
+				required: true,
 				hidden: false,
 				index: 100,
-				type: 'tel',
 			},
 		};
-		expect( isFormFields( validWithPhone ) ).toBe( true );
-
-		const wrongPhoneType = {
-			...validWithPhone,
-			phone: {
-				...validWithPhone.phone,
-				type: 'text', // should be 'tel'
-			},
-		};
-		expect( isFormFields( wrongPhoneType ) ).toBe( false );
-	} );
-
-	it( 'should accept fields with validation arrays', () => {
-		const fieldsWithValidation = {
-			email: {
-				label: 'Email address',
-				optionalLabel: 'Email address (optional)',
-				required: true,
-				hidden: false,
-				index: 0,
-				validation: [],
-			},
-			first_name: {
-				label: 'First name',
-				optionalLabel: 'First name (optional)',
-				required: true,
-				hidden: false,
-				index: 10,
-				validation: [ { type: 'string', minLength: 1 } ],
-			},
-			last_name: {
-				label: 'Last name',
-				optionalLabel: 'Last name (optional)',
-				required: true,
-				hidden: false,
-				index: 20,
-				validation: false,
-			},
-		};
-		expect( isFormFields( fieldsWithValidation ) ).toBe( true );
+		expect( isFormFields( fieldsWithOptionalProps ) ).toBe( true );
 	} );
 
 	it( 'should accept complete core fields structure matching PHP', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add a type guard for FormFields (the field shape passed by server -> client in `plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php`) This type guard checks the shape of the `defaultFields` option, and uses the default fields returned by [`CheckoutFields::get_core_fields`](https://github.com/woocommerce/woocommerce/blob/edbe28ca59ed77e35cdd76b4ec310242a6857305/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutFields.php#L664) to define it. Therefore, any additional fields added will not affect the check. It checks only for the core, base fields.
- Update `default-fields.ts` to get the `defaultFields` setting with coercion and include the default type, which is again a copy of the `get_core_fields` value from PHP - `getSettingWithCoercion` also forces a type check.

Closes WOOPLUG-4572 (https://github.com/woocommerce/woocommerce/issues/58709)

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/55879 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/17a2740e-f966-4e60-86ba-9d7a283d2f2c) | <img width="696" alt="image" src="https://github.com/user-attachments/assets/1efd6757-336c-41b8-b351-254fa5317c94" /> |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add a post/page and enter the code editor, paste the following:

```
<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image",{"imageSizing":"cropped"}],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;,{&quot;imageSizing&quot;:&quot;cropped&quot;}],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div>
<!-- /wp:woocommerce/all-products -->
```

2. Save the page.
3. Edit the site header, remove the mini-cart block.
4. Go to the post on the front end and ensure the all products block loads.
5. Add this snippet

```php
add_action( 'woocommerce_blocks_loaded', function() {
	$registry = \Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class );
	$registry->add( 'defaultFields', 'Should not break!' );
});
```
6. Load the all products block, ensure it loads correctly. Optional, go to the JS console and type `wc.wcSettings.allSettings.defaultFields` to verify the data was overwritten properly.

### Testing that has already taken place:

Considered how extensions could maliciously mess with the data. It is possible for them to overwrite data by using 

```php
add_action( 'woocommerce_blocks_loaded', function() {
	$registry = \Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class );
	$registry->add( 'defaultFields', 'malformed_data' );
});
```

I think the chance of this happening is low, but if they do, and the core fields do not contain the required props (as defined in get_core_fields) then it will reject, and default to the default set of fields defined in this PR (in `plugins/woocommerce/client/blocks/assets/js/settings/shared/default-fields.ts`).

If _required_ custom fields are registered and the data is overwritten like this, it will not be possible to check out because those fields will be expected, but not shown to the shopper as part of `defaultFields`.

I believe hardening that is out of scope for this PR and should be looked at separately.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
