### PR TITLE
Add to Cart + Options block: Find first non-disabled radio

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-4711
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-4711
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug with disabled radio buttons receiving the incorrect tabIndex

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -153,11 +153,36 @@ const { state } = store(
 				} );
 			},
 			get pillTabIndex(): number {
-				const { selectedValue } = getContext< Context >();
-				const { isPillSelected, index } = state;
-				if ( isPillSelected || ( index === 0 && ! selectedValue ) ) {
+				const { selectedValue, options, name } =
+					getContext< Context >();
+				const { isPillSelected, isPillDisabled, index } = state;
+
+				if ( isPillSelected ) {
 					return 0;
 				}
+
+				if ( ! selectedValue ) {
+					const { selectedAttributes, availableVariations } =
+						getContext< AddToCartWithOptionsStoreContext >(
+							'woocommerce/add-to-cart-with-options'
+						);
+
+					const firstNonDisabledPill = options.findIndex(
+						( option ) => {
+							return isAttributeValueValid( {
+								attributeName: name,
+								attributeValue: option.value,
+								selectedAttributes,
+								availableVariations,
+							} );
+						}
+					);
+
+					if ( index === firstNonDisabledPill && ! isPillDisabled ) {
+						return 0;
+					}
+				}
+
 				return -1;
 			},
 			get index() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/59013.

In https://github.com/woocommerce/woocommerce/pull/58691, we started setting the `tabIndex` of the radio pills to follow best practices. However, I didn't take disabled radio buttons into account, so they were receiving an incorrect `tabIndex` of `0`, which isn't possible when they're disabled. This updates the logic so that disabled radios are not considered when setting the `tabIndex` of the first option.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Edit the variations of a variable product to make it so there the first attribute can get disabled in some cases.
4. Try to focus the option group where the first attribute is disabled.
5. Ensure you can focus it.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
