### PR TITLE
Add heading and paragraph inner blocks to order status block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4533-enhancement-order-confirmation-blocks-styling-issues
+++ b/plugins/woocommerce/changelog/wooplug-4533-enhancement-order-confirmation-blocks-styling-issues
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add header and paragraph as inner blocks to Order Status block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/order-confirmation-status",
 	"version": "1.0.0",
 	"title": "Order Status",
-	"description": "Display order status message that changes based on order state (received, completed, failed, etc.). Content is dynamically generated and cannot be modified through the editor.",
+	"description": "Display an order status message that changes based on order state (received, completed, failed, etc.). Content is dynamically generated and cannot be modified through the editor.",
 	"category": "woocommerce",
 	"keywords": [
 		"WooCommerce"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/order-confirmation-status",
 	"version": "1.0.0",
 	"title": "Order Status",
-	"description": "Display a \"thank you\" message, or a sentence regarding the current order status.",
+	"description": "Display order status message that changes based on order state (received, completed, failed, etc.). Content is dynamically generated and cannot be modified through the editor.",
 	"category": "woocommerce",
 	"keywords": [
 		"WooCommerce"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
  * Internal dependencies
@@ -14,31 +15,32 @@ const Edit = (): JSX.Element => {
 		className: 'wc-block-order-confirmation-status',
 	} );
 
-	// @TODO Think about wrapping with Noninteractive component?
 	return (
-		<div { ...blockProps }>
-			<InnerBlocks
-				template={ [
-					[
-						'core/heading',
-						{
-							level: 1,
-							content: __( 'Order received', 'woocommerce' ),
-						},
-					],
-					[
-						'core/paragraph',
-						{
-							content: __(
-								'Thank you. Your order has been received.',
-								'woocommerce'
-							),
-						},
-					],
-				] }
-				templateLock="all"
-			/>
-		</div>
+		<Noninteractive>
+			<div { ...blockProps }>
+				<InnerBlocks
+					template={ [
+						[
+							'core/heading',
+							{
+								level: 1,
+								content: __( 'Order received', 'woocommerce' ),
+							},
+						],
+						[
+							'core/paragraph',
+							{
+								content: __(
+									'Thank you. Your order has been received.',
+									'woocommerce'
+								),
+							},
+						],
+					] }
+					templateLock="all"
+				/>
+			</div>
+		</Noninteractive>
 	);
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,15 +14,30 @@ const Edit = (): JSX.Element => {
 		className: 'wc-block-order-confirmation-status',
 	} );
 
+	// @TODO Think about wrapping with Noninteractive component?
 	return (
 		<div { ...blockProps }>
-			<h1>{ __( 'Order received', 'woocommerce' ) }</h1>
-			<p>
-				{ __(
-					'Thank you. Your order has been received.',
-					'woocommerce'
-				) }
-			</p>
+			<InnerBlocks
+				template={ [
+					[
+						'core/heading',
+						{
+							level: 1,
+							content: __( 'Order received', 'woocommerce' ),
+						},
+					],
+					[
+						'core/paragraph',
+						{
+							content: __(
+								'Thank you. Your order has been received.',
+								'woocommerce'
+							),
+						},
+					],
+				] }
+				templateLock="all"
+			/>
 		</div>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/index.tsx
@@ -9,6 +9,7 @@ import { Icon, info } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import save from './save';
 
 registerBlockType( metadata, {
 	icon: {
@@ -19,11 +20,19 @@ registerBlockType( metadata, {
 			/>
 		),
 	},
-	attributes: {
-		...metadata.attributes,
-	},
 	edit,
-	save() {
-		return null;
-	},
+	save,
+	deprecated: [
+		{
+			attributes: {
+				...metadata.attributes,
+			},
+			save() {
+				return null;
+			},
+			migrate( attributes: ( typeof metadata )[ 'attributes' ] ) {
+				return attributes;
+			},
+		},
+	],
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/save.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/order-confirmation/status/save.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+const Save = () => {
+	const blockProps = useBlockProps.save( {
+		className: 'wc-block-order-confirmation-status',
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+};
+
+export default Save;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -55,6 +55,43 @@ class Status extends AbstractOrderConfirmationBlock {
 	}
 
 	/**
+	 * Get default status texts for 'order received' scenario.
+	 *
+	 * @param \WC_Order|null $order Order object or null for no permission case.
+	 * @return array Array with 'title' and 'description' keys.
+	 */
+	private function get_default_status_texts( $order ) {
+		return array(
+			/**
+			 * Filter the title shown after a checkout is complete.
+			 *
+			 * @since 9.6.0
+			 *
+			 * @param string         $title The title.
+			 * @param WC_Order|false $order The order created during checkout, or false if order data is not available.
+			 */
+			'title'       => apply_filters(
+				'woocommerce_thankyou_order_received_title',
+				esc_html__( 'Order received', 'woocommerce' ),
+				$order
+			),
+			/**
+			 * Filter the description shown when an order is cancelled.
+			 *
+			 * @since 9.6.0
+			 *
+			 * @param string         $description The description text.
+			 * @param WC_Order|false $order The order, or false if order data is not available.
+			 */
+			'description' => apply_filters(
+				'woocommerce_thankyou_order_received_text',
+				esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ),
+				$order
+			),
+		);
+	}
+
+	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order    $order Order object.
@@ -80,79 +117,59 @@ class Status extends AbstractOrderConfirmationBlock {
 		// Override with specific texts for certain order statuses.
 		switch ( $status ) {
 			case 'cancelled':
-				$title_text = wp_kses_post(
-					/**
-					 * Filter the title shown after a checkout is complete.
-					 *
-					 * @since 9.6.0
-					 *
-					 * @param string         $title The title.
-					 * @param WC_Order|false $order The order created during checkout, or false if order data is not available.
-					 */
-					apply_filters(
-						'woocommerce_thankyou_order_received_title',
-						esc_html__( 'Order cancelled', 'woocommerce' ),
-						$order
-					)
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$title_text = apply_filters(
+					'woocommerce_thankyou_order_received_title',
+					esc_html__( 'Order cancelled', 'woocommerce' ),
+					$order
 				);
-				$description_text = wp_kses_post(
 					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_text',
-						esc_html__( 'Your order has been cancelled.', 'woocommerce' ),
-						$order
-					)
+				$description_text = apply_filters(
+					'woocommerce_thankyou_order_received_text',
+					esc_html__( 'Your order has been cancelled.', 'woocommerce' ),
+					$order
 				);
 				break;
 			case 'refunded':
-				$title_text = wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_title',
-						esc_html__( 'Order refunded', 'woocommerce' ),
-						$order
-					)
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$title_text       = apply_filters(
+					'woocommerce_thankyou_order_received_title',
+					esc_html__( 'Order refunded', 'woocommerce' ),
+					$order
 				);
-				$description_text = wp_kses_post(
-					sprintf(
+				$description_text = sprintf(
 						// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-						apply_filters(
-							'woocommerce_thankyou_order_received_text',
-							// translators: %s: date and time of the order refund.
+					apply_filters(
+						'woocommerce_thankyou_order_received_text',
+						// translators: %s: date and time of the order refund.
 							esc_html__( 'Your order was refunded %s.', 'woocommerce' ),
-							$order
-						),
-						wc_format_datetime( $order->get_date_modified() )
-					)
+						$order
+					),
+					wc_format_datetime( $order->get_date_modified() )
 				);
 				break;
 			case 'completed':
-				$title_text = wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_title',
-						esc_html__( 'Order completed', 'woocommerce' ),
-						$order
-					)
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$title_text = apply_filters(
+					'woocommerce_thankyou_order_received_title',
+					esc_html__( 'Order completed', 'woocommerce' ),
+					$order
 				);
-				$description_text = wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_text',
-						esc_html__( 'Thank you. Your order has been fulfilled.', 'woocommerce' ),
-						$order
-					)
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$description_text = apply_filters(
+					'woocommerce_thankyou_order_received_text',
+					esc_html__( 'Thank you. Your order has been fulfilled.', 'woocommerce' ),
+					$order
 				);
 				break;
 			case 'failed':
-				$title_text = wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_title',
-						esc_html__( 'Order failed', 'woocommerce' ),
-						$order
-					)
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$title_text = apply_filters(
+					'woocommerce_thankyou_order_received_title',
+					esc_html__( 'Order failed', 'woocommerce' ),
+					$order
 				);
+
 				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				$order_received_text = apply_filters(
 					'woocommerce_thankyou_order_received_text',
@@ -237,33 +254,6 @@ class Status extends AbstractOrderConfirmationBlock {
 		}
 
 		return $actions;
-	}
-
-	/**
-	 * Get default status texts for 'order received' scenario.
-	 *
-	 * @param \WC_Order|null $order Order object or null for no permission case.
-	 * @return array Array with 'title' and 'description' keys.
-	 */
-	private function get_default_status_texts( $order ) {
-		return array(
-			'title'       => wp_kses_post(
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-				apply_filters(
-					'woocommerce_thankyou_order_received_title',
-					esc_html__( 'Order received', 'woocommerce' ),
-					$order
-				)
-			),
-			'description' => wp_kses_post(
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-				apply_filters(
-					'woocommerce_thankyou_order_received_text',
-					esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ),
-					$order
-				)
-			),
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/Status.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\Utils\HtmlTextReplacementProcessor;
 
 /**
  * Status class.
@@ -64,17 +65,22 @@ class Status extends AbstractOrderConfirmationBlock {
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
 		if ( ! $permission ) {
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-			return '<p>' . wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ), null ) ) . '</p>';
+			$default_texts = $this->get_default_status_texts( null );
+			return $this->update_inner_blocks_content( $content, $default_texts['title'], $default_texts['description'] );
 		}
 
-		$content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order->get_id() ] );
-		$status  = $order->get_status();
+		$hook_content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order->get_id() ] );
+		$status       = $order->get_status();
 
-		// Unlike the core handling, this includes some extra messaging for completed orders so the text is appropriate for other order statuses.
+		// Initialize with default texts, specific statuses will override these.
+		$default_texts    = $this->get_default_status_texts( $order );
+		$title_text       = $default_texts['title'];
+		$description_text = $default_texts['description'];
+
+		// Override with specific texts for certain order statuses.
 		switch ( $status ) {
 			case 'cancelled':
-				$content .= '<h1>' . wp_kses_post(
+				$title_text = wp_kses_post(
 					/**
 					 * Filter the title shown after a checkout is complete.
 					 *
@@ -88,98 +94,176 @@ class Status extends AbstractOrderConfirmationBlock {
 						esc_html__( 'Order cancelled', 'woocommerce' ),
 						$order
 					)
-				) . '</h1>';
-				$content .= '<p>' . wp_kses_post(
-						// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				);
+				$description_text = wp_kses_post(
+					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_text',
 						esc_html__( 'Your order has been cancelled.', 'woocommerce' ),
 						$order
 					)
-				) . '</p>';
+				);
 				break;
 			case 'refunded':
-					$content .= '<h1>' . wp_kses_post(
+				$title_text = wp_kses_post(
+					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+					apply_filters(
+						'woocommerce_thankyou_order_received_title',
+						esc_html__( 'Order refunded', 'woocommerce' ),
+						$order
+					)
+				);
+				$description_text = wp_kses_post(
+					sprintf(
 						// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 						apply_filters(
-							'woocommerce_thankyou_order_received_title',
-							esc_html__( 'Order refunded', 'woocommerce' ),
+							'woocommerce_thankyou_order_received_text',
+							// translators: %s: date and time of the order refund.
+							esc_html__( 'Your order was refunded %s.', 'woocommerce' ),
 							$order
-						)
-					) . '</h1>';
-					$content .= '<p>' . wp_kses_post(
-						sprintf(
-							// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-							apply_filters(
-								'woocommerce_thankyou_order_received_text',
-								// translators: %s: date and time of the order refund.
-								esc_html__( 'Your order was refunded %s.', 'woocommerce' ),
-								$order
-							),
-							wc_format_datetime( $order->get_date_modified() )
-						)
-					) . '</p>';
+						),
+						wc_format_datetime( $order->get_date_modified() )
+					)
+				);
 				break;
 			case 'completed':
-				$content .= '<h1>' . wp_kses_post(
+				$title_text = wp_kses_post(
 					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_title',
 						esc_html__( 'Order completed', 'woocommerce' ),
 						$order
 					)
-				) . '</h1>';
-				$content .= '<p>' . wp_kses_post(
+				);
+				$description_text = wp_kses_post(
 					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_text',
 						esc_html__( 'Thank you. Your order has been fulfilled.', 'woocommerce' ),
 						$order
 					)
-				) . '</p>';
+				);
 				break;
 			case 'failed':
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-				$order_received_text = apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' ), null );
-				$actions             = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woocommerce' ) . '</a> ';
-
-				if ( wc_get_page_permalink( 'myaccount' ) ) {
-					$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button">' . esc_html__( 'My account', 'woocommerce' ) . '</a> ';
-				}
-				$content .= '<h1>' . wp_kses_post(
+				$title_text = wp_kses_post(
 					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_title',
 						esc_html__( 'Order failed', 'woocommerce' ),
 						$order
 					)
-				) . '</h1>';
-				$content .= '
-				<p>' . $order_received_text . '</p>
-				<p class="wc-block-order-confirmation-status__actions">' . $actions . '</p>
-			';
-				break;
-			default:
-				$content .= '<h1>' . wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_title',
-						esc_html__( 'Order received', 'woocommerce' ),
-						$order
-					)
-				) . '</h1>';
-				$content .= '<p>' . wp_kses_post(
-					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-					apply_filters(
-						'woocommerce_thankyou_order_received_text',
-						esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ),
-						$order
-					)
-				) . '</p>';
+				);
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				$order_received_text = apply_filters(
+					'woocommerce_thankyou_order_received_text',
+					esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woocommerce' ),
+					null
+				);
+				$actions             = $this->build_failed_order_actions( $order );
+				$description_text    = $order_received_text . '<br><span class="wc-block-order-confirmation-status__actions">' . $actions . '</span>';
 				break;
 		}
 
-		return $content;
+		$updated_content = $this->update_inner_blocks_content( $content, $title_text, $description_text );
+
+		return $hook_content . $updated_content;
+	}
+
+	/**
+	 * Get fallback HTML for title and description.
+	 *
+	 * @param string $title_text Dynamic title text.
+	 * @param string $description_text Dynamic description text.
+	 * @return string Fallback HTML.
+	 */
+	private function get_fallback_html( $title_text, $description_text ) {
+		return '<h1>' . esc_html( $title_text ) . '</h1><p>' . wp_kses_post( $description_text ) . '</p>';
+	}
+
+	/**
+	 * Update inner blocks content with dynamic title and description using WP_HTML_Processor.
+	 *
+	 * @param string $content Block content.
+	 * @param string $title_text Dynamic title text.
+	 * @param string $description_text Dynamic description text.
+	 * @return string Updated content.
+	 */
+	private function update_inner_blocks_content( $content, $title_text, $description_text ) {
+		// Fallback if no content or WP_HTML_Processor is unavailable.
+		if ( empty( $content ) || ! class_exists( 'WP_HTML_Processor' ) ) {
+			return $this->get_fallback_html( $title_text, $description_text );
+		}
+
+		$processor = HtmlTextReplacementProcessor::create_fragment( $content );
+
+		$in_heading   = false;
+		$in_paragraph = false;
+
+		while ( $processor->next_token() ) {
+			switch ( $processor->get_token_type() ) {
+				case '#tag':
+					$tag_name      = $processor->get_tag();
+					$is_closer_tag = $processor->is_tag_closer();
+					if ( in_array( $tag_name, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ), true ) ) {
+						$in_heading = ! $is_closer_tag;
+					} elseif ( 'P' === $tag_name ) {
+						$in_paragraph = ! $is_closer_tag;
+					}
+					break;
+				case '#text':
+					if ( $in_heading ) {
+						$processor->unsafe_replace_text_with_raw_html( esc_html( $title_text ) );
+					} elseif ( $in_paragraph ) {
+						$processor->unsafe_replace_text_with_raw_html( wp_kses_post( $description_text ) );
+					}
+					break;
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Build action buttons for failed orders.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return string HTML for action buttons.
+	 */
+	private function build_failed_order_actions( $order ) {
+		$actions = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woocommerce' ) . '</a> ';
+
+		if ( wc_get_page_permalink( 'myaccount' ) ) {
+			$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button">' . esc_html__( 'My account', 'woocommerce' ) . '</a> ';
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Get default status texts for 'order received' scenario.
+	 *
+	 * @param \WC_Order|null $order Order object or null for no permission case.
+	 * @return array Array with 'title' and 'description' keys.
+	 */
+	private function get_default_status_texts( $order ) {
+		return array(
+			'title'       => wp_kses_post(
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				apply_filters(
+					'woocommerce_thankyou_order_received_title',
+					esc_html__( 'Order received', 'woocommerce' ),
+					$order
+				)
+			),
+			'description' => wp_kses_post(
+				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				apply_filters(
+					'woocommerce_thankyou_order_received_text',
+					esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ),
+					$order
+				)
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/HtmlTextReplacementProcessor.php
+++ b/plugins/woocommerce/src/Blocks/Utils/HtmlTextReplacementProcessor.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+/**
+ * HTML processor for replacing text content with raw HTML.
+ *
+ * Extends WP_HTML_Processor to provide unsafe text replacement functionality
+ * for use in block rendering contexts.
+ *
+ * @since 9.8.0
+ * @internal This class is not intended for public use.
+ */
+class HtmlTextReplacementProcessor extends \WP_HTML_Processor {
+	/**
+	 * Replace the contents of a text node with arbitrary HTML.
+	 *
+	 * This method does not perform any safety checking on the provided HTML.
+	 *
+	 * @param string $raw_html The raw HTML to replace the text content with.
+	 * @return bool True if the text was successfully replaced, false otherwise.
+	 */
+	public function unsafe_replace_text_with_raw_html( string $raw_html ): bool {
+		if ( '#text' === $this->get_token_type() ) {
+			$this->set_bookmark( '_wc_html_raw_html_replace_' );
+			// The bookmark names are prefixed with `_` so the key below has an extra `_`.
+			$bm                      = $this->bookmarks['__wc_html_raw_html_replace_'];
+			$this->lexical_updates[] = new \WP_HTML_Text_Replacement(
+				$bm->start,
+				$bm->length,
+				$raw_html
+			);
+			$this->release_bookmark( '_wc_html_raw_html_replace_' );
+
+			return true;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce/issues/58614

This PR adds inner blocks support to Order Status, now the block has a `core/heading` and `core/paragraph` blocks as its children whereas previously it was hardcoded to `h1` and `p` tags without possibility to individually style each of its parts.

The content of the block is still powered by the server and is different depending on the order status. The content of the inner blocks are updated with the new WordPress HTML API ([`WP_HTML_Processor`](https://developer.wordpress.org/reference/classes/wp_html_processor/))

One downside of this approach is that the inner blocks seem to be editable on the editor, but edits don't have any effect on the frontend experience. I tried to alleviate it by changing the description of the block to:

> Display order status message that changes based on order state (received, completed, failed, etc.). **Content is dynamically generated and cannot be modified through the editor.**

I am seeking feedback on this aspect. If it's not enough, we can consider more "drastic" options, like:
- wrapping the block with [`Noninteractive`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/client/blocks/assets/js/base/components/noninteractive) component (I've tested it, and it works fine for preventing the edits, but you also lose the ability to just click on a heading or paragraph and edit its styles, you need to select proper blocks from the list to do it)
- adding a more prominent warning/information to the user when they try to edit the texts (ideas? 🙏)

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="143" alt="Screenshot 2025-06-17 at 16 37 28" src="https://github.com/user-attachments/assets/fa81a2cd-cb6d-454c-aa61-10f069c6aeb1" /> | <img width="300" alt="Screenshot 2025-06-17 at 16 36 15" src="https://github.com/user-attachments/assets/aeb16f17-4757-4758-a4bd-21a0f8ea73ea" /> |

<details>
<summary>Screen recording showing initial setup of the block and support for styling</summary>

https://github.com/user-attachments/assets/a1ed7868-c06e-4a2b-be6d-66dface0b084

</details>

<details>
<summary>Screen recording showing that the text in the block is still updated server side based on the order status</summary>

https://github.com/user-attachments/assets/d7d81dae-e7d4-4e73-a007-64dc1979a546

</details>

### How to test the changes in this Pull Request:

Prerequisites (don't check out this branch yet):
- Create a new order and keep track of the confirmation screen URL that you landed on, it should be of the following shape: `/checkout/order-received/ID/?key=wc_order_XXXXXXXXXXXX` (we will use that throughout the testing)
- "Order Status" block is present in the "Order Confirmation" template in your local environment (if you've done some edits to the template, you can reset it to the default state from the Templates editor screen)

After both of these, checkout this branch in your local environment. The following steps will assume the testing is happening on this branch.

#### Compatibility with the previous block structure

1. Visit the order confirmation URL you've stored and verify that you can see the Order Status block there and that the contents of the block properly reflect the status of the order
2. Change the status of the order in the admin panel (visit `/wp-admin/admin.php?page=wc-orders&action=edit&id=ID`, while replacing `ID` with the ID you got in the prerequisites)
3. Visit the order confirmation URL and confirm that the change is properly reflected

#### Block migration

1. Open the "Order Confirmation" template in the editor (Templates → Search for "Order Confirmation" → Click the template)
2. Click "Save"
3. Repeat steps 1-3 from the first section

#### Modifying the styling of the block

1. Open the "Order Confirmation" template in the editor (Templates → Search for "Order Confirmation" → Click the template)
2. Click on the "Order Status" block (either in the editor or from the list view)
3. Open the list view and verify that the block has two inner blocks – heading and paragraph
4. Verify that these blocks are locked, and you can't add a new block as their sibling
5. Change attributes of new inner blocks as you please (heading level, colors, typography, etc.)
6. Repeat steps 1-3 from the first section and verify that the changes to style are properly reflected


#### Migrating non block template to the block template

Order confirmation template is using blocks by default now, but we still have some code paths that cover this migration so let's go through them quickly.

1. Create a new page in the editor
2. Open code editor and past this code into the input

    ```
    <!-- wp:woocommerce/legacy-template {"template":"order-confirmation"} /-->
    ```

3. Go back to the visual editor
4. Click on the block that we've added in step 2.
5. See on overlay that offers you to "Transform into blocks" – click this button
6. Verify that the newly inserted blocks structure has "Order Status" block with inner content of heading and paragraph blocks as intended
7. You can close the editor and remove the page

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
