### PR TITLE
Clear cache on copy or delete email template

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-818-email-template-cache-is-not-flushed-following-edits
+++ b/plugins/woocommerce/changelog/wooplug-818-email-template-cache-is-not-flushed-following-edits
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear cache when copy or delete email template to theme

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1186,6 +1186,7 @@ class WC_Email extends WC_Settings_API {
 				 */
 				do_action( 'woocommerce_copy_email_template', $template_type, $this );
 
+				wc_clear_template_cache();
 				?>
 				<div class="updated">
 					<p><?php echo esc_html__( 'Template file copied to theme.', 'woocommerce' ); ?></p>
@@ -1217,6 +1218,8 @@ class WC_Email extends WC_Settings_API {
 					 * @param string $email The email object
 					 */
 					do_action( 'woocommerce_delete_email_template', $template_type, $this );
+
+					wc_clear_template_cache();
 					?>
 					<div class="updated">
 						<p><?php echo esc_html__( 'Template file deleted from theme.', 'woocommerce' ); ?></p>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure the template cache is flushed after copying or deleting email template from the Email Settings screen.

Closes [WOOPLUG-818: Email template cache is not flushed following edits](https://linear.app/a8c/issue/WOOPLUG-818/email-template-cache-is-not-flushed-following-edits) (https://github.com/woocommerce/woocommerce/issues/34622).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Prerequisites:**

1. Enable a persistent object caching layer. I tested with Memcached and Redis, but other options should have the same behavior.
2. Remove any WooCommerce template overrides that you might have in place.
3. Flush the cache `wp cache flush`.

**Instructions:**
1. Create a new order.
2. Change the order status to **Completed** and inspect the **Completed order** email that was sent. This step [sets the initial template cache](https://github.com/woocommerce/woocommerce/blob/bde74a418e70d829270d713d18c5da42cc793822/plugins/woocommerce/includes/wc-core-functions.php#L307).
3. Navigate to **WooCommerce** → **Settings** → **Emails** → **Completed order** and use the **Copy file to theme** button (located at the bottom of the screen).
4. Toggle the template editor from the **View template** and make some test changes to the template, for example:
```php
// Add this line at the bottom of the template just above `do_action( 'woocommerce_email_footer', $email );`.
echo 'Test template override!!!';
```
5. Change the status of the order to something else, for example **Processing** and then change it back to **Completed**.
6. The **Completed order** email that was sent should use the cached core template rather than the updated template.
7. Use **Delete template file** in **WooCommerce** → **Settings** → **Emails** → **Completed order**  and flush the cache `wp cache flush`.
8. Apply the changes from this PR and repeat the same steps 1-5.
9. The **Completed order** email should now use the updated template.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Clear cache when copy or delete email template to theme

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that the email template cache is automatically cleared after copying or deleting email templates in WooCommerce, preventing outdated templates from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->