### PR TITLE
Performance: Optimize cart state initialization by bypassing REST API

### DIFF
--- a/plugins/woocommerce/changelog/update-shared-state-cart-init
+++ b/plugins/woocommerce/changelog/update-shared-state-cart-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve block performance by avoiding unnecessary REST API initialization when fetching cart data

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -99,16 +99,16 @@ trait BlocksSharedState {
 		self::check_consent( $consent_statement );
 
 		if ( null === self::$blocks_shared_cart_state ) {
-			$cart_exists                    = isset( WC()->cart );
-			$cart_has_contents              = $cart_exists && ! WC()->cart->is_empty();
+			$cart_exists       = isset( WC()->cart );
+			$cart_has_contents = $cart_exists && ! WC()->cart->is_empty();
 			if ( isset( WC()->cart ) ) {
 				$cart_controller = new CartController();
-				$cart_object = $cart_controller->get_cart_for_response();
+				$cart_object     = $cart_controller->get_cart_for_response();
 
-				$store_api = Package::container()->get( StoreApi::class );
+				$store_api         = Package::container()->get( StoreApi::class );
 				$schema_controller = $store_api->container()->get( SchemaController::class );
-				$cart_schema = $schema_controller->get( CartSchema::IDENTIFIER );
-				$cart_response = $cart_schema->get_item_response( $cart_object );
+				$cart_schema       = $schema_controller->get( CartSchema::IDENTIFIER );
+				$cart_response     = $cart_schema->get_item_response( $cart_object );
 
 				self::$blocks_shared_cart_state = $cart_response;
 			} else {

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -101,7 +101,7 @@ trait BlocksSharedState {
 		if ( null === self::$blocks_shared_cart_state ) {
 			$cart_exists       = isset( WC()->cart );
 			$cart_has_contents = $cart_exists && ! WC()->cart->is_empty();
-			if ( isset( WC()->cart ) ) {
+			if ( $cart_exists ) {
 				$cart_controller = new CartController();
 				$cart_object     = $cart_controller->get_cart_for_response();
 

--- a/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Automattic\WooCommerce\Blocks\Utils;
 
 use InvalidArgumentException;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema;
 
 /**
  * Manages the registration of interactivity config and state that is commonly shared by WooCommerce blocks.
@@ -96,9 +101,19 @@ trait BlocksSharedState {
 		if ( null === self::$blocks_shared_cart_state ) {
 			$cart_exists                    = isset( WC()->cart );
 			$cart_has_contents              = $cart_exists && ! WC()->cart->is_empty();
-			self::$blocks_shared_cart_state = $cart_exists
-				? rest_do_request( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) )->data
-				: array();
+			if ( isset( WC()->cart ) ) {
+				$cart_controller = new CartController();
+				$cart_object = $cart_controller->get_cart_for_response();
+
+				$store_api = Package::container()->get( StoreApi::class );
+				$schema_controller = $store_api->container()->get( SchemaController::class );
+				$cart_schema = $schema_controller->get( CartSchema::IDENTIFIER );
+				$cart_response = $cart_schema->get_item_response( $cart_object );
+
+				self::$blocks_shared_cart_state = $cart_response;
+			} else {
+				self::$blocks_shared_cart_state = array();
+			}
 
 			if ( $cart_has_contents ) {
 				self::prevent_cache();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:


This PR improves the performance of WooCommerce blocks by eliminating unnecessary REST API initialization when fetching cart data for the shared block state.

The current implementation uses `rest_do_request()` to fetch cart data, which triggers the full REST API initialization on first use. This initialization includes:
- WP_REST_Server setup
- WooCommerce Store API route registration (~96ms on a non-opcached system)
- Authentication system initialization (~60ms on a non-opcached system)

This results in approximately 200ms of overhead on the first block render that needs cart data. For an op-cached system, this was reduced to 20ms, but still represents room for improvement.

### Solution
Instead of going through the REST API, this change directly calls the cart controller and schema to get the same cart data structure without the REST API initialization penalty.




Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
|        |       |



### How to test the changes in this Pull Request:


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a WooCommerce site with products.
2. View a product page while logged out.
3. The page should load faster while maintaining all cart functionality.
4. Add items to cart and verify the cart state is properly reflected in blocks.

Optionally, you may add timings to the cart blocks like so:

in `plugins/woocommerce/src/Blocks/Utils/BlocksSharedState.php`

```
			$t0 = microtime( true );
			self::$blocks_shared_cart_state = $cart_exists
				? rest_do_request( new \WP_REST_Request( 'GET', '/wc/store/v1/cart' ) )->data
				: array();
			$t1 = microtime( true );
			$elap_ms = ( $t1 - $t0 ) * 1000;
			error_log("Took $elap_ms to initialize cart.");
```

Expect to see 20-200ms on trunk, depending on system config, and about ~2ms with the changes in this branch.


### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>