### PR TITLE
Ensure entities display correctly when used as thousand/decimal separator in `FormattedMonetaryAmount`

### DIFF
--- a/plugins/woocommerce/changelog/2025-06-20-10-40-34-690102
+++ b/plugins/woocommerce/changelog/2025-06-20-10-40-34-690102
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent html entities showing incorrectly in FormattedMonetaryAmount component

--- a/plugins/woocommerce/client/blocks/assets/js/utils/html-entities.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/html-entities.ts
@@ -1,40 +1,14 @@
 /**
- * Decodes HTML entities in a string using a textarea element.
- * 
- * This approach is preferred over @wordpress/html-entities to avoid
- * issues with ESM modules and WordPress package dependencies.
- * 
- * The textarea method is safe for HTML entity decoding because:
- * - It doesn't execute JavaScript
- * - It only decodes HTML entities, doesn't render HTML elements
- * - The textarea element doesn't have a script execution context
- * 
- * @param text The text containing HTML entities to decode
- * @return The text with HTML entities decoded
+ * Utility function to decode HTML entities in a string. Inspired by Gutenberg's stripHtml function (currently unstable).
+ *
+ * @param text
  */
-export const decodeHtmlEntities = ( text: string ): string => {
+export const decodeHtmlEntities = ( text: unknown ): string => {
 	if ( typeof text !== 'string' ) {
 		return '';
 	}
-	
-	// Return early for empty strings to avoid unnecessary DOM manipulation
-	if ( ! text.trim() ) {
-		return text;
-	}
-	
-	// Only process strings that contain HTML entities
-	if ( ! text.includes( '&' ) ) {
-		return text;
-	}
-	
-	try {
-		const textarea = document.createElement( 'textarea' );
-		textarea.innerHTML = text;
-		return textarea.value;
-	} catch ( error ) {
-		// Fallback to original text if decoding fails
-		// eslint-disable-next-line no-console
-		console.warn( 'Failed to decode HTML entities:', error );
-		return text;
-	}
+
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = text;
+	return doc.body.textContent || '';
 };

--- a/plugins/woocommerce/client/blocks/assets/js/utils/html-entities.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/html-entities.ts
@@ -1,0 +1,40 @@
+/**
+ * Decodes HTML entities in a string using a textarea element.
+ * 
+ * This approach is preferred over @wordpress/html-entities to avoid
+ * issues with ESM modules and WordPress package dependencies.
+ * 
+ * The textarea method is safe for HTML entity decoding because:
+ * - It doesn't execute JavaScript
+ * - It only decodes HTML entities, doesn't render HTML elements
+ * - The textarea element doesn't have a script execution context
+ * 
+ * @param text The text containing HTML entities to decode
+ * @return The text with HTML entities decoded
+ */
+export const decodeHtmlEntities = ( text: string ): string => {
+	if ( typeof text !== 'string' ) {
+		return '';
+	}
+	
+	// Return early for empty strings to avoid unnecessary DOM manipulation
+	if ( ! text.trim() ) {
+		return text;
+	}
+	
+	// Only process strings that contain HTML entities
+	if ( ! text.includes( '&' ) ) {
+		return text;
+	}
+	
+	try {
+		const textarea = document.createElement( 'textarea' );
+		textarea.innerHTML = text;
+		return textarea.value;
+	} catch ( error ) {
+		// Fallback to original text if decoding fails
+		// eslint-disable-next-line no-console
+		console.warn( 'Failed to decode HTML entities:', error );
+		return text;
+	}
+};

--- a/plugins/woocommerce/client/blocks/assets/js/utils/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/index.ts
@@ -13,3 +13,4 @@ export * from './is-widget-editor-page';
 export * from './trim-words';
 export * from './find-block';
 export * from './get-unique-id';
+export * from './html-entities';

--- a/plugins/woocommerce/client/blocks/assets/js/utils/test/html-entities.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/utils/test/html-entities.test.ts
@@ -1,0 +1,297 @@
+/**
+ * External dependencies
+ */
+import { decodeHtmlEntities } from '@woocommerce/utils';
+
+describe( 'decodeHtmlEntities', () => {
+	describe( 'Input validation', () => {
+		it( 'returns empty string for non-string inputs', () => {
+			expect( decodeHtmlEntities( null ) ).toBe( '' );
+			expect( decodeHtmlEntities( undefined ) ).toBe( '' );
+			expect( decodeHtmlEntities( 123 ) ).toBe( '' );
+			expect( decodeHtmlEntities( {} ) ).toBe( '' );
+			expect( decodeHtmlEntities( [] ) ).toBe( '' );
+			expect( decodeHtmlEntities( true ) ).toBe( '' );
+			expect( decodeHtmlEntities( false ) ).toBe( '' );
+			expect( decodeHtmlEntities( Symbol( 'test' ) ) ).toBe( '' );
+		} );
+
+		it( 'handles empty strings', () => {
+			expect( decodeHtmlEntities( '' ) ).toBe( '' );
+		} );
+
+		it( 'preserves whitespace in strings without entities', () => {
+			expect( decodeHtmlEntities( '   ' ) ).toBe( '   ' );
+			expect( decodeHtmlEntities( '\t\n' ) ).toBe( '\t\n' );
+		} );
+	} );
+
+	describe( 'Common HTML entities', () => {
+		it( 'decodes basic HTML entities', () => {
+			expect( decodeHtmlEntities( '&amp;' ) ).toBe( '&' );
+			expect( decodeHtmlEntities( '&lt;' ) ).toBe( '<' );
+			expect( decodeHtmlEntities( '&gt;' ) ).toBe( '>' );
+			expect( decodeHtmlEntities( '&quot;' ) ).toBe( '"' );
+			expect( decodeHtmlEntities( '&apos;' ) ).toBe( "'" );
+			expect( decodeHtmlEntities( '&#39;' ) ).toBe( "'" );
+		} );
+
+		it( 'decodes non-breaking space', () => {
+			// Note: jsdom may handle this differently than real browsers
+			const result = decodeHtmlEntities( '&nbsp;' );
+			// Could be either regular space or non-breaking space depending on jsdom version
+			expect( [ ' ', '\u00A0' ] ).toContain( result );
+		} );
+
+		it( 'decodes special characters', () => {
+			expect( decodeHtmlEntities( '&hellip;' ) ).toBe( '…' );
+			expect( decodeHtmlEntities( '&copy;' ) ).toBe( '©' );
+			expect( decodeHtmlEntities( '&reg;' ) ).toBe( '®' );
+			expect( decodeHtmlEntities( '&trade;' ) ).toBe( '™' );
+		} );
+
+		it( 'decodes currency symbols', () => {
+			expect( decodeHtmlEntities( '&pound;' ) ).toBe( '£' );
+			expect( decodeHtmlEntities( '&euro;' ) ).toBe( '€' );
+			expect( decodeHtmlEntities( '&yen;' ) ).toBe( '¥' );
+		} );
+	} );
+
+	describe( 'Numeric and hex entities', () => {
+		it( 'decodes decimal numeric entities', () => {
+			expect( decodeHtmlEntities( '&#8364;' ) ).toBe( '€' );
+			expect( decodeHtmlEntities( '&#169;' ) ).toBe( '©' );
+			expect( decodeHtmlEntities( '&#8482;' ) ).toBe( '™' );
+			expect( decodeHtmlEntities( '&#65;' ) ).toBe( 'A' );
+		} );
+
+		it( 'decodes hexadecimal entities', () => {
+			expect( decodeHtmlEntities( '&#x20AC;' ) ).toBe( '€' );
+			expect( decodeHtmlEntities( '&#x00A9;' ) ).toBe( '©' );
+			expect( decodeHtmlEntities( '&#x2122;' ) ).toBe( '™' );
+			expect( decodeHtmlEntities( '&#x41;' ) ).toBe( 'A' );
+		} );
+	} );
+
+	describe( 'Complex scenarios', () => {
+		it( 'decodes multiple entities in one string', () => {
+			const result = decodeHtmlEntities(
+				'&lt;div&gt;&nbsp;&amp;&nbsp;&lt;/div&gt;'
+			);
+			// Handle both possible nbsp conversions
+			expect( [
+				'<div> & </div>',
+				'<div>\u00A0&\u00A0</div>',
+			] ).toContain( result );
+		} );
+
+		it( 'handles mixed content with entities and plain text', () => {
+			const result = decodeHtmlEntities(
+				'Price: €&nbsp;50.00 &amp; tax'
+			);
+			expect( [
+				'Price: € 50.00 & tax',
+				'Price: €\u00A050.00 & tax',
+			] ).toContain( result );
+		} );
+
+		it( 'preserves text without entities', () => {
+			const plainText = 'This is plain text with no entities!';
+			expect( decodeHtmlEntities( plainText ) ).toBe( plainText );
+		} );
+
+		it( 'handles incomplete entities', () => {
+			// Browsers handle incomplete entities if:
+			// It is a legacy ISO Latin 1 entity (character code < 256)
+			// There's no "name character" following it (or it's at end of string)
+			// Historical SGML legacy: HTML up to 4.01 was SGML-based, allowing semicolon omission when entity isn't followed by a name character (e.g., &amp works but &amp4 doesn't)
+			expect( decodeHtmlEntities( '&amp' ) ).toBe( '&' );
+
+			// Incomplete numeric entities should not be decoded
+			expect( decodeHtmlEntities( '&#' ) ).toBe( '&#' );
+			expect( decodeHtmlEntities( '&' ) ).toBe( '&' );
+			expect( decodeHtmlEntities( 'test & text' ) ).toBe( 'test & text' );
+		} );
+
+		it( 'handles entities at string boundaries', () => {
+			expect( decodeHtmlEntities( '&amp;test' ) ).toBe( '&test' );
+			expect( decodeHtmlEntities( 'test&amp;' ) ).toBe( 'test&' );
+		} );
+	} );
+
+	describe( 'WooCommerce-specific use cases', () => {
+		it( 'handles price formatting with thousand separators', () => {
+			const result1 = decodeHtmlEntities( '1&nbsp;000.50' );
+			expect( [ '1 000.50', '1\u00A0000.50' ] ).toContain( result1 );
+
+			const result2 = decodeHtmlEntities( '€&nbsp;999&nbsp;999.99' );
+			expect( [ '€ 999 999.99', '€\u00A0999\u00A0999.99' ] ).toContain(
+				result2
+			);
+		} );
+
+		it( 'handles product names with special characters', () => {
+			expect( decodeHtmlEntities( 'T-shirt &amp; Jeans' ) ).toBe(
+				'T-shirt & Jeans'
+			);
+			expect(
+				decodeHtmlEntities( 'Coffee &quot;Premium&quot; Blend' )
+			).toBe( 'Coffee "Premium" Blend' );
+			expect( decodeHtmlEntities( 'Men&apos;s Clothing' ) ).toBe(
+				"Men's Clothing"
+			);
+		} );
+
+		it( 'handles product descriptions with multiple entities', () => {
+			const description =
+				'This product is &lt;strong&gt;amazing&lt;/strong&gt; &amp; costs &pound;50&nbsp;only!';
+			const result = decodeHtmlEntities( description );
+			expect( [
+				'This product is <strong>amazing</strong> & costs £50 only!',
+				'This product is <strong>amazing</strong> & costs £50\u00A0only!',
+			] ).toContain( result );
+		} );
+
+		it( 'handles international characters and symbols', () => {
+			expect( decodeHtmlEntities( 'Caf&eacute; &amp; Restaurant' ) ).toBe(
+				'Café & Restaurant'
+			);
+			expect(
+				decodeHtmlEntities( '&copy; 2024 &mdash; All rights reserved' )
+			).toBe( '© 2024 — All rights reserved' );
+		} );
+	} );
+
+	describe( 'HTML content handling', () => {
+		it( 'extracts text content from HTML tags', () => {
+			expect( decodeHtmlEntities( '<p>Hello &amp; welcome</p>' ) ).toBe(
+				'Hello & welcome'
+			);
+
+			const result = decodeHtmlEntities(
+				'<div><span>Test&nbsp;text</span></div>'
+			);
+			expect( [ 'Test text', 'Test\u00A0text' ] ).toContain( result );
+		} );
+
+		it( 'removes HTML tags while preserving decoded entities', () => {
+			expect(
+				decodeHtmlEntities( '<strong>Bold &amp; Beautiful</strong>' )
+			).toBe( 'Bold & Beautiful' );
+		} );
+
+		it( 'handles self-closing tags', () => {
+			expect( decodeHtmlEntities( 'Line 1<br/>Line 2' ) ).toBe(
+				'Line 1Line 2'
+			);
+		} );
+
+		it( 'handles nested HTML structures', () => {
+			expect(
+				decodeHtmlEntities(
+					'<div><p>Nested <em>&amp;</em> text</p></div>'
+				)
+			).toBe( 'Nested & text' );
+		} );
+	} );
+
+	describe( 'Performance and edge cases', () => {
+		it( 'handles very long strings', () => {
+			const longString = '&amp;'.repeat( 1000 );
+			const expected = '&'.repeat( 1000 );
+			expect( decodeHtmlEntities( longString ) ).toBe( expected );
+		} );
+
+		it( 'handles strings with many different entities', () => {
+			const complexString =
+				'&amp;&lt;&gt;&quot;&apos;&copy;&reg;&trade;&pound;&euro;&yen;';
+			const result = decodeHtmlEntities( complexString );
+			// Some browsers might handle &apos; differently
+			expect( [ '&<>"\'©®™£€¥', '&<>"\'©®™£€¥' ] ).toContain( result );
+		} );
+
+		it( 'handles unusual but valid entity formats', () => {
+			expect( decodeHtmlEntities( '&#x0041;' ) ).toBe( 'A' ); // Hex with leading zeros
+			expect( decodeHtmlEntities( '&#065;' ) ).toBe( 'A' ); // Decimal with leading zeros
+		} );
+
+		it( 'handles entity-like strings that are not valid entities', () => {
+			expect( decodeHtmlEntities( '&invalidentity;' ) ).toBe(
+				'&invalidentity;'
+			);
+			expect( decodeHtmlEntities( '&#cfsdf;' ) ).toBe( '&#cfsdf;' );
+			expect( decodeHtmlEntities( '&#xGGGG;' ) ).toBe( '&#xGGGG;' );
+		} );
+	} );
+
+	describe( 'Document creation behavior', () => {
+		it( 'creates a new document for each call', () => {
+			const spy = jest.spyOn(
+				document.implementation,
+				'createHTMLDocument'
+			);
+
+			decodeHtmlEntities( 'test1' );
+			decodeHtmlEntities( 'test2' );
+
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( spy ).toHaveBeenCalledWith( '' );
+
+			spy.mockRestore();
+		} );
+	} );
+
+	describe( 'Script and style handling', () => {
+		it( 'removes script tags and their content', () => {
+			expect(
+				decodeHtmlEntities( '<script>alert("test")</script>Hello' )
+			).toBe( 'alert("test")Hello' );
+		} );
+
+		it( 'removes style tags and their content', () => {
+			expect(
+				decodeHtmlEntities( '<style>body { color: red; }</style>Hello' )
+			).toBe( 'body { color: red; }Hello' );
+		} );
+
+		it( 'handles encoded script tags', () => {
+			expect(
+				decodeHtmlEntities(
+					'&lt;script&gt;alert("xss")&lt;/script&gt;'
+				)
+			).toBe( '<script>alert("xss")</script>' );
+		} );
+	} );
+
+	describe( 'Real-world entity combinations', () => {
+		it( 'handles common French entities', () => {
+			expect(
+				decodeHtmlEntities( 'Cr&egrave;me br&ucirc;l&eacute;e' )
+			).toBe( 'Crème brûlée' );
+		} );
+
+		it( 'handles common German entities', () => {
+			expect( decodeHtmlEntities( 'M&uuml;nchen &amp; K&ouml;ln' ) ).toBe(
+				'München & Köln'
+			);
+		} );
+
+		it( 'handles mathematical symbols', () => {
+			expect( decodeHtmlEntities( '5 &lt; 10 &amp; 10 &gt; 5' ) ).toBe(
+				'5 < 10 & 10 > 5'
+			);
+			expect(
+				decodeHtmlEntities( '&plusmn;5 &divide; 2 = &plusmn;2.5' )
+			).toBe( '±5 ÷ 2 = ±2.5' );
+		} );
+
+		it( 'handles quotes and punctuation', () => {
+			expect(
+				decodeHtmlEntities( '&ldquo;Hello&rdquo; &mdash; world' )
+			).toBe( '“Hello” — world' );
+			expect(
+				decodeHtmlEntities( '&lsquo;Test&rsquo; &ndash; example' )
+			).toBe( '‘Test’ – example' );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
@@ -10,12 +10,12 @@ import clsx from 'clsx';
 import type { ReactElement } from 'react';
 import type { Currency } from '@woocommerce/types';
 import { SITE_CURRENCY } from '@woocommerce/settings';
+import { decodeHtmlEntities } from '@woocommerce/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { decodeHtmlEntities } from '@woocommerce/utils';
 
 export interface FormattedMonetaryAmountProps
 	extends Omit< NumberFormatProps, 'onValueChange' | 'displayType' > {
@@ -38,8 +38,9 @@ const currencyToNumberFormat = ( currency: Currency ) => {
 	// Decode HTML entities in separators
 	const decodedThousandSeparator = decodeHtmlEntities( thousandSeparator );
 	const decodedDecimalSeparator = decodeHtmlEntities( decimalSeparator );
-	
-	const hasDuplicateSeparator = decodedThousandSeparator === decodedDecimalSeparator;
+
+	const hasDuplicateSeparator =
+		decodedThousandSeparator === decodedDecimalSeparator;
 	if ( hasDuplicateSeparator ) {
 		// eslint-disable-next-line no-console
 		console.warn(
@@ -47,7 +48,9 @@ const currencyToNumberFormat = ( currency: Currency ) => {
 		);
 	}
 	return {
-		thousandSeparator: hasDuplicateSeparator ? '' : decodedThousandSeparator,
+		thousandSeparator: hasDuplicateSeparator
+			? ''
+			: decodedThousandSeparator,
 		decimalSeparator: decodedDecimalSeparator,
 		fixedDecimalScale: true,
 		prefix: decodeHtmlEntities( prefix ),

--- a/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/formatted-monetary-amount/index.tsx
@@ -15,6 +15,7 @@ import { SITE_CURRENCY } from '@woocommerce/settings';
  * Internal dependencies
  */
 import './style.scss';
+import { decodeHtmlEntities } from '@woocommerce/utils';
 
 export interface FormattedMonetaryAmountProps
 	extends Omit< NumberFormatProps, 'onValueChange' | 'displayType' > {
@@ -34,7 +35,11 @@ export interface FormattedMonetaryAmountProps
  */
 const currencyToNumberFormat = ( currency: Currency ) => {
 	const { prefix, suffix, thousandSeparator, decimalSeparator } = currency;
-	const hasDuplicateSeparator = thousandSeparator === decimalSeparator;
+	// Decode HTML entities in separators
+	const decodedThousandSeparator = decodeHtmlEntities( thousandSeparator );
+	const decodedDecimalSeparator = decodeHtmlEntities( decimalSeparator );
+	
+	const hasDuplicateSeparator = decodedThousandSeparator === decodedDecimalSeparator;
 	if ( hasDuplicateSeparator ) {
 		// eslint-disable-next-line no-console
 		console.warn(
@@ -42,11 +47,11 @@ const currencyToNumberFormat = ( currency: Currency ) => {
 		);
 	}
 	return {
-		thousandSeparator: hasDuplicateSeparator ? '' : thousandSeparator,
-		decimalSeparator,
+		thousandSeparator: hasDuplicateSeparator ? '' : decodedThousandSeparator,
+		decimalSeparator: decodedDecimalSeparator,
 		fixedDecimalScale: true,
-		prefix,
-		suffix,
+		prefix: decodeHtmlEntities( prefix ),
+		suffix: decodeHtmlEntities( suffix ),
 		isNumericString: true,
 	};
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Creates a `decodeHtmlEntities` function to parse entities and display them correctly.
	- This is based on Gutenberg's util, but since that's currently unstable I didn't want to include it here, I just copied it for our use case and wrote more tests.
- Uses this functionality in `FormattedMonetaryAmount` to ensure the thousand separator and decimal separator show the correct entity, not the encoded string.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4055

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="358" alt="image" src="https://github.com/user-attachments/assets/d0b20e38-3e1c-48f6-acc8-310519e42736" />  |  <img width="354" alt="image" src="https://github.com/user-attachments/assets/aaf29970-d003-4379-a84c-83d9e01c76a9" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC -> Settings -> General and add `&middot;` to the thousand separator and/or decimal separator
2. Go to the front end and add products to the cart until the value is over 1000
3. Check the separator shows correctly as expected
4. Try adding script tags, style tags, and other HTML tags to try to break the checkout, e.g. by introducing new styling or executing arbitrary JS code.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
