### PR TITLE
Blocks E2E: Fix flaky gallery test due to network issue during creating template

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-3076-flaky-test-should-open-dialog-on-the-frontend
+++ b/plugins/woocommerce/changelog/wooplug-3076-flaky-test-should-open-dialog-on-the-frontend
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix flaky e2e test related to template creation.
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -68,11 +68,38 @@ const getThumbnailImageIdByNth = async (
 
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
-		const template = await requestUtils.createTemplate( 'wp_template', {
-			slug: blockData.slug,
-			title: 'Custom Single Product',
-			content: 'placeholder',
-		} );
+		let template;
+		const maxRetries = 3;
+		let retryCount = 0;
+		let lastError;
+
+		while ( retryCount < maxRetries ) {
+			try {
+				template = await requestUtils.createTemplate( 'wp_template', {
+					slug: blockData.slug,
+					title: 'Custom Single Product',
+					content: 'placeholder',
+				} );
+			} catch ( verifyError ) {
+				lastError = verifyError;
+			}
+
+			retryCount++;
+			if ( retryCount < maxRetries ) {
+				// Exponential backoff for retries
+				await new Promise( ( resolve ) =>
+					setTimeout( resolve, Math.pow( 2, retryCount ) * 200 )
+				);
+			}
+		}
+
+		if ( lastError ) {
+			throw lastError;
+		}
+
+		if ( ! template ) {
+			throw new Error( 'Template was not created.' );
+		}
 
 		await admin.visitSiteEditor( {
 			postId: template.id,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -97,7 +97,12 @@ test.describe( `${ blockData.name }`, () => {
 		}
 
 		if ( ! template ) {
-			throw lastError ?? new Error( 'Template was not created.' );
+			throw (
+				lastError ??
+				new Error(
+					`Template was not created after ${ maxRetries } attempts.`
+				)
+			);
 		}
 
 		await admin.visitSiteEditor( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
@@ -80,6 +80,9 @@ test.describe( `${ blockData.name }`, () => {
 					title: 'Custom Single Product',
 					content: 'placeholder',
 				} );
+				// Success – exit the loop and clear previous error.
+				lastError = undefined;
+				break;
 			} catch ( verifyError ) {
 				lastError = verifyError;
 			}
@@ -93,12 +96,8 @@ test.describe( `${ blockData.name }`, () => {
 			}
 		}
 
-		if ( lastError ) {
-			throw lastError;
-		}
-
 		if ( ! template ) {
-			throw new Error( 'Template was not created.' );
+			throw lastError ?? new Error( 'Template was not created.' );
 		}
 
 		await admin.visitSiteEditor( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -80,6 +80,9 @@ test.describe( `${ blockData.slug } Block`, () => {
 					title: 'Product Details Test',
 					content: '',
 				} );
+				// Success – exit the loop and clear previous error.
+				lastError = undefined;
+				break;
 			} catch ( verifyError ) {
 				lastError = verifyError;
 			}
@@ -93,12 +96,8 @@ test.describe( `${ blockData.slug } Block`, () => {
 			}
 		}
 
-		if ( lastError ) {
-			throw lastError;
-		}
-
 		if ( ! template ) {
-			throw new Error( 'Template was not created.' );
+			throw lastError ?? new Error( 'Template was not created.' );
 		}
 
 		await admin.visitSiteEditor( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-details/single-product-details.block_theme.spec.ts
@@ -97,7 +97,12 @@ test.describe( `${ blockData.slug } Block`, () => {
 		}
 
 		if ( ! template ) {
-			throw lastError ?? new Error( 'Template was not created.' );
+			throw (
+				lastError ??
+				new Error(
+					`Template was not created after ${ maxRetries } attempts.`
+				)
+			);
 		}
 
 		await admin.visitSiteEditor( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes wooplug-3076.

Similar to https://github.com/woocommerce/woocommerce/pull/58457, we have a network issue during creating template for testing. While this is not ideal, I couldn't find other way to handle the network issue, suggestion is more than welcome.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Ensure the test 'should open dialog on the frontend' passes in CI (8/10) without retrying and passes locally.

```sh
pnpm --filter="@woocommerce/plugin-woocommerce" test:e2e:blocks tests/e2e/tests/product-gallery/product-gallery.block_theme.spec.ts
```

<!-- End testing instructions -->