### PR TITLE
Ensure plain text email preview is aligned left when sent to email

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4615-plain-text-emails-are-aligned-center-when-sending-an-email
+++ b/plugins/woocommerce/changelog/wooplug-4615-plain-text-emails-are-aligned-center-when-sending-an-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure plain text email preview is aligned left when sent to email

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -307,7 +307,7 @@ class EmailPreview {
 		}
 
 		if ( 'plain' === $this->email->get_email_type() ) {
-			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap;text-align: left;">';
+			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap; text-align: ' . ( is_rtl() ? 'right' : 'left' ) . ';">';
 			$content .= $this->email->get_content_plain();
 			$content .= '</pre>';
 		} else {

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -307,7 +307,7 @@ class EmailPreview {
 		}
 
 		if ( 'plain' === $this->email->get_email_type() ) {
-			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap;">';
+			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap;text-align: left;">';
 			$content .= $this->email->get_content_plain();
 			$content .= '</pre>';
 		} else {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4615, closes #58789.

(For Bug Fixes) Bug introduced in PR #54844.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="605" alt="Screenshot 2025-06-12 at 23 15 59" src="https://github.com/user-attachments/assets/4eaf9fcf-28cb-4b10-a236-d4a9556569f8" />     |  <img width="626" alt="Screenshot 2025-06-12 at 23 15 52" src="https://github.com/user-attachments/assets/77ccfa88-be39-4558-ae3e-ad1abfc4d67a" />     |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure your website can send actual emails.
2. Go to **WooCommerce > Settings > Emails** and click on `Manage` any of the emails.
3. Change the `Email type` to plain text.
4. Send the email to any Gmail/Google Workspace email.
5. Observe, that the email is aligned left, as is in the email preview on the website.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
