### PR TITLE
Consider variable products without purchasable variations as out-of-stock in some blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-variable-products-handling
+++ b/plugins/woocommerce/changelog/fix-variable-products-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Product Stock Indicator and Add to Cart + Options blocks to consider variable products without purchasable variations as out of stock

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -301,8 +301,6 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
-	 * @hint If the function gets updated, make sure to update has_available_variations too, as they share similar logic.
-	 *
 	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
 	 *
 	 * @return array[]|WC_Product_Variation[]
@@ -353,17 +351,15 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Check if there are available variations for the current product.
+	 * Check if there are variations that can be purchased for the current product.
 	 *
 	 * @internal
-	 * @hint If the function gets updated, make sure to update get_available_variations too, as they share similar logic.
 	 *
-	 * @since  9.9.0
+	 * @since  10.0.0
 	 * @return bool
 	 */
-	public function has_available_variations() {
-		$variation_ids           = $this->get_children();
-		$hide_out_of_stock_items = ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) );
+	public function has_purchasable_variations() {
+		$variation_ids = $this->get_children();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -374,20 +370,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ( $hide_out_of_stock_items && ! $variation->is_in_stock() ) ) {
-				continue;
-			}
-
-			/**
-			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
-			 *
-			 * @since 2.6.8
-			 *
-			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
-			 * @param  int                   $product_id  The ID of the variation.
-			 * @param  WC_Product_Variation  $variation   The variation object.
-			 */
-			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
+			if ( ! $variation || ! $variation->exists() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -369,7 +369,6 @@ class WC_Product_Variable extends WC_Product {
 
 			$variation = wc_get_product( $variation_id );
 
-			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
 			if ( ! $variation || ! $variation->is_purchasable() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -369,7 +369,7 @@ class WC_Product_Variable extends WC_Product {
 
 			$variation = wc_get_product( $variation_id );
 
-			if ( ! $variation || ! $variation->is_purchasable() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
+			if ( ! $variation || ! $variation->is_purchasable() || ! $variation->is_in_stock() ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -67,7 +67,7 @@ class WC_Product_Variable extends WC_Product {
 		 *
 		 * @since 7.8.0
 		 */
-		return apply_filters( 'woocommerce_product_add_to_cart_aria_describedby', $this->is_purchasable() ? __( 'This product has multiple variants. The options may be chosen on the product page', 'woocommerce' ) : '', $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_aria_describedby', $this->is_purchasable() && $this->has_purchasable_variations() ? __( 'This product has multiple variants. The options may be chosen on the product page', 'woocommerce' ) : '', $this );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_text() {
-		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->is_purchasable() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' ), $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->is_purchasable() && $this->has_purchasable_variations() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' ), $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -67,7 +67,7 @@ class WC_Product_Variable extends WC_Product {
 		 *
 		 * @since 7.8.0
 		 */
-		return apply_filters( 'woocommerce_product_add_to_cart_aria_describedby', $this->is_purchasable() && $this->has_purchasable_variations() ? __( 'This product has multiple variants. The options may be chosen on the product page', 'woocommerce' ) : '', $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_aria_describedby', $this->is_purchasable() ? __( 'This product has multiple variants. The options may be chosen on the product page', 'woocommerce' ) : '', $this );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_text() {
-		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->is_purchasable() && $this->has_purchasable_variations() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' ), $this );
+		return apply_filters( 'woocommerce_product_add_to_cart_text', $this->is_purchasable() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' ), $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -370,7 +370,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
+			if ( ! $variation || ! $variation->is_purchasable() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -265,9 +265,9 @@ class AddToCartWithOptions extends AbstractBlock {
 			*/
 			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
-			if ( ! $is_disabled_compatibility_layer ) {
+			if ( ! $is_disabled_compatibility_layer && ! Utils::is_not_purchasable_product( $product ) ) {
 				ob_start();
-				if ( ProductType::SIMPLE === $product_type && $product->is_in_stock() && $product->is_purchasable() ) {
+				if ( ProductType::SIMPLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
 					 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -261,7 +261,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			* This hook allows to disable the compatibility layer for the blockified.
 			*
 			* @since 7.6.0
-			* @param boolean.
+			* @param boolean $is_disabled_compatibility_layer Whether the compatibility layer should be disabled.
 			*/
 			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -350,7 +350,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				$hooks_before = ob_get_clean();
 
 				ob_start();
-				if ( ProductType::SIMPLE === $product_type && $product->is_in_stock() && $product->is_purchasable() ) {
+				if ( ProductType::SIMPLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_after_add_to_cart_quantity.
 					 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -44,10 +44,12 @@ class QuantitySelector extends AbstractBlock {
 		$product = AddToCartWithOptionsUtils::get_product_from_context( $block, $previous_product );
 
 		if ( ! $product ) {
+			$product = $previous_product;
+
 			return '';
 		}
 
-		if ( AddToCartWithOptionsUtils::is_not_purchasable_simple_product( $product ) ) {
+		if ( AddToCartWithOptionsUtils::is_not_purchasable_product( $product ) ) {
 			$product = $previous_product;
 
 			return '';
@@ -57,8 +59,9 @@ class QuantitySelector extends AbstractBlock {
 		$can_only_be_purchased_one_at_a_time = $product->is_sold_individually();
 		$managing_stock                      = $product->managing_stock();
 		$stock_quantity                      = $product->get_stock_quantity();
+		$allows_backorders                   = $product->backorders_allowed();
 
-		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time || ( $managing_stock && $stock_quantity <= 1 ) ) {
+		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time || ( $managing_stock && $stock_quantity <= 1 && ! $allows_backorders ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -125,13 +125,19 @@ class Utils {
 	}
 
 	/**
-	 * Check if a product is a simple product that is not purchasable or not in stock.
+	 * Check if a product is not purchasable or not in stock.
 	 *
 	 * @param \WC_Product $product The product to check.
-	 * @return bool True if the product is a simple product that is not purchasable or not in stock.
+	 * @return bool True if the product is not purchasable or not in stock.
 	 */
-	public static function is_not_purchasable_simple_product( $product ) {
-		return ProductType::SIMPLE === $product->get_type() && ( ! $product->is_in_stock() || ! $product->is_purchasable() );
+	public static function is_not_purchasable_product( $product ) {
+		if ( $product->is_type( 'simple' ) ) {
+			return ! $product->is_in_stock() || ! $product->is_purchasable();
+		} elseif ( $product->is_type( 'variable' ) ) {
+			return ! $product->has_purchasable_variations();
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -137,7 +137,7 @@ class Utils {
 			return ! $product->has_purchasable_variations();
 		}
 
-		return true;
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -134,7 +134,7 @@ class Utils {
 		if ( $product->is_type( 'simple' ) ) {
 			return ! $product->is_in_stock() || ! $product->is_purchasable();
 		} elseif ( $product->is_type( 'variable' ) ) {
-			return ! $product->has_purchasable_variations();
+			return ! $product->is_in_stock() || ! $product->has_purchasable_variations();
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 
 /**
  * Block type for variation selector in add to cart with options.
@@ -31,7 +32,7 @@ class VariationSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) && ! Utils::is_not_purchasable_product( $product ) ) {
 			return $content;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
-use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 
 /**
  * Block type for variation selector in add to cart with options.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -90,7 +90,7 @@ class ProductButton extends AbstractBlock {
 
 		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 
-		if ( $is_descendant_of_add_to_cart_form && Utils::is_not_purchasable_simple_product( $product ) ) {
+		if ( $is_descendant_of_add_to_cart_form && Utils::is_not_purchasable_product( $product ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -143,8 +143,6 @@ class ProductButton extends AbstractBlock {
 			)
 		);
 
-		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
-
 		$default_quantity = 1;
 
 		if ( ! $is_descendant_of_add_to_cart_form ) {

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -30,7 +30,7 @@ class ProductAvailabilityUtils {
 		// at the parent product level, check if any of its variations is in stock.
 		// We will show a custom availability message if all variations are out of stock.
 		if ( ! $product_availability && $product->get_type() === ProductType::VARIABLE ) {
-			if ( ! $product->has_available_variations() ) {
+			if ( ! $product->has_purchasable_variations() ) {
 				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\Utils;
 
 use Automattic\WooCommerce\Blocks\Templates\ProductStockIndicator;
 use Automattic\WooCommerce\Enums\ProductType;
+
 /**
  * Utility functions for product availability.
  */
@@ -26,12 +27,15 @@ class ProductAvailabilityUtils {
 		}
 
 		$product_availability = $product->get_availability();
-		// If the product is a variable product and availability isn't controlled
-		// at the parent product level, check if any of its variations is in stock.
-		// We will show a custom availability message if all variations are out of stock.
-		if ( ! $product_availability && $product->get_type() === ProductType::VARIABLE ) {
+
+		// If the product is a variable product, make sure at least one of its
+		// variations is purchasable.
+		if (
+			( 'in-stock' === $product_availability['class'] || 'available-on-backorder' === $product_availability['class'] ) &&
+			ProductType::VARIABLE === $product->get_type()
+		) {
 			if ( ! $product->has_purchasable_variations() ) {
-				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
+				$product_availability['availability'] = __( 'Out of stock', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}
 		}

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -23,6 +23,8 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
 
+<!-- wp:woocommerce/product-stock-indicator /-->
+
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -41,9 +41,9 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'has_available_variations' should return true when all variations are available.
+	 * @testdox 'has_purchasable_variations' should return true when all variations are purchasable.
 	 */
-	public function test_has_available_variations_returns_true_when_all_variations_are_available() {
+	public function test_has_purchasable_variations_returns_true_when_all_variations_are_purchasable() {
 
 		$product = WC_Helper_Product::create_variation_product();
 
@@ -51,15 +51,15 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( is_array( $variations[0] ) );
 		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertTrue( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertTrue( $has_purchasable_variations );
 	}
 
 	/**
-	 * @testdox 'has_available_variations' returns true when some variations are available.
+	 * @testdox 'has_purchasable_variations' returns true when some variations are purchasable.
 	 */
-	public function test_has_available_variations_returns_true_when_some_variations_are_available() {
+	public function test_has_purchasable_variations_returns_true_when_some_variations_are_purchasable() {
 
 		$product = new WC_Product_Variable();
 
@@ -105,15 +105,15 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( is_array( $variations[0] ) );
 		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertTrue( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertTrue( $has_purchasable_variations );
 	}
 
 	/**
-	 * @testdox 'has_available_variations' returns false when all variations are not available.
+	 * @testdox 'has_purchasable_variations' returns false when all variations are not purchasable.
 	 */
-	public function test_has_available_variations_returns_false_when_all_variations_are_not_available() {
+	public function test_has_purchasable_variations_returns_false_when_all_variations_are_not_purchasable() {
 
 		$product = new WC_Product_Variable();
 
@@ -158,8 +158,8 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$variations = $product->get_available_variations( 'array' );
 		$this->assertTrue( empty( $variations ) );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertFalse( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertFalse( $has_purchasable_variations );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces several changes:

1. Replaces the `has_available_variations()` with `has_purchasable_variations()` method in variable products, so we consider as out-of-stock any variable product that has no purchasable variations, independently if they are available (shown up in the UI) or not. See discussion in https://github.com/woocommerce/woocommerce/pull/58185#pullrequestreview-2868481710 for more context.
2. Updates several _Add to Cart + Options_ inner blocks for variable products to not show up if the variable product doesn't have any purchasable variation.
3. Updates the `variable-product-add-to-cart-with-options.html` template part so it contains the Product Stock Indicator block. This way, an 'out of stock' text is displayed when viewing variable products out of stock.
4. We updated some checks to consider that if a product/variation is out of stock but allows backorders, it's purchasable.

Closes #58685.

### How to test the changes in this Pull Request:

#### Testing `has_purchasable_variations()`

1. Go to the _Shop_ page, click on _Edit Site_ and add the _Product Stock Indicator_ block inside the _Product Collection_.

![imatge](https://github.com/user-attachments/assets/061531ae-5c40-47cb-9973-5e7794df6324)

2. Edit a variable product so stock is managed at the variation level.

![imatge](https://github.com/user-attachments/assets/28d66ddb-ed8e-4a82-bfb9-036f19998469)

3. Set all variations as out of stock.

![imatge](https://github.com/user-attachments/assets/3afc371c-6b16-410d-9c78-2d2d21a278c1)

4. Verify the _Out of stock_ message appears in the frontend.

![imatge](https://github.com/user-attachments/assets/37eaed52-ed7f-4603-afd7-bdf7327a009c)

5. Set one variation as _On backorder_ and verify the message in the frontend updates accordingly after refreshing the page.

![imatge](https://github.com/user-attachments/assets/8d852144-6bee-4063-ba00-4dc961cd695c)

6. Set one variation as _In stock_ and verify there is no longer a message in the frontend.

![imatge](https://github.com/user-attachments/assets/2a5ed8cb-cdc9-48f7-8063-767f276447df)

#### Testing the _Add to Cart + Options_ inner blocks

1. Go to a variable product page. Edit it to add the _Add to Cart + Options_ block if needed.
2. Edit the variations status as before, and verify the add to cart form updates accordingly:

In stock | On backorder | Out of stock
--- | --- | ---
![imatge](https://github.com/user-attachments/assets/a41d379a-773c-4552-8fc0-2c748986fc6d) | ![imatge](https://github.com/user-attachments/assets/9f9a7cf5-3b10-4b8a-9b36-87c0c354d080) | ![imatge](https://github.com/user-attachments/assets/977b5706-6c23-4dcd-ac98-6a52b380bb94)