### PR TITLE
Fix: Make coupon code discount total lookup case insensitive

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4647-forcing-of-lowercase-coupon-codes-breaks-functionality-in
+++ b/plugins/woocommerce/changelog/wooplug-4647-forcing-of-lowercase-coupon-codes-breaks-functionality-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Made coupon code discount total lookup case insensitive

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -114,7 +114,7 @@ export const useStoreCartCoupons = ( context = '' ): StoreCartCoupon => {
 									'Coupon code "%s" has been removed from your cart.',
 									'woocommerce'
 								),
-								couponCode
+								decodeEntities( couponCode )
 							),
 							{
 								id: 'coupon-form',

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -178,7 +178,7 @@ export const useStoreCart = (
 				? cartData.coupons.map(
 						( coupon: CartResponseCouponItem ) => ( {
 							...coupon,
-							label: coupon.code,
+							label: decodeEntities( coupon.code ),
 						} )
 				  )
 				: EMPTY_CART_COUPONS,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-notices.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-notices.shopper.block_theme.spec.ts
@@ -68,7 +68,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
 
 		await expect(
-			page.getByText( 'Coupon code "TESTCOUPON" already applied!', {
+			page.getByText( 'Coupon code "testcoupon" already applied!', {
 				exact: true,
 			} )
 		).toBeVisible();
@@ -122,7 +122,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 
 		await expect(
 			page.getByText(
-				'BLOCK ERROR NOTICE: Coupon code "TESTCOUPON" already applied!'
+				'BLOCK ERROR NOTICE: Coupon code "testcoupon" already applied!'
 			)
 		).toBeVisible();
 
@@ -175,7 +175,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 
 		await expect(
 			page.getByText(
-				'CLASSIC ERROR NOTICE: Coupon code "TESTCOUPON" already applied!'
+				'CLASSIC ERROR NOTICE: Coupon code "testcoupon" already applied!'
 			)
 		).toBeVisible();
 
@@ -229,7 +229,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
 
 		await expect(
-			page.getByText( 'Coupon code "TESTCOUPON" already applied!', {
+			page.getByText( 'Coupon code "testcoupon" already applied!', {
 				exact: true,
 			} )
 		).toBeVisible();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-notices.shopper.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/cart/cart-checkout-block-notices.shopper.classic_theme.spec.ts
@@ -70,7 +70,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
 
 		await expect(
-			page.getByText( 'Coupon code "TESTCOUPON" already applied!', {
+			page.getByText( 'Coupon code "testcoupon" already applied!', {
 				exact: true,
 			} )
 		).toBeVisible();
@@ -122,7 +122,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 
 		await expect(
 			page.getByText(
-				'CLASSIC ERROR NOTICE: Coupon code "TESTCOUPON" already applied!'
+				'CLASSIC ERROR NOTICE: Coupon code "testcoupon" already applied!'
 			)
 		).toBeVisible();
 
@@ -177,7 +177,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 
 		await expect(
 			page.getByText(
-				'BLOCK ERROR NOTICE: Coupon code "TESTCOUPON" already applied!'
+				'BLOCK ERROR NOTICE: Coupon code "testcoupon" already applied!'
 			)
 		).toBeVisible();
 
@@ -227,7 +227,7 @@ test.describe( 'Shopper → Notice Templates', () => {
 		await page.getByRole( 'button', { name: 'Apply coupon' } ).click();
 
 		await expect(
-			page.getByText( 'Coupon code "TESTCOUPON" already applied!' )
+			page.getByText( 'Coupon code "testcoupon" already applied!' )
 		).toBeVisible();
 
 		// We're explicitly checking the CSS classes and that the SVG is hidden.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1287,7 +1287,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// Check to make sure coupon is not already applied.
 		$applied_coupons = $this->get_items( 'coupon' );
 		foreach ( $applied_coupons as $applied_coupon ) {
-			if ( $applied_coupon->get_code() === $coupon->get_code() ) {
+			if ( wc_is_same_coupon( $applied_coupon->get_code(), $coupon->get_code() ) ) {
 				return new WP_Error(
 					'invalid_coupon',
 					sprintf(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -130,7 +130,7 @@ if ( wc_tax_enabled() ) {
 						$coupon_info = json_decode( $coupon_info, true );
 						$post_id     = $coupon_info[0]; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					} else {
-						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", $item->get_code(), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", wc_sanitize_coupon_code( $item->get_code() ), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 					}
 					$class = $order->is_editable() ? 'code editable' : 'code';
 					?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -130,7 +130,7 @@ if ( wc_tax_enabled() ) {
 						$coupon_info = json_decode( $coupon_info, true );
 						$post_id     = $coupon_info[0]; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					} else {
-						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", $item->get_code(), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' AND post_date < %s LIMIT 1;", $item->get_code(), $order->get_date_created()->format( 'Y-m-d H:i:s' ) ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 					}
 					$class = $order->is_editable() ? 'code editable' : 'code';
 					?>

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1919,8 +1919,6 @@ class WC_Cart extends WC_Legacy_Cart {
 		 *
 		 * @since 2.0.0
 		 * @param string $coupon_code The coupon code that was applied.
-		 * @param WC_Coupon $the_coupon The coupon object that was applied.
-		 * @param WC_Cart $this The cart object.
 		 */
 		do_action( 'woocommerce_applied_coupon', $coupon_code );
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1908,6 +1908,14 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		$the_coupon->add_coupon_message( WC_Coupon::WC_COUPON_SUCCESS );
 
+		/**
+		 * Action ran after a coupon is applied.
+		 *
+		 * @since 2.0.0
+		 * @param string $coupon_code The coupon code that was applied.
+		 * @param WC_Coupon $the_coupon The coupon object that was applied.
+		 * @param WC_Cart $this The cart object.
+		 */
 		do_action( 'woocommerce_applied_coupon', $the_coupon->get_code() );
 
 		return true;

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1854,7 +1854,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		// Check if applied.
-		if ( $this->has_discount( $coupon_code ) ) {
+		if ( $this->has_discount( $the_coupon->get_code() ) ) {
 			$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED );
 			return false;
 		}
@@ -1892,7 +1892,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 		}
 
-		$this->applied_coupons[] = $coupon_code;
+		$this->applied_coupons[] = $the_coupon->get_code();
 
 		// Choose free shipping.
 		if ( $the_coupon->get_free_shipping() ) {
@@ -1908,7 +1908,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		$the_coupon->add_coupon_message( WC_Coupon::WC_COUPON_SUCCESS );
 
-		do_action( 'woocommerce_applied_coupon', $coupon_code );
+		do_action( 'woocommerce_applied_coupon', $the_coupon->get_code() );
 
 		return true;
 	}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1985,7 +1985,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				break;
 			}
 		}
-		return wc_cart_round_discount( $tax_amount, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN );
+		return wc_cart_round_discount( $tax_amount, wc_get_price_decimals() );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1943,7 +1943,13 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function get_coupon_discount_amount( $code, $ex_tax = true ) {
 		$totals          = $this->get_coupon_discount_totals();
-		$discount_amount = isset( $totals[ $code ] ) ? $totals[ $code ] : 0;
+		$discount_amount = 0;
+		foreach ( $totals as $key => $value ) {
+			if ( wc_is_same_coupon( $key, $code ) ) {
+				$discount_amount = $value;
+				break;
+			}
+		}
 
 		if ( ! $ex_tax ) {
 			$discount_amount += $this->get_coupon_discount_tax_amount( $code );
@@ -1959,8 +1965,15 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float discount amount
 	 */
 	public function get_coupon_discount_tax_amount( $code ) {
-		$totals = $this->get_coupon_discount_tax_totals();
-		return wc_cart_round_discount( isset( $totals[ $code ] ) ? $totals[ $code ] : 0, wc_get_price_decimals() );
+		$totals     = $this->get_coupon_discount_tax_totals();
+		$tax_amount = 0;
+		foreach ( $totals as $key => $value ) {
+			if ( wc_is_same_coupon( $key, $code ) ) {
+				$tax_amount = $value;
+				break;
+			}
+		}
+		return wc_cart_round_discount( $tax_amount, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1810,16 +1810,22 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function has_discount( $coupon_code = '' ) {
-		return $coupon_code ? in_array(
-			wc_strtolower( wc_format_coupon_code( $coupon_code ) ),
-			array_map(
-				function ( $code ) {
-					return wc_strtolower( wc_format_coupon_code( $code ) );
-				},
-				$this->applied_coupons
-			),
-			true
-		) : count( $this->applied_coupons ) > 0;
+		$applied_coupons = $this->get_applied_coupons();
+
+		if ( ! $coupon_code ) {
+			return count( $applied_coupons ) > 0;
+		}
+
+		$coupon_code = wc_format_coupon_code( $coupon_code );
+
+		// Check if the coupon is in applied coupons using case-insensitive comparison.
+		foreach ( $applied_coupons as $applied_coupon ) {
+			if ( wc_is_same_coupon( $applied_coupon, $coupon_code ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -1854,7 +1860,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		// Check if applied.
-		if ( $this->has_discount( $the_coupon->get_code() ) ) {
+		if ( $this->has_discount( $coupon_code ) ) {
 			$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED );
 			return false;
 		}
@@ -1892,7 +1898,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 		}
 
-		$this->applied_coupons[] = $the_coupon->get_code();
+		$this->applied_coupons[] = $coupon_code;
 
 		// Choose free shipping.
 		if ( $the_coupon->get_free_shipping() ) {
@@ -1916,7 +1922,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		 * @param WC_Coupon $the_coupon The coupon object that was applied.
 		 * @param WC_Cart $this The cart object.
 		 */
-		do_action( 'woocommerce_applied_coupon', $the_coupon->get_code() );
+		do_action( 'woocommerce_applied_coupon', $coupon_code );
 
 		return true;
 	}
@@ -2004,19 +2010,13 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function remove_coupon( $coupon_code ) {
 		$coupon_code = wc_format_coupon_code( $coupon_code );
-		$position    = array_search(
-			wc_strtolower( $coupon_code ),
-			array_map(
-				function ( $code ) {
-					return wc_strtolower( wc_format_coupon_code( $code ) );
-				},
-				$this->get_applied_coupons()
-			),
-			true
-		);
 
-		if ( false !== $position ) {
-			unset( $this->applied_coupons[ $position ] );
+		// Find the coupon in applied coupons using case-insensitive comparison.
+		foreach ( $this->get_applied_coupons() as $key => $applied_coupon ) {
+			if ( wc_is_same_coupon( $applied_coupon, $coupon_code ) ) {
+				unset( $this->applied_coupons[ $key ] );
+				break;
+			}
 		}
 
 		WC()->session->set( 'refresh_totals', true );

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -786,7 +786,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		global $wpdb;
 		return $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
+				"SELECT ID FROM $wpdb->posts WHERE LOWER(post_title) = LOWER(%s) AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
 				wc_sanitize_coupon_code( $code )
 			)
 		);

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -294,7 +294,7 @@ function wc_cart_totals_coupon_html( $coupon ) {
 
 	$discount_amount_html = apply_filters( 'woocommerce_coupon_discount_amount_html', $discount_amount_html, $coupon );
 	// translators: %s: coupon code.
-	$coupon_html = $discount_amount_html . ' <a role="button" aria-label="' . sprintf( esc_attr__( 'Remove %s coupon', 'woocommerce' ), $coupon->get_code() ) . '" href="' . esc_url( add_query_arg( 'remove_coupon', rawurlencode( $coupon->get_code() ), Constants::is_defined( 'WOOCOMMERCE_CHECKOUT' ) ? wc_get_checkout_url() : wc_get_cart_url() ) ) . '" class="woocommerce-remove-coupon" data-coupon="' . esc_attr( $coupon->get_code() ) . '">' . __( '[Remove]', 'woocommerce' ) . '</a>';
+	$coupon_html = $discount_amount_html . ' <a role="button" aria-label="' . esc_attr( sprintf( __( 'Remove %s coupon', 'woocommerce' ), $coupon->get_code() ) ) . '" href="' . esc_url( add_query_arg( 'remove_coupon', rawurlencode( $coupon->get_code() ), Constants::is_defined( 'WOOCOMMERCE_CHECKOUT' ) ? wc_get_checkout_url() : wc_get_cart_url() ) ) . '" class="woocommerce-remove-coupon" data-coupon="' . esc_attr( $coupon->get_code() ) . '">' . __( '[Remove]', 'woocommerce' ) . '</a>';
 
 	echo wp_kses( apply_filters( 'woocommerce_cart_totals_coupon_html', $coupon_html, $coupon, $discount_amount_html ), array_replace_recursive( wp_kses_allowed_html( 'post' ), array( 'a' => array( 'data-coupon' => true ) ) ) ); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
 }

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -380,10 +380,11 @@ function wc_cart_totals_shipping_method_label( $method ) {
  *
  * @param  double $value Amount to round.
  * @param  int    $precision DP to round.
+ * @param  int    $round_mode Round mode.
  * @return float
  */
-function wc_cart_round_discount( $value, $precision ) {
-	return wc_round_discount( $value, $precision );
+function wc_cart_round_discount( $value, $precision, $round_mode = WC_DISCOUNT_ROUNDING_MODE ) {
+	return wc_round_discount( $value, $precision, $round_mode );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -380,11 +380,10 @@ function wc_cart_totals_shipping_method_label( $method ) {
  *
  * @param  double $value Amount to round.
  * @param  int    $precision DP to round.
- * @param  int    $round_mode Round mode.
  * @return float
  */
-function wc_cart_round_discount( $value, $precision, $round_mode = WC_DISCOUNT_ROUNDING_MODE ) {
-	return wc_round_discount( $value, $precision, $round_mode );
+function wc_cart_round_discount( $value, $precision ) {
+	return wc_round_discount( $value, $precision );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2591,11 +2591,10 @@ function wc_decimal_to_fraction( $decimal ) {
  *
  * @param  double $value Amount to round.
  * @param  int    $precision DP to round.
- * @param  int    $round_mode Round mode.
  * @return float
  */
-function wc_round_discount( $value, $precision, $round_mode = WC_DISCOUNT_ROUNDING_MODE ) {
-	return NumberUtil::round( $value, $precision, $round_mode ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
+function wc_round_discount( $value, $precision ) {
+	return NumberUtil::round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -38,7 +38,6 @@ require WC_ABSPATH . 'includes/wc-order-step-logger-functions.php';
 /**
  * Filters on data used in admin and frontend.
  */
-add_filter( 'woocommerce_coupon_code', 'html_entity_decode' );
 add_filter( 'woocommerce_coupon_code', 'wc_sanitize_coupon_code' );
 add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integers by default.
 add_filter( 'woocommerce_shipping_rate_label', 'sanitize_text_field' ); // Shipping rate label.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2591,10 +2591,11 @@ function wc_decimal_to_fraction( $decimal ) {
  *
  * @param  double $value Amount to round.
  * @param  int    $precision DP to round.
+ * @param  int    $round_mode Round mode.
  * @return float
  */
-function wc_round_discount( $value, $precision ) {
-	return NumberUtil::round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
+function wc_round_discount( $value, $precision, $round_mode = WC_DISCOUNT_ROUNDING_MODE ) {
+	return NumberUtil::round( $value, $precision, $round_mode ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -39,6 +39,7 @@ require WC_ABSPATH . 'includes/wc-order-step-logger-functions.php';
  * Filters on data used in admin and frontend.
  */
 add_filter( 'woocommerce_coupon_code', 'wc_sanitize_coupon_code' );
+add_filter( 'woocommerce_coupon_code', 'wc_strtolower' );
 add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integers by default.
 add_filter( 'woocommerce_shipping_rate_label', 'sanitize_text_field' ); // Shipping rate label.
 add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -376,14 +376,7 @@ function wc_format_coupon_code( $value ) {
  * Due to the unfiltered_html captability that some (admin) users have, we need to account for slashes.
  *
  * The html_entity_decode() call handles coupon codes that contain special characters like ampersands (&), quotes ("),
- * and other HTML entities. This ensures that:
- *
- * 1. User input like "AT&amp;T-SPECIAL" gets decoded to "AT&T-SPECIAL" before sanitization
- * 2. Quote characters in codes like "SUMMER&quot;2024&quot;" are properly handled
- * 3. Double-encoded entities like "&amp;amp;" are correctly processed
- * 4. Case-insensitive matching works properly regardless of how entities are encoded
- *
- * Without this decoding step, coupon codes with special characters would fail to match
+ * and other HTML entities. Without this decoding step, coupon codes with special characters would fail to match
  * during application, causing legitimate coupons to be rejected.
  *
  * @see WC_Cart_Test::test_coupon_codes_with_special_characters

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -381,7 +381,7 @@ function wc_format_coupon_code( $value ) {
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT, get_bloginfo( 'charset' ) ), 0, 'db' ), 'entities' );
+	$value = wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
 	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -376,11 +376,12 @@ function wc_format_coupon_code( $value ) {
  * Due to the unfiltered_html captability that some (admin) users have, we need to account for slashes.
  *
  * @since  3.6.0
+ * @since  10.0.0 Decode HTML entities here instead of via woocommerce_coupon_code filter.
  * @param  string $value Coupon code to format.
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	$value = wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
+	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT ), 0, 'db' ), 'entities' );
 	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -375,13 +375,26 @@ function wc_format_coupon_code( $value ) {
  *
  * Due to the unfiltered_html captability that some (admin) users have, we need to account for slashes.
  *
+ * The html_entity_decode() call handles coupon codes that contain special characters like ampersands (&), quotes ("),
+ * and other HTML entities. This ensures that:
+ *
+ * 1. User input like "AT&amp;T-SPECIAL" gets decoded to "AT&T-SPECIAL" before sanitization
+ * 2. Quote characters in codes like "SUMMER&quot;2024&quot;" are properly handled
+ * 3. Double-encoded entities like "&amp;amp;" are correctly processed
+ * 4. Case-insensitive matching works properly regardless of how entities are encoded
+ *
+ * Without this decoding step, coupon codes with special characters would fail to match
+ * during application, causing legitimate coupons to be rejected.
+ *
+ * @see WC_Cart_Test::test_coupon_codes_with_special_characters
+ *
  * @since  3.6.0
  * @since  10.0.0 Decode HTML entities here instead of via woocommerce_coupon_code filter.
  * @param  string $value Coupon code to format.
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	$value = wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
+	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT, get_bloginfo( 'charset' ) ), 0, 'db' ), 'entities' );
 	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -381,7 +381,7 @@ function wc_format_coupon_code( $value ) {
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT ), 0, 'db' ), 'entities' );
+	$value = wp_kses( sanitize_post_field( 'post_title', html_entity_decode( $value ?? '', ENT_COMPAT, get_bloginfo( 'charset' ) ), 0, 'db' ), 'entities' );
 	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartCouponSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartCouponSchema.php
@@ -93,7 +93,7 @@ class CartCouponSchema extends AbstractSchema {
 		$cart       = $controller->get_cart_instance();
 		$coupon     = new \WC_Coupon( $coupon_code );
 		return [
-			'code'          => $coupon_code,
+			'code'          => $coupon->get_code(),
 			'discount_type' => $coupon->get_discount_type(),
 			'totals'        => (object) $this->prepare_currency_response(
 				[

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/CartCouponSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/CartCouponSchema.php
@@ -89,18 +89,16 @@ class CartCouponSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $coupon_code ) {
-		$controller           = new CartController();
-		$cart                 = $controller->get_cart_instance();
-		$total_discounts      = $cart->get_coupon_discount_totals();
-		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
-		$coupon               = new \WC_Coupon( $coupon_code );
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+		$coupon     = new \WC_Coupon( $coupon_code );
 		return [
 			'code'          => $coupon_code,
 			'discount_type' => $coupon->get_discount_type(),
 			'totals'        => (object) $this->prepare_currency_response(
 				[
-					'total_discount'     => $this->prepare_money_response( isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0, wc_get_price_decimals() ),
-					'total_discount_tax' => $this->prepare_money_response( isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
+					'total_discount'     => $this->prepare_money_response( $cart->get_coupon_discount_amount( $coupon_code ), wc_get_price_decimals() ),
+					'total_discount_tax' => $this->prepare_money_response( $cart->get_coupon_discount_tax_amount( $coupon_code ), wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
 				]
 			),
 		];

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -997,7 +997,7 @@ class CartController {
 			);
 		}
 
-		if ( $this->has_coupon( $coupon->get_code() ) ) {
+		if ( $this->has_coupon( $coupon_code ) ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
@@ -1051,7 +1051,7 @@ class CartController {
 					sprintf(
 						/* translators: %s: coupon code */
 						esc_html__( '"%s" has already been applied and cannot be used in conjunction with other coupons.', 'woocommerce' ),
-						esc_html( $code )
+						esc_html( $individual_use_coupon->get_code() )
 					),
 					400
 				);
@@ -1080,7 +1080,7 @@ class CartController {
 			$applied_coupons = array_diff( $applied_coupons, $coupons_to_remove );
 		}
 
-		$applied_coupons[] = $coupon->get_code();
+		$applied_coupons[] = $coupon_code;
 		$cart->set_applied_coupons( $applied_coupons );
 
 		/**
@@ -1092,7 +1092,7 @@ class CartController {
 		 *
 		 * @param string $coupon_code The coupon code that was applied.
 		 */
-		do_action( 'woocommerce_applied_coupon', $coupon->get_code() );
+		do_action( 'woocommerce_applied_coupon', $coupon_code );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -997,13 +997,13 @@ class CartController {
 			);
 		}
 
-		if ( $this->has_coupon( $coupon_code ) ) {
+		if ( $this->has_coupon( $coupon->get_code() ) ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
 					/* translators: %s coupon code */
 					esc_html__( 'Coupon code "%s" has already been applied.', 'woocommerce' ),
-					esc_html( $coupon_code )
+					esc_html( $coupon->get_code() )
 				),
 				400
 			);
@@ -1080,7 +1080,7 @@ class CartController {
 			$applied_coupons = array_diff( $applied_coupons, $coupons_to_remove );
 		}
 
-		$applied_coupons[] = $coupon_code;
+		$applied_coupons[] = $coupon->get_code();
 		$cart->set_applied_coupons( $applied_coupons );
 
 		/**
@@ -1092,7 +1092,7 @@ class CartController {
 		 *
 		 * @param string $coupon_code The coupon code that was applied.
 		 */
-		do_action( 'woocommerce_applied_coupon', $coupon_code );
+		do_action( 'woocommerce_applied_coupon', $coupon->get_code() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -1004,7 +1004,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 400, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_invalid_coupon', $data['code'] );
-		$this->assertEquals( 'Coupon &quot;NON_EXISTING_COUPON&quot; cannot be applied because it does not exist.', $data['message'] );
+		$this->assertEquals( 'Coupon &quot;non_existing_coupon&quot; cannot be applied because it does not exist.', $data['message'] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -485,22 +485,22 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$test_cases = array(
 			// Ampersand test cases.
 			array(
-				'coupon_code' => 'AT&T-SPECIAL',
-				'user_inputs' => array( 'AT&T-SPECIAL', 'AT&amp;T-SPECIAL', 'at&t-special' ),
+				'coupon_code' => 'TEST&COUPON-SPECIAL',
+				'user_inputs' => array( 'TEST&COUPON-SPECIAL', 'TEST&amp;COUPON-SPECIAL', 'test&coupon-special' ),
 				'discount'    => 15,
 				'description' => 'Coupon with ampersand',
 			),
 			// Quote test cases.
 			array(
-				'coupon_code' => 'BEN&JERRY\'S',
-				'user_inputs' => array( 'BEN&JERRY\'S', 'BEN&amp;JERRY\'S', 'ben&jerry\'s' ),
+				'coupon_code' => 'TEST&COUPON\'S',
+				'user_inputs' => array( 'TEST&COUPON\'S', 'TEST&amp;COUPON\'S', 'test&coupon\'s' ),
 				'discount'    => 20,
 				'description' => 'Coupon with ampersand and apostrophe',
 			),
 			// Quote characters test.
 			array(
-				'coupon_code' => 'SUMMER"2024"',
-				'user_inputs' => array( 'SUMMER"2024"', 'SUMMER&quot;2024&quot;', 'summer"2024"' ),
+				'coupon_code' => 'TEST"2024"',
+				'user_inputs' => array( 'TEST"2024"', 'TEST&quot;2024&quot;', 'test"2024"' ),
 				'discount'    => 25,
 				'description' => 'Coupon with quote characters',
 			),

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -400,6 +400,21 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	 * @see https://github.com/woocommerce/woocommerce/issues/58864
 	 */
 	public function test_coupon_discount_amount_case_sensitivity() {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '20.0000',
+			'tax_rate_name'     => 'TAX20',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+		);
+
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
 		// Create a product to add to cart.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 100 );

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -400,6 +400,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	 * @see https://github.com/woocommerce/woocommerce/issues/58864
 	 */
 	public function test_coupon_discount_amount_case_sensitivity() {
+		$old_calc_taxes = get_option( 'woocommerce_calc_taxes', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 
 		$tax_rate = array(
@@ -413,7 +414,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			'tax_rate_order'    => '1',
 		);
 
-		WC_Tax::_insert_tax_rate( $tax_rate );
+		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
 		// Create a product to add to cart.
 		$product = WC_Helper_Product::create_simple_product();
@@ -459,5 +460,11 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC()->cart->remove_coupons();
 		$product->delete( true );
 		$coupon->delete( true );
+
+		// Restore global state.
+		update_option( 'woocommerce_calc_taxes', $old_calc_taxes );
+		if ( $tax_rate_id ) {
+			WC_Tax::_delete_tax_rate( $tax_rate_id );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -388,4 +388,61 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		$this->assertCount( 1, $notices['error'] );
 		$this->assertMatchesRegularExpression( '/Please choose product options by visiting/', $notices['error'][0]['notice'] );
 	}
+
+	/**
+	 * Test case sensitivity fix for coupon discount amounts.
+	 *
+	 * This test verifies that the fix for issue #58864 works correctly.
+	 * It creates a coupon with uppercase code in the database, applies it with lowercase code,
+	 * and ensures that get_coupon_discount_amount and get_coupon_discount_tax_amount
+	 * return the correct values regardless of case.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/58864
+	 */
+	public function test_coupon_discount_amount_case_sensitivity() {
+		// Create a product to add to cart.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Create a coupon with uppercase code.
+		$coupon = WC_Helper_Coupon::create_coupon( 'TESTCOUPON123' );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Add product to cart.
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		// Apply the coupon using lowercase code.
+		$applied = WC()->cart->apply_coupon( 'testcoupon123' );
+		$this->assertTrue( $applied, 'Coupon should be applied successfully with lowercase code' );
+
+		// Verify the coupon is in applied coupons (should be stored in original case).
+		$applied_coupons = WC()->cart->get_applied_coupons();
+		$this->assertContains( 'TESTCOUPON123', $applied_coupons, 'Coupon should be stored in original uppercase case' );
+
+		// Test get_coupon_discount_amount with lowercase code.
+		$discount_amount = WC()->cart->get_coupon_discount_amount( 'testcoupon123' );
+		$this->assertEquals( 10.00, $discount_amount, 'get_coupon_discount_amount should return correct value with lowercase code' );
+
+		// Test get_coupon_discount_amount with uppercase code.
+		$discount_amount_upper = WC()->cart->get_coupon_discount_amount( 'TESTCOUPON123' );
+		$this->assertEquals( 10.00, $discount_amount_upper, 'get_coupon_discount_amount should return correct value with uppercase code' );
+
+		// Test get_coupon_discount_tax_amount with lowercase code.
+		$tax_amount = WC()->cart->get_coupon_discount_tax_amount( 'testcoupon123' );
+		$this->assertEquals( 2.00, $tax_amount, 'get_coupon_discount_tax_amount should return correct value with lowercase code' );
+
+		// Test get_coupon_discount_tax_amount with uppercase code.
+		$tax_amount_upper = WC()->cart->get_coupon_discount_tax_amount( 'TESTCOUPON123' );
+		$this->assertEquals( 2.00, $tax_amount_upper, 'get_coupon_discount_tax_amount should return correct value with uppercase code' );
+
+		// Clean up.
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		$product->delete( true );
+		$coupon->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -467,4 +467,124 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 			WC_Tax::_delete_tax_rate( $tax_rate_id );
 		}
 	}
+
+		/**
+		 * Test coupon codes with special characters (ampersands, quotes, etc.).
+		 *
+		 * This test verifies that coupon codes containing special characters work correctly
+		 * when users input them in various formats (raw, HTML-encoded, etc.).
+		 * It tests the html_entity_decode() functionality in wc_format_coupon_code().
+		 */
+	public function test_coupon_codes_with_special_characters() {
+		// Create a product to add to cart.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		// Test cases with various special character scenarios.
+		$test_cases = array(
+			// Ampersand test cases.
+			array(
+				'coupon_code' => 'AT&T-SPECIAL',
+				'user_inputs' => array( 'AT&T-SPECIAL', 'AT&amp;T-SPECIAL', 'at&t-special' ),
+				'discount'    => 15,
+				'description' => 'Coupon with ampersand',
+			),
+			// Quote test cases.
+			array(
+				'coupon_code' => 'BEN&JERRY\'S',
+				'user_inputs' => array( 'BEN&JERRY\'S', 'BEN&amp;JERRY\'S', 'ben&jerry\'s' ),
+				'discount'    => 20,
+				'description' => 'Coupon with ampersand and apostrophe',
+			),
+			// Quote characters test.
+			array(
+				'coupon_code' => 'SUMMER"2024"',
+				'user_inputs' => array( 'SUMMER"2024"', 'SUMMER&quot;2024&quot;', 'summer"2024"' ),
+				'discount'    => 25,
+				'description' => 'Coupon with quote characters',
+			),
+		);
+
+		foreach ( $test_cases as $test_case ) {
+			$coupon_code = $test_case['coupon_code'];
+			$user_inputs = $test_case['user_inputs'];
+			$discount    = $test_case['discount'];
+			$description = $test_case['description'];
+
+			// Create coupon with special characters.
+			$coupon = WC_Helper_Coupon::create_coupon( $coupon_code );
+			$coupon->set_discount_type( 'fixed_cart' );
+			$coupon->set_amount( $discount );
+			$coupon->save();
+
+			foreach ( $user_inputs as $user_input ) {
+				// Add product to cart and clear any previously applied coupons.
+				WC()->cart->add_to_cart( $product->get_id(), 1 );
+				WC()->cart->remove_coupons();
+				WC()->cart->calculate_totals();
+
+				// Apply coupon with user input variation.
+				$applied = WC()->cart->apply_coupon( $user_input );
+				$this->assertTrue(
+					$applied,
+					sprintf(
+						'%s: Coupon should be applied successfully with user input "%s"',
+						$description,
+						$user_input
+					)
+				);
+
+				// Verify discount amount is correct.
+				$applied_coupons = WC()->cart->get_applied_coupons();
+				$this->assertNotEmpty( $applied_coupons, sprintf( '%s: Should have applied coupons', $description ) );
+
+				// Get the applied coupon code and verify discount amount.
+				$applied_coupon_code = reset( $applied_coupons );
+				$discount_amount     = WC()->cart->get_coupon_discount_amount( $applied_coupon_code );
+				$this->assertEquals(
+					(float) $discount,
+					$discount_amount,
+					sprintf(
+						'%s: Discount amount should be %s for user input "%s"',
+						$description,
+						$discount,
+						$user_input
+					)
+				);
+
+				WC()->cart->empty_cart();
+			}
+
+			$coupon->delete( true );
+		}
+
+		// Test edge case: Double-encoded input (simulating form submission issues).
+		$coupon = WC_Helper_Coupon::create_coupon( 'COMPANY&CO' );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 30 );
+		$coupon->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		// Test with double-encoded input (what might come from a problematic form).
+		$double_encoded_input = 'COMPANY&amp;amp;CO';
+		$applied              = WC()->cart->apply_coupon( $double_encoded_input );
+		$this->assertTrue(
+			$applied,
+			'Double-encoded coupon input should still be applied successfully'
+		);
+
+		$applied_coupons = WC()->cart->get_applied_coupons();
+		$applied_coupon  = reset( $applied_coupons );
+		$discount_amount = WC()->cart->get_coupon_discount_amount( $applied_coupon );
+		$this->assertEquals( 30.0, $discount_amount, 'Double-encoded input should produce correct discount' );
+
+		// Clean up.
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		$product->delete( true );
+		$coupon->delete( true );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -436,7 +436,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 
 		// Verify the coupon is in applied coupons (should be stored in original case).
 		$applied_coupons = WC()->cart->get_applied_coupons();
-		$this->assertContains( 'TESTCOUPON123', $applied_coupons, 'Coupon should be stored in original uppercase case' );
+		$this->assertContains( 'testcoupon123', $applied_coupons, 'Coupon should be stored in provided case' );
 
 		// Test get_coupon_discount_amount with lowercase code.
 		$discount_amount = WC()->cart->get_coupon_discount_amount( 'testcoupon123' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`strtolower` was removed from coupon formatting in https://github.com/woocommerce/woocommerce/pull/56319 which has broken some methods used to lookup coupon discount amounts if the case of the coupon differs between user input, and the coupon code stored in the DB.

The fix is to normalize (lowercase) coupon codes when looking up discount amounts.

This PR also changes:

- Store API to return actual codes so the correct case is displayed in cart block
- adds a unit test for coupon case handling

Closes #58864

(For Bug Fixes) Bug introduced in PR #56319

### How to test the changes in this Pull Request:

There is a new php unit test for this.

1. Create a coupon called TESTCOUPON with value 0
2. Use the snippet below
3. Go to the classic cart and confirm a $10 coupon applies and the amount shown below says "Discount amount is: 10".

```
/**
 * Changes the discount amount of the fixed cart coupon.
 *
 * @param WC_Coupon $coupon The coupon.
 *
 * @return void
 */
function change_coupon_discount_amount( $coupon ) {
	if ( is_admin() ) {
		return;
	}

	if ( strtolower( $coupon->get_code() ) !== 'testcoupon' ) {
		return;
	}

	$coupon->set_amount( 10 );
}
add_action( 'woocommerce_coupon_loaded', 'change_coupon_discount_amount' );

/**
 * Adds a coupon to the cart.
 *
 * @return void
 */
function apply_coupon() {
	$applied_coupons = array_map( 'wc_strtolower', WC()->cart->get_applied_coupons() );

	if ( ! in_array( 'testcoupon', $applied_coupons, true ) ) {
		WC()->cart->apply_coupon( 'testcoupon' );
	}
}
add_action( 'woocommerce_before_calculate_totals', 'apply_coupon' );

/**
 * Echoes the discount amount of the fixed cart coupon.
 *
 * @return void
 */
function echo_discount_amount() {
	if ( ! WC()->cart->has_discount() ) {
		return;
	}

	echo 'Discount amount is: ' . WC()->cart->get_coupon_discount_amount( 'testcoupon', WC()->cart->display_cart_ex_tax );
}
add_action( 'woocommerce_after_cart', 'echo_discount_amount' );
```

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues with coupon code matching by making coupon lookups case-insensitive, ensuring coupons work regardless of letter casing.
  - Improved error messages to display the correct coupon code format.
  - Enhanced coupon sanitization to better handle HTML entities.
  - Fixed coupon retrieval queries to be case-insensitive for accurate coupon identification.

- **New Features**
  - Added an action hook that triggers after a coupon is applied, enabling integrations with external systems.

- **Tests**
  - Introduced new tests to confirm coupon discount calculations are accurate regardless of coupon code case.

- **Refactor**
  - Streamlined coupon discount and tax retrieval for improved reliability and consistency.
  - Unified coupon code comparisons across cart operations for consistent behavior.
  - Updated rounding functions to support customizable rounding modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->