### PR TITLE
CYS: Prevent crash during rare font installation edge case

### DIFF
--- a/plugins/woocommerce/changelog/58998-fix-cys-crash
+++ b/plugins/woocommerce/changelog/58998-fix-cys-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Prevent crash during rare font installation edge case.

--- a/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -35,7 +35,7 @@ export const FontPairing = () => {
 	const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 	const [ custom ] = useGlobalSetting( 'typography.fontFamilies.custom' ) as [
-		Array< FontFamily >
+		Array< FontFamily > | undefined
 	];
 
 	// theme.json file font families
@@ -100,11 +100,12 @@ export const FontPairing = () => {
 
 		const customFonts = FONT_PAIRINGS_WHEN_AI_IS_OFFLINE.map( ( pair ) => {
 			const fontFamilies = pair.settings.typography.fontFamilies;
-			const fonts = custom.filter( ( customFont ) =>
-				fontFamilies.theme.some(
-					( themeFont ) => themeFont.slug === customFont.slug
-				)
-			);
+			const fonts =
+				custom?.filter( ( customFont ) =>
+					fontFamilies.theme.some(
+						( themeFont ) => themeFont.slug === customFont.slug
+					)
+				) ?? [];
 
 			return {
 				...pair,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Analyzing the report of the flaky test (https://github.com/woocommerce/woocommerce/issues/50268) - [zip file](https://github.com/woocommerce/woocommerce/actions/runs/15760588500/artifacts/3364108555), I noticed that in some cases, CYS crashes.

According to the logs, on the test env, the CYS crashes when the server returns this payload when it tries to install the fonts:

```
{
  "code": "rest_font_upload_unknown_error",
  "message": "Unable to create directory wp-content/uploads/fonts. Is its parent directory writable by the server?",
  "data": {
    "status": 500
  }
}
```


This is the stack trace:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at http://localhost:7880/wp-content/plugins/woocommerce/assets/client/admin/chunks/customize-store.js?ver=0989900cae3044d37adb:1:108843
    at Array.map (<anonymous>)
    at http://localhost:7880/wp-content/plugins/woocommerce/assets/client/admin/chunks/customize-store.js?ver=0989900cae3044d37adb:1:108787
    at Object.Wt [as useMemo] (http://localhost:7880/wp-includes/js/dist/vendor/react-dom.min.js?ver=18.3.1.1:10:50064)
    at e.useMemo (http://localhost:7880/wp-includes/js/dist/vendor/react.min.js?ver=18.3.1.1:10:9894)
    at Co (http://localhost:7880/wp-content/plugins/woocommerce/assets/client/admin/chunks/customize-store.js?ver=0989900cae3044d37adb:1:108547)
    at ht (http://localhost:7880/wp-includes/js/dist/vendor/react-dom.min.js?ver=18.3.1.1:10:45677)
    at vr (http://localhost:7880/wp-includes/js/dist/vendor/react-dom.min.js?ver=18.3.1.1:10:56342)
    at Qs (http://localhost:7880/wp-includes/js/dist/vendor/react-dom.min.js?ver=18.3.1.1:10:121002)
    at wl (http://localhost:7880/wp-includes/js/dist/vendor/react-dom.min.js?ver=18.3.1.1:10:88341)
```

I tried to replicate the same error, but even with it, the CYS flow doesn't crash on my env. Analyzing the stack trace, I found that the issue is on this line:


https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx#L103-L107

In some cases, `custom` can be `undefined`. Given that we didn't get any report and CYS is in maintenance mode, I think that adding a optional chaining operator is enough.

Closes https://github.com/woocommerce/woocommerce/issues/50268

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/8c487335-a853-4e7f-966d-c28936b35912" /> |  <video src="https://github.com/user-attachments/assets/d2c01176-e5eb-4a5a-8792-bc05da2cde80" />     |






<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On trunk, update [this line](https://github.com/woocommerce/woocommerce/blob/c69d72395121a4b0d486f259eae783cf9c4d577b/plugins/woocommerce/client/admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx#L37-L40) with:
```ts
const custom = undefined
```
2. On line 103, disable the TS check with `@ts-expect-error`.
3. Run `pnpm --filter="@woocommerce/plugin-woocommerce" build`.
4. Visit `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
5. Disable tracking.
6. Run the CYS flow.
7. On the sidebar, click `choose fonts`.
8. Click on `usage tracking`.
9. Click on `opt in`.
10. See the crash.
11. Remove from the `wp_posts` table, all the rows with post_type `wp_font_face` and `wp_font_family`.
12. Checkout this branch.
13. Assign to `custom` variable the `undefined` value (like the step 1).
14. Repeat 3-9.
15. See that CYS doesn't crash. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
CYS: Prevent crash during rare font installation edge case.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
