### PR TITLE
Fix product images not displaying in transactional emails

### DIFF
--- a/plugins/woocommerce/changelog/2025-06-20-10-08-35-352964
+++ b/plugins/woocommerce/changelog/2025-06-20-10-08-35-352964
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove lazy loading attributes from product images in transactional emails to ensure proper display in email clients
+Prevent lazy loading in product images in transactional emails to ensure proper display in email clients

--- a/plugins/woocommerce/changelog/2025-06-20-10-08-35-352964
+++ b/plugins/woocommerce/changelog/2025-06-20-10-08-35-352964
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove lazy loading attributes from product images in transactional emails to ensure proper display in email clients

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1517,19 +1517,21 @@ class WC_Email extends WC_Settings_API {
 				$img_attributes = $matches[1];
 
 				// Extract data-src and use it as src if present.
-				if ( preg_match( '/data-src="([^"]*)"/', $img_attributes, $data_src_match ) ) {
-					$img_attributes = preg_replace( '/src="[^"]*"/', 'src="' . $data_src_match[1] . '"', $img_attributes );
-					$img_attributes = preg_replace( '/data-src="[^"]*"/', '', $img_attributes );
+				if ( preg_match( '/data-src=(["\']?)([^"\'>\s]*)\1/', $img_attributes, $data_src_match ) ) {
+					$img_attributes = preg_replace( '/src=(["\']?)[^"\'>\s]*\1/', 'src="' . esc_attr( $data_src_match[2] ) . '"', $img_attributes );
+					$img_attributes = preg_replace( '/data-src=(["\']?)[^"\'>\s]*\1/', '', $img_attributes );
 				}
 
-				// Remove lazyload class.
-				$img_attributes = preg_replace( '/class="([^"]*)\s*lazyload\s*([^"]*)"/', 'class="$1 $2"', $img_attributes );
-				$img_attributes = preg_replace( '/class="([^"]*)\s*lazyload"/', 'class="$1"', $img_attributes );
-				$img_attributes = preg_replace( '/class="lazyload\s*([^"]*)"/', 'class="$1"', $img_attributes );
-				$img_attributes = preg_replace( '/class="lazyload"/', '', $img_attributes );
-
-				// Remove any empty class attributes.
-				$img_attributes = preg_replace( '/class="\s*"/', '', $img_attributes );
+				// Remove lazyload class and clean up whitespace.
+				$img_attributes = preg_replace_callback(
+					'/class=(["\']?)([^"\'>\s]*(?:\s+[^"\'>\s]+)*)\1/',
+					function ( $class_matches ) {
+						$classes = array_filter( array_map( 'trim', explode( ' ', $class_matches[2] ) ) );
+						$classes = array_diff( $classes, array( 'lazyload' ) );
+						return empty( $classes ) ? '' : 'class="' . implode( ' ', $classes ) . '"';
+					},
+					$img_attributes
+				);
 
 				return '<img' . $img_attributes . '>';
 			},

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -322,7 +322,8 @@ class WC_Email extends WC_Settings_API {
 		add_action( 'phpmailer_init', array( $this, 'handle_multipart' ) );
 		add_action( 'woocommerce_update_options_email_' . $this->id, array( $this, 'process_admin_options' ) );
 
-		add_filter( 'woocommerce_order_item_thumbnail', array( $this, 'remove_lazy_loading_from_thumbnail' ), 999, 1 );
+		// Use priority 1 to ensure our skip classes are added before lazy loading plugins process the images.
+		add_filter( 'wp_get_attachment_image_attributes', array( $this, 'prevent_lazy_loading_on_attachment' ), 1, 1 );
 	}
 
 	/**
@@ -1495,47 +1496,38 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * Remove lazy loading from product thumbnails in email context.
-	 * This is hooked into the woocommerce_order_item_thumbnail filter.
+	 * Prevent lazy loading on attachment images in email context by adding skip classes.
+	 * This is hooked into the wp_get_attachment_image_attributes filter.
 	 *
-	 * @param string $thumbnail_html The thumbnail HTML.
-	 * @return string The thumbnail HTML with lazy loading removed.
+	 * @param array $attributes The image attributes array.
+	 * @return array The modified image attributes array.
 	 */
-	public function remove_lazy_loading_from_thumbnail( $thumbnail_html ) {
+	public function prevent_lazy_loading_on_attachment( $attributes ) {
 		// Only process if we're currently sending an email.
 		if ( ! $this->sending ) {
-			return $thumbnail_html;
+			return $attributes;
 		}
 
-		if ( strpos( $thumbnail_html, 'lazyload' ) === false && strpos( $thumbnail_html, 'data-src' ) === false ) {
-			return $thumbnail_html;
-		}
-
-		return preg_replace_callback(
-			'/<img([^>]*)>/i',
-			function ( $matches ) {
-				$img_attributes = $matches[1];
-
-				// Extract data-src and use it as src if present.
-				if ( preg_match( '/data-src=(["\']?)([^"\'>\s]*)\1/', $img_attributes, $data_src_match ) ) {
-					$img_attributes = preg_replace( '/src=(["\']?)[^"\'>\s]*\1/', 'src="' . esc_attr( $data_src_match[2] ) . '"', $img_attributes );
-					$img_attributes = preg_replace( '/data-src=(["\']?)[^"\'>\s]*\1/', '', $img_attributes );
+		// Add skip classes to prevent lazy loading plugins from applying lazy loading.
+		// These are the most common skip classes used by popular lazy loading plugins.
+		if ( isset( $attributes['class'] ) ) {
+			$classes = array_filter( array_map( 'trim', explode( ' ', $attributes['class'] ) ) );
+			// Add skip classes if they don't already exist.
+			$skip_classes = array( 'skip-lazy', 'no-lazyload', 'lazyload-disabled', 'no-lazy', 'skip-lazyload' );
+			foreach ( $skip_classes as $skip_class ) {
+				if ( ! in_array( $skip_class, $classes, true ) ) {
+					$classes[] = $skip_class;
 				}
+			}
+			$attributes['class'] = implode( ' ', $classes );
+		} else {
+			// No class attribute exists, add one with skip classes.
+			$attributes['class'] = 'skip-lazy no-lazyload lazyload-disabled no-lazy skip-lazyload';
+		}
 
-				// Remove lazyload class and clean up whitespace.
-				$img_attributes = preg_replace_callback(
-					'/class=(["\']?)([^"\'>\s]*(?:\s+[^"\'>\s]+)*)\1/',
-					function ( $class_matches ) {
-						$classes = array_filter( array_map( 'trim', explode( ' ', $class_matches[2] ) ) );
-						$classes = array_diff( $classes, array( 'lazyload' ) );
-						return empty( $classes ) ? '' : 'class="' . implode( ' ', $classes ) . '"';
-					},
-					$img_attributes
-				);
+		// Add data-skip-lazy attribute as an additional safeguard.
+		$attributes['data-skip-lazy'] = 'true';
 
-				return '<img' . $img_attributes . '>';
-			},
-			$thumbnail_html
-		);
+		return $attributes;
 	}
 }

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1508,21 +1508,18 @@ class WC_Email extends WC_Settings_API {
 			return $attributes;
 		}
 
-		// Add skip classes to prevent lazy loading plugins from applying lazy loading.
+		// Skip classes to prevent lazy loading plugins from applying lazy loading.
 		// These are the most common skip classes used by popular lazy loading plugins.
+		$skip_classes = array( 'skip-lazy', 'no-lazyload', 'lazyload-disabled', 'no-lazy', 'skip-lazyload' );
+
+		// Add skip classes to prevent lazy loading plugins from applying lazy loading.
 		if ( isset( $attributes['class'] ) ) {
-			$classes = array_filter( array_map( 'trim', explode( ' ', $attributes['class'] ) ) );
-			// Add skip classes if they don't already exist.
-			$skip_classes = array( 'skip-lazy', 'no-lazyload', 'lazyload-disabled', 'no-lazy', 'skip-lazyload' );
-			foreach ( $skip_classes as $skip_class ) {
-				if ( ! in_array( $skip_class, $classes, true ) ) {
-					$classes[] = $skip_class;
-				}
-			}
+			$classes             = array_filter( array_map( 'trim', explode( ' ', $attributes['class'] ) ) );
+			$classes             = array_unique( array_merge( $classes, $skip_classes ) );
 			$attributes['class'] = implode( ' ', $classes );
 		} else {
 			// No class attribute exists, add one with skip classes.
-			$attributes['class'] = 'skip-lazy no-lazyload lazyload-disabled no-lazy skip-lazyload';
+			$attributes['class'] = implode( ' ', $skip_classes );
 		}
 
 		// Add data-skip-lazy attribute as an additional safeguard.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -321,6 +321,8 @@ class WC_Email extends WC_Settings_API {
 		}
 		add_action( 'phpmailer_init', array( $this, 'handle_multipart' ) );
 		add_action( 'woocommerce_update_options_email_' . $this->id, array( $this, 'process_admin_options' ) );
+
+		add_filter( 'woocommerce_order_item_thumbnail', array( $this, 'remove_lazy_loading_from_thumbnail' ), 999, 1 );
 	}
 
 	/**
@@ -1490,5 +1492,48 @@ class WC_Email extends WC_Settings_API {
 		/** Service for rendering emails from block content @var BlockEmailRenderer $renderer */
 		$renderer = wc_get_container()->get( BlockEmailRenderer::class );
 		return $renderer->maybe_render_block_email( $this );
+	}
+
+	/**
+	 * Remove lazy loading from product thumbnails in email context.
+	 * This is hooked into the woocommerce_order_item_thumbnail filter.
+	 *
+	 * @param string $thumbnail_html The thumbnail HTML.
+	 * @return string The thumbnail HTML with lazy loading removed.
+	 */
+	public function remove_lazy_loading_from_thumbnail( $thumbnail_html ) {
+		// Only process if we're currently sending an email.
+		if ( ! $this->sending ) {
+			return $thumbnail_html;
+		}
+
+		if ( strpos( $thumbnail_html, 'lazyload' ) === false && strpos( $thumbnail_html, 'data-src' ) === false ) {
+			return $thumbnail_html;
+		}
+
+		return preg_replace_callback(
+			'/<img([^>]*)>/i',
+			function ( $matches ) {
+				$img_attributes = $matches[1];
+
+				// Extract data-src and use it as src if present.
+				if ( preg_match( '/data-src="([^"]*)"/', $img_attributes, $data_src_match ) ) {
+					$img_attributes = preg_replace( '/src="[^"]*"/', 'src="' . $data_src_match[1] . '"', $img_attributes );
+					$img_attributes = preg_replace( '/data-src="[^"]*"/', '', $img_attributes );
+				}
+
+				// Remove lazyload class.
+				$img_attributes = preg_replace( '/class="([^"]*)\s*lazyload\s*([^"]*)"/', 'class="$1 $2"', $img_attributes );
+				$img_attributes = preg_replace( '/class="([^"]*)\s*lazyload"/', 'class="$1"', $img_attributes );
+				$img_attributes = preg_replace( '/class="lazyload\s*([^"]*)"/', 'class="$1"', $img_attributes );
+				$img_attributes = preg_replace( '/class="lazyload"/', '', $img_attributes );
+
+				// Remove any empty class attributes.
+				$img_attributes = preg_replace( '/class="\s*"/', '', $img_attributes );
+
+				return '<img' . $img_attributes . '>';
+			},
+			$thumbnail_html
+		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Product images were missing in emails after upgrading to the new email template system when lazy loading attributes were being applied. Email clients don’t support JavaScript-based lazy loading, which caused images to show placeholder data instead of actual product images. This fix removes lazy loading attributes from product thumbnails in email contexts.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58950. 

Bug introduced in PR [#54440](https://github.com/woocommerce/woocommerce/pull/54440).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     ![Screenshot 2025-06-20 at 9 57 02](https://github.com/user-attachments/assets/8c704cd1-800c-4b5a-82e3-37d377ecc843)   |    ![Screenshot 2025-06-20 at 11 29 23](https://github.com/user-attachments/assets/f6742878-8bbb-4e6d-ae42-a2a21e60615f)  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable email improvements: WooCommerce > Settings > Emails > Enable new email templates
2. Enable a theme/plugin that adds lazy loading to product images
3. Place a test order or send a test email
4. Check the email HTML - you should see the broken lazy loading structure

**Popular plugins that add lazy loading:** Autoptimize, WP Rocket, Lazy Load by WP Rocket, Smush

Or use a manual snippet:
```
add_filter( 'woocommerce_order_item_thumbnail', function( $image, $item ) {
    if ( strpos( $image, '<img' ) !== false ) {
        $image = str_replace( 'class="', 'class="lazyload ', $image );
        $image = str_replace( 'src="', 'src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="', $image );
    }
    return $image;
}, 10, 2 );
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
