### PR TITLE
Add tests for `woocommerce_sale_badge_text` hook

### DIFF
--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -23,4 +23,93 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup, 'The Single Product Block contains the Product Sale Badge block.' );
 		$this->assertStringContainsString( 'Sale', $markup, 'The Product Sale Badge block contains the sale text.' );
 	}
+
+	/**
+	 * Tests that the woocommerce_sale_badge_text filter works correctly in Single Product block.
+	 */
+	public function test_product_sale_badge_render_single_product_block_with_custom_text() {
+		global $product;
+		$product = new \WC_Product_Simple();
+		$product->set_regular_price( 10 );
+		$product->set_sale_price( 5 );
+		$product_id = $product->save();
+
+		$default_sale_text = null;
+		/** @var \WC_Product|null */
+		$received_product = null;
+
+		add_filter(
+			'woocommerce_sale_badge_text',
+			function ( $sale_text, $product_obj ) use ( &$default_sale_text, &$received_product ) {
+				$default_sale_text = $sale_text;
+				$received_product  = $product_obj;
+				return 'Special Offer!';
+			},
+			10,
+			2
+		);
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-sale-badge /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup, 'The Single Product Block contains the Product Sale Badge block.' );
+		$this->assertStringContainsString( 'Special Offer!', $markup, 'The Product Sale Badge block contains the custom sale text.' );
+		$this->assertStringNotContainsString( 'Sale', $markup, 'The Product Sale Badge block does not contain the default sale text.' );
+
+		$this->assertInstanceOf( \WC_Product::class, $received_product, 'The filter received a WC_Product object.' );
+		/**
+		 * Check that the filter received the correct parameters.
+		 */
+		$this->assertEquals( $product_id, $received_product->get_id(), 'The filter received the correct product object.' );
+		$this->assertEquals( 'Sale', $default_sale_text, 'The default sale text is not modified.' );
+
+		remove_all_filters( 'woocommerce_sale_badge_text' );
+	}
+
+	/**
+	 * Tests that the woocommerce_sale_badge_text filter works correctly in Product Collection block.
+	 */
+	public function test_product_sale_badge_render_product_collection_block_with_custom_text() {
+		$product1 = \WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 20 );
+		$product1->set_sale_price( 15 );
+		$product1->save();
+
+		$product2 = \WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 30 );
+		$product2->set_sale_price( 25 );
+		$product2->save();
+
+		$product_ids = array( $product1->get_id(), $product2->get_id() );
+
+		$default_sale_text = null;
+		/** @var \WC_Product|null */
+		$received_product = null;
+
+		add_filter(
+			'woocommerce_sale_badge_text',
+			function ( $sale_text, $product_obj ) use ( &$default_sale_text, &$received_product ) {
+				$default_sale_text = $sale_text;
+				$received_product  = $product_obj;
+				$sale_price        = (float) $product_obj->get_sale_price();
+				if ( $sale_price < 20 ) {
+					return 'Special Deal!';
+				}
+				return 'Limited Time!';
+			},
+			10,
+			2
+		);
+
+		$collection_block  = '<!-- wp:woocommerce/product-collection {"query":{"isProductCollectionBlock":true,"woocommerceHandPickedProducts":[' . implode( ',', $product_ids ) . ']}} -->';
+		$collection_block .= '<!-- wp:woocommerce/product-template -->';
+		$collection_block .= '<!-- wp:woocommerce/product-sale-badge /-->';
+		$collection_block .= '<!-- /wp:woocommerce/product-template -->';
+		$collection_block .= '<!-- /wp:woocommerce/product-collection -->';
+
+		$markup = do_blocks( $collection_block );
+
+		$this->assertStringContainsString( 'Special Deal!', $markup, 'Product with sale price < 20 should show "Special Deal!"' );
+		$this->assertStringContainsString( 'Limited Time!', $markup, 'Product with sale price >= 20 should show "Limited Time!"' );
+		$this->assertStringNotContainsString( 'Sale', $markup, 'Default "Sale" text should not appear when filter is applied' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -22,6 +22,8 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup, 'The Single Product Block contains the Product Sale Badge block.' );
 		$this->assertStringContainsString( 'Sale', $markup, 'The Product Sale Badge block contains the sale text.' );
+
+		$product->delete();
 	}
 
 	/**
@@ -63,6 +65,7 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 		$this->assertEquals( 'Sale', $default_sale_text, 'The default sale text is not modified.' );
 
 		remove_all_filters( 'woocommerce_sale_badge_text' );
+		$product->delete();
 	}
 
 	/**
@@ -111,5 +114,8 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Special Deal!', $markup, 'Product with sale price < 20 should show "Special Deal!"' );
 		$this->assertStringContainsString( 'Limited Time!', $markup, 'Product with sale price >= 20 should show "Limited Time!"' );
 		$this->assertStringNotContainsString( 'Sale', $markup, 'Default "Sale" text should not appear when filter is applied' );
+
+		$product1->delete();
+		$product2->delete();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -103,7 +103,7 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 			2
 		);
 
-		$collection_block  = '<!-- wp:woocommerce/product-collection {"query":{"isProductCollectionBlock":true,"woocommerceHandPickedProducts":[' . implode( ',', $product_ids ) . ']}} -->';
+		$collection_block  = '<!-- wp:woocommerce/product-collection {"queryId":0,"query":{"isProductCollectionBlock":true,"woocommerceHandPickedProducts":[' . implode( ',', $product_ids ) . ']}} -->';
 		$collection_block .= '<!-- wp:woocommerce/product-template -->';
 		$collection_block .= '<!-- wp:woocommerce/product-sale-badge /-->';
 		$collection_block .= '<!-- /wp:woocommerce/product-template -->';

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductSaleBadge.php
@@ -115,6 +115,11 @@ class ProductSaleBadge extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Limited Time!', $markup, 'Product with sale price >= 20 should show "Limited Time!"' );
 		$this->assertStringNotContainsString( 'Sale', $markup, 'Default "Sale" text should not appear when filter is applied' );
 
+		$this->assertInstanceOf( \WC_Product::class, $received_product, 'The filter received a WC_Product object.' );
+		$this->assertEquals( 'Sale', $default_sale_text, 'The default sale text is not modified.' );
+
+		remove_all_filters( 'woocommerce_sale_badge_text' );
+
 		$product1->delete();
 		$product2->delete();
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


This PR adds a unit test for the `woocommerce_sale_badge_text`. This test ensures that the filter works as expected in the Single Product Block and Product Collection Block scenarios.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter=@woocommerce/plugin-woocommerce test:php:env --filter=ProductSaleBadge`
2. Ensure that the test passes.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
