### PR TITLE
[Payments NOX] Switch GET endpoints to POST

### DIFF
--- a/packages/js/data/changelog/update-WOOPLUG-4735-switch-nox-endpoints-from-get-to-post
+++ b/packages/js/data/changelog/update-WOOPLUG-4735-switch-nox-endpoints-from-get-to-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Change Payments NOX GET endpoints to POST.
+
+

--- a/packages/js/data/src/payment-settings/resolvers.ts
+++ b/packages/js/data/src/payment-settings/resolvers.ts
@@ -22,10 +22,8 @@ export function* getPaymentProviders( country?: string ) {
 		const paymentProvidersResponse: PaymentProvidersResponse =
 			yield apiFetch( {
 				method: 'POST',
-				path:
-					WC_ADMIN_NAMESPACE +
-					'/settings/payments/providers?' +
-					( country ? `location=${ country }` : '' ),
+				path: WC_ADMIN_NAMESPACE + '/settings/payments/providers',
+				data: country ? { location: country } : {},
 			} );
 		yield getPaymentProvidersSuccess(
 			paymentProvidersResponse.providers,

--- a/packages/js/data/src/payment-settings/resolvers.ts
+++ b/packages/js/data/src/payment-settings/resolvers.ts
@@ -21,6 +21,7 @@ export function* getPaymentProviders( country?: string ) {
 	try {
 		const paymentProvidersResponse: PaymentProvidersResponse =
 			yield apiFetch( {
+				method: 'POST',
 				path:
 					WC_ADMIN_NAMESPACE +
 					'/settings/payments/providers?' +
@@ -43,6 +44,7 @@ export function* getOfflinePaymentGateways( country?: string ) {
 
 export function* getWooPayEligibility() {
 	const response: WooPayEligibilityResponse = yield apiFetch( {
+		method: 'POST',
 		path: `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/woopay-eligibility`,
 	} );
 

--- a/packages/js/data/src/woopayments-onboarding/resolvers.ts
+++ b/packages/js/data/src/woopayments-onboarding/resolvers.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -19,16 +18,10 @@ export function* getOnboardingData( source?: string | null ) {
 	yield getOnboardingDataRequest();
 
 	try {
-		let path = `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/onboarding`;
-
-		// Add source parameter if provided
-		if ( source ) {
-			path = addQueryArgs( path, { source } );
-		}
-
 		const response: OnboardingDataResponse = yield apiFetch( {
 			method: 'POST',
-			path,
+			path: `${ WC_ADMIN_NAMESPACE }/settings/payments/woopayments/onboarding`,
+			data: source ? { source } : {},
 		} );
 
 		yield getOnboardingDataSuccess( response );

--- a/packages/js/data/src/woopayments-onboarding/resolvers.ts
+++ b/packages/js/data/src/woopayments-onboarding/resolvers.ts
@@ -27,6 +27,7 @@ export function* getOnboardingData( source?: string | null ) {
 		}
 
 		const response: OnboardingDataResponse = yield apiFetch( {
+			method: 'POST',
 			path,
 		} );
 

--- a/plugins/woocommerce/changelog/update-WOOPLUG-4735-switch-nox-endpoints-from-get-to-post
+++ b/plugins/woocommerce/changelog/update-WOOPLUG-4735-switch-nox-endpoints-from-get-to-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Change Payments NOX GET endpoints to POST.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestController.php
@@ -65,7 +65,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			'/' . $this->rest_base . '/onboarding',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
+					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'get_onboarding_details' ),
 					'validation_callback' => 'rest_validate_request_arg',
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
@@ -343,7 +343,7 @@ class WooPaymentsRestController extends RestApiControllerBase {
 			'/' . $this->rest_base . '/woopay-eligibility',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
+					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'get_woopay_eligibility' ),
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),
 				),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsRestController.php
@@ -77,7 +77,7 @@ class PaymentsRestController extends RestApiControllerBase {
 			'/' . $this->rest_base . '/providers',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
+					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => fn( $request ) => $this->run( $request, 'get_providers' ),
 					'validation_callback' => 'rest_validate_request_arg',
 					'permission_callback' => fn( $request ) => $this->check_permissions( $request ),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestControllerIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestControllerIntegrationTest.php
@@ -267,7 +267,7 @@ class WooPaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -291,7 +291,7 @@ class WooPaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$request->set_param( 'location', $country_code );
 		$response = $this->server->dispatch( $request );
 
@@ -341,7 +341,7 @@ class WooPaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		update_option( 'woocommerce_default_country', $country_code ); // Liechtenstein.
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -366,7 +366,7 @@ class WooPaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		// Arrange.
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$request->set_param( 'location', $location );
 		$response = $this->server->dispatch( $request );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsRestControllerTest.php
@@ -76,7 +76,7 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -102,7 +102,7 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_onboarding_details( $country_code );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$request->set_param( 'location', $country_code );
 		$response = $this->server->dispatch( $request );
 
@@ -153,7 +153,7 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_onboarding_details( $country_code );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -181,7 +181,7 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 			->method( 'get_onboarding_details' );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$request->set_param( 'location', $location );
 		$response = $this->server->dispatch( $request );
 
@@ -203,7 +203,7 @@ class WooPaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 			->willThrowException( new \Exception( 'Test exception' ) );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/onboarding' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/onboarding' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerIntegrationTest.php
@@ -223,7 +223,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -248,7 +248,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -296,7 +296,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -342,7 +342,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->enable_core_paypal_pg();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -391,7 +391,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		update_option( 'woocommerce_default_country', 'LI' ); // Liechtenstein.
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -433,7 +433,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->enable_core_paypal_pg();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'XX' );
 		$response = $this->server->dispatch( $request );
 
@@ -466,7 +466,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->enable_core_paypal_pg();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'U' );
 		$response = $this->server->dispatch( $request );
 
@@ -474,7 +474,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 400, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', '12' );
 		$response = $this->server->dispatch( $request );
 
@@ -482,7 +482,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 400, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'USA' );
 		$response = $this->server->dispatch( $request );
 
@@ -508,7 +508,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->mock_payment_gateways();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -925,7 +925,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 200, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -944,7 +944,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		delete_user_meta( $this->store_admin_id, Payments::PAYMENTS_NOX_PROFILE_KEY );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -986,7 +986,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 200, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -1006,7 +1006,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		delete_user_meta( get_current_user_id(), Incentive::PREFIX . 'dismissed' );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -1058,7 +1058,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 200, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -1164,7 +1164,7 @@ class PaymentsRestControllerIntegrationTest extends WC_REST_Unit_Test_Case {
 		);
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsRestControllerTest.php
@@ -73,7 +73,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -102,7 +102,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_extension_suggestions_categories();
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -190,7 +190,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		add_filter( 'user_has_cap', $filter_callback );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -264,7 +264,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_extension_suggestions_categories();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -314,7 +314,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_extension_suggestions_categories();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -363,7 +363,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_extension_suggestions_categories();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -406,7 +406,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->mock_extension_suggestions_categories();
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'US' );
 		$response = $this->server->dispatch( $request );
 
@@ -455,7 +455,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		update_option( 'woocommerce_default_country', 'LI' ); // Liechtenstein.
 
 		// Act.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request  = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert.
@@ -488,7 +488,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_payment_providers_with_invalid_location() {
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'U' );
 		$response = $this->server->dispatch( $request );
 
@@ -496,7 +496,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 400, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', '12' );
 		$response = $this->server->dispatch( $request );
 
@@ -504,7 +504,7 @@ class PaymentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertSame( 400, $response->get_status() );
 
 		// Act.
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT . '/providers' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT . '/providers' );
 		$request->set_param( 'location', 'USA' );
 		$response = $this->server->dispatch( $request );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

To avoid caching of the Paymens NOX API requests, we replaced all GET endpoints with POST. While this is not nice from a HTTP semantics standpoint, this is the cleanest way to avoid responses being cached by the various systems stores may have in place.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4735

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. The code changes should make sense
2. Spin up a new JurassicNinja store with the PR's branch build (here is a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce=update/WOOPLUG-4735-switch-nox-endpoints-from-get-to-post))
3. Click on the WooCommerce main menu item, skip the core profiler when redirected to it, and set your store location to United States.
4. Open your browser Dev Tools and enable recording ("Preserve log" for Chrome) for the Network tab.
5. Go to the Payments Settings page and you should see the suggestions and offline PMs group:
![Screenshot 2025-05-15 at 15 18 54](https://github.com/user-attachments/assets/a9a895e0-1b4c-4734-a5bf-6c0c80351318)
6. Smoke test installing suggested extensions.
7. Install WooPayments and complete its onboarding with a test account (no need for a live account).
8. Inspect the network requests for `/wp-json/wc-admin/settings/payments/providers`, `/wp-json/wc-admin/settings/payments/woopayments/onboarding` and they should be POST requests, not GET ones.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
