### PR TITLE
Prevent some block styles being loaded on every page in classic themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-58791-block-json-styles-classic-themes
+++ b/plugins/woocommerce/changelog/fix-58791-block-json-styles-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent some block styles being loaded on every page in classic themes

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AbstractBlock.php
@@ -214,6 +214,26 @@ abstract class AbstractBlock {
 		$chunks = preg_filter( '/.js/', '', $blocks );
 		return $chunks;
 	}
+
+	/**
+	 * Removes the style property from block metadata for WooCommerce blocks.
+	 * Intended to be used in classic themes for blocks with manually enqueued styles.
+	 *
+	 * @internal
+	 *
+	 * @param array $metadata Block metadata.
+	 * @return array Modified block metadata.
+	 */
+	public function remove_style_from_block_metadata( $metadata ) {
+		if (
+			strpos( $metadata['name'], 'woocommerce/' ) === 0 &&
+			! empty( $metadata['style'] )
+		) {
+			$metadata['style'] = null;
+		}
+		return $metadata;
+	}
+
 	/**
 	 * Registers the block type with WordPress.
 	 *
@@ -227,7 +247,8 @@ abstract class AbstractBlock {
 
 		// Conditionally override these, otherwise rely on block.json metadata.
 		if ( $this->get_block_type_style() ) {
-			$block_settings['style'] = $this->get_block_type_style();
+			$block_types_styles      = $this->get_block_type_style();
+			$block_settings['style'] = $block_types_styles;
 		}
 
 		if ( $this->get_block_type_editor_style() ) {
@@ -250,10 +271,7 @@ abstract class AbstractBlock {
 			! is_admin() &&
 			! wp_is_block_theme() &&
 			! empty( $block_settings['style'] ) &&
-			(
-				! function_exists( 'wp_should_load_separate_core_block_assets' ) ||
-				! wp_should_load_separate_core_block_assets()
-			)
+			! wp_should_load_separate_core_block_assets()
 		) {
 			$style_handles           = $block_settings['style'];
 			$block_settings['style'] = null;
@@ -272,10 +290,30 @@ abstract class AbstractBlock {
 
 		// Prefer to register with metadata if the path is set in the block's class.
 		if ( ! empty( $metadata_path ) ) {
+			// In classic themes, remove the `style` property from block.json to
+			// avoid styles being enqueued on all pages.
+			// @see https://github.com/woocommerce/woocommerce/issues/58791.
+			if (
+				! wp_is_block_theme() &&
+				! empty( $block_types_styles ) &&
+				! wp_should_load_separate_core_block_assets()
+			) {
+				add_filter( 'block_type_metadata', [ $this, 'remove_style_from_block_metadata' ] );
+			}
+
 			register_block_type_from_metadata(
 				$metadata_path,
 				$block_settings
 			);
+
+			if (
+				! wp_is_block_theme() &&
+				! empty( $block_types_styles ) &&
+				! wp_should_load_separate_core_block_assets()
+			) {
+				remove_filter( 'block_type_metadata', [ $this, 'remove_style_from_block_metadata' ] );
+			}
+
 			return;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -35,7 +35,6 @@ class AddToCartForm extends AbstractBlock {
 		return wp_parse_args( $attributes, $defaults );
 	}
 
-
 	/**
 	 * Enqueue assets specific to this block.
 	 * We enqueue frontend scripts only if the quantitySelectorStyle is set to 'stepper'.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EnableBlockJsonAssetsTrait.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EnableBlockJsonAssetsTrait.php
@@ -22,7 +22,13 @@ trait EnableBlockJsonAssetsTrait {
 	 * @return null
 	 */
 	protected function get_block_type_style() {
-		return null;
+		if ( wp_is_block_theme() ) {
+			return null;
+		}
+
+		$this->asset_api->register_style( 'woocommerce-' . $this->block_name . '-style', 'assets/client/blocks/woocommerce/' . $this->block_name . '-style.css', [], 'all', true );
+
+		return [ 'wc-blocks-style', 'woocommerce-' . $this->block_name . '-style' ];
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58791.

### How to test the changes in this Pull Request:

1. Switch to a classic theme, go to a page where there are no WooCommerce Blocks (ie, `/my-account`).
2. Verify no CSS related to WooCommerce Blocks is loaded.
3. Create a post and add some WooCommerce Blocks, like _Single Product_.
4. Visit the post in the frontend and verify the styles are loaded correctly.
5. Do some smoke testing in block themes too to verify styles are loaded as expected.
