### PR TITLE
Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky
+++ b/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -232,7 +232,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		// We need to make sure the block updated before saving.
 		// @see https://github.com/woocommerce/woocommerce/issues/57718
-		await expect( editor.canvas.getByLabel( 'Color' ) ).toBeVisible();
+		await expect(
+			editor.canvas.getByLabel( 'Color', { exact: true } )
+		).toBeVisible();
 
 		await editor.saveSiteEditorEntities();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -230,6 +230,10 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.getByRole( 'radio', { name: 'Dropdown' } ).click();
 
+		// We need to make sure the block updated before saving.
+		// @see https://github.com/woocommerce/woocommerce/issues/57718
+		await expect( editor.canvas.getByLabel( 'Color' ) ).toBeVisible();
+
 		await editor.saveSiteEditorEntities();
 
 		await page.goto( '/hoodie' );

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -57,7 +57,7 @@
 		"test:e2e": "pnpm test:e2e:default --project=e2e",
 		"test:e2e:default": "pnpm test:e2e:install && pnpm test:e2e:with-env default",
 		"test:e2e:install": "pnpm playwright install chromium",
-		"test:e2e:blocks": "pnpm --filter='@woocommerce/block-library' test:e2e tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts --repeat-each=50",
+		"test:e2e:blocks": "pnpm --filter='@woocommerce/block-library' test:e2e",
 		"test:e2e:with-env": "pnpm test:e2e:install && bash ./tests/e2e-pw/run-tests-with-env.sh",
 		"test:e2e:pressable": "pnpm test:e2e:with-env default-pressable",
 		"test:e2e:wpcom": "pnpm test:e2e:with-env default-wpcom",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -57,7 +57,7 @@
 		"test:e2e": "pnpm test:e2e:default --project=e2e",
 		"test:e2e:default": "pnpm test:e2e:install && pnpm test:e2e:with-env default",
 		"test:e2e:install": "pnpm playwright install chromium",
-		"test:e2e:blocks": "pnpm --filter='@woocommerce/block-library' test:e2e",
+		"test:e2e:blocks": "pnpm --filter='@woocommerce/block-library' test:e2e tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts --repeat-each=50",
 		"test:e2e:with-env": "pnpm test:e2e:install && bash ./tests/e2e-pw/run-tests-with-env.sh",
 		"test:e2e:pressable": "pnpm test:e2e:with-env default-pressable",
 		"test:e2e:wpcom": "pnpm test:e2e:with-env default-wpcom",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #57718.

This PR makes sure the Variation Selector changed from _Pills_ to _Dropdown_ before saving the template, fixing the 'doesn't allow selecting invalid variations in dropdown mode' flaky test in _Add to Cart + Options_ block.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass and 'doesn't allow selecting invalid variations in dropdown mode'  isn't flaky anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of the "Add to Cart + Options" block when selecting invalid variations in dropdown mode, ensuring smoother user interactions.
	- Enhanced editor stability by ensuring product option changes fully update before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->