### PR TITLE
[dev] Monorepo: drop unused `concurrently` package from dependencies

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -9,9 +9,10 @@
 	},
 	"versionGroups": [
 		{
-			"label": "Banned dependencies: classnames(->clsx)",
+			"label": "Banned dependencies: classnames(->clsx), concurrently(->pnpm)",
 			"dependencies": [
-				"classnames"
+				"classnames",
+				"concurrently"
 			],
 			"packages": [
 				"**"

--- a/packages/js/admin-layout/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/admin-layout/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/admin-layout/package.json
+++ b/packages/js/admin-layout/package.json
@@ -61,7 +61,6 @@
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/components/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/components/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -153,7 +153,6 @@
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/babel-preset-default": "next",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/csv-export/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/csv-export/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -55,7 +55,6 @@
 		"@types/jest": "27.5.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/currency/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/currency/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -69,7 +69,6 @@
 		"@types/react": "18.3.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/customer-effort-score/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/customer-effort-score/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -82,7 +82,6 @@
 		"@woocommerce/navigation": "workspace:*",
 		"@woocommerce/tracks": "workspace:*",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/data/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/data/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -85,7 +85,6 @@
 		"@types/react": "18.3.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/date/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/date/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -45,7 +45,6 @@
 		"@types/qs": "^6.9.10",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"d3-time-format": "^2.3.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/experimental/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/experimental/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -68,7 +68,6 @@
 		"@woocommerce/internal-js-tests": "workspace:*",
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/browserslist-config": "wp-6.6",
-		"concurrently": "^7.6.0",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/explat/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/explat/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -69,7 +69,6 @@
 		"@types/react": "18.3.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/expression-evaluation/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/expression-evaluation/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/expression-evaluation/package.json
+++ b/packages/js/expression-evaluation/package.json
@@ -58,7 +58,6 @@
 		"@types/jest": "27.5.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/navigation/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/navigation/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -78,7 +78,6 @@
 		"@types/qs": "^6.9.10",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/notices/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/notices/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/notices/package.json
+++ b/packages/js/notices/package.json
@@ -70,7 +70,6 @@
 		"@babel/core": "7.25.7",
 		"@types/lodash": "^4.14.202",
 		"@woocommerce/eslint-plugin": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/number/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/number/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -58,7 +58,6 @@
 		"@types/lodash": "^4.14.202",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/onboarding/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/onboarding/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -79,7 +79,6 @@
 		"@woocommerce/internal-js-tests": "workspace:*",
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",

--- a/packages/js/product-editor/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/product-editor/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -106,7 +106,6 @@
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/block-editor": "wp-6.6",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"copy-webpack-plugin": "13.0.x",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",

--- a/packages/js/remote-logging/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/remote-logging/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/remote-logging/package.json
+++ b/packages/js/remote-logging/package.json
@@ -65,7 +65,6 @@
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
 		"@wordpress/jest-console": "^5.4.0",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/packages/js/settings-editor/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/settings-editor/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/settings-editor/package.json
+++ b/packages/js/settings-editor/package.json
@@ -93,7 +93,6 @@
 		"@woocommerce/internal-style-build": "workspace:*",
 		"@wordpress/block-editor": "wp-6.6",
 		"@wordpress/browserslist-config": "next",
-		"concurrently": "^7.6.0",
 		"copy-webpack-plugin": "13.0.x",
 		"css-loader": "6.11.x",
 		"eslint": "^8.55.0",

--- a/packages/js/tracks/changelog/58765-dev-deps-cleanup-concurrently
+++ b/packages/js/tracks/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -59,7 +59,6 @@
 		"@types/jest": "27.5.x",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@woocommerce/internal-js-tests": "workspace:*",
-		"concurrently": "^7.6.0",
 		"eslint": "^8.55.0",
 		"jest": "27.5.x",
 		"jest-cli": "27.5.x",

--- a/plugins/woocommerce/changelog/58765-dev-deps-cleanup-concurrently
+++ b/plugins/woocommerce/changelog/58765-dev-deps-cleanup-concurrently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Monorepo: drop the unused `concurrently` package from dependencies.

--- a/plugins/woocommerce/client/admin/package.json
+++ b/plugins/woocommerce/client/admin/package.json
@@ -178,7 +178,6 @@
 		"babel-plugin-transform-react-remove-prop-types": "0.4.24",
 		"chalk": "^4.1.2",
 		"comment-parser": "^1.4.1",
-		"concurrently": "^7.6.0",
 		"config": "3.3.7",
 		"copy-webpack-plugin": "13.0.x",
 		"cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,9 +157,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       css-loader:
         specifier: 6.11.x
         version: 6.11.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -622,9 +619,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       css-loader:
         specifier: 6.11.x
         version: 6.11.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -710,9 +704,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -771,9 +762,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -874,9 +862,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       css-loader:
         specifier: 6.11.x
         version: 6.11.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -1016,9 +1001,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -1089,9 +1071,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       d3-time-format:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1483,9 +1462,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: wp-6.6
         version: 6.0.1
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       css-loader:
         specifier: 6.11.x
         version: 6.11.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -1571,9 +1547,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -1617,9 +1590,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -1927,9 +1897,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -1985,9 +1952,6 @@ importers:
       '@woocommerce/eslint-plugin':
         specifier: workspace:*
         version: link:../eslint-plugin
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -2037,9 +2001,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -2128,9 +2089,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       css-loader:
         specifier: 6.11.x
         version: 6.11.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -2381,9 +2339,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       copy-webpack-plugin:
         specifier: 13.0.x
         version: 13.0.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -2481,9 +2436,6 @@ importers:
       '@wordpress/jest-console':
         specifier: ^5.4.0
         version: 5.4.0(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.100)(@types/node@20.17.8)(typescript@5.7.2)))
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -2680,9 +2632,6 @@ importers:
       '@wordpress/browserslist-config':
         specifier: next
         version: 6.13.1-next.a9f418477.0
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       copy-webpack-plugin:
         specifier: 13.0.x
         version: 13.0.0(webpack@5.97.1(@swc/core@1.3.100))
@@ -2765,9 +2714,6 @@ importers:
       '@woocommerce/internal-js-tests':
         specifier: workspace:*
         version: link:../internal-js-tests
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       eslint:
         specifier: ^8.55.0
         version: 8.55.0
@@ -3461,9 +3407,6 @@ importers:
       comment-parser:
         specifier: ^1.4.1
         version: 1.4.1
-      concurrently:
-        specifier: ^7.6.0
-        version: 7.6.0
       config:
         specifier: 3.3.7
         version: 3.3.7
@@ -32701,13 +32644,13 @@ snapshots:
       '@types/node': 20.17.8
     optional: true
 
-  '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.4.0
-      eslint: 7.32.0
+      eslint: 8.55.0
       functional-red-black-tree: 1.0.1
       ignore: 5.3.0
       regexpp: 3.2.0
@@ -36146,14 +36089,14 @@ snapshots:
   '@wordpress/eslint-plugin@9.3.0(@babel/core@7.25.7)(eslint@7.32.0)(typescript@5.7.2)':
     dependencies:
       '@babel/eslint-parser': 7.23.3(@babel/core@7.25.7)(eslint@7.32.0)
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       '@wordpress/prettier-config': 1.4.0(wp-prettier@2.2.1-beta-1)
       cosmiconfig: 7.1.0
       eslint: 7.32.0
       eslint-config-prettier: 7.2.0(eslint@7.32.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)
-      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
       eslint-plugin-jsdoc: 36.1.1(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@7.2.0(eslint@7.32.0))(eslint@7.32.0)(wp-prettier@2.2.1-beta-1)
@@ -42254,12 +42197,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2):
+  eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.7.2)
       eslint: 7.32.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@7.32.0)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@8.55.0)(typescript@5.7.2))(eslint@8.55.0)(typescript@5.7.2)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Followup of #58699 

Cleans up pnpm migration leftovers: bans `concurrently` package as we rely on pnpm for concurrently running tasks.

### How to test the changes in this Pull Request:

- CI-checks shall pass

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Monorepo: drop the unused `concurrently` package from dependencies.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

