### PR TITLE
Fix fulfillment object rendering

### DIFF
--- a/plugins/woocommerce/changelog/58978-fix-58970-order-fulfillments-clean-up-script-loading
+++ b/plugins/woocommerce/changelog/58978-fix-58970-order-fulfillments-clean-up-script-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Replace script output of wcFulfillmentsSettings with wp_localize_script
+

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -44,19 +44,16 @@ class FulfillmentsRenderer {
 		add_action( 'admin_footer', array( $this, 'render_fulfillment_drawer_slot' ) );
 		// Hook into the admin enqueue scripts to load the fulfillment drawer component.
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_components' ) );
-		// Hook into the admin head to print the fulfillments object, which contains the shipping providers.
-		add_action( 'wp_head', array( $this, 'print_fulfillments_object' ) );
-		add_action( 'admin_head', array( $this, 'print_fulfillments_object' ) );
 		// Hook into the order details before order table to render the fulfillment customer details.
 		add_action( 'woocommerce_order_details_before_order_table', array( $this, 'render_fulfillment_customer_details' ) );
 		// Initialize the renderer for bulk actions.
-		add_action( 'admin_init', array( $this, 'init_bulk_actions' ) );
+		add_action( 'admin_init', array( $this, 'init_admin_hooks' ) );
 	}
 
 	/**
 	 * Initialize the renderer.
 	 */
-	public function init_bulk_actions() {
+	public function init_admin_hooks() {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// For custom orders table, we need to add the bulk actions to the custom orders table.
 			add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this, 'define_fulfillment_bulk_actions' ) );
@@ -89,9 +86,7 @@ class FulfillmentsRenderer {
 	}
 
 	/**
-	 * Render the fulfillment column row data for legacy support.
-	 *
-	 * @deprecated 4.0.0 Use render_fulfillment_column_row_data instead.
+	 * Render the fulfillment column row data for legacy order list support.
 	 *
 	 * @param string $column_name The name of the column.
 	 */
@@ -108,15 +103,7 @@ class FulfillmentsRenderer {
 	 * @param WC_Order $order The order object.
 	 */
 	public function render_fulfillment_column_row_data( string $column_name, WC_Order $order ) {
-		// Check if we've already fetched the fulfillments for this order.
-		$fulfillments = $this->fulfillments_cache[ $order->get_id() ] ?? null;
-
-		// If not, fetch them and cache them.
-		if ( null === $fulfillments ) {
-			$data_store                                   = wc_get_container()->get( FulfillmentsDataStore::class );
-			$fulfillments                                 = $data_store->read_fulfillments( WC_Order::class, '' . $order->get_id() );
-			$this->fulfillments_cache[ $order->get_id() ] = $fulfillments;
-		}
+		$fulfillments = $this->maybe_read_fulfillments( $order );
 
 		// Render the column data based on the column name.
 		switch ( $column_name ) {
@@ -259,8 +246,7 @@ class FulfillmentsRenderer {
 					continue;
 				}
 
-				$data_store   = wc_get_container()->get( FulfillmentsDataStore::class );
-				$fulfillments = $data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+				$fulfillments = $this->maybe_read_fulfillments( $order );
 
 				// Fulfill all existing fulfillments.
 				foreach ( $fulfillments as $fulfillment ) {
@@ -301,8 +287,7 @@ class FulfillmentsRenderer {
 	 * @param WC_Order $order The order object.
 	 */
 	public function render_fulfillment_customer_details( WC_Order $order ) {
-		$fulfillments_data_store = wc_get_container()->get( FulfillmentsDataStore::class );
-		$fulfillments            = $fulfillments_data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		$fulfillments = $this->maybe_read_fulfillments( $order );
 
 		if ( ! empty( $fulfillments ) ) {
 			?>
@@ -349,7 +334,7 @@ class FulfillmentsRenderer {
 	}
 
 	/**
-	 * Loads the payment method promotions scripts and styles.
+	 * Loads the fulfillments scripts and styles.
 	 */
 	public function load_components() {
 		if ( ! $this->should_render_fulfillment_drawer() ) {
@@ -357,15 +342,6 @@ class FulfillmentsRenderer {
 		}
 		WCAdminAssets::register_style( 'fulfillments', 'style', array( 'wp-components' ) );
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'fulfillments', true );
-	}
-
-	/**
-	 * Prints the fulfillments object in the admin header.
-	 */
-	public function print_fulfillments_object() {
-		if ( ! $this->should_render_fulfillment_object() ) {
-			return;
-		}
 
 		$fulfillment_settings = array(
 			/**
@@ -391,19 +367,25 @@ class FulfillmentsRenderer {
 			'currency_symbols' => get_woocommerce_currency_symbols(),
 		);
 
-		?>
-		<script type="text/javascript">
-			window.wcFulfillmentSettings = <?php echo wp_json_encode( $fulfillment_settings ); ?>;
-		</script>
-		<?php
+		wp_localize_script( 'wc-admin-fulfillments', 'wcFulfillmentSettings', $fulfillment_settings );
 	}
+
 
 	/**
 	 * Check if the fulfillment drawer should be rendered.
+	 * Check if the fulfillment drawer should be rendered (admin only).
 	 *
 	 * @return bool True if the fulfillment drawer should be rendered, false otherwise.
 	 */
 	protected function should_render_fulfillment_drawer(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
 		$current_screen = get_current_screen();
 		if ( ! $current_screen || ! $current_screen->id ) {
 			return false;
@@ -413,17 +395,23 @@ class FulfillmentsRenderer {
 	}
 
 	/**
-	 * Check if the fulfillment object should be rendered.
+	 * Fetches the fulfillments for the given order, caching them to avoid multiple fetches.
 	 *
-	 * @return bool True if the fulfillment object should be rendered, false otherwise.
+	 * @param WC_Order $order The order object.
+	 *
+	 * @return array The fulfillments for the order.
 	 */
-	protected function should_render_fulfillment_object(): bool {
-		// Check if we are on the order details page in the customer area.
-		if ( ! is_admin() && function_exists( 'is_view_order_page' ) && is_view_order_page() ) {
-			return true;
+	private function maybe_read_fulfillments( WC_Order $order ): array {
+		// Check if we've already fetched the fulfillments for this order.
+		if ( isset( $this->fulfillments_cache[ $order->get_id() ] ) ) {
+			return $this->fulfillments_cache[ $order->get_id() ];
 		}
 
-		// Check if the current screen is the orders page or the edit order page on the admin side.
-		return $this->should_render_fulfillment_drawer();
+		// If not, fetch them and cache them.
+		$data_store                                   = wc_get_container()->get( FulfillmentsDataStore::class );
+		$fulfillments                                 = $data_store->read_fulfillments( WC_Order::class, '' . $order->get_id() );
+		$this->fulfillments_cache[ $order->get_id() ] = $fulfillments;
+
+		return $fulfillments;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -340,9 +340,25 @@ class FulfillmentsRenderer {
 		if ( ! $this->should_render_fulfillment_drawer() ) {
 			return;
 		}
+
+		$this->register_fulfillments_assets();
+		$this->load_fulfillments_js_settings();
+	}
+
+	/**
+	 * Register the fulfillment assets.
+	 */
+	protected function register_fulfillments_assets() {
 		WCAdminAssets::register_style( 'fulfillments', 'style', array( 'wp-components' ) );
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'fulfillments', true );
+	}
 
+	/**
+	 * Load the fulfillments JS settings.
+	 *
+	 * @return void
+	 */
+	protected function load_fulfillments_js_settings() {
 		$fulfillment_settings = array(
 			/**
 			 * Filter to modify the shipping providers.
@@ -369,7 +385,6 @@ class FulfillmentsRenderer {
 
 		wp_localize_script( 'wc-admin-fulfillments', 'wcFulfillmentSettings', $fulfillment_settings );
 	}
-
 
 	/**
 	 * Check if the fulfillment drawer should be rendered.

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
@@ -32,7 +32,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$this->assertNotFalse( has_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $renderer, 'render_fulfillment_column_row_data' ) ) );
 		$this->assertNotFalse( has_action( 'admin_footer', array( $renderer, 'render_fulfillment_drawer_slot' ) ) );
 		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $renderer, 'load_components' ) ) );
-		$this->assertNotFalse( has_action( 'admin_init', array( $renderer, 'init_bulk_actions' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $renderer, 'init_admin_hooks' ) ) );
 		$container->reset_replacement( CustomOrdersTableController::class );
 	}
 
@@ -54,7 +54,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$this->assertNotFalse( has_action( 'manage_shop_order_posts_custom_column', array( $renderer, 'render_fulfillment_column_row_data_legacy' ) ) );
 		$this->assertNotFalse( has_action( 'admin_footer', array( $renderer, 'render_fulfillment_drawer_slot' ) ) );
 		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $renderer, 'load_components' ) ) );
-		$this->assertNotFalse( has_action( 'admin_init', array( $renderer, 'init_bulk_actions' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $renderer, 'init_admin_hooks' ) ) );
 		$container->reset_replacement( CustomOrdersTableController::class );
 	}
 
@@ -71,7 +71,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$container->replace( CustomOrdersTableController::class, $cot_mock );
 
 		$renderer = new FulfillmentsRenderer();
-		$renderer->init_bulk_actions();
+		$renderer->init_admin_hooks();
 		$this->assertNotFalse( has_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $renderer, 'define_fulfillment_bulk_actions' ) ) );
 		$this->assertNotFalse( has_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $renderer, 'handle_fulfillment_bulk_actions' ) ) );
 		$container->reset_replacement( CustomOrdersTableController::class );
@@ -90,7 +90,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$container->replace( CustomOrdersTableController::class, $cot_mock );
 
 		$renderer = new FulfillmentsRenderer();
-		$renderer->init_bulk_actions();
+		$renderer->init_admin_hooks();
 		$this->assertNotFalse( has_filter( 'bulk_actions-edit-shop_order', array( $renderer, 'define_fulfillment_bulk_actions' ) ) );
 		$this->assertNotFalse( has_filter( 'handle_bulk_actions-edit-shop_order', array( $renderer, 'handle_fulfillment_bulk_actions' ) ) );
 		$container->reset_replacement( CustomOrdersTableController::class );
@@ -227,60 +227,6 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$renderer->render_fulfillment_drawer_slot();
 		$output = ob_get_clean();
 		$this->assertStringContainsString( '<div id="wc_order_fulfillments_panel_container"></div>', $output );
-	}
-
-	/**
-	 * Test the print_fulfillments_object method.
-	 */
-	public function test_render_fulfillment_object_renders_on_admin_orders_page() {
-		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
-			->onlyMethods( array( 'should_render_fulfillment_object', 'should_render_fulfillment_drawer' ) )
-			->getMock();
-
-		$renderer->method( 'should_render_fulfillment_object' )->willReturn( true );
-		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( true );
-
-		ob_start();
-		$renderer->print_fulfillments_object();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'wcFulfillmentSettings', $output );
-	}
-
-	/**
-	 * Test the print_fulfillments_object method renders on customer order details page.
-	 */
-	public function test_render_fulfillment_object_renders_on_customer_order_details_page() {
-		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
-			->onlyMethods( array( 'should_render_fulfillment_object', 'should_render_fulfillment_drawer' ) )
-			->getMock();
-
-		$renderer->method( 'should_render_fulfillment_object' )->willReturn( true );
-		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( false );
-
-		ob_start();
-		$renderer->print_fulfillments_object();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'wcFulfillmentSettings', $output );
-	}
-
-	/**
-	 * Test the print_fulfillments_object method does not render on other pages.
-	 */
-	public function test_render_fulfillment_object_does_not_render_on_other_pages() {
-		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
-			->onlyMethods( array( 'should_render_fulfillment_object', 'should_render_fulfillment_drawer' ) )
-			->getMock();
-
-		$renderer->method( 'should_render_fulfillment_object' )->willReturn( false );
-		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( false );
-
-		ob_start();
-		$renderer->print_fulfillments_object();
-		$output = ob_get_clean();
-
-		$this->assertStringNotContainsString( 'wcFulfillmentSettings', $output );
 	}
 
 	/**
@@ -450,5 +396,45 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$this->assertTrue( $fulfillments[0]->get_is_fulfilled(), 'Fulfillment is not marked as fulfilled.' );
 
 		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Test that the load_components method doesn't render on other pages.
+	 */
+	public function test_load_components_doesnt_render_on_other_pages() {
+		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
+			->onlyMethods( array( 'should_render_fulfillment_drawer' ) )
+			->getMock();
+		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( false );
+
+		// Register a dummy script for the test.
+		wp_register_script( 'wc-admin-fulfillments', 'https://example.com/dummy.js' ); // phpcs:ignore
+
+		ob_start();
+		$renderer->load_components();
+		wp_print_scripts();
+		$output = ob_get_clean();
+		$this->assertStringNotContainsString( 'wc-admin-fulfillments', $output );
+		$this->assertStringNotContainsString( 'var wcFulfillmentSettings', $output );
+	}
+
+	/**
+	 * Test that the load_components method renders on the orders page.
+	 */
+	public function test_load_components_renders_on_orders_page() {
+		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
+			->onlyMethods( array( 'should_render_fulfillment_drawer' ) )
+			->getMock();
+		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( true );
+
+		// Register a dummy script for the test.
+		wp_register_script( 'wc-admin-fulfillments', 'https://example.com/dummy.js' ); // phpcs:ignore
+
+		ob_start();
+		$renderer->load_components();
+		wp_print_scripts();
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'wc-admin-fulfillments', $output );
+		$this->assertStringContainsString( 'var wcFulfillmentSettings', $output );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
@@ -403,18 +403,20 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_load_components_doesnt_render_on_other_pages() {
 		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
-			->onlyMethods( array( 'should_render_fulfillment_drawer' ) )
+			->onlyMethods( array( 'should_render_fulfillment_drawer', 'register_fulfillments_assets' ) )
 			->getMock();
 		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( false );
-
-		// Register a dummy script for the test.
-		wp_register_script( 'wc-admin-fulfillments', 'https://example.com/dummy.js' ); // phpcs:ignore
+		$renderer->method( 'register_fulfillments_assets' )->willReturnCallback(
+			function () {
+				wp_enqueue_script( 'wc-admin-fulfillments', 'dummy-path', array(), '1.0.0', array( 'in_footer' => false ) );
+			}
+		);
 
 		ob_start();
 		$renderer->load_components();
 		wp_print_scripts();
 		$output = ob_get_clean();
-		$this->assertStringNotContainsString( 'wc-admin-fulfillments', $output );
+		$this->assertStringNotContainsString( 'wc-admin-fulfillments-js', $output );
 		$this->assertStringNotContainsString( 'var wcFulfillmentSettings', $output );
 	}
 
@@ -423,18 +425,20 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_load_components_renders_on_orders_page() {
 		$renderer = $this->getMockBuilder( FulfillmentsRenderer::class )
-			->onlyMethods( array( 'should_render_fulfillment_drawer' ) )
+			->onlyMethods( array( 'should_render_fulfillment_drawer', 'register_fulfillments_assets' ) )
 			->getMock();
 		$renderer->method( 'should_render_fulfillment_drawer' )->willReturn( true );
-
-		// Register a dummy script for the test.
-		wp_register_script( 'wc-admin-fulfillments', 'https://example.com/dummy.js' ); // phpcs:ignore
+		$renderer->method( 'register_fulfillments_assets' )->willReturnCallback(
+			function () {
+				wp_enqueue_script( 'wc-admin-fulfillments', 'dummy-path', array(), '1.0.0', array( 'in_footer' => false ) );
+			}
+		);
 
 		ob_start();
 		$renderer->load_components();
 		wp_print_scripts();
 		$output = ob_get_clean();
-		$this->assertStringContainsString( 'wc-admin-fulfillments', $output );
+		$this->assertStringContainsString( 'wc-admin-fulfillments-js', $output );
 		$this->assertStringContainsString( 'var wcFulfillmentSettings', $output );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This replaces the fulfillment settings object rendering with `wp_localize_script` from directly rendering the script tags and JSON encoded PHP object, also fixes some comments and renames a method. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4693.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Tests should pass, and the order screen should have the `wcFulfillmentsSettings` object filled with providers, statuses and currency symbols settings. 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Replace script output of wcFulfillmentsSettings with wp_localize_script
</details>
