### PR TITLE
Pause rollout of email improvements to existing stores

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4632-stop-automatically-opting-in-existing-stores-on-update
+++ b/plugins/woocommerce/changelog/wooplug-4632-stop-automatically-opting-in-existing-stores-on-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Pause rollout of email improvements to existing stores

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 */
 		public function get_default_subject() {
 			return $this->email_improvements_enabled
-				? __( '[{site_title}]: Cha-ching! You\'ve got a new order: #{order_number}', 'woocommerce' )
+				? __( '[{site_title}]: You\'ve got a new order: #{order_number}', 'woocommerce' )
 				: __( '[{site_title}]: New order #{order_number}', 'woocommerce' );
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailImprovements/EmailImprovements.php
@@ -118,7 +118,8 @@ class EmailImprovements {
 		if ( self::is_email_customizer_enabled() ) {
 			return false;
 		}
-		return true;
+		// Temporarily paused roll-out to gather more feedback.
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/templates/emails/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/admin-new-order.php
@@ -32,7 +32,7 @@ echo $email_improvements_enabled ? '<div class="email-introduction">' : '';
 $text = __( 'You’ve received the following order from %s:', 'woocommerce' );
 if ( $email_improvements_enabled ) {
 	/* translators: %s: Customer billing full name */
-	$text = __( 'Woo! You’ve received a new order from %s:', 'woocommerce' );
+	$text = __( 'You’ve received a new order from %s:', 'woocommerce' );
 }
 ?>
 <p><?php printf( esc_html( $text ), esc_html( $order->get_formatted_billing_full_name() ) ); ?></p>

--- a/plugins/woocommerce/templates/emails/block/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-new-order.php
@@ -33,7 +33,7 @@ printf( esc_html__( 'New order: #%s,', 'woocommerce' ), '<!--[woocommerce/order-
 <p>
 <?php
 /* translators: %s: Customer full name */
-printf( esc_html__( 'Woo! You’ve received a new order from %s', 'woocommerce' ), '<!--[woocommerce/customer-full-name]-->' );
+printf( esc_html__( 'You’ve received a new order from %s', 'woocommerce' ), '<!--[woocommerce/customer-full-name]-->' );
 ?>
 </p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/plain/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/plain/admin-new-order.php
@@ -29,7 +29,7 @@ echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 $text = __( 'You’ve received the following order from %s:', 'woocommerce' );
 if ( $email_improvements_enabled ) {
 	/* translators: %s: Customer billing full name */
-	$text = __( 'Woo! You’ve received a new order from %s:', 'woocommerce' );
+	$text = __( 'You’ve received a new order from %s:', 'woocommerce' );
 }
 echo sprintf( esc_html( $text ), esc_html( $order->get_formatted_billing_full_name() ) ) . "\n\n";
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Directly related to https://github.com/woocommerce/woocommerce/pull/57896, we're pausing the roll-out process, so the existing stores are not automatically opted-in, but they'll continue to see inbox note and modal on the dashboard inviting them to try them out.

We also removed `Cha-ching!` and `Woo!` from new emails, which some folks really disliked.

Note that failing linting job is unrelated to this PR - I asked in Slack (p1749990317017409-slack-C01DT6U03HC).

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4606, closes WOOPLUG-4631, closes WOOPLUG-4632, closes #58827, closes #58826.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the testing instruction in https://github.com/woocommerce/woocommerce/pull/57896. 
2. The change in this PR is, that website `ii.` should not have the feature auto-enabled, and should act the same as `iii.`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->