### PR TITLE
Fix Products by Attribute 'can change attributes from the sidebar' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-50483-can-change-attributes-from-sidebar-flaky-test
+++ b/plugins/woocommerce/changelog/fix-50483-can-change-attributes-from-sidebar-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix Products by Attribute 'can change attributes from the sidebar' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products-by-attribute/products-by-attribute.block_theme.spec.ts
@@ -41,6 +41,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		await blockLocator.getByText( 'Color' ).click();
 		await blockLocator.getByText( 'Done' ).click();
 		await page.getByText( 'Filter by Product Attribute' ).click();
+		await expect( blockLocator.getByRole( 'listitem' ) ).toHaveCount( 9 );
 		await page.getByText( 'Color' ).click();
 		await page.getByText( 'Size' ).click();
 		await expect( blockLocator.getByRole( 'listitem' ) ).toHaveCount( 1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #50483.

This PR updates a flaky e2e test to make sure products are loaded before changing attributes in the sidebar in the _Products by Attribute_ block.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass and 'can change attributes from the sidebar'  isn't flaky (in Blocks e2e tests 9/10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the "Products by Attribute" feature by addressing a flaky test related to changing attributes from the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->