### PR TITLE
Prevent warnings when accessing invalid post types via REST api

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4635-php-warning-in-wc_rest_check_post_permissions-when-an
+++ b/plugins/woocommerce/changelog/wooplug-4635-php-warning-in-wc_rest_check_post_permissions-when-an
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent warnings when accessing invalid post types via REST api

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -240,7 +240,10 @@ function wc_rest_check_post_permissions( $post_type, $context = 'read', $object_
 	} else {
 		$cap              = $contexts[ $context ];
 		$post_type_object = get_post_type_object( $post_type );
-		$permission       = current_user_can( $post_type_object->cap->$cap, $object_id );
+		$permission       = false;
+		if ( $post_type_object instanceof WP_Post_Type ) {
+			$permission = current_user_can( $post_type_object->cap->$cap, $object_id );
+		}
 	}
 
 	return apply_filters( 'woocommerce_rest_check_permissions', $permission, $context, $object_id, $post_type );

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/api-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/api-functions.php
@@ -183,6 +183,15 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_rest_check_post_permissions() with invalid post type.
+	 *
+	 * @since 2.6.0
+	 */
+	public function test_wc_rest_check_post_permissions_invalid_post_type() {
+		$this->assertFalse( wc_rest_check_post_permissions( 'invalid_post_type' ) );
+	}
+
+	/**
 	 * Test wc_rest_check_user_permissions().
 	 *
 	 * @since 2.6.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Check the post type is valid before trying to access properties of it.
- Add PHP unit test to ensure the changes work correctly. The test will fail if there are warnings/errors.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4635

(For Bug Fixes) Bug introduced in PR # .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code to snippet on your site: `wc_rest_check_post_permissions( 'invalid_post_type' )`
2. Load the site and ensure there are no PHP warnings.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue causing PHP warnings when accessing invalid post types via the WooCommerce REST API.

- **Tests**
  - Prepared a unit test to verify handling of invalid post types in REST API permission checks (currently inactive).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->