### PR TITLE
Add filter and action for fulfillment creation

### DIFF
--- a/plugins/woocommerce/changelog/58793-add-57412-wc_fulfillments_before_create-hook
+++ b/plugins/woocommerce/changelog/58793-add-57412-wc_fulfillments_before_create-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add before create filter and after create action for fulfillments.
+

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/fulfill-items-button.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/fulfill-items-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, select } from '@wordpress/data';
 import { useState } from 'react';
 
 /**
@@ -23,33 +23,31 @@ export default function FulfillItemsButton( {
 	const { order, fulfillment, notifyCustomer } = useFulfillmentContext();
 	const [ isExecuting, setIsExecuting ] = useState( false );
 	const { saveFulfillment } = useDispatch( FulfillmentStore );
-	const { getError } = useSelect(
-		( select ) => ( { getError: select( FulfillmentStore ).getError } ),
-		[]
-	);
 
 	const handleFulfillItems = async () => {
-		setIsExecuting( true );
 		setError( null );
 		if ( ! fulfillment || ! order ) {
-			setIsExecuting( false );
 			return;
 		}
 		if ( getFulfillmentItems( fulfillment ).length === 0 ) {
 			setError( __( 'Select items to be fulfilled.', 'woocommerce' ) );
-			setIsExecuting( false );
 			return;
 		}
+
+		setIsExecuting( true );
+
+		// Mark fulfillment as fulfilled.
 		fulfillment.is_fulfilled = true;
 		fulfillment.status = 'fulfilled';
-
 		await saveFulfillment( order.id, fulfillment, notifyCustomer );
-		const error = getError( order.id );
+
+		const error = select( FulfillmentStore ).getError( order.id );
 		if ( error ) {
 			setError( error );
 		} else {
 			setIsEditing( false );
 		}
+
 		setIsExecuting( false );
 	};
 

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/fulfill-items-button.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/fulfill-items-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from 'react';
 
 /**
@@ -23,8 +23,12 @@ export default function FulfillItemsButton( {
 	const { order, fulfillment, notifyCustomer } = useFulfillmentContext();
 	const [ isExecuting, setIsExecuting ] = useState( false );
 	const { saveFulfillment } = useDispatch( FulfillmentStore );
+	const { getError } = useSelect(
+		( select ) => ( { getError: select( FulfillmentStore ).getError } ),
+		[]
+	);
 
-	const handleFulfillItems = () => {
+	const handleFulfillItems = async () => {
 		setIsExecuting( true );
 		setError( null );
 		if ( ! fulfillment || ! order ) {
@@ -32,22 +36,21 @@ export default function FulfillItemsButton( {
 			return;
 		}
 		if ( getFulfillmentItems( fulfillment ).length === 0 ) {
-			setError( 'Select items to be fulfilled.' );
+			setError( __( 'Select items to be fulfilled.', 'woocommerce' ) );
 			setIsExecuting( false );
 			return;
 		}
 		fulfillment.is_fulfilled = true;
 		fulfillment.status = 'fulfilled';
-		saveFulfillment( order.id, fulfillment, notifyCustomer )
-			.then( () => {
-				setIsEditing( false );
-			} )
-			.catch( ( error ) => {
-				setError( error );
-			} )
-			.finally( () => {
-				setIsExecuting( false );
-			} );
+
+		await saveFulfillment( order.id, fulfillment, notifyCustomer );
+		const error = getError( order.id );
+		if ( error ) {
+			setError( error );
+		} else {
+			setIsEditing( false );
+		}
+		setIsExecuting( false );
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/save-draft-button.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/save-draft-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from 'react';
 
 /**
@@ -23,8 +23,12 @@ export default function SaveAsDraftButton( {
 	const { order, fulfillment, notifyCustomer } = useFulfillmentContext();
 	const [ isExecuting, setIsExecuting ] = useState( false );
 	const { saveFulfillment } = useDispatch( FulfillmentStore );
+	const { getError } = useSelect(
+		( select ) => ( { getError: select( FulfillmentStore ).getError } ),
+		[]
+	);
 
-	const handleFulfillItems = () => {
+	const handleFulfillItems = async () => {
 		setError( null );
 		setIsExecuting( true );
 
@@ -34,19 +38,17 @@ export default function SaveAsDraftButton( {
 		}
 		if ( getFulfillmentItems( fulfillment ).length === 0 ) {
 			setIsExecuting( false );
-			setError( 'Select items to be fulfilled.' );
+			setError( __( 'Select items to be fulfilled.', 'woocommerce' ) );
 			return;
 		}
-		saveFulfillment( order.id, fulfillment, notifyCustomer )
-			.then( () => {
-				setIsEditing( false );
-			} )
-			.catch( ( error ) => {
-				setError( error );
-			} )
-			.finally( () => {
-				setIsExecuting( false );
-			} );
+		await saveFulfillment( order.id, fulfillment, notifyCustomer );
+		const error = getError( order.id );
+		if ( error ) {
+			setError( error );
+		} else {
+			setIsEditing( false );
+		}
+		setIsExecuting( false );
 	};
 
 	return (

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/save-draft-button.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/action-buttons/save-draft-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, select } from '@wordpress/data';
 import { useState } from 'react';
 
 /**
@@ -23,26 +23,19 @@ export default function SaveAsDraftButton( {
 	const { order, fulfillment, notifyCustomer } = useFulfillmentContext();
 	const [ isExecuting, setIsExecuting ] = useState( false );
 	const { saveFulfillment } = useDispatch( FulfillmentStore );
-	const { getError } = useSelect(
-		( select ) => ( { getError: select( FulfillmentStore ).getError } ),
-		[]
-	);
 
 	const handleFulfillItems = async () => {
 		setError( null );
-		setIsExecuting( true );
-
 		if ( ! fulfillment || ! order ) {
-			setIsExecuting( false );
 			return;
 		}
 		if ( getFulfillmentItems( fulfillment ).length === 0 ) {
-			setIsExecuting( false );
 			setError( __( 'Select items to be fulfilled.', 'woocommerce' ) );
 			return;
 		}
+		setIsExecuting( true );
 		await saveFulfillment( order.id, fulfillment, notifyCustomer );
-		const error = getError( order.id );
+		const error = select( FulfillmentStore ).getError( order.id );
 		if ( error ) {
 			setError( error );
 		} else {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/index.tsx
@@ -16,28 +16,9 @@ interface MetadataViewerProps {
 }
 
 export default function MetadataViewer( { fulfillment }: MetadataViewerProps ) {
-	// TODO: Remove debug code when all is ready.
-	const publicMetadata = true
-		? [
-				{
-					id: 1,
-					key: __( 'Created on', 'woocommerce' ),
-					value: 'February 18, 2020, 12:00pm',
-				},
-				{
-					id: 2,
-					key: __( 'Source', 'woocommerce' ),
-					value: 'Easyship',
-				},
-				{
-					id: 3,
-					key: __( 'Service level', 'woocommerce' ),
-					value: 'Express',
-				},
-		  ]
-		: fulfillment.meta_data.filter(
-				( meta ) => meta.key.startsWith( '_' ) === false
-		  );
+	const publicMetadata = fulfillment.meta_data.filter(
+		( meta ) => meta.key.startsWith( '_' ) === false
+	);
 
 	return (
 		<FulfillmentCard

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/index.tsx
@@ -31,7 +31,7 @@ export default function MetadataViewer( { fulfillment }: MetadataViewerProps ) {
 			}
 		>
 			{ publicMetadata.length === 0 && (
-				<p>{ __( 'No information available.', 'woocommerce' ) }</p>
+				<p>{ __( 'No metadata available.', 'woocommerce' ) }</p>
 			) }
 			{ publicMetadata.length > 0 && (
 				<MetaList

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/test/index.test.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/metadata-viewer/test/index.test.js
@@ -42,7 +42,17 @@ jest.mock( '../../user-interface/meta-list/meta-list', () => ( {
 
 describe( 'MetadataViewer component', () => {
 	it( 'renders header and icon', () => {
-		render( <MetadataViewer fulfillment={ { meta_data: [] } } /> );
+		render(
+			<MetadataViewer
+				fulfillment={ {
+					meta_data: [
+						{ key: 'test_key', value: 'test_value' },
+						{ key: 'test_key_2', value: 'test_value_2' },
+						{ key: 'test_key_3', value: 'test_value_3' },
+					],
+				} }
+			/>
+		);
 		expect( screen.getByTestId( 'card-header' ) ).toHaveTextContent(
 			'Fulfillment details'
 		);
@@ -50,9 +60,25 @@ describe( 'MetadataViewer component', () => {
 	} );
 
 	it( 'renders list of metadata items', () => {
-		render( <MetadataViewer fulfillment={ { meta_data: [] } } /> );
+		render(
+			<MetadataViewer
+				fulfillment={ {
+					meta_data: [
+						{ key: 'test_key', value: 'test_value' },
+						{ key: 'test_key_2', value: 'test_value_2' },
+						{ key: 'test_key_3', value: 'test_value_3' },
+					],
+				} }
+			/>
+		);
 		const list = screen.getByTestId( 'meta-list' );
 		expect( list ).toBeInTheDocument();
 		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 3 );
+	} );
+	it( 'renders empty state when no metadata', () => {
+		render( <MetadataViewer fulfillment={ { meta_data: [] } } /> );
+		expect(
+			screen.getByText( /No metadata available/ )
+		).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/index.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/shipment-form/index.tsx
@@ -49,6 +49,7 @@ export default function ShipmentForm() {
 							setSelectedOption( SHIPMENT_OPTION_TRACKING_NUMBER )
 						}
 						label={ __( 'Tracking Number', 'woocommerce' ) }
+						__nextHasNoMarginBottom
 					/>
 					{ selectedOption === SHIPMENT_OPTION_TRACKING_NUMBER && (
 						<ShipmentTrackingNumberForm />
@@ -67,6 +68,7 @@ export default function ShipmentForm() {
 							setSelectedOption( SHIPMENT_OPTION_MANUAL_ENTRY )
 						}
 						label={ __( 'Enter manually', 'woocommerce' ) }
+						__nextHasNoMarginBottom
 					/>
 					{ selectedOption === SHIPMENT_OPTION_MANUAL_ENTRY && (
 						<ShipmentManualEntryForm />
@@ -83,6 +85,7 @@ export default function ShipmentForm() {
 							setSelectedOption( SHIPMENT_OPTION_NO_INFO )
 						}
 						label={ __( 'No shipment information', 'woocommerce' ) }
+						__nextHasNoMarginBottom
 					/>
 				</div>
 			</div>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/store.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/store.ts
@@ -11,6 +11,24 @@ import { Order, Fulfillment } from './types';
 
 export const STORE_NAME = 'order/fulfillments';
 
+const getFulfillmentErrorMessage = (
+	error: unknown,
+	defaultMessage: string
+): string => {
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		'code' in error
+	) {
+		const apiError = error as { message: string; code: string };
+		if ( apiError.code === 'woocommerce_fulfillment_error' ) {
+			return apiError.message;
+		}
+	}
+	return defaultMessage;
+};
+
 const actionTypes = {
 	SET_ORDER: 'SET_ORDER',
 	SET_LOADING: 'SET_LOADING',
@@ -101,9 +119,10 @@ const publicActions = {
 			} catch ( error: unknown ) {
 				dispatch.setError(
 					orderId,
-					error instanceof Error
-						? error.message
-						: 'Failed to save fulfillment'
+					getFulfillmentErrorMessage(
+						error,
+						'Failed to save fulfillment'
+					)
 				);
 			} finally {
 				dispatch.setLoading( orderId, false );
@@ -133,9 +152,10 @@ const publicActions = {
 			} catch ( error: unknown ) {
 				dispatch.setError(
 					orderId,
-					error instanceof Error
-						? error.message
-						: 'Failed to update fulfillment'
+					getFulfillmentErrorMessage(
+						error,
+						'Failed to update fulfillment'
+					)
 				);
 			} finally {
 				dispatch.setLoading( orderId, false );
@@ -156,9 +176,10 @@ const publicActions = {
 			} catch ( error: unknown ) {
 				dispatch.setError(
 					orderId,
-					error instanceof Error
-						? error.message
-						: 'Failed to delete fulfillment'
+					getFulfillmentErrorMessage(
+						error,
+						'Failed to delete fulfillment'
+					)
 				);
 			} finally {
 				dispatch.setLoading( orderId, false );

--- a/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
@@ -48,6 +48,13 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		// Set fulfillment properties.
 		$data->set_date_updated( current_time( 'mysql' ) );
 
+		/**
+		 * Filter to modify the fulfillment data before it is created.
+		 *
+		 * @since 9.9.0
+		 */
+		$data = apply_filters( 'wc_fulfillment_before_create', $data );
+
 		// Save the fulfillment to the database.
 		global $wpdb;
 		$rows_inserted = $wpdb->insert(
@@ -79,6 +86,13 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		// Apply changes let's the object know that the current object reflects the database and no "changes" exist between the two.
 		$data->apply_changes();
 		$data->set_object_read( true );
+
+		/**
+		 * Action to perform after a fulfillment is created.
+		 *
+		 * @since 9.9.0
+		 */
+		do_action( 'wc_fulfillment_after_create', $data );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentException.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentException.php
@@ -1,0 +1,25 @@
+<?php declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Fulfillments;
+
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
+
+/**
+ * FulfillmentException class.
+ * This exception is thrown when there is an issue with fulfillment operations,
+ * such as creating, updating, or deleting fulfillments.
+ */
+class FulfillmentException extends ApiException {
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $message          User-friendly translated error message, e.g. 'Fulfillment creation failed'.
+	 * @param int    $http_status_code Optional. Proper HTTP status code to respond with.
+	 *                                 Defaults to 400 (Bad request).
+	 * @param array  $additional_data  Optional. Extra data (key value pairs) to expose in the error response.
+	 *                                 Defaults to empty array.
+	 */
+	public function __construct( string $message, int $http_status_code = 400, array $additional_data = array() ) {
+		parent::__construct( 'woocommerce_fulfillment_error', $message, $http_status_code, $additional_data );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -406,9 +406,6 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			$fulfillment = new Fulfillment( $fulfillment_id );
 			$this->validate_fulfillment( $fulfillment, $fulfillment_id, $order_id );
 			$fulfillment->delete();
-
-			$fulfillment->set_date_deleted( current_time( 'mysql' ) );
-			$fulfillment->save();
 		} catch ( ApiException $ex ) {
 			return $this->prepare_error_response(
 				$ex->getErrorCode(),

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -7,6 +7,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Fulfillments;
 
+use Automattic\WooCommerce\Internal\Admin\Settings\Exceptions\ApiException;
 use Automattic\WooCommerce\Internal\RestApiControllerBase;
 use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
 use WC_Order;
@@ -257,6 +258,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			$fulfillment->set_entity_id( "$order_id" );
 
 			$fulfillment->save();
+		} catch ( ApiException $ex ) {
+			return $this->prepare_error_response(
+				$ex->getErrorCode(),
+				$ex->getMessage(),
+				WP_Http::BAD_REQUEST
+			);
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),
@@ -330,6 +337,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			}
 			$fulfillment->save();
 			$fulfillment->save_meta_data();
+		} catch ( ApiException $ex ) {
+			return $this->prepare_error_response(
+				$ex->getErrorCode(),
+				$ex->getMessage(),
+				WP_Http::BAD_REQUEST
+			);
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),
@@ -360,6 +373,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			$fulfillment = new Fulfillment( $fulfillment_id );
 			$this->validate_fulfillment( $fulfillment, $fulfillment_id, $order_id );
 			$fulfillment->delete();
+		} catch ( ApiException $ex ) {
+			return $this->prepare_error_response(
+				$ex->getErrorCode(),
+				$ex->getMessage(),
+				WP_Http::BAD_REQUEST
+			);
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),
@@ -436,6 +455,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 				}
 			}
 			$fulfillment->save();
+		} catch ( ApiException $ex ) {
+			return $this->prepare_error_response(
+				$ex->getErrorCode(),
+				$ex->getMessage(),
+				WP_Http::BAD_REQUEST
+			);
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),
@@ -470,6 +495,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 
 			$fulfillment->delete_meta_data( $request->get_param( 'meta_key' ) );
 			$fulfillment->save();
+		} catch ( ApiException $ex ) {
+			return $this->prepare_error_response(
+				$ex->getErrorCode(),
+				$ex->getMessage(),
+				WP_Http::BAD_REQUEST
+			);
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -422,10 +422,10 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 
 		if ( $fulfillment->get_is_fulfilled() && $notify_customer ) {
 			/**
-		 * Trigger the fulfillment deleted notification.
-		 *
-		 * @since 9.9.0
-		 */
+			 * Trigger the fulfillment deleted notification.
+			 *
+			 * @since 9.9.0
+			 */
 			do_action( 'woocommerce_fulfillment_deleted_notification', $order_id, $fulfillment, wc_get_order( $order_id ) );
 		}
 		return new WP_REST_Response(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -132,7 +132,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the fulfillment before create hook is called when creating a fulfillment with an error.
+	 * Create a test fulfillment to use in the tests.
 	 *
 	 * @param int $order_id The ID of the order to create a fulfillment for.
 	 *

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -1,0 +1,190 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\DataStores\Fulfillments;
+
+use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
+use Automattic\WooCommerce\Internal\Fulfillments\Fulfillment;
+use WC_Helper_Order;
+use WC_Order;
+use WC_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * Class OrderFulfillmentsRestControllerHookTest
+ *
+ * @package Automattic\WooCommerce\Tests\Internal\Fulfillments
+ */
+class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
+	/**
+	 * @var FulfillmentsDataStore
+	 */
+	private FulfillmentsDataStore $store;
+
+	/**
+	 * @var WC_Order
+	 */
+	private WC_Order $order;
+
+	/**
+	 * Setup test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->store = new FulfillmentsDataStore();
+		$this->order = WC_Helper_Order::create_order( get_current_user_id() );
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * This method is called after each test method is executed.
+	 * It is used to clean up any data created during the tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Remove any fulfillments added during the tests.
+		global $wpdb;
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_order_fulfillments;" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wc_order_fulfillment_meta;" );
+	}
+
+	/**
+	 * Test that the fulfillment before create hook is called when creating a fulfillment.
+	 */
+	public function test_fulfillment_before_create_hook_is_called() {
+		$hook_called = false;
+		add_filter(
+			'wc_fulfillment_before_create',
+			function ( $fulfillment ) use ( &$hook_called ) {
+				$hook_called = true;
+				return $fulfillment;
+			}
+		);
+
+		$this->store->create( $this->get_test_fulfillment( $this->order->get_id() ) );
+		$this->assertTrue( $hook_called, 'The fulfillment before create hook was not called.' );
+		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
+	}
+
+	/**
+	 * Test that the fulfillment before create hook can prevent creating a fulfillment.
+	 */
+	public function test_fulfillment_before_create_hook_can_interrupt() {
+		$hook_called = false;
+
+		add_filter(
+			'wc_fulfillment_before_create',
+			function () use ( &$hook_called ) {
+				$hook_called = true;
+				throw new \Exception( 'Fulfillment creation prevented by hook.' );
+			}
+		);
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Fulfillment creation prevented by hook.' );
+		$this->store->create( $this->get_test_fulfillment( $this->order->get_id() ) );
+
+		$this->assertTrue( $hook_called, 'The fulfillment before create hook was not called.' );
+
+		// Check that no fulfillment was created.
+		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$this->assertCount( 0, $fulfillments, 'Fulfillment was created.' );
+	}
+
+	/**
+	 * Test that the fulfillment after create hook is called when creating a fulfillment.
+	 */
+	public function test_fulfillment_after_create_hook_is_called() {
+		$hook_called = false;
+
+		add_action(
+			'wc_fulfillment_after_create',
+			function ( $fulfillment ) use ( &$hook_called, &$received_fulfillment ) {
+				$received_fulfillment = $fulfillment;
+				$hook_called          = true;
+				return $fulfillment;
+			},
+			10,
+			2
+		);
+
+		$this->store->create( $this->get_test_fulfillment( $this->order->get_id() ) );
+		$this->assertTrue( $hook_called, 'The fulfillment after create hook was not called.' );
+
+		// Compare the received fulfillment with the expected data.
+		$sent_data = $this->get_test_fulfillment_data( $this->order->get_id() );
+		$this->assertEquals( $received_fulfillment->get_entity_type(), $sent_data['entity_type'], );
+		$this->assertEquals( $received_fulfillment->get_entity_id(), $sent_data['entity_id'], );
+		$this->assertEquals( $received_fulfillment->get_status(), $sent_data['status'], );
+		$this->assertEquals( $received_fulfillment->get_is_fulfilled(), $sent_data['is_fulfilled'], );
+		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key' ), $sent_data['meta_data'][0]['value'] );
+		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key_2' ), $sent_data['meta_data'][1]['value'] );
+		$this->assertEquals( $received_fulfillment->get_items(), $sent_data['meta_data'][2]['value'] );
+		$this->assertNotNull( $received_fulfillment->get_id(), 'Fulfillment ID should not be null.' );
+		$this->assertGreaterThan( 0, $received_fulfillment->get_id(), 'Fulfillment ID should be greater than 0.' );
+
+		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
+	}
+
+	/**
+	 * Test that the fulfillment before create hook is called when creating a fulfillment with an error.
+	 *
+	 * @param int $order_id The ID of the order to create a fulfillment for.
+	 *
+	 * @return Fulfillment
+	 */
+	private function get_test_fulfillment( $order_id ): Fulfillment {
+		// Create a fulfillment for the order.
+		$test_data   = $this->get_test_fulfillment_data( $order_id );
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_props( $test_data );
+		$fulfillment->set_meta_data( $test_data['meta_data'] );
+		return $fulfillment;
+	}
+
+	/**
+	 * Get test fulfillment data.
+	 *
+	 * @param int $order_id The ID of the order to create a fulfillment for.
+	 * @return array
+	 */
+	private function get_test_fulfillment_data( $order_id ): array {
+		return array(
+			'entity_type'  => WC_Order::class,
+			'entity_id'    => $order_id,
+			'status'       => 'unfulfilled',
+			'is_fulfilled' => false,
+			'meta_data'    => array(
+				array(
+					'id'    => 0,
+					'key'   => 'test_meta_key',
+					'value' => 'test_meta_value',
+				),
+				array(
+					'id'    => 0,
+					'key'   => 'test_meta_key_2',
+					'value' => 'test_meta_value_2',
+				),
+				array(
+					'id'    => 0,
+					'key'   => '_items',
+					'value' => array(
+						array(
+							'item_id' => 1,
+							'qty'     => 2,
+						),
+						array(
+							'item_id' => 2,
+							'qty'     => 3,
+						),
+					),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds before and after fulfillment create hooks to `FulfillmentsDataStore`:

- new filter `wc_fulfillment_before_create`: Allows modification of the fulfillment before saving, or interrupting the fulfillment creation process with an exception. 
- new action `wc_fulfillment_after_create`: Notifies when a fulfillment is created. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4007 WOOPLUG-4008.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Changes should make sense, tests should pass.

#### Preparation

1. Checkout this branch
2. Rebuild assets with `npm run watch:build`
3. Run `composer dumpautoload` just in case the autoloader can't load a file.

#### Testing fulfillment modification 

1. Add a filter that modifies the fulfillment before save to your theme's _functions.php_ file (or any other place that will run the code): 

```php
add_filter( 'wc_fulfillment_before_create', function ( $fulfillment ) {
    $fulfillment->add_meta_data( 'dummy meta', 'test_create' );
    return $fulfillment;
} );
```

4. Try to create a fulfillment from the UI
5. It should show the new meta data on the fulfillment UI.

#### Testing fulfillment creation blocking

1. Remove the previous filter.
1. Add a filter that interrupts the creation of the fulfillment to your theme's _functions.php_ file (or any other place that will run the code): 

```php
add_filter( 'wc_fulfillment_before_create', function ( $fulfillment ) { 
    throw new FulfillmentException( 'This will show on the UI.' );
} );
```

2. Try to create a fulfillment from the UI
3. It should show the error on the fulfillment UI.

#### Testing fulfillment after create hook

1. Remove all previous filters.
2. Add this action to see if the hook works:

```php
add_action( 'wc_fulfillment_after_create', function ( $fulfillment ) {
   $fulfillment->add_meta_data('finished_creation', 'yes');
   $fulfillment->save();
} );
```

3. Create a fulfillment, and see if the meta is visible.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Add before create filter and after create action for fulfillments.
</details>
