### PR TITLE
Add filter to disable inline css for custom html email templates to resolve Emogrifier styling issues.

### DIFF
--- a/plugins/woocommerce/changelog/2025-08-12-18-31-11-054449
+++ b/plugins/woocommerce/changelog/2025-08-12-18-31-11-054449
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow the ability to override the method used to apply inline styles to html emails dynamic content.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -803,7 +803,7 @@ class WC_Email extends WC_Settings_API {
 	 *
 	 * We only inline CSS for html emails.
 	 *
-	 * @version 4.0.0
+	 * @version 10.2.0
 	 * @param string|null $content Content that will receive inline styles.
 	 * @return string
 	 */
@@ -812,7 +812,7 @@ class WC_Email extends WC_Settings_API {
 			/**
 			 * Filter to allow the ability to override the email inline styling method.
 			 *
-			 * @since x.x.x
+			 * @since 10.2.0
 			 *
 			 * @param callable $style_inline_callback The default email inline styling callback.
 			 * @param string|null $content Content that will receive inline styles.
@@ -834,7 +834,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Apply inline styles to dynamic content using Emogrifier library (if supported).
 	 *
-	 * @since x.x.x
+	 * @since 10.2.0
 	 * @param string|null $content Content that will receive inline styles.
 	 * @return string
 	 */

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -801,7 +801,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Apply inline styles to dynamic content.
 	 *
-	 * We only inline CSS for html emails, and to do so we use Emogrifier library (if supported).
+	 * We only inline CSS for html emails.
 	 *
 	 * @version 4.0.0
 	 * @param string|null $content Content that will receive inline styles.
@@ -832,9 +832,7 @@ class WC_Email extends WC_Settings_API {
 
 
 	/**
-	 * Apply inline styles to dynamic content.
-	 *
-	 * We only inline CSS for html emails, and to do so we use Emogrifier library (if supported).
+	 * Apply inline styles to dynamic content using Emogrifier library (if supported).
 	 *
 	 * @since x.x.x
 	 * @param string|null $content Content that will receive inline styles.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -863,7 +863,7 @@ class WC_Email extends WC_Settings_API {
 			try {
 				$css_inliner = CssInliner::fromHtml( $content )->inlineCss( $css );
 
-				do_action( 'woocommerce_emogrifier', $css_inliner, $this );
+				do_action( 'woocommerce_emogrifier', $css_inliner, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 				$dom_document = $css_inliner->getDomDocument();
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -863,7 +863,15 @@ class WC_Email extends WC_Settings_API {
 			try {
 				$css_inliner = CssInliner::fromHtml( $content )->inlineCss( $css );
 
-				do_action( 'woocommerce_emogrifier', $css_inliner, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				/**
+				 * Action hook fired when an email content has been processed by Emogrifier CssInliner instance.
+				 *
+				 * @since 4.1.0
+				 *
+				 * @param CssInliner $css_inliner CssInliner instance.
+				 * @param WC_Email $this WC_Email instance.
+				 */
+				do_action( 'woocommerce_emogrifier', $css_inliner, $this );
 
 				$dom_document = $css_inliner->getDomDocument();
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -809,49 +809,80 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function style_inline( $content ) {
 		if ( in_array( $this->get_content_type(), array( 'text/html', 'multipart/alternative' ), true ) ) {
-			$css  = '';
-			$css .= $this->get_must_use_css_styles();
-			$css .= "\n";
-
-			ob_start();
-			wc_get_template( 'emails/email-styles.php' );
-			$css .= ob_get_clean();
-
 			/**
-			 * Provides an opportunity to filter the CSS styles included in e-mails.
+			 * Filter to allow the ability to override the email inline styling method.
 			 *
-			 * @since 2.3.0
+			 * @since x.x.x
 			 *
-			 * @param string    $css   CSS code.
-			 * @param \WC_Email $email E-mail instance.
+			 * @param callable $style_inline_callback The default email inline styling callback.
+			 * @param string|null $content Content that will receive inline styles.
+			 * @param WC_Email $this The WC_Email object.
 			 */
-			$css = apply_filters( 'woocommerce_email_styles', $css, $this );
+			$style_inline_callback = apply_filters( 'woocommerce_mail_style_inline_callback', array( $this, 'apply_inline_style' ), $content, $this );
 
-			$css_inliner_class = CssInliner::class;
-
-			if ( $this->supports_emogrifier() && class_exists( $css_inliner_class ) ) {
-				try {
-					$css_inliner = CssInliner::fromHtml( $content )->inlineCss( $css );
-
-					do_action( 'woocommerce_emogrifier', $css_inliner, $this );
-
-					$dom_document = $css_inliner->getDomDocument();
-
-					// When the email is rendered in the block editor, we don't want to remove the elements with display: none.
-					// The main reason is using preview text in the email body which is hidden by default.
-					if ( ! $this->block_email_editor_enabled ) {
-						HtmlPruner::fromDomDocument( $dom_document )->removeElementsWithDisplayNone();
-					}
-					$content = CssToAttributeConverter::fromDomDocument( $dom_document )
-						->convertCssToVisualAttributes()
-						->render();
-				} catch ( Exception $e ) {
-					$logger = wc_get_logger();
-					$logger->error( $e->getMessage(), array( 'source' => 'emogrifier' ) );
-				}
-			} else {
-				$content = '<style type="text/css">' . $css . '</style>' . $content;
+			if ( ! is_callable( $style_inline_callback ) ) {
+				$style_inline_callback = array( $this, 'apply_inline_style' );
 			}
+
+			return call_user_func( $style_inline_callback, $content );
+		}
+
+		return $content;
+	}
+
+
+	/**
+	 * Apply inline styles to dynamic content.
+	 *
+	 * We only inline CSS for html emails, and to do so we use Emogrifier library (if supported).
+	 *
+	 * @since x.x.x
+	 * @param string|null $content Content that will receive inline styles.
+	 * @return string
+	 */
+	private function apply_inline_style( $content ) {
+		$css  = '';
+		$css .= $this->get_must_use_css_styles();
+		$css .= "\n";
+
+		ob_start();
+		wc_get_template( 'emails/email-styles.php' );
+		$css .= ob_get_clean();
+
+		/**
+		 * Provides an opportunity to filter the CSS styles included in e-mails.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param string    $css   CSS code.
+		 * @param \WC_Email $email E-mail instance.
+		 */
+		$css = apply_filters( 'woocommerce_email_styles', $css, $this );
+
+		$css_inliner_class = CssInliner::class;
+
+		if ( $this->supports_emogrifier() && class_exists( $css_inliner_class ) ) {
+			try {
+				$css_inliner = CssInliner::fromHtml( $content )->inlineCss( $css );
+
+				do_action( 'woocommerce_emogrifier', $css_inliner, $this );
+
+				$dom_document = $css_inliner->getDomDocument();
+
+				// When the email is rendered in the block editor, we don't want to remove the elements with display: none.
+				// The main reason is using preview text in the email body which is hidden by default.
+				if ( ! $this->block_email_editor_enabled ) {
+					HtmlPruner::fromDomDocument( $dom_document )->removeElementsWithDisplayNone();
+				}
+				$content = CssToAttributeConverter::fromDomDocument( $dom_document )
+					->convertCssToVisualAttributes()
+					->render();
+			} catch ( Exception $e ) {
+				$logger = wc_get_logger();
+				$logger->error( $e->getMessage(), array( 'source' => 'emogrifier' ) );
+			}
+		} else {
+			$content = '<style type="text/css">' . $css . '</style>' . $content;
 		}
 
 		return $content;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**This PR introduces a new filter `woocommerce_email_style_inline`, allowing developers to selectively disable WooCommerce's automatic inline CSS styling for specific email templates.**

By default, WooCommerce uses the Emogrifier library in the `style_inline( $content )` method to inline styles for HTML emails. However, this behavior can be problematic when using custom-built responsive email templates:

- **Emogrifier** strips out <style> tags placed in the <head> of custom templates, breaking responsive layouts.

- Since our html email templates are already styled and optimized, running them through Emogrifier introduces unnecessary processing and causes layout issues.

- Disabling Emogrifier for such templates helps preserve intended styles and improves performance.

This filter give us control to opt out of the inline style process for specific emails, making it safer and more efficient to use custom HTML templates in WooCommerce emails.



### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

With inline styles.
<!-- Before -->
https://github.com/user-attachments/assets/1d6bb8e3-bdfc-452f-b9ce-6b02eb720d21 

Without inline styles.
<!-- After -->
https://github.com/user-attachments/assets/9a48ea63-9d8f-4971-bf93-2929bdbc2e3f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for external plugins or custom code to dynamically enable or disable inline CSS styling in WooCommerce emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->