### PR TITLE
Change `Release: Feature highlight notification` trigger to run on the same day as the feature freeze

### DIFF
--- a/.github/workflows/release-feature-highlights-notification.yml
+++ b/.github/workflows/release-feature-highlights-notification.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       event-version: ${{ steps.find-feature-freeze-event.outputs.event-version }}
       event-title: ${{ steps.find-feature-freeze-event.outputs.event-title }}
-      event-date: ${{ steps.find-feature-freeze-event.outputs.event-date }}
+      deadline-date: ${{ steps.find-feature-freeze-event.outputs.deadline-date }}
     steps:
       - name: Install node-ical
         run: npm install node-ical
@@ -49,14 +49,18 @@ jobs:
                 const versionMatch = ffEvent.summary.match(/WooCommerce (\d+\.\d+) Feature Freeze/i);
                 const version = versionMatch ? versionMatch[1] : '';
 
+                // Calculate deadline date (4 days after the event)
+                const deadlineDate = new Date(ffEvent.start);
+                deadlineDate.setDate(deadlineDate.getDate() + 4);
+
                 core.setOutput('event-title', ffEvent.summary);
-                core.setOutput('event-date', ffEvent.start.toDateString());
                 core.setOutput('event-version', version);
+                core.setOutput('deadline-date', deadlineDate.toDateString());
                 console.log(`Feature Freeze event for version ${version} found:`, ffEvent);
               } else {
                 core.setOutput('event-title', '');
-                core.setOutput('event-date', '');
                 core.setOutput('event-version', '');
+                core.setOutput('deadline-date', '');
                 console.log('No Feature Freeze events found.');
               }
             } catch (error) {
@@ -76,10 +80,10 @@ jobs:
           slack-optional-unfurl_links: false
           slack-text: |
             :megaphone1: Hey teams!
-            The feature freeze for *${{ needs.check-feature-freeze.outputs.event-title }}* is scheduled for *${{ needs.check-feature-freeze.outputs.event-date }}, by EOD (UTC)*.
-            If your team has contributed changes to *${{ needs.check-feature-freeze.outputs.event-version }}* kindly review your work and, if needed, share a *Feature Highlight* or *Developer Advisory* for the beta announcement post by <https://woocorerelease.wordpress.com/?start=feature-highlight|using the format in the release P2>.
+            The feature freeze for *${{ needs.check-feature-freeze.outputs.event-title }}* is scheduled for today.
+            If your team has contributed changes to *${{ needs.check-feature-freeze.outputs.event-version }}* kindly review your work and, if needed, share a *Feature Highlight* or *Developer Advisory* for the announcement post by <https://woocorerelease.wordpress.com/?start=feature-highlight|using the format in the release P2>.
             You can <https://github.com/woocommerce/woocommerce/pulls?q=is%3Apr+milestone%3A${{ needs.check-feature-freeze.outputs.event-version }}.0+is%3Aclosed+author%3A%40me+|review a list of your own ${{ needs.check-feature-freeze.outputs.event-version }} PRs> to identify if any of those contributions merits a post.
             
-            :scribbl-clock: *Please aim to submit your highlights by ${{ needs.check-feature-freeze.outputs.event-date }}, end of day*. Thanks!
+            :scribbl-clock: *Please aim to submit your highlights by ${{ needs.check-feature-freeze.outputs.deadline-date }}, end of day*. Thanks!
             
             cc <!subteam^S086N376UTS>

--- a/.github/workflows/release-feature-highlights-notification.yml
+++ b/.github/workflows/release-feature-highlights-notification.yml
@@ -15,18 +15,17 @@ jobs:
       - name: Install node-ical
         run: npm install node-ical
 
-      - name: Check for Feature Freeze events in a week
+      - name: Check for Feature Freeze events today
         id: find-feature-freeze-event
         uses: actions/github-script@v7
         with:
           script: |
             const ical = require('node-ical');
             
-            console.log('Checking for Feature Freeze events in a week...');
+            console.log('Checking for Feature Freeze events today...');
             
             try {
-              const aWeekFromNow = new Date();
-              aWeekFromNow.setDate((new Date()).getDate() + 7);
+              const today = new Date();
 
               const events = await ical.async.fromURL('https://calendar.google.com/calendar/ical/${{ secrets.RELEASE_CALENDAR_ID }}/public/basic.ics');
 
@@ -34,7 +33,7 @@ jobs:
                 .filter(event => event.type === 'VEVENT')
                 .filter(event => {
                   if (!event.start) return false;
-                  return new Date(event.start).toDateString() === new Date(aWeekFromNow).toDateString();
+                  return new Date(event.start).toDateString() === new Date(today).toDateString();
                 });
 
               const ffEvent = dayEvents.find(event => {
@@ -64,7 +63,7 @@ jobs:
               core.setFailed(`Failed to fetch calendar events: ${error.message}`);
             }
 
-  notify-upcoming-feature-freeze:
+  notify-feature-freeze-today:
     needs: check-feature-freeze
     if: needs.check-feature-freeze.outputs.event-title != ''
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the date to trigger the feature highlight notification to be the same date as the feature freeze event. It also updates the notification to be 4 days after the message is sent.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

⚠️ If you want to test on your own Slack workspace, follow the instructions from the `Steps to set up a Slack app` from https://github.com/woocommerce/woocommerce/pull/58417, otherwise follow these 👇 

### Steps
1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
- `RELEASE_CALENDAR_ID`: Create a new **public** calendar under any Google account and set this to the calendar ID (follow [this guide](https://xfanatical.com/blog/how-to-find-your-google-calendar-id/) to get the ID).
3. In the forked repo, create a PR with the branch `feature-highlight-on-feature-freeze` and merge it (to get these changes into the `trunk` branch).
4. In your calendar, create a new day event with the title `WooCommerce X.Y Feature Freeze` (replace X.Y with any version number).
5. In the forked repo, go to `Actions` and manually run the `Release: Feature highlight notification`.
6. When the workflow finishes, go to the corresponding Slack channel and ensure you have received the message from the workflow and that the version, dates, and links are correct.
7. Remove the event and run the workflow again, see that the `notify-upcoming-feature-freeze` is skipped, and make sure you don't get any Slack messages.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to send feature freeze notifications on the actual event day instead of a week in advance.
  - Slack notifications now reference the correct deadline for submitting highlights.
  - Improved clarity in notification messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->