### PR TITLE
Fix regressions in Product Price block class names

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-product-price-classes
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-product-price-classes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix regressions in Product Price block class names
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/frontend.ts
@@ -50,20 +50,12 @@ const productPriceStore = store(
 					return;
 				}
 
-				const priceWrapper = element.ref.querySelector(
-					'.wc-block-components-product-price'
-				);
-
-				if ( ! priceWrapper ) {
-					return;
-				}
-
 				const newPriceHTML =
 					productDataState?.productData?.price_html ||
 					productDataState?.originalProductData?.price_html;
 
 				if ( newPriceHTML ) {
-					priceWrapper.innerHTML = sanitize( newPriceHTML, {
+					element.ref.innerHTML = sanitize( newPriceHTML, {
 						ALLOWED_TAGS,
 						ALLOWED_ATTR,
 					} );

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/price/frontend.ts
@@ -50,12 +50,20 @@ const productPriceStore = store(
 					return;
 				}
 
+				const priceWrapper = element.ref.querySelector(
+					'.wc-block-components-product-price'
+				);
+
+				if ( ! priceWrapper ) {
+					return;
+				}
+
 				const newPriceHTML =
 					productDataState?.productData?.price_html ||
 					productDataState?.originalProductData?.price_html;
 
 				if ( newPriceHTML ) {
-					element.ref.innerHTML = sanitize( newPriceHTML, {
+					priceWrapper.innerHTML = sanitize( newPriceHTML, {
 						ALLOWED_TAGS,
 						ALLOWED_ATTR,
 					} );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -79,9 +79,7 @@ class ProductPrice extends AbstractBlock {
 			$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
 			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( 'variable' );
 
-			$wrapper_attributes = array(
-				'class' => 'wp-block-woocommerce-product-price',
-			);
+			$wrapper_attributes = array();
 
 			if ( $is_interactive ) {
 				wp_enqueue_script_module( 'woocommerce/product-price' );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -80,21 +80,23 @@ class ProductPrice extends AbstractBlock {
 			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( 'variable' );
 
 			$wrapper_attributes = array();
+			$watch_attribute    = '';
 
 			if ( $is_interactive ) {
 				wp_enqueue_script_module( 'woocommerce/product-price' );
 				$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-price';
-				$wrapper_attributes['data-wp-watch']       = 'callbacks.updatePrice';
+				$watch_attribute                           = 'data-wp-watch="callbacks.updatePrice"';
 			}
 
 			return sprintf(
-				'<div %1$s><div class="wc-block-components-product-price wc-block-grid__product-price %2$s %3$s" style="%4$s">
-					%5$s
+				'<div %1$s><div class="wc-block-components-product-price wc-block-grid__product-price %2$s %3$s" style="%4$s" %5$s>
+					%6$s
 				</div></div>',
 				get_block_wrapper_attributes( $wrapper_attributes ),
 				esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 				esc_attr( $styles_and_classes['classes'] ),
 				esc_attr( $styles_and_classes['styles'] ?? '' ),
+				$watch_attribute,
 				$product->get_price_html()
 			);
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR #58384.

This PR fixes a couple of regressions introduced in #58384:

1. The `wp-block-woocommerce-product-price` class appeared twice, because we were defining it manually and `get_block_wrapper_attributes()` was defining it too.
2. In variable products, the `wc-block-components-product-price` wrapper was lost, because we were setting the Product Price HTML on the wrapper `<div>` instead of on `.wc-block-components-product-price`. We need to set it in `.wc-block-components-product-price` because that element is the one containing all the styling classes and styles.

### How to test the changes in this Pull Request:

1. Go to the frontend of a simple product.
2. Using your browser devtools' inspector, search for `.wp-block-woocommerce-product-price`, verify the class isn't repeated.
3. Go to the frontend of a variable product.
4. Using your browser devtools' inspector, search for `.wc-block-components-product-price`, verify a div with that class is inside the _Product Price_ block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected issues with CSS classes applied to the Product Price block, ensuring proper styling and behavior when adding products with options to the cart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->