### PR TITLE
Revert "Add to Cart + Options block: Improve a11y for variation radios"

### DIFF
--- a/plugins/woocommerce/changelog/58691-update-atcwo-tabindex
+++ b/plugins/woocommerce/changelog/58691-update-atcwo-tabindex
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Blockified Add to Cart with Options block: add "tabindex" and "aria-checked" attributes to variation option radio inputs.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -152,14 +152,6 @@ const { state } = store(
 					availableVariations,
 				} );
 			},
-			get pillTabIndex(): number {
-				const { selectedValue } = getContext< Context >();
-				const { isPillSelected, index } = state;
-				if ( isPillSelected || ( index === 0 && ! selectedValue ) ) {
-					return 0;
-				}
-				return -1;
-			},
 			get index() {
 				const context = getContext< Context >();
 				return context.options.findIndex(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -153,19 +153,17 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				'<input type="radio" %s/>',
 				$this->get_normalized_attributes(
 					array(
-						'class'                      => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input',
-						'name'                       => $attribute_slug,
-						'value'                      => $attribute_term['value'],
-						'data-wp-bind--checked'      => 'state.isPillSelected',
-						'data-wp-bind--disabled'     => 'state.isPillDisabled',
-						'data-wp-watch'              => 'callbacks.watchSelected',
-						'data-wp-on--click'          => 'actions.toggleSelected',
-						'data-wp-on--keydown'        => 'actions.handleKeyDown',
-						'data-wp-context'            => array(
+						'class'                  => 'wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input',
+						'name'                   => $attribute_slug,
+						'value'                  => $attribute_term['value'],
+						'data-wp-bind--checked'  => 'state.isPillSelected',
+						'data-wp-bind--disabled' => 'state.isPillDisabled',
+						'data-wp-watch'          => 'callbacks.watchSelected',
+						'data-wp-on--click'      => 'actions.toggleSelected',
+						'data-wp-on--keydown'    => 'actions.handleKeyDown',
+						'data-wp-context'        => array(
 							'option' => $attribute_term,
 						),
-						'data-wp-bind--aria-checked' => 'state.isPillSelected',
-						'data-wp-bind--tabindex'     => 'state.pillTabIndex',
 					),
 				),
 				$attribute_term['label']


### PR DESCRIPTION
Reverts woocommerce/woocommerce#58691.

After discussing with @Aljullu in https://github.com/woocommerce/woocommerce/issues/59013, I don't think we need the accessibility changes from https://github.com/woocommerce/woocommerce/pull/58691. 

They are safe to remove in isolation: this will remove the manual addition of the `tabIndex` and `aria-checked` attributes, both of which are not required as the pills use native `radio` inputs.

Closes https://github.com/woocommerce/woocommerce/issues/59013.