### PR TITLE
wc_delete_product_transients: Restrict to write contexts

### DIFF
--- a/plugins/woocommerce/changelog/wc_delete_product_transients-restrict
+++ b/plugins/woocommerce/changelog/wc_delete_product_transients-restrict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Prevent performance issues by restricting product transient deletion to appropriate write contexts only

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -158,7 +158,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		/**
 		* Last‑chance filter. Return `true` to allow, `false` to block.
 		*
-		* @since 9.10.0
+		* @since 10.1.0
 		* @param bool $is_write_context Result of WooCommerce’s own context test.
 		* @param int  $post_id          Product ID for which the flush was requested.
 		*/

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -130,17 +130,27 @@ function wc_product_dimensions_enabled() {
  * @param bool $force               Force execution even if context check fails (default false).
  */
 function wc_delete_product_transients( $post_id = 0, $force = false ) {
+	$is_cli_or_cron = wp_doing_cron()
+		|| ( defined( 'WP_CLI' ) && WP_CLI );
+
+	$is_rest_write  = defined( 'REST_REQUEST' ) && REST_REQUEST
+		&& isset( $_SERVER['REQUEST_METHOD'] )
+		&& in_array( $_SERVER['REQUEST_METHOD'], [ 'POST', 'PUT', 'PATCH', 'DELETE' ], true );
+
+	$is_admin_page  = is_admin() && ! wp_doing_ajax();  // wp‑admin screens.
+
+	// Allow admin-ajax.php, but only from editors or shop managers. This stops regular tracking requests like platform_tracks from queuing jobs.
+	$is_privileged_ajax =
+		defined( 'DOING_AJAX' ) && DOING_AJAX
+		&& current_user_can( 'edit_products' );
+
 	$is_write_context = (
-		is_admin()
-		|| wp_doing_cron()
-		|| ( defined( 'WP_CLI' ) && WP_CLI )
-		|| (
-			defined( 'REST_REQUEST' )            // REST route *AND* method is mutating.
-			&& REST_REQUEST
-			&& isset( $_SERVER['REQUEST_METHOD'] )
-			&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true )
-		)
+		   $is_cli_or_cron
+		|| $is_rest_write
+		|| $is_admin_page
+		|| $is_privileged_ajax
 	);
+
 	/**
 	 * Last‑chance filter. Return `true` to allow, `false` to block.
 	 *

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -174,7 +174,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 				'wc_delete_product_transients() must not be called during normal front‑end rendering. It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
 				'woocommerce'
 			),
-			'9.10.0'
+			'10.1.0'
 		);
 		return;
 	}

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -122,9 +122,51 @@ function wc_product_dimensions_enabled() {
 /**
  * Clear transient cache for product data.
  *
+ * IMPORTANT: This MUST be called only when product data is *mutated*.
+ * Calling it on read/display code paths can create unbounded action‑scheduler
+ * rows and DOS the site.
+ *
+ *
  * @param int $post_id (default: 0) The product ID.
+ * @param bool $force               Force execution even if context check fails (default false).
  */
-function wc_delete_product_transients( $post_id = 0 ) {
+function wc_delete_product_transients( $post_id = 0, $force = false ) {
+	$is_write_context = (
+		is_admin()
+		|| wp_doing_cron()
+		|| ( defined( 'WP_CLI' ) && WP_CLI )
+		|| (
+			defined( 'REST_REQUEST' )            // REST route *AND* method is mutating
+			&& REST_REQUEST
+			&& isset( $_SERVER['REQUEST_METHOD'] )
+			&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true )
+		)
+	);
+	/**
+	 * Last‑chance filter. Return `true` to allow, `false` to block.
+	 *
+	 * @param bool $is_write_context Result of WooCommerce’s own context test.
+	 * @param int  $post_id          Product ID for which the flush was requested.
+	 */
+	$is_write_context = apply_filters(
+		'woocommerce_allow_product_transient_deletion',
+		$is_write_context,
+		$post_id
+	);
+
+	if ( ! $is_write_context && ! $force ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			esc_html__(
+				'wc_delete_product_transients() must not be called during normal front‑end rendering. ' .
+				'It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
+				'woocommerce'
+			),
+			'9.10.0'
+		);
+		return;
+	}
+
 	// Transient data to clear with a fixed name which may be stale after product updates.
 	$transients_to_clear = array(
 		'wc_products_onsale',

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -126,7 +126,6 @@ function wc_product_dimensions_enabled() {
  * Calling it on read/display code paths can create unbounded action‑scheduler
  * rows and DOS the site.
  *
- *
  * @param int $post_id (default: 0) The product ID.
  * @param bool $force               Force execution even if context check fails (default false).
  */
@@ -136,7 +135,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		|| wp_doing_cron()
 		|| ( defined( 'WP_CLI' ) && WP_CLI )
 		|| (
-			defined( 'REST_REQUEST' )            // REST route *AND* method is mutating
+			defined( 'REST_REQUEST' )            // REST route *AND* method is mutating.
 			&& REST_REQUEST
 			&& isset( $_SERVER['REQUEST_METHOD'] )
 			&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true )
@@ -145,6 +144,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 	/**
 	 * Last‑chance filter. Return `true` to allow, `false` to block.
 	 *
+	 * @since 9.10.0
 	 * @param bool $is_write_context Result of WooCommerce’s own context test.
 	 * @param int  $post_id          Product ID for which the flush was requested.
 	 */

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -144,7 +144,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		defined( 'DOING_AJAX' ) && DOING_AJAX
 		&& current_user_can( 'edit_products' );
 
-	$is_unit_test = defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS;
+	$is_unit_test = class_exists( 'WC_Unit_Test_Case' );
 
 	$is_write_context = (
 		$is_cli_or_cron

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -126,18 +126,18 @@ function wc_product_dimensions_enabled() {
  * Calling it on read/display code paths can create unbounded action‑scheduler
  * rows and DOS the site.
  *
- * @param int $post_id (default: 0) The product ID.
+ * @param int  $post_id (default: 0) The product ID.
  * @param bool $force               Force execution even if context check fails (default false).
  */
 function wc_delete_product_transients( $post_id = 0, $force = false ) {
 	$is_cli_or_cron = wp_doing_cron()
 		|| ( defined( 'WP_CLI' ) && WP_CLI );
 
-	$is_rest_write  = defined( 'REST_REQUEST' ) && REST_REQUEST
+	$is_rest_write = defined( 'REST_REQUEST' ) && REST_REQUEST
 		&& isset( $_SERVER['REQUEST_METHOD'] )
-		&& in_array( $_SERVER['REQUEST_METHOD'], [ 'POST', 'PUT', 'PATCH', 'DELETE' ], true );
+		&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
 
-	$is_admin_page  = is_admin() && ! wp_doing_ajax();  // wp‑admin screens.
+	$is_admin_page = is_admin() && ! wp_doing_ajax();  // wp‑admin screens.
 
 	// Allow admin-ajax.php, but only from editors or shop managers. This stops regular tracking requests like platform_tracks from queuing jobs.
 	$is_privileged_ajax =
@@ -145,7 +145,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		&& current_user_can( 'edit_products' );
 
 	$is_write_context = (
-		   $is_cli_or_cron
+		$is_cli_or_cron
 		|| $is_rest_write
 		|| $is_admin_page
 		|| $is_privileged_ajax
@@ -168,8 +168,7 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			esc_html__(
-				'wc_delete_product_transients() must not be called during normal front‑end rendering. ' .
-				'It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
+				'wc_delete_product_transients() must not be called during normal front‑end rendering. It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
 				'woocommerce'
 			),
 			'9.10.0'

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -144,11 +144,14 @@ function wc_delete_product_transients( $post_id = 0, $force = false ) {
 		defined( 'DOING_AJAX' ) && DOING_AJAX
 		&& current_user_can( 'edit_products' );
 
+	$is_unit_test = defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS;
+
 	$is_write_context = (
 		$is_cli_or_cron
 		|| $is_rest_write
 		|| $is_admin_page
 		|| $is_privileged_ajax
+		|| $is_unit_test
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -130,53 +130,55 @@ function wc_product_dimensions_enabled() {
  * @param bool $force               Force execution even if context check fails (default false).
  */
 function wc_delete_product_transients( $post_id = 0, $force = false ) {
-	$is_cli_or_cron = wp_doing_cron()
-		|| ( defined( 'WP_CLI' ) && WP_CLI );
+	if ( ! $force ) {
+		$is_cli_or_cron = wp_doing_cron()
+			|| ( defined( 'WP_CLI' ) && WP_CLI );
 
-	$is_rest_write = defined( 'REST_REQUEST' ) && REST_REQUEST
-		&& isset( $_SERVER['REQUEST_METHOD'] )
-		&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
+		$is_rest_write = defined( 'REST_REQUEST' ) && REST_REQUEST
+			&& isset( $_SERVER['REQUEST_METHOD'] )
+			&& in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'PATCH', 'DELETE' ), true );
 
-	$is_admin_page = is_admin() && ! wp_doing_ajax();  // wp‑admin screens.
+		$is_admin_page = is_admin() && ! wp_doing_ajax();  // wp‑admin screens.
 
-	// Allow admin-ajax.php, but only from editors or shop managers. This stops regular tracking requests like platform_tracks from queuing jobs.
-	$is_privileged_ajax =
-		defined( 'DOING_AJAX' ) && DOING_AJAX
-		&& current_user_can( 'edit_products' );
+		// Allow admin-ajax.php, but only from editors or shop managers. This stops regular tracking requests like platform_tracks from queuing jobs.
+		$is_privileged_ajax =
+			defined( 'DOING_AJAX' ) && DOING_AJAX
+			&& current_user_can( 'edit_products' );
 
-	$is_unit_test = class_exists( 'WC_Unit_Test_Case' );
+		$is_unit_test = class_exists( 'WC_Unit_Test_Case' );
 
-	$is_write_context = (
-		$is_cli_or_cron
-		|| $is_rest_write
-		|| $is_admin_page
-		|| $is_privileged_ajax
-		|| $is_unit_test
-	);
-
-	/**
-	 * Last‑chance filter. Return `true` to allow, `false` to block.
-	 *
-	 * @since 9.10.0
-	 * @param bool $is_write_context Result of WooCommerce’s own context test.
-	 * @param int  $post_id          Product ID for which the flush was requested.
-	 */
-	$is_write_context = apply_filters(
-		'woocommerce_allow_product_transient_deletion',
-		$is_write_context,
-		$post_id
-	);
-
-	if ( ! $is_write_context && ! $force ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			esc_html__(
-				'wc_delete_product_transients() must not be called during normal front‑end rendering. It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
-				'woocommerce'
-			),
-			'10.1.0'
+		$is_write_context = (
+			$is_cli_or_cron
+			|| $is_rest_write
+			|| $is_admin_page
+			|| $is_privileged_ajax
+			|| $is_unit_test
 		);
-		return;
+
+		/**
+		* Last‑chance filter. Return `true` to allow, `false` to block.
+		*
+		* @since 9.10.0
+		* @param bool $is_write_context Result of WooCommerce’s own context test.
+		* @param int  $post_id          Product ID for which the flush was requested.
+		*/
+		$is_write_context = apply_filters(
+			'woocommerce_allow_product_transient_deletion',
+			$is_write_context,
+			$post_id
+		);
+
+		if ( ! $is_write_context ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				esc_html__(
+					'wc_delete_product_transients() must not be called during normal front‑end rendering. It is intended only for code paths that alter product data (admin, REST writes, CLI, cron).',
+					'woocommerce'
+				),
+				'10.1.0'
+			);
+			return;
+		}
 	}
 
 	// Transient data to clear with a fixed name which may be stale after product updates.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Change `wc_delete_product_transients()` to do no work if this is executed on the front-end of the site. This is a defensive programming technique meant to limit the impact of 3rd party plugins calling this function incorrectly.

The issue is that some plugins call `wc_delete_product_transients()` on the display layer. This can lead to a constant churn of async jobs being scheduled. On one client site, we saw millions of actionscheduler rows for this job. It seems that as soon as the job finishes for a product variation, the next front-end view queues another job for the same product.

### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
|        |       |



### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product with some variations.
2. Install the `currency-switcher-for-woocommerce.zip` plugin (note: Paid plugin).
3. Visit the front-end of the site, specifically one of the product pages:

See that one front-end visit can trigger many different delete transient jobs, especially when related products are set to display:
<img width="1414" alt="Screenshot 2025-06-13 at 2 43 33 PM" src="https://github.com/user-attachments/assets/f7df4e40-99e6-4685-abca-44e37f8583be" />

4. Wait for those jobs to complete, then revisit the front-end page. Note that a batch of jobs is re-queued.
5. Now apply the changes here and notice that visiting the front-end does not queue up new jobs (or at least queues up significantly fewer jobs).


### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>