### PR TITLE
[NOX in LYS] Enhance text contrast for completed and inactive sidebar steps in LYS for better accessibility

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPRD-582-completed-colors
+++ b/plugins/woocommerce/changelog/update-WOOPRD-582-completed-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improved text contrast for completed/inactive sidebar steps in “Launch Your Store” to enhance accessibility.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/styles.scss
@@ -303,15 +303,15 @@
 
 							.edit-site-sidebar-navigation-item.is-complete {
 								text-decoration: line-through;
-								color: $gray-700;
+								color: $gray-800;
 
 								&:hover {
 									background: transparent;
-									color: $gray-700;
+									color: $gray-800;
 								}
 
 								.components-flex-block {
-									color: $gray-700;
+									color: $gray-800;
 								}
 							}
 						}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR improves the visual accessibility of the sidebar stepper in the “Launch Your Store” (LYS) by updating the text color for completed and inactive steps.

Changes:
- Adjusted the text color for inactive and completed step labels from Gray 700 (#757575) to Gray 800 (#2F2F2F).

Closes WOOPRD-582

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="303" alt="Screenshot 2025-06-16 at 15 51 41" src="https://github.com/user-attachments/assets/a17dc016-bfb6-4851-a65c-102d455a2920" /> | <img width="318" alt="Screenshot 2025-06-16 at 15 51 15" src="https://github.com/user-attachments/assets/61a600cc-0759-44a7-a20d-ba4369a76ca0" /> |

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
1. Create a new JN store with WooCommerce on this PR's branch, WooPayments and WCPay Dev Tools (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=update/WOOPRD-582-completed-colors)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Go to WooCommerce > Home and click on Launch your store task.
<img width="1704" alt="Screenshot 2025-05-30 at 12 14 13" src="https://github.com/user-attachments/assets/98b6edef-7a34-4f84-a371-a65332392bc7" />

4. Click on the Set up payments link.
<img width="1694" alt="Screenshot 2025-05-30 at 12 15 33" src="https://github.com/user-attachments/assets/f4941826-2054-4241-aac1-262077c6dd59" />

5. Verify that a page to install WooPayments is displayed. Click on Install.
<img width="1718" alt="Screenshot 2025-05-30 at 12 16 24" src="https://github.com/user-attachments/assets/55b07c29-e21a-4095-bc09-ea66043e2c50" />

6. Click "Continue" on the payment methods selection screen.
7. Inspect the completed steps and verify the color is #2f2f2f.


### Testing that has already taken place:
Check above

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved text contrast for completed and inactive steps in the "Launch Your Store" sidebar, enhancing readability and accessibility for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->