### PR TITLE
Fix: Ensure usePages includes hooks added before hookAdded action registration

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4634-race-condition-hooks-added-after-pages-initialization-but
+++ b/plugins/woocommerce/changelog/wooplug-4634-race-condition-hooks-added-after-pages-initialization-but
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure usePages includes hooks added before hookAdded action registration

--- a/plugins/woocommerce/client/admin/client/layout/controller.js
+++ b/plugins/woocommerce/client/admin/client/layout/controller.js
@@ -374,6 +374,9 @@ export function usePages() {
 		const namespace = `woocommerce/woocommerce/watch_${ PAGES_FILTER }`;
 		addAction( 'hookAdded', namespace, handleHookAdded );
 
+		// Refresh pages to catch any hooks added between initial getPages and this effect
+		setPages( getPages() );
+
 		return () => {
 			removeAction( 'hookAdded', namespace );
 		};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

While reviewing PR https://github.com/woocommerce/woocommerce-analytics/pull/1008, I occasionally encounter an Access denied error message when attempting to access the dev page. I found that it's because the page filter is added after the initial `getPages()` call but before the `hookAdded` action registration, which causes a race condition and prevents the page from being available.

<img width="784" alt="Screenshot 2025-06-16 at 11 33 06" src="https://github.com/user-attachments/assets/ed02b762-464a-4c01-b368-6bad1a149c70" />

This PR fixes a timing issue by refreshing the pages immediately after registering the `"hookAdded"` action to ensure all hooks are included.

Closes WOOPLUG-4634


### How to test the changes in this Pull Request:

1. Add a hook to `woocommerce_admin_pages_list` after the initial render but before the effect in `usePages` runs.
2. Verify that the new page is included in the pages state after the effect runs.


Optionally, you can test PR[ #1008](https://github.com/woocommerce/woocommerce-analytics/pull/1008) using this branch to verify consistent access to the WA dev page.

### Testing that has already taken place:

- Manual verification of the timing scenario.


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message <!-- Add a changelog message here -->

Fix: Ensure usePages includes hooks added before hookAdded action registration

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where some page-related hooks might not have been recognized if added before initialization, ensuring all relevant hooks are consistently included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->