### PR TITLE
Improve `has_purchasable_variations` function query

### DIFF
--- a/plugins/woocommerce/changelog/fix-variable-products-handling
+++ b/plugins/woocommerce/changelog/fix-variable-products-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Product Stock Indicator and Add to Cart + Options blocks to consider variable products without purchasable variations as out of stock

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -301,8 +301,6 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
-	 * @hint If the function gets updated, make sure to update has_available_variations too, as they share similar logic.
-	 *
 	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
 	 *
 	 * @return array[]|WC_Product_Variation[]
@@ -353,17 +351,15 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Check if there are available variations for the current product.
+	 * Check if there are variations that can be purchased for the current product.
 	 *
 	 * @internal
-	 * @hint If the function gets updated, make sure to update get_available_variations too, as they share similar logic.
 	 *
-	 * @since  9.9.0
+	 * @since  10.0.0
 	 * @return bool
 	 */
-	public function has_available_variations() {
-		$variation_ids           = $this->get_children();
-		$hide_out_of_stock_items = ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) );
+	public function has_purchasable_variations() {
+		$variation_ids = $this->get_children();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -374,20 +370,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ( $hide_out_of_stock_items && ! $variation->is_in_stock() ) ) {
-				continue;
-			}
-
-			/**
-			 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
-			 *
-			 * @since 2.6.8
-			 *
-			 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
-			 * @param  int                   $product_id  The ID of the variation.
-			 * @param  WC_Product_Variation  $variation   The variation object.
-			 */
-			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
+			if ( ! $variation || ! $variation->exists() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -359,7 +359,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return bool
 	 */
 	public function has_purchasable_variations() {
-		$variation_ids = $this->get_children();
+		$variation_ids = $this->get_variation_ids();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -380,6 +380,33 @@ class WC_Product_Variable extends WC_Product {
 
 		// There were either no variations, or they were hidden because of the "continues" above.
 		return false;
+	}
+
+	/**
+	 * Get the variation IDs for the current product.
+	 *
+	 * @return array
+	 */
+	private function get_variation_ids() {
+		global $wpdb;
+		$product_id = $this->get_id();
+
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT v.ID AS variation_id
+				FROM {$wpdb->posts} AS v
+				INNER JOIN {$wpdb->wc_product_meta_lookup} AS ml ON ml.product_id = v.ID
+				INNER JOIN {$wpdb->wc_product_meta_lookup} AS parent_ml ON parent_ml.product_id = v.post_parent
+				WHERE v.post_type = 'product_variation'
+				AND v.post_status = 'publish'
+				AND v.post_parent = %d
+				AND ml.stock_status = 'instock'
+				AND (ml.price > 0 OR parent_ml.price = 0)",
+				$product_id
+			)
+		);
+
+		return array_map( 'absint', $variation_ids );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -370,7 +370,7 @@ class WC_Product_Variable extends WC_Product {
 			$variation = wc_get_product( $variation_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-			if ( ! $variation || ! $variation->exists() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
+			if ( ! $variation || ! $variation->is_purchasable() || ! ( $variation->is_in_stock() || $variation->backorders_allowed() ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -265,9 +265,9 @@ class AddToCartWithOptions extends AbstractBlock {
 			*/
 			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 
-			if ( ! $is_disabled_compatibility_layer ) {
+			if ( ! $is_disabled_compatibility_layer && ! Utils::is_not_purchasable_product( $product ) ) {
 				ob_start();
-				if ( ProductType::SIMPLE === $product_type && $product->is_in_stock() && $product->is_purchasable() ) {
+				if ( ProductType::SIMPLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
 					 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -261,7 +261,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			* This hook allows to disable the compatibility layer for the blockified.
 			*
 			* @since 7.6.0
-			* @param boolean.
+			* @param boolean $is_disabled_compatibility_layer Whether the compatibility layer should be disabled.
 			*/
 			$is_disabled_compatibility_layer = apply_filters( 'woocommerce_disable_compatibility_layer', false );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -44,10 +44,12 @@ class QuantitySelector extends AbstractBlock {
 		$product = AddToCartWithOptionsUtils::get_product_from_context( $block, $previous_product );
 
 		if ( ! $product ) {
+			$product = $previous_product;
+
 			return '';
 		}
 
-		if ( AddToCartWithOptionsUtils::is_not_purchasable_simple_product( $product ) ) {
+		if ( AddToCartWithOptionsUtils::is_not_purchasable_product( $product ) ) {
 			$product = $previous_product;
 
 			return '';
@@ -57,8 +59,9 @@ class QuantitySelector extends AbstractBlock {
 		$can_only_be_purchased_one_at_a_time = $product->is_sold_individually();
 		$managing_stock                      = $product->managing_stock();
 		$stock_quantity                      = $product->get_stock_quantity();
+		$allows_backorders                   = $product->backorders_allowed();
 
-		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time || ( $managing_stock && $stock_quantity <= 1 ) ) {
+		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time || ( $managing_stock && $stock_quantity <= 1 && ! $allows_backorders ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -125,13 +125,19 @@ class Utils {
 	}
 
 	/**
-	 * Check if a product is a simple product that is not purchasable or not in stock.
+	 * Check if a product is not purchasable or not in stock.
 	 *
 	 * @param \WC_Product $product The product to check.
-	 * @return bool True if the product is a simple product that is not purchasable or not in stock.
+	 * @return bool True if the product is not purchasable or not in stock.
 	 */
-	public static function is_not_purchasable_simple_product( $product ) {
-		return ProductType::SIMPLE === $product->get_type() && ( ! $product->is_in_stock() || ! $product->is_purchasable() );
+	public static function is_not_purchasable_product( $product ) {
+		if ( $product->is_type( 'simple' ) ) {
+			return ! $product->is_in_stock() || ! $product->is_purchasable();
+		} elseif ( $product->is_type( 'variable' ) ) {
+			return ! $product->has_purchasable_variations();
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -137,7 +137,7 @@ class Utils {
 			return ! $product->has_purchasable_variations();
 		}
 
-		return true;
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 
 /**
  * Block type for variation selector in add to cart with options.
@@ -31,7 +32,7 @@ class VariationSelector extends AbstractBlock {
 	protected function render( $attributes, $content, $block ): string {
 		global $product;
 
-		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+		if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) && ! Utils::is_not_purchasable_product( $product ) ) {
 			return $content;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelector.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
-use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 
 /**
  * Block type for variation selector in add to cart with options.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -90,7 +90,7 @@ class ProductButton extends AbstractBlock {
 
 		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
 
-		if ( $is_descendant_of_add_to_cart_form && Utils::is_not_purchasable_simple_product( $product ) ) {
+		if ( $is_descendant_of_add_to_cart_form && Utils::is_not_purchasable_product( $product ) ) {
 			$product = $previous_product;
 
 			return '';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -143,8 +143,6 @@ class ProductButton extends AbstractBlock {
 			)
 		);
 
-		$is_descendant_of_add_to_cart_form = isset( $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] ) ? $block->context['woocommerce/isDescendantOfAddToCartWithOptions'] : false;
-
 		$default_quantity = 1;
 
 		if ( ! $is_descendant_of_add_to_cart_form ) {

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -30,7 +30,7 @@ class ProductAvailabilityUtils {
 		// at the parent product level, check if any of its variations is in stock.
 		// We will show a custom availability message if all variations are out of stock.
 		if ( ! $product_availability && $product->get_type() === ProductType::VARIABLE ) {
-			if ( ! $product->has_available_variations() ) {
+			if ( ! $product->has_purchasable_variations() ) {
 				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\Utils;
 
 use Automattic\WooCommerce\Blocks\Templates\ProductStockIndicator;
 use Automattic\WooCommerce\Enums\ProductType;
+
 /**
  * Utility functions for product availability.
  */
@@ -26,12 +27,15 @@ class ProductAvailabilityUtils {
 		}
 
 		$product_availability = $product->get_availability();
-		// If the product is a variable product and availability isn't controlled
-		// at the parent product level, check if any of its variations is in stock.
-		// We will show a custom availability message if all variations are out of stock.
-		if ( ! $product_availability && $product->get_type() === ProductType::VARIABLE ) {
+
+		// If the product is a variable product, make sure at least one of its
+		// variations is purchasable.
+		if (
+			( 'in-stock' === $product_availability['class'] || 'available-on-backorder' === $product_availability['class'] ) &&
+			ProductType::VARIABLE === $product->get_type()
+		) {
 			if ( ! $product->has_purchasable_variations() ) {
-				$product_availability['availability'] = __( 'This product is currently out of stock and unavailable.', 'woocommerce' );
+				$product_availability['availability'] = __( 'Out of stock', 'woocommerce' );
 				$product_availability['class']        = 'out-of-stock';
 			}
 		}

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -23,6 +23,8 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
 
+<!-- wp:woocommerce/product-stock-indicator /-->
+
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-variable-test.php
@@ -41,9 +41,9 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox 'has_available_variations' should return true when all variations are available.
+	 * @testdox 'has_purchasable_variations' should return true when all variations are purchasable.
 	 */
-	public function test_has_available_variations_returns_true_when_all_variations_are_available() {
+	public function test_has_purchasable_variations_returns_true_when_all_variations_are_purchasable() {
 
 		$product = WC_Helper_Product::create_variation_product();
 
@@ -51,15 +51,15 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( is_array( $variations[0] ) );
 		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertTrue( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertTrue( $has_purchasable_variations );
 	}
 
 	/**
-	 * @testdox 'has_available_variations' returns true when some variations are available.
+	 * @testdox 'has_purchasable_variations' returns true when some variations are purchasable.
 	 */
-	public function test_has_available_variations_returns_true_when_some_variations_are_available() {
+	public function test_has_purchasable_variations_returns_true_when_some_variations_are_purchasable() {
 
 		$product = new WC_Product_Variable();
 
@@ -105,15 +105,15 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( is_array( $variations[0] ) );
 		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertTrue( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertTrue( $has_purchasable_variations );
 	}
 
 	/**
-	 * @testdox 'has_available_variations' returns false when all variations are not available.
+	 * @testdox 'has_purchasable_variations' returns false when all variations are not purchasable.
 	 */
-	public function test_has_available_variations_returns_false_when_all_variations_are_not_available() {
+	public function test_has_purchasable_variations_returns_false_when_all_variations_are_not_purchasable() {
 
 		$product = new WC_Product_Variable();
 
@@ -158,8 +158,8 @@ class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
 		$variations = $product->get_available_variations( 'array' );
 		$this->assertTrue( empty( $variations ) );
 
-		$has_available_variations = $product->has_available_variations();
-		$this->assertIsBool( $has_available_variations );
-		$this->assertFalse( $has_available_variations );
+		$has_purchasable_variations = $product->has_purchasable_variations();
+		$this->assertIsBool( $has_purchasable_variations );
+		$this->assertFalse( $has_purchasable_variations );
 	}
 }


### PR DESCRIPTION
Replace the method for fetching variation IDs with a new private method, get_variation_ids(), which improves the query for in-stock variations. This change enhances performance and clarity in the has_purchasable_variations() method.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
