### PR TITLE
Testing - Please ignore

### DIFF
--- a/plugins/woocommerce/changelog/fix-54286-limit-wc-comment-count-transient-clearing
+++ b/plugins/woocommerce/changelog/fix-54286-limit-wc-comment-count-transient-clearing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Limit clearing of wc_count_comments transient to applicable comments.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -18,6 +18,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Comments {
 
 	/**
+	 * Cache Group
+	 *
+	 * @var string COMMENT_COUNT_CACHE_GROUP The cache group to use for comment counts.
+	 */
+	private const COMMENT_COUNT_CACHE_GROUP = 'wc_comment_counts';
+
+	/**
 	 * Hook in methods.
 	 */
 	public static function init() {
@@ -38,15 +45,19 @@ class WC_Comments {
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
 		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
-		// Exclude product reviews.
-		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 1 );
+		// Secure potential remaining Action Logs.
+		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_action_log_comments' ), 10, 2 );
+		add_filter( 'comment_feed_where', array( __CLASS__, 'exclude_action_log_comments_from_feed_where' ) );
+
+		// Exclude product reviews from general comments.
+		add_filter( 'comments_clauses', array( ReviewsUtil::class, 'comments_clauses_without_product_reviews' ), 10, 2 );
 
 		// Count comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
 
 		// Delete comments count cache whenever there is a new comment or a comment status changes.
-		add_action( 'wp_insert_comment', array( __CLASS__, 'delete_comments_count_cache' ) );
-		add_action( 'wp_set_comment_status', array( __CLASS__, 'delete_comments_count_cache' ) );
+		add_action( 'wp_insert_comment', array( __CLASS__, 'increment_comments_count_cache_on_wp_insert_comment' ), 10, 2 );
+		add_action( 'transition_comment_status', array( __CLASS__, 'update_comments_count_cache_on_comment_status_change' ), 10, 3 );
 
 		// Support avatars for `review` comment type.
 		add_filter( 'get_avatar_comment_types', array( __CLASS__, 'add_avatar_for_review_comment_type' ) );
@@ -92,7 +103,7 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function exclude_order_comments( $clauses ) {
-		$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " comment_type != 'order_note' ";
+		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 		return $clauses;
 	}
 
@@ -113,7 +124,7 @@ class WC_Comments {
 	 * @return string
 	 */
 	public static function exclude_order_comments_from_feed_where( $where ) {
-		return $where . ( $where ? ' AND ' : '' ) . " comment_type != 'order_note' ";
+		return $where . ( trim( $where ) ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 	}
 
 	/**
@@ -124,7 +135,7 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function exclude_webhook_comments( $clauses ) {
-		$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
+		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
 		return $clauses;
 	}
 
@@ -139,14 +150,31 @@ class WC_Comments {
 	}
 
 	/**
-	 * Exclude webhook comments from queries and RSS.
+	 * Exclude action_log comments from queries and RSS.
 	 *
 	 * @since  2.1
 	 * @param  string $where The WHERE clause of the query.
 	 * @return string
 	 */
-	public static function exclude_webhook_comments_from_feed_where( $where ) {
-		return $where . ( $where ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
+	public static function exclude_action_log_comments_from_feed_where( $where ) {
+		return $where . ( trim( $where ) ? ' AND ' : '' ) . " comment_type != 'action_log' ";
+	}
+
+	/**
+	 * Exclude action_log comments from queries.
+	 *
+	 * @param array            $clauses       A compacted array of comment query clauses.
+	 * @param WP_Comment_Query $comment_query The WP_Comment_Query being filtered.
+	 *
+	 * @return array
+	 * @since  9.9
+	 */
+	public static function exclude_action_log_comments( $clauses, $comment_query ) {
+		if ( 'action_log' !== $comment_query->query_vars['type'] ) {
+			$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . " comment_type != 'action_log' ";
+		}
+
+		return $clauses;
 	}
 
 	/**
@@ -216,79 +244,123 @@ class WC_Comments {
 	}
 
 	/**
+	 * Callback for 'wp_insert_comment' to delete the comment count cache if the comment is included in the count.
+	 *
+	 * @param int        $comment_id The comment ID.
+	 * @param WP_Comment $comment    Comment object.
+	 *
+	 * @return void
+	 */
+	public static function increment_comments_count_cache_on_wp_insert_comment( $comment_id, $comment ) {
+		if ( ! self::is_comment_excluded_from_wp_comment_counts( $comment ) ) {
+			$comment_status = wp_get_comment_status( $comment );
+			if ( false !== $comment_status ) {
+				wp_cache_incr( 'wc_count_comments_' . $comment_status, 1, self::COMMENT_COUNT_CACHE_GROUP );
+			}
+		}
+	}
+
+	/**
+	 * Callback for 'comment_status_change' to delete the comment count cache if the comment is included in the count.
+	 *
+	 * @param int|string $new_status The new comment status.
+	 * @param int|string $old_status The old comment status.
+	 * @param WP_Comment $comment    Comment object.
+	 *
+	 * @return void
+	 */
+	public static function update_comments_count_cache_on_comment_status_change( $new_status, $old_status, $comment ) {
+		if ( ! self::is_comment_excluded_from_wp_comment_counts( $comment ) ) {
+			wp_cache_incr( 'wc_count_comments_' . $new_status, 1, self::COMMENT_COUNT_CACHE_GROUP );
+			wp_cache_decr( 'wc_count_comments_' . $old_status, 1, self::COMMENT_COUNT_CACHE_GROUP );
+		}
+	}
+
+	/**
+	 * Determines whether the given comment should be included in the core WP comment counts that are displayed in the
+	 * WordPress admin.
+	 *
+	 * @param WP_Comment $comment Comment object.
+	 *
+	 * @return bool
+	 */
+	private static function is_comment_excluded_from_wp_comment_counts( $comment ) {
+		return in_array( $comment->comment_type, array( 'action_log', 'order_note', 'webhook_delivery' ), true )
+			|| get_post_type( $comment->comment_post_ID ) === 'product';
+	}
+
+	/**
 	 * Delete comments count cache whenever there is
 	 * new comment or the status of a comment changes. Cache
 	 * will be regenerated next time WC_Comments::wp_count_comments()
 	 * is called.
 	 */
 	public static function delete_comments_count_cache() {
-		delete_transient( 'wc_count_comments' );
+		$comment_status_keys = array(
+			'wc_count_comments_approved',
+			'wc_count_comments_unapproved',
+			'wc_count_comments_spam',
+			'wc_count_comments_trash',
+			'wc_count_comments_post-trashed',
+		);
+		wp_cache_delete_multiple( $comment_status_keys, self::COMMENT_COUNT_CACHE_GROUP );
 	}
 
 	/**
 	 * Remove order notes, webhook delivery logs, and product reviews from wp_count_comments().
 	 *
-	 * @since  2.2
-	 * @param  object $stats   Comment stats.
-	 * @param  int    $post_id Post ID.
+	 * @param array|object $stats   Comment stats.
+	 * @param int          $post_id Post ID.
+	 *
 	 * @return object
+	 * @since  2.2
 	 */
 	public static function wp_count_comments( $stats, $post_id ) {
-		global $wpdb;
-
-		if ( 0 === $post_id ) {
-			$stats = get_transient( 'wc_count_comments' );
-
-			if ( ! $stats ) {
-				$stats = array(
-					'total_comments' => 0,
-					'all'            => 0,
-				);
-
-				$count = $wpdb->get_results(
-					"
-					SELECT comment_approved, COUNT(*) AS num_comments
-					FROM {$wpdb->comments}
-					LEFT JOIN {$wpdb->posts} ON comment_post_ID = {$wpdb->posts}.ID
-					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery') AND {$wpdb->posts}.post_type NOT IN ('product')
-					GROUP BY comment_approved
-					",
-					ARRAY_A
-				);
-
-				$approved = array(
-					'0'            => 'moderated',
-					'1'            => 'approved',
-					'spam'         => 'spam',
-					'trash'        => 'trash',
-					'post-trashed' => 'post-trashed',
-				);
-
-				foreach ( (array) $count as $row ) {
-					// Don't count post-trashed toward totals.
-					if ( ! in_array( $row['comment_approved'], array( 'post-trashed', 'trash', 'spam' ), true ) ) {
-						$stats['all']            += $row['num_comments'];
-						$stats['total_comments'] += $row['num_comments'];
-					} elseif ( ! in_array( $row['comment_approved'], array( 'post-trashed', 'trash' ), true ) ) {
-						$stats['total_comments'] += $row['num_comments'];
-					}
-					if ( isset( $approved[ $row['comment_approved'] ] ) ) {
-						$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
-					}
-				}
-
-				foreach ( $approved as $key ) {
-					if ( empty( $stats[ $key ] ) ) {
-						$stats[ $key ] = 0;
-					}
-				}
-
-				$stats = (object) $stats;
-				set_transient( 'wc_count_comments', $stats );
-			}
+		if ( 0 !== $post_id || ! empty( $stats ) ) {
+			// If $stats isn't empty, another plugin may have already made changes to the values that we can't account for, so we don't attempt to modify it.
+			return $stats;
 		}
 
-		return $stats;
+		$comment_counts = array();
+
+		// WordPress is inconsistent in the names it uses for approved/unapproved comment statuses, so we need to remap the names.
+		$stat_key_to_comment_query_status_mapping = array(
+			'approved'     => 'approve',
+			'moderated'    => 'hold',
+			'spam'         => 'spam',
+			'trash'        => 'trash',
+			'post-trashed' => 'post-trashed',
+		);
+
+		$comment_query_status_to_comment_status_mapping = array(
+			'approve'      => 'approved',
+			'hold'         => 'unapproved',
+			'spam'         => 'spam',
+			'trash'        => 'trash',
+			'post-trashed' => 'post-trashed',
+		);
+
+		$args = array(
+			'count'                     => true,
+			'update_comment_meta_cache' => false,
+			'orderby'                   => 'none',
+		);
+
+		foreach ( $stat_key_to_comment_query_status_mapping as $stat_key => $query_status ) {
+			// For simplicity, the cache key is by the comment status returned by wp_get_comment_status() and used by wp_transition_comment_status().
+			$cache_key = 'wc_count_comments_' . $comment_query_status_to_comment_status_mapping[ $query_status ];
+			$count     = wp_cache_get( $cache_key, self::COMMENT_COUNT_CACHE_GROUP );
+			if ( false === $count ) {
+				$count = (int) get_comments( array_merge( $args, array( 'status' => $query_status ) ) );
+				wp_cache_set( $cache_key, $count, self::COMMENT_COUNT_CACHE_GROUP, 3 * DAY_IN_SECONDS );
+			}
+			$comment_counts[ $stat_key ] = (int) $count;
+		}
+
+		$comment_counts['all']            = $comment_counts['approved'] + $comment_counts['moderated'];
+		$comment_counts['total_comments'] = $comment_counts['all'] + $comment_counts['spam'];
+
+		return (object) $comment_counts;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -279,6 +279,7 @@ class WC_Install {
 		),
 		'9.8.5' => array(
 			'wc_update_985_enable_new_payments_settings_page_feature',
+			'wc_update_990_remove_wc_count_comments_transient',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2955,7 +2955,16 @@ function wc_update_980_remove_order_attribution_install_banner_dismissed_option(
 }
 
 /**
- * One-time force enable the new Payments Settings page feature for all stores.
+ * Remove the transient wc_count_comments as this has migrated to use cache.
+ */
+function wc_update_990_remove_wc_count_comments_transient() {
+	delete_transient( 'wc_count_comments' );
+}
+
+/**
+ * Remove all notes of type 'email' from wp_wc_admin_notes table.
+ *
+ * @return void
  */
 function wc_update_985_enable_new_payments_settings_page_feature() {
 	update_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled', 'yes' );

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsUtil.php
@@ -10,16 +10,52 @@ class ReviewsUtil {
 	/**
 	 * Removes product reviews from the edit-comments page to fix the "Mine" tab counter.
 	 *
-	 * @param  array|mixed $clauses A compacted array of comment query clauses.
+	 * @param array|mixed       $clauses A compacted array of comment query clauses.
+	 * @param \WP_Comment_Query $comment_query The WP_Comment_Query instance being filtered.
+	 *
 	 * @return array|mixed
 	 */
-	public static function comments_clauses_without_product_reviews( $clauses ) {
-		global $wpdb, $current_screen;
+	public static function comments_clauses_without_product_reviews( $clauses, $comment_query ) {
+		global $wpdb;
 
-		if ( isset( $current_screen->base ) && 'edit-comments' === $current_screen->base ) {
-			$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
-			$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
+		if ( ! empty( $comment_query->query_vars['post_type'] ) ) {
+			$post_type = $comment_query->query_vars['post_type'];
+			if ( ! is_array( $post_type ) ) {
+				$post_type = explode( ',', $post_type );
+			}
+			if ( in_array( 'product', $post_type, true ) ) {
+				return $clauses;
+			}
 		}
+
+		/**
+		 * Any comment queries with these values are likely to be custom handling where we don't want to change default behavior.
+		 * This may change for the `type` query vars in the future if we break out review replies as their own type.
+		 */
+		foreach ( array( 'ID', 'parent', 'parent__in', 'post_author__in', 'post_author', 'post_name', 'type', 'type__in', 'type__not_in', 'post_type__in', 'comment__in', 'comment__not_in' ) as $arg ) {
+			if ( ! empty( $comment_query->query_vars[ $arg ] ) ) {
+				return $clauses;
+			}
+		}
+
+		if ( ! empty( $comment_query->query_vars['post_id'] ) && absint( $comment_query->query_vars['post_id'] ) > 0 ) {
+			if ( 'product' === get_post_type( absint( $comment_query->query_vars['post_id'] ) ) ) {
+				return $clauses;
+			}
+		}
+
+		if ( ! empty( $comment_query->query_vars['post__in'] ) ) {
+			$post_ids = wp_parse_id_list( $comment_query->query_vars['post__in'] );
+			_prime_post_caches( $post_ids, false, false );
+			foreach ( $post_ids as $post_id ) {
+				if ( 'product' === get_post_type( $post_id ) ) {
+					return $clauses;
+				}
+			}
+		}
+
+		$clauses['join']  .= " LEFT JOIN {$wpdb->posts} AS wp_posts_to_exclude_reviews ON comment_post_ID = wp_posts_to_exclude_reviews.ID ";
+		$clauses['where'] .= ( trim( $clauses['where'] ) ? ' AND ' : '' ) . " wp_posts_to_exclude_reviews.post_type NOT IN ('product') ";
 
 		return $clauses;
 	}


### PR DESCRIPTION
Improve caching of wc_count_comments counts to avoid re-queries after every order note. (#54984)

* Limit clearing of wc_count_comments transient to applicable comments.

Updates the callback handling for hooks related to comment modification to only clear the wc_count_comments transient for comment and post types that aren't included in the counted results stored in cache.

* lint fixes

* switch to incrementing/decrementing the count instead of deleting the cache.

* fix update callback name to reflect 9.9.0

* Automatically expire cache after 3 days until we can implement a scheduled job to reprime the data.

* Switch to using get_comments() instead of custom query so any other extensions can continue to modify the comment query as needed

* Modify tests for non-screen based filtering of product reviews

* restore accidentally deleted dataprovider

* excluding product type filter for comment__in/not_in as likely custom queries checking the trim'ed state of the where clause when determining whether to prefix with 'AND'

* lint fixes

* more lint fixes

* lint fixes in test

* excluded action log entries from comment feed avoided flushing cache group to directly delete specific keys for status

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced comment count caching for better site performance by reducing unnecessary cache clearing and introducing more efficient cache management.
- **Bug Fixes**
  - Improved exclusion logic to ensure certain comment types (e.g., action logs, product reviews) are properly filtered in queries and feeds.
- **Tests**
  - Updated and expanded test coverage for comment filtering logic to ensure accuracy and robustness.
- **Chores**
  - Added a database update to remove obsolete comment count transients during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->