### PR TITLE
Add missing classes used by some express payment methods to the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-58806-add-to-cart-with-options-express-payment-methods-classes
+++ b/plugins/woocommerce/changelog/fix-58806-add-to-cart-with-options-express-payment-methods-classes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add missing classes used by some express payment methods to the Add to Cart + Options block
+
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -454,8 +454,13 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			// These hidden inputs are used by extensions or Express Payment methods to gather information of the form state.
 			$hidden_input = '';
-			if ( ProductType::VARIABLE === $product_type ) {
+			if ( ProductType::SIMPLE === $product_type ) {
+				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+			} elseif ( ProductType::GROUPED === $product_type ) {
+				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+			} elseif ( ProductType::VARIABLE === $product_type ) {
 				$hidden_input = '<div class="single_variation_wrap">
+					<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />
 					<input type="hidden" name="product_id" value="' . $product->get_id() . '" />
 					<input type="hidden"
 						name="variation_id"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -111,14 +111,14 @@ class AddToCartWithOptions extends AbstractBlock {
 	protected function render( $attributes, $content, $block ) {
 		global $product;
 
-		$post_id = $block->context['postId'];
+		$product_id = $block->context['postId'];
 
-		if ( ! isset( $post_id ) ) {
+		if ( ! isset( $product_id ) ) {
 			return '';
 		}
 
 		$previous_product = $product;
-		$product          = wc_get_product( $post_id );
+		$product          = wc_get_product( $product_id );
 		if ( ! $product instanceof \WC_Product ) {
 			$product = $previous_product;
 
@@ -455,13 +455,13 @@ class AddToCartWithOptions extends AbstractBlock {
 			// These hidden inputs are used by extensions or Express Payment methods to gather information of the form state.
 			$hidden_input = '';
 			if ( ProductType::SIMPLE === $product_type ) {
-				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . esc_attr( $product_id ) . '" />';
 			} elseif ( ProductType::GROUPED === $product_type ) {
-				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
+				$hidden_input = '<input type="hidden" name="add-to-cart" value="' . esc_attr( $product_id ) . '" />';
 			} elseif ( ProductType::VARIABLE === $product_type ) {
 				$hidden_input = '<div class="single_variation_wrap">
-					<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />
-					<input type="hidden" name="product_id" value="' . $product->get_id() . '" />
+					<input type="hidden" name="add-to-cart" value="' . esc_attr( $product_id ) . '" />
+					<input type="hidden" name="product_id" value="' . esc_attr( $product_id ) . '" />
 					<input type="hidden"
 						name="variation_id"
 						data-wp-interactive="woocommerce/add-to-cart-with-options"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -426,7 +426,6 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			$cart_redirect_after_add = get_option( 'woocommerce_cart_redirect_after_add' );
 			$form_attributes         = '';
-			$hidden_input            = '';
 			$legacy_mode             = $hooks_before || $hooks_after || 'yes' === $cart_redirect_after_add;
 			if ( $legacy_mode ) {
 				// If an extension is hoooking into the form or we need to redirect to the cart,
@@ -446,20 +445,24 @@ class AddToCartWithOptions extends AbstractBlock {
 					'enctype' => 'multipart/form-data',
 					'class'   => 'cart',
 				);
-				if ( ProductType::SIMPLE === $product_type ) {
-					$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
-				} elseif ( ProductType::GROUPED === $product_type ) {
-					$hidden_input = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
-				} elseif ( ProductType::VARIABLE === $product_type ) {
-					$hidden_input  = '<input type="hidden" name="add-to-cart" value="' . $product->get_id() . '" />';
-					$hidden_input .= '<input type="hidden" name="product_id" value="' . $product->get_id() . '" />';
-					$hidden_input .= '<input type="hidden" name="variation_id" data-wp-interactive="woocommerce/add-to-cart-with-options" data-wp-bind--value="state.variationId" />';
-				}
 			} else {
 				// Otherwise, we use the Interactivity API.
 				$form_attributes = array(
 					'data-wp-on--submit' => 'actions.handleSubmit',
 				);
+			}
+
+			// These hidden inputs are used by extensions or Express Payment methods to gather information of the form state.
+			$hidden_input = '';
+			if ( ProductType::VARIABLE === $product_type ) {
+				$hidden_input = '<div class="single_variation_wrap">
+					<input type="hidden" name="product_id" value="' . $product->get_id() . '" />
+					<input type="hidden"
+						name="variation_id"
+						data-wp-interactive="woocommerce/add-to-cart-with-options"
+						data-wp-bind--value="state.variationId"
+					/>
+				</div>';
 			}
 
 			$form_html = sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -220,7 +220,7 @@ class ProductButton extends AbstractBlock {
 		';
 
 		$button_directives = $is_descendant_of_add_to_cart_form ?
-			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid" data-wp-class--wc-variation-is-unavailable="woocommerce/add-to-cart-with-options::!state.isFormValid"' :
+			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid"' :
 			'data-wp-on--click="actions.addCartItem"';
 		$anchor_directive  = $is_descendant_of_add_to_cart_form ? '' : 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -219,7 +219,9 @@ class ProductButton extends AbstractBlock {
 			data-wp-init="actions.refreshCartItems"
 		';
 
-		$button_directives = $is_descendant_of_add_to_cart_form ? '' : 'data-wp-on--click="actions.addCartItem"';
+		$button_directives = $is_descendant_of_add_to_cart_form ?
+			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid" data-wp-class--wc-variation-is-unavailable="woocommerce/add-to-cart-with-options::!state.isFormValid"' :
+			'data-wp-on--click="actions.addCartItem"';
 		$anchor_directive  = $is_descendant_of_add_to_cart_form ? '' : 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"';
 
 		$span_button_directives = '
@@ -245,6 +247,12 @@ class ProductButton extends AbstractBlock {
 				),
 			)
 		);
+
+		$button_classes = isset( $args['class'] ) ? esc_attr( $args['class'] . ' wc-interactive' ) : 'wc-interactive';
+		if ( $is_descendant_of_add_to_cart_form ) {
+			$button_classes             .= ' single_add_to_cart_button';
+			$args['attributes']['value'] = $product->get_id();
+		}
 
 		/**
 		 * Filters the add to cart button class.
@@ -272,7 +280,7 @@ class ProductButton extends AbstractBlock {
 				array(
 					'{wrapper_attributes}'     => $wrapper_attributes,
 					'{html_element}'           => $html_element,
-					'{button_classes}'         => isset( $args['class'] ) ? esc_attr( $args['class'] . ' wc-interactive' ) : 'wc-interactive',
+					'{button_classes}'         => $button_classes,
 					'{button_styles}'          => esc_attr( $styles_and_classes['styles'] ),
 					'{attributes}'             => isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
 					'{add_to_cart_text}'       => $is_ajax_button ? '' : $add_to_cart_text,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the Add to Cart + Options block with some additional classes and markup to make it more compatible with some express payment methods that depend on a certain HTML structure.

For now, it only works in simple products. Supporting variable products is a bit trickier because we have the _Pills_ style, which is completely different from the dropdowns. We might need payment methods to update their integrations, but I will investigate it further.

Part of #58806.
Part of WOOPLUG-4625.

### How to test the changes in this Pull Request:

1. Install a payment gateway that supports express payment methods. [WooCommerce Stripe Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/) is an easy one to test.
2. Enable it in test mode and go to the frontend of your store.
3. Try purchasing a simple product with the express payment button. Verify it opens a popup for you to pay with the correct price.

https://github.com/user-attachments/assets/e923cc69-01bf-419c-9e75-2a1a2b005e49

4. Install [WooCommerce Product Add-Ons](https://woocommerce.com/products/product-add-ons/), add some add-ons to a simple product and do some smoke testing to make sure you can still add them to the cart (and add-ons are added to cart as expected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where certain express payment methods were missing required classes in the Add to Cart with Options block, ensuring better compatibility and functionality.
	- Improved handling of hidden form inputs for all product types, ensuring necessary information is always available for payment extensions and express checkout options.
	- Enhanced button rendering in product blocks, providing more consistent styling and behavior within add-to-cart forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->