### PR TITLE
[dev] CI: update ignore-list for trunk merges.

### DIFF
--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -11,6 +11,8 @@ on:
             - '**/changelog.txt'
             - '**/readme.txt'
             - '.gitignore'
+            - '.coderabbit.yml'
+            - 'CODEOWNERS'
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - '**/*.md'
       - '**/changelog.txt'
       - '.gitignore'
+      - '.coderabbit.yml'
       - 'CODEOWNERS'
       - '.github/**'
       - '!.github/workflows/ci.yml'

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -15,6 +15,8 @@ on:
             - '**/changelog.txt'
             - '**/readme.txt'
             - '.gitignore'
+            - '.coderabbit.yml'
+            - 'CODEOWNERS'
             - '**/tests/**'
             - '**/*.md'
             - '.husky/**'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ignore changes in `.coderabbit.yml` and `CODEOWNERS` in workflows running on trunk merge.

### How to test the changes in this Pull Request:

- CI-checks shall pass in the PR
- CI-checks should not run on trunk merge (for all consequent merges)
