### PR TITLE
Use email sender options for stock notifications

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-819-enhancement-notifications-out-of-stock-send-to-default
+++ b/plugins/woocommerce/changelog/wooplug-819-enhancement-notifications-out-of-stock-send-to-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use email sender options for low stock, no stock, and backorder notifications.

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -816,6 +816,22 @@ class WC_Emails {
 	}
 
 	/**
+	 * Add email sender filters.
+	 */
+	private function add_email_sender_filters() {
+		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+	}
+
+	/**
+	 * Remove email sender filters.
+	 */
+	private function remove_email_sender_filters() {
+		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+	}
+
+	/**
 	 * Low stock notification email.
 	 *
 	 * @param WC_Product $product Product instance.
@@ -852,8 +868,7 @@ class WC_Emails {
 			html_entity_decode( wp_strip_all_tags( $product->get_stock_quantity() ) )
 		);
 
-		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->add_email_sender_filters();
 
 		wp_mail(
 			/**
@@ -903,8 +918,7 @@ class WC_Emails {
 			apply_filters( 'woocommerce_email_attachments', array(), 'low_stock', $product, null )
 		);
 
-		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->remove_email_sender_filters();
 	}
 
 	/**
@@ -940,8 +954,7 @@ class WC_Emails {
 		/* translators: %s: product name */
 		$message = sprintf( __( '%s is out of stock.', 'woocommerce' ), html_entity_decode( wp_strip_all_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ) );
 
-		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->add_email_sender_filters();
 
 		wp_mail(
 			/**
@@ -991,8 +1004,7 @@ class WC_Emails {
 			apply_filters( 'woocommerce_email_attachments', array(), 'no_stock', $product, null )
 		);
 
-		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->remove_email_sender_filters();
 	}
 
 	/**
@@ -1027,8 +1039,7 @@ class WC_Emails {
 		/* translators: 1: backordered quantity 2: product name 3: order number */
 		$message = sprintf( __( '%1$s units of %2$s have been backordered in order #%3$s.', 'woocommerce' ), $backordered_quantity, html_entity_decode( wp_strip_all_tags( $args['product']->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ), $order->get_order_number() );
 
-		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->add_email_sender_filters();
 
 		wp_mail(
 			/**
@@ -1078,8 +1089,7 @@ class WC_Emails {
 			apply_filters( 'woocommerce_email_attachments', array(), 'backorder', $args, null )
 		);
 
-		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
-		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+		$this->remove_email_sender_filters();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -852,6 +852,9 @@ class WC_Emails {
 			html_entity_decode( wp_strip_all_tags( $product->get_stock_quantity() ) )
 		);
 
+		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
+
 		wp_mail(
 			/**
 			 * Filter the recipient of the low stock notification email.
@@ -899,6 +902,9 @@ class WC_Emails {
 			 */
 			apply_filters( 'woocommerce_email_attachments', array(), 'low_stock', $product, null )
 		);
+
+		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 	}
 
 	/**
@@ -933,6 +939,9 @@ class WC_Emails {
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product out of stock', 'woocommerce' ) );
 		/* translators: %s: product name */
 		$message = sprintf( __( '%s is out of stock.', 'woocommerce' ), html_entity_decode( wp_strip_all_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ) );
+
+		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 
 		wp_mail(
 			/**
@@ -981,6 +990,9 @@ class WC_Emails {
 			 */
 			apply_filters( 'woocommerce_email_attachments', array(), 'no_stock', $product, null )
 		);
+
+		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 	}
 
 	/**
@@ -1014,6 +1026,9 @@ class WC_Emails {
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product backorder', 'woocommerce' ) );
 		/* translators: 1: backordered quantity 2: product name 3: order number */
 		$message = sprintf( __( '%1$s units of %2$s have been backordered in order #%3$s.', 'woocommerce' ), $backordered_quantity, html_entity_decode( wp_strip_all_tags( $args['product']->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ), $order->get_order_number() );
+
+		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 
 		wp_mail(
 			/**
@@ -1062,6 +1077,9 @@ class WC_Emails {
 			 */
 			apply_filters( 'woocommerce_email_attachments', array(), 'backorder', $args, null )
 		);
+
+		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
+		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:



Closes [WOOPLUG-819: \[Enhancement\]: notifications > Out of stock send to default wordpress@mydomain.tld > spam box](https://linear.app/a8c/issue/WOOPLUG-819/enhancement-notifications-out-of-stock-send-to-default) (https://github.com/woocommerce/woocommerce/issues/34631).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Ensure the Inventory notifications are enabled from **WooCommerce** → **Settings** → **Products** → **Inventory**.
2. Update the email sender options from **WooCommerce** → **Settings** → **Emails**.
3. Create a new product and enable **Stock management**, set the quantity above the low stock threshold, and allow backorders from the **Inventory** tab.
4. Create a new order with the specified product and quantity to trigger the low stock threshold.
5. Create another order with the specified product and quantity to trigger the no stock (0) threshold.
6. Create another order with the specified product that should be out of stock so that the backorder notification is triggered.
7. Confirm all three emails use the sender address and name set in **WooCommerce** → **Settings** → **Emails**.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Use email sender options for low stock, no stock, and backorder notifications.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancement**
  - Stock-related notification emails (low stock, out of stock, backorder) now use the configured sender name and email address, ensuring consistency with your WooCommerce email settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->