### PR TITLE
[NOX In-context] Use NOX-specific styles in PMs selection step header instead of global WC classes

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPLUG-4397-pm-selection-header-classes
+++ b/plugins/woocommerce/changelog/update-WOOPLUG-4397-pm-selection-header-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use NOX-specific styles in PMs selection step header instead of global WooCommerce classes.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.scss
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.scss
@@ -21,10 +21,15 @@
 	.woocommerce-recommended-payment-methods {
 		margin-top: 24px;
 		background: transparent;
+		top: $gap-small;
 
-		.woocommerce-layout__header-wrapper {
-			background: transparent;
-			align-items: start;
+		&__header {
+			&--title {
+				h1 {
+					font-weight: 500;
+					font-size: 14px;
+				}
+			}
 		}
 	}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -178,7 +178,7 @@ export default function PaymentMethodsSelection() {
 						</Button>
 					</div>
 					<div className="woocommerce-recommended-payment-methods__header--description">
-							{ __(
+						{ __(
 							"Select which payment methods you'd like to offer to your shoppers. You can update these at any time.",
 							'woocommerce'
 						) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/index.tsx
@@ -161,10 +161,10 @@ export default function PaymentMethodsSelection() {
 
 	return (
 		<div className="settings-payments-onboarding-modal__step--content">
-			<div className="woocommerce-layout__header woocommerce-recommended-payment-methods">
-				<div className="woocommerce-layout__header-wrapper">
-					<div className="woocommerce-layout__header-title-and-close">
-						<h1 className="components-truncate components-text woocommerce-layout__header-heading woocommerce-layout__header-left-align woocommerce-settings-payments-header__title">
+			<div className="woocommerce-recommended-payment-methods">
+				<div className="woocommerce-recommended-payment-methods__header">
+					<div className="woocommerce-recommended-payment-methods__header--title">
+						<h1 className="components-truncate components-text">
 							{ __(
 								'Choose your payment methods',
 								'woocommerce'
@@ -177,9 +177,8 @@ export default function PaymentMethodsSelection() {
 							<Icon icon={ close } />
 						</Button>
 					</div>
-
-					<div className="woocommerce-settings-payments-header__description">
-						{ __(
+					<div className="woocommerce-recommended-payment-methods__header--description">
+							{ __(
 							"Select which payment methods you'd like to offer to your shoppers. You can update these at any time.",
 							'woocommerce'
 						) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -137,13 +137,14 @@
 		overflow: hidden; // Prevent content from spilling out
 		padding: 0 !important; // There is a padding on the parent container that we need to override.
 		border-bottom: none !important;
+		position: fixed;
 
 		@media screen and (max-width: $break-medium) {
 			height: calc(100% - 100px); // Account for small screen content being longer on the page.
-			margin-top: $gap-larger;
+			margin-top: -2px; // Compensate for the border on the header.
 		}
 
-		.woocommerce-layout__header-wrapper {
+		&__header {
 			// This is the padding for the header. Controlling each side to adapt to the content.
 			padding: calc($gap-large / 2) $gap-large $gap-large $gap-large * 1.5;
 			border-bottom: 1px solid $gray-200;
@@ -151,6 +152,36 @@
 			background: $white;
 			position: relative;
 			z-index: 1;
+			min-height: 40px;
+			gap: 8px;
+			display: flex;
+    		align-items: center;
+			flex-wrap: wrap;
+
+			&--title {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				width: 100%;
+
+				h1 {
+					padding: 0;
+					height: auto;
+					margin-top: 0;
+  					margin-bottom: 0;
+					font-weight: 590;
+					font-size: 16px;
+					color: #070707;
+				}
+			}
+
+			&--description {
+				font-size: 13px;
+				font-weight: 400;
+				line-height: 20px;
+				color: #757575;
+				flex-basis: 100%;
+			}
 
 			@media screen and (max-width: $break-medium) {
 				padding: $gap $gap-large;
@@ -160,13 +191,6 @@
 				@media screen and (max-width: $break-medium) {
 					padding: 0 !important;
 				}
-			}
-
-			.woocommerce-layout__header-title-and-close {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-				width: 100%;
 			}
 		}
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/payment-methods-selection/style.scss
@@ -155,7 +155,7 @@
 			min-height: 40px;
 			gap: 8px;
 			display: flex;
-    		align-items: center;
+			align-items: center;
 			flex-wrap: wrap;
 
 			&--title {
@@ -168,7 +168,7 @@
 					padding: 0;
 					height: auto;
 					margin-top: 0;
-  					margin-bottom: 0;
+					margin-bottom: 0;
 					font-weight: 590;
 					font-size: 16px;
 					color: #070707;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR replaces the use of global WooCommerce layout classes (e.g. woocommerce-layout__header) in the Payment Methods (PMs) selection step within NOX. These classes were originally copied when the step was moved inside NOX, but make the layout fragile, as changes from outside NOX could break the step.

The update introduces NOX-specific CSS classes to improve maintainability and reduce dependency on unrelated global styles. This helps ensure visual consistency and prevents unexpected style regressions in the future.

Closes WOOPLUG-4397

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN store with WooCommerce on this PR's branch (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=update/WOOPLUG-4397-pm-selection-header-classes)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Click on the "Payments" main menu item, and you should see the Payments Settings page.
4. Click the "Install" button next to the WooPayments gateway.
5. When the modal opens, confirm that it lands on the recommended payment methods selection screen.
6. Make sure the header title, description, and close button are all displayed properly and match what’s shown in the currently released version.
7. Review the layout and appearance on mobile and tablet screen sizes to ensure it looks correct across devices.

### Testing that has already taken place:

Check above

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
