### PR TITLE
Font Picker E2E test: refactor response handling to ensure all font families are loaded before proceed with test

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-2456-flaky-test-clicking-opt-in-new-fonts-should-be-available
+++ b/plugins/woocommerce/changelog/wooplug-2456-flaky-test-clicking-opt-in-new-fonts-should-be-available
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Font Picker E2E test: refactor response handling to ensure all font families are loaded before proceed with test

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -275,7 +275,7 @@ test.describe(
 				'.woocommerce-customize-store_global-styles-variations_item'
 			);
 
-			await fontPickers.count();
+			await expect( fontPickers ).toHaveCount( 10 );
 
 			await assembler
 				.locator(

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler/font-picker.spec.js
@@ -247,23 +247,35 @@ test.describe(
 				assembler.getByText( 'Access more fonts' )
 			).toBeVisible();
 
+			const responseFontFamilies = page.waitForResponse(
+				async ( response ) => {
+					if (
+						response
+							.url()
+							.includes( '/wp-json/wp/v2/font-families' ) &&
+						response.status() === 200
+					) {
+						const json = await response.json();
+						return json.length >= 12;
+					}
+
+					return false;
+				}
+			);
+
 			await assembler.getByRole( 'button', { name: 'Opt in' } ).click();
 
 			await assembler
 				.getByText( 'Access more fonts' )
 				.waitFor( { state: 'hidden' } );
 
-			await page.waitForResponse(
-				( response ) =>
-					response.url().includes( '/wp-json/wp/v2/font-families' ) &&
-					response.status() === 200
-			);
+			await responseFontFamilies;
 
 			const fontPickers = assembler.locator(
 				'.woocommerce-customize-store_global-styles-variations_item'
 			);
 
-			await expect.poll( () => fontPickers.count() ).toEqual( 10 );
+			await fontPickers.count();
 
 			await assembler
 				.locator(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR improves the Font Picker E2E test to reduce flakiness.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/50268 (WOOPLUG-2456) .


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that the CI jobs regarding the E2E tests are green
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a changelog entry describing improvements to the Font Picker test in the WooCommerce plugin.

- **Tests**
	- Enhanced the reliability of the Font Picker test by ensuring it waits for all expected font families to load before proceeding. 
	- Simplified the assertion for the number of font pickers displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->