### PR TITLE
Fix Add to Cart + Options grouped products e2e test

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-e2e-test
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Add to Cart + Options grouped products e2e test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -158,8 +158,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 		pageObject,
 		editor,
 	} ) => {
-		await pageObject.setFeatureFlags();
-
 		await pageObject.updateSingleProductTemplate();
 
 		await editor.saveSiteEditorEntities( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes e2e tests in `trunk`. We merged https://github.com/woocommerce/woocommerce/pull/58727 and https://github.com/woocommerce/woocommerce/pull/58602 in parallel, one was removing the feature flags for the _Add to Cart + Options_ block and the other one was adding a test that depended on those feature flags. :grimacing: 

This PR removes the part of the test where we were updating the feature flags.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass.