### PR TITLE
Check that product availability contains a class before accessing it

### DIFF
--- a/plugins/woocommerce/changelog/fix-product_availability_class_check
+++ b/plugins/woocommerce/changelog/fix-product_availability_class_check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Check that product availability contains a class before accessing it
+
+

--- a/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductAvailabilityUtils.php
@@ -31,6 +31,7 @@ class ProductAvailabilityUtils {
 		// If the product is a variable product, make sure at least one of its
 		// variations is purchasable.
 		if (
+			isset( $product_availability['class'] ) &&
 			( 'in-stock' === $product_availability['class'] || 'available-on-backorder' === $product_availability['class'] ) &&
 			ProductType::VARIABLE === $product->get_type()
 		) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes the issue reported by @jimjasson in https://github.com/woocommerce/woocommerce/pull/58845#discussion_r2158883780.

This PR adds an extra protection in case an extension or some other code is hooking into the `woocommerce_get_availability` filter and is not returning an array with a `class` key.

### How to test the changes in this Pull Request:

1. Add this code snippet to your site:

```PHP
add_filter( 'woocommerce_get_availability', '__return_false' );
```

2. In the frontend, go to a product page and verify there are no warnings printed on the screen.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/8aaec3c2-71fd-416b-a7e3-75b8f2ec9076) | ![imatge](https://github.com/user-attachments/assets/3c3b78c0-adfc-45cc-bcaa-3680f8b722b1)
