### PR TITLE
Update stable tag to 9.9.4

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online
 Requires at least: 6.7
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 9.9.3
+Stable tag: 9.9.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR updates the stable tag to 9.9.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the stable version tag in the WooCommerce plugin readme to 9.9.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->