### PR TITLE
Fix shipping rate cache hashes in Store API

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-rate-cache-hash
+++ b/plugins/woocommerce/changelog/fix-shipping-rate-cache-hash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Invalidate shipping hashes when rate prices change.

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -346,8 +346,10 @@ final class WC_Cart_Totals {
 				$shipping_line->tax_class = get_option( 'woocommerce_shipping_tax_class', 'inherit' );
 				$shipping_line->taxable   = true;
 				$shipping_line->total     = wc_add_number_precision_deep( $shipping_object->cost );
-				$shipping_line->taxes     = wc_add_number_precision_deep( $shipping_object->taxes, false );
-				$shipping_line->taxes     = array_map( array( $this, 'round_item_subtotal' ), $shipping_line->taxes );
+				$shipping_line->taxes     = array_map(
+					array( $this, 'round_item_subtotal' ),
+					wc_add_number_precision_deep( $shipping_object->taxes, false )
+				);
 				$shipping_line->total_tax = array_sum( $shipping_line->taxes );
 				return $shipping_line;
 			},

--- a/plugins/woocommerce/includes/class-wc-shipping-rate.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-rate.php
@@ -8,6 +8,8 @@
  * @since   2.6.0
  */
 
+declare( strict_types=1 );
+
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
@@ -15,14 +17,13 @@ use Automattic\WooCommerce\Enums\ProductTaxStatus;
 /**
  * Shipping rate class.
  */
-class WC_Shipping_Rate {
+class WC_Shipping_Rate implements JsonSerializable {
 
 	/**
 	 * Stores data for this rate.
 	 *
-	 * @since 3.2.0
 	 * @since 9.2.0 Added description and delivery_time.
-	 * @var   array
+	 * @var array
 	 */
 	protected $data = array(
 		'id'            => '',
@@ -39,8 +40,7 @@ class WC_Shipping_Rate {
 	/**
 	 * Stores meta data for this rate.
 	 *
-	 * @since 2.6.0
-	 * @var   array
+	 * @var array
 	 */
 	protected $meta_data = array();
 
@@ -70,34 +70,31 @@ class WC_Shipping_Rate {
 	}
 
 	/**
-	 * Magic methods to support direct access to props.
+	 * Magic method to support direct access to data prop.
 	 *
-	 * @since 3.2.0
 	 * @param string $key Key.
 	 * @return bool
 	 */
 	public function __isset( $key ) {
-		if ( 'meta_data' === $key ) {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Use `array_key_exists` to check for meta_data on WC_Shipping_Rate to get the correct result.', 'woocommerce' ), '6.0' );
-		}
 		return isset( $this->data[ $key ] );
 	}
 
 	/**
 	 * Magic methods to support direct access to props.
 	 *
-	 * @since 3.2.0
 	 * @param string $key Key.
 	 * @return mixed
 	 */
 	public function __get( $key ) {
 		if ( is_callable( array( $this, "get_{$key}" ) ) ) {
 			return $this->{"get_{$key}"}();
-		} elseif ( isset( $this->data[ $key ] ) ) {
-			return $this->data[ $key ];
-		} else {
-			return '';
 		}
+
+		if ( isset( $this->data[ $key ] ) ) {
+			return $this->data[ $key ];
+		}
+
+		return '';
 	}
 
 	/**
@@ -113,6 +110,18 @@ class WC_Shipping_Rate {
 		} else {
 			$this->data[ $key ] = $value;
 		}
+	}
+
+	/**
+	 * When converted to JSON.
+	 *
+	 * @return object|array
+	 */
+	public function jsonSerialize() {
+		return array(
+			'data'      => $this->data,
+			'meta_data' => $this->meta_data,
+		);
 	}
 
 	/**
@@ -215,6 +224,13 @@ class WC_Shipping_Rate {
 	 * @return string
 	 */
 	public function get_id() {
+		/**
+		 * Filter the shipping rate ID.
+		 *
+		 * @since 3.2.0
+		 * @param string $id The shipping rate ID.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_id', $this->data['id'], $this );
 	}
 
@@ -225,6 +241,13 @@ class WC_Shipping_Rate {
 	 * @return string
 	 */
 	public function get_method_id() {
+		/**
+		 * Filter the shipping method ID.
+		 *
+		 * @since 3.2.0
+		 * @param string $method_id The shipping method ID.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_method_id', $this->data['method_id'], $this );
 	}
 
@@ -235,6 +258,13 @@ class WC_Shipping_Rate {
 	 * @return int
 	 */
 	public function get_instance_id() {
+		/**
+		 * Filter the shipping rate instance ID.
+		 *
+		 * @since 3.2.0
+		 * @param int $instance_id The shipping rate instance ID.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_instance_id', $this->data['instance_id'], $this );
 	}
 
@@ -244,6 +274,13 @@ class WC_Shipping_Rate {
 	 * @return string
 	 */
 	public function get_label() {
+		/**
+		 * Filter the shipping rate label.
+		 *
+		 * @since 3.2.0
+		 * @param string $label The shipping rate label.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_label', $this->data['label'], $this );
 	}
 
@@ -254,6 +291,13 @@ class WC_Shipping_Rate {
 	 * @return string
 	 */
 	public function get_cost() {
+		/**
+		 * Filter the shipping rate cost.
+		 *
+		 * @since 3.2.0
+		 * @param string $cost The shipping rate cost.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_cost', $this->data['cost'], $this );
 	}
 
@@ -264,6 +308,13 @@ class WC_Shipping_Rate {
 	 * @return array
 	 */
 	public function get_taxes() {
+		/**
+		 * Filter the shipping rate taxes.
+		 *
+		 * @since 3.2.0
+		 * @param array $taxes The shipping rate taxes.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
 		return apply_filters( 'woocommerce_shipping_rate_taxes', $this->data['taxes'], $this );
 	}
 
@@ -273,9 +324,17 @@ class WC_Shipping_Rate {
 	 * @return float
 	 */
 	public function get_shipping_tax() {
-		return apply_filters( 'woocommerce_get_shipping_tax', count( $this->taxes ) > 0 && ! WC()->customer->get_is_vat_exempt() ? (float) array_sum( $this->taxes ) : 0.0, $this );
-	}
+		$taxes = $this->get_taxes();
 
+		/**
+		 * Filter the shipping rate taxes.
+		 *
+		 * @since 3.2.0
+		 * @param array $taxes The shipping rate taxes.
+		 * @param WC_Shipping_Rate $this The shipping rate object.
+		 */
+		return apply_filters( 'woocommerce_get_shipping_tax', count( $taxes ) > 0 && ! WC()->customer->get_is_vat_exempt() ? (float) array_sum( $taxes ) : 0.0, $this );
+	}
 
 	/**
 	 * Get tax status.

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -843,7 +843,7 @@ class CartController {
 		$cart = $this->get_cart_instance();
 		return [
 			'line_items' => $cart->get_cart_hash(),
-			'shipping'   => md5( wp_json_encode( [ $cart->shipping_methods, wc()->session->get( 'chosen_shipping_methods' ) ] ) ),
+			'shipping'   => md5( wp_json_encode( [ $cart->get_shipping_methods(), wc()->session->get( 'chosen_shipping_methods' ) ] ) ),
 			'fees'       => md5( wp_json_encode( $cart->get_fees() ) ),
 			'coupons'    => md5( wp_json_encode( $cart->get_applied_coupons() ) ),
 			'taxes'      => md5( wp_json_encode( $cart->get_taxes() ) ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There is a problem with shipping rate hash generation which causes rates to remain cached even when they change. Two issues were identified:

1. `get_cart_hashes` was using `$cart->shipping_methods` rather than `$cart->get_shipping_methods()`. This is a protected variable so returned an empty string
2. `WC_Shipping_Rate` would not contain rate information when json encoded because all data is private. Implementing `JsonSerializable` fixes this.

### How to test the changes in this Pull Request:

Before using this PR:

1. Enable Local Pickup. Set rate cost to 1. Leave this screen open.
2. Add item to cart and go to block checkout. Fill out form. Do no place order yet.
3. In pickup settings, set cost to 2.
4. Place order. Confirmation page shows 1 was charged.
5. Set local pickup price back to 1.
6. Repeat steps 2-4 above with this PR. Confirmation page shows 2 was charged (correct).

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
