### PR TITLE
All Products block: Add E2E test

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
@@ -30,7 +30,7 @@ test.describe( `${ BLOCK_NAME } Block`, () => {
 		).toHaveCount( 9 );
 	} );
 
-	// Check this regression: https://github.com/woocommerce/woocommerce/issues/49000.
+	// Check this regression: hhttps://github.com/woocommerce/woocommerce/pull/58741.
 	// The block has a dependency on the Mini Cart block/Checkout/Cart blocks.
 	// This test checks that the block can be inserted and it is rendered on the frontend without the mini cart block.
 	test( 'block can be inserted and it is rendered on the frontend without the mini cart block', async ( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect, test } from '@woocommerce/e2e-utils';
+import { BLOCK_THEME_SLUG, expect, test } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -10,16 +10,54 @@ import { expect, test } from '@woocommerce/e2e-utils';
 const BLOCK_NAME = 'woocommerce/all-products';
 
 test.describe( `${ BLOCK_NAME } Block`, () => {
-	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.createNewPost();
-		await editor.insertBlock( { name: BLOCK_NAME } );
-	} );
-
 	test( 'block can be inserted and it is rendered on the frontend', async ( {
 		editor,
+		admin,
 		page,
 	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: BLOCK_NAME } );
 		await editor.publishAndVisitPost();
+
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'wp-json/wc/store/v1/products' ) &&
+				response.status() === 200
+		);
+
+		await expect(
+			page.locator( '.wc-block-grid__product.wc-block-layout' )
+		).toHaveCount( 9 );
+	} );
+
+	// Check this regression: https://github.com/woocommerce/woocommerce/issues/49000.
+	// The block has a dependency on the Mini Cart block/Checkout/Cart blocks.
+	// This test checks that the block can be inserted and it is rendered on the frontend without the mini cart block.
+	test.only( 'block can be inserted and it is rendered on the frontend without the mini cart block', async ( {
+		editor,
+		admin,
+		page,
+	} ) => {
+		const templatePath = 'header';
+		await admin.visitSiteEditor( {
+			postId: `${ BLOCK_THEME_SLUG }//${ templatePath }`,
+			postType: 'wp_template_part',
+			canvas: 'edit',
+		} );
+
+		await editor.setContent( '' );
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await admin.createNewPost();
+		await editor.insertBlock( { name: BLOCK_NAME } );
+		await editor.publishAndVisitPost();
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'wp-json/wc/store/v1/products' ) &&
+				response.status() === 200
+		);
 
 		await expect(
 			page.locator( '.wc-block-grid__product.wc-block-layout' )

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts
@@ -33,7 +33,7 @@ test.describe( `${ BLOCK_NAME } Block`, () => {
 	// Check this regression: https://github.com/woocommerce/woocommerce/issues/49000.
 	// The block has a dependency on the Mini Cart block/Checkout/Cart blocks.
 	// This test checks that the block can be inserted and it is rendered on the frontend without the mini cart block.
-	test.only( 'block can be inserted and it is rendered on the frontend without the mini cart block', async ( {
+	test( 'block can be inserted and it is rendered on the frontend without the mini cart block', async ( {
 		editor,
 		admin,
 		page,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds E2E test to catch future regression related to the strict dependency that there is between the `All Products` block and `Mini Cart/Cart/Checkout` blocks. For more details, check: https://github.com/woocommerce/woocommerce/pull/58741

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter="@woocommerce/plugin-woocommerce" test:e2e:blocks plugins/woocommerce/client/blocks/tests/e2e/tests/all-products/all-products.block_theme.spec.ts`
2. Ensure that the E2E tests don't fail.
3. Revert the fix via the command: `git revert fd9ca98`
4. Ensure that the E2E tests fail

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test coverage for the All Products block, including a new regression test to ensure correct rendering when the Mini Cart block is removed from the site editor's header template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->