### PR TITLE
Load supported email editor blocks from supports settings

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
+++ b/packages/js/email-editor/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add loading allowed blocks in the email editor by metadata `supports.email`.

--- a/packages/js/email-editor/src/blocks/core/supported-blocks.ts
+++ b/packages/js/email-editor/src/blocks/core/supported-blocks.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { Block } from '@wordpress/blocks';
+
+/**
+ * Set supports.email = true for the blocks that are supported in the block email editor.
+ */
+export function setEmailBlockSupport() {
+	addFilter(
+		'blocks.registerBlockType',
+		'woocommerce-email-editor/supports-email',
+		( settings: Block, name ) => {
+			const ALLOWED_BLOCK_TYPES = new Set( [
+				'core/button',
+				'core/buttons',
+				'core/column',
+				'core/columns',
+				'core/group',
+				'core/heading',
+				'core/image',
+				'core/list',
+				'core/list-item',
+				'core/paragraph',
+				'core/quote',
+				'core/spacer',
+				'core/social-link',
+				'core/social-links',
+			] );
+
+			if ( ALLOWED_BLOCK_TYPES.has( name ) ) {
+				return {
+					...settings,
+					supports: {
+						...settings.supports,
+						email: true,
+					},
+				};
+			}
+
+			return settings;
+		}
+	);
+}

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -28,6 +28,8 @@ import { filterSetUrlAttribute } from './core/block-edit';
 import { enhanceSocialLinksBlock } from './core/social-links';
 import { modifyMoveToTrashAction } from './core/move-to-trash';
 
+export { getAllowedBlockNames } from './utils';
+
 export function initBlocks() {
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -27,10 +27,12 @@ import { enhanceQuoteBlock } from './core/quote';
 import { filterSetUrlAttribute } from './core/block-edit';
 import { enhanceSocialLinksBlock } from './core/social-links';
 import { modifyMoveToTrashAction } from './core/move-to-trash';
+import { setEmailBlockSupport } from './core/supported-blocks';
 
 export { getAllowedBlockNames } from './utils';
 
 export function initBlocks() {
+	setEmailBlockSupport();
 	filterSetUrlAttribute();
 	deactivateStackOnMobile();
 	hideExpandOnClick();

--- a/packages/js/email-editor/src/blocks/utils.ts
+++ b/packages/js/email-editor/src/blocks/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { getBlockTypes, Block } from '@wordpress/blocks';
+
+/**
+ * Returns an array of block names that support the 'email' feature.
+ */
+export function getAllowedBlockNames(): string[] {
+	try {
+		return getBlockTypes()
+			.filter( ( block: Block ) => {
+				// @ts-expect-error: 'email' is a custom property
+				return block.supports?.email === true;
+			} )
+			.map( ( block ) => block.name );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to get allowed block names:', error );
+		return [];
+	}
+}

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -9,7 +9,7 @@ import '@wordpress/format-library'; // Enables text formatting capabilities
 /**
  * Internal dependencies
  */
-import { initBlocks } from './blocks';
+import { getAllowedBlockNames, initBlocks } from './blocks';
 import { initializeLayout } from './layouts/flex-email';
 import { InnerEditor } from './components/block-editor';
 import { createStore, storeName, editorCurrentPostType } from './store';
@@ -31,6 +31,9 @@ function Editor() {
 		[]
 	);
 	useContentValidation();
+
+	// Set allowed blockTypes to the editor settings.
+	settings.allowedBlockTypes = getAllowedBlockNames();
 
 	return (
 		<StrictMode>

--- a/packages/php/email-editor/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
+++ b/packages/php/email-editor/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove usage of `settings.allowedBlockTypes` from the email editor configuration.

--- a/packages/php/email-editor/src/Engine/Renderer/readme.md
+++ b/packages/php/email-editor/src/Engine/Renderer/readme.md
@@ -4,7 +4,7 @@
 
 ## Adding support for a core block
 
-1. Add block into `ALLOWED_BLOCK_TYPES` in `packages/php/email-editor/src/Engine/SettingsController.php`.
+1. Add block into `ALLOWED_BLOCK_TYPES` in `packages/js/email-editor/src/blocks/core/supported-blocks.ts`.
 2. Make sure the block is registered in the editor. Currently all core blocks are registered in the editor.
 3. If necessary, add BlockRender class (e.g. Heading) into `packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/` folder.
 

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -98,6 +98,7 @@ class Email_Editor {
 		$this->logger->info( 'Initializing email editor' );
 		do_action( 'woocommerce_email_editor_initialized' );
 		add_filter( 'woocommerce_email_editor_rendering_theme_styles', array( $this, 'extend_email_theme_styles' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		$this->register_block_patterns();
 		$this->register_email_post_types();
 		$this->register_block_templates();
@@ -284,6 +285,16 @@ class Email_Editor {
 			$theme->merge( new WP_Theme_JSON( $email_theme ) );
 		}
 		return $theme;
+	}
+
+	/**
+	 * Enqueue admin styles that are needed by the email editor.
+	 *
+	 * @return void
+	 */
+	public function enqueue_admin_styles(): void {
+		// Calling action that loads registered blockTypes.
+		do_action( 'enqueue_block_editor_assets' );
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/class-settings-controller.php
+++ b/packages/php/email-editor/src/Engine/class-settings-controller.php
@@ -13,23 +13,6 @@ namespace Automattic\WooCommerce\EmailEditor\Engine;
  */
 class Settings_Controller {
 
-	const ALLOWED_BLOCK_TYPES = array(
-		'core/button',
-		'core/buttons',
-		'core/column',
-		'core/columns',
-		'core/group',
-		'core/heading',
-		'core/image',
-		'core/list',
-		'core/list-item',
-		'core/paragraph',
-		'core/quote',
-		'core/spacer',
-		'core/social-link',
-		'core/social-links',
-	);
-
 	const DEFAULT_SETTINGS = array(
 		'enableCustomUnits' => array( 'px', '%' ),
 	);
@@ -70,8 +53,7 @@ class Settings_Controller {
 		$core_default_settings = \get_default_block_editor_settings();
 		$theme_settings        = $this->theme_controller->get_settings();
 
-		$settings                      = array_merge( $core_default_settings, self::DEFAULT_SETTINGS );
-		$settings['allowedBlockTypes'] = self::ALLOWED_BLOCK_TYPES;
+		$settings = array_merge( $core_default_settings, self::DEFAULT_SETTINGS );
 		// Assets for iframe editor (component styles, scripts, etc.).
 		$settings['__unstableResolvedAssets'] = $this->iframe_assets;
 		$editor_content_styles                = file_get_contents( __DIR__ . '/content-editor.css' );

--- a/plugins/woocommerce/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
+++ b/plugins/woocommerce/changelog/wooplug-4675-load-supported-email-editor-blocks-from-supports-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add loading block categories on the email editor page.

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -131,11 +131,18 @@ class PageRenderer {
 		);
 
 		// The email editor needs to load block categories to avoid warning and missing category names.
-		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L116-L120
+		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L116-L120.
 		wp_add_inline_script(
 			'wp-blocks',
 			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $edited_item ) ) ),
 			'after'
+		);
+
+		// Preload server-registered block schemas to avoid warning about missing block titles.
+		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L144C1-L148C3.
+		wp_add_inline_script(
+			'wp-blocks',
+			sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( get_block_editor_server_block_settings() ) )
 		);
 
 		$current_user_email = wp_get_current_user()->user_email;

--- a/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/PageRenderer.php
@@ -130,6 +130,14 @@ class PageRenderer {
 			$assets_params['version']
 		);
 
+		// The email editor needs to load block categories to avoid warning and missing category names.
+		// See: https://github.com/WordPress/WordPress/blob/753817d462955eb4e40a89034b7b7c375a1e43f3/wp-admin/edit-form-blocks.php#L116-L120
+		wp_add_inline_script(
+			'wp-blocks',
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $edited_item ) ) ),
+			'after'
+		);
+
 		$current_user_email = wp_get_current_user()->user_email;
 
 		// Fetch all email types from WooCommerce including those added by other plugins.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4675

- A new functionality for the email editor when blocks are loaded by the `supports.email` property.
- Moving constant with allowed blocks from the PHP package to the JS package.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the email editor feature in WooCommerce > Settings > Advanced> Features
2. Go to WooCommerce > Settings > Emails and open an email in the editor
3. Verify allowed blocks in the email editor and it's funcionality

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>