### PR TITLE
Add ability to query and sort orders by shipping and billing fields

### DIFF
--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -729,6 +729,24 @@ class OrdersTableQuery {
 			'order_total'   => "{$this->tables['orders']}.total_amount",
 		);
 
+		$address_fields = array(
+			'first_name',
+			'last_name',
+			'company',
+			'address_1',
+			'address_2',
+			'city',
+			'state',
+			'postcode',
+			'country',
+			'phone',
+		);
+		foreach( array( 'billing', 'shipping' ) as $address_type ) {
+			foreach ( $address_fields as $address_field ) {
+				$mapping[] = "{$address_type}_{$address_field}";
+			}
+		}
+
 		$order   = $this->args['order'] ?? '';
 		$orderby = $this->args['orderby'] ?? '';
 
@@ -1257,13 +1275,7 @@ class OrdersTableQuery {
 				continue;
 			}
 
-			$this->join(
-				$this->tables['addresses'],
-				$address_type,
-				$wpdb->prepare( "{$this->tables['orders']}.id = {$address_type}.order_id AND {$address_type}.address_type = %s", $address_type ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				'inner',
-				false
-			);
+			$this->join_address_table( $address_type );
 
 			foreach ( $fields as $arg_key ) {
 				$column_name = str_replace( "{$address_type}_", '', $arg_key );
@@ -1312,6 +1324,13 @@ class OrdersTableQuery {
 		foreach ( $this->args['orderby'] as $_orderby => $order ) {
 			if ( in_array( $_orderby, $meta_orderby_keys, true ) ) {
 				$_orderby = $this->meta_query->get_orderby_clause_for_key( $_orderby );
+			} else if (str_starts_with( $_orderby, 'billing_' ) || str_starts_with( $_orderby, 'shipping_' ) ) {
+				list( $address_type, $address_field ) = explode( '_', $_orderby, 2 );
+				if ( ! isset( $this->join[ $address_type ] )) {
+					$this->join_address_table( $address_type );
+				}
+
+				$_orderby = "{$address_type}.{$address_field}";
 			}
 
 			$orderby_array[] = "{$_orderby} {$order}";
@@ -1502,5 +1521,19 @@ class OrdersTableQuery {
 	 */
 	public function get_query_args(): array {
 		return $this->query_args;
+	}
+
+	private function join_address_table( $address_type = 'billing' ): void {
+		global $wpdb;
+
+		if ( isset( $this->join[ $address_type ] ) ) return;
+
+		$this->join(
+			$this->tables['addresses'],
+			$address_type,
+			$wpdb->prepare( "{$this->tables['orders']}.id = {$address_type}.order_id AND {$address_type}.address_type = %s", $address_type ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			'inner',
+			false
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -741,7 +741,7 @@ class OrdersTableQuery {
 			'country',
 			'phone',
 		);
-		foreach( array( 'billing', 'shipping' ) as $address_type ) {
+		foreach ( array( 'billing', 'shipping' ) as $address_type ) {
 			foreach ( $address_fields as $address_field ) {
 				$mapping[] = "{$address_type}_{$address_field}";
 			}
@@ -1324,9 +1324,9 @@ class OrdersTableQuery {
 		foreach ( $this->args['orderby'] as $_orderby => $order ) {
 			if ( in_array( $_orderby, $meta_orderby_keys, true ) ) {
 				$_orderby = $this->meta_query->get_orderby_clause_for_key( $_orderby );
-			} else if (str_starts_with( $_orderby, 'billing_' ) || str_starts_with( $_orderby, 'shipping_' ) ) {
+			} elseif ( str_starts_with( $_orderby, 'billing_' ) || str_starts_with( $_orderby, 'shipping_' ) ) {
 				list( $address_type, $address_field ) = explode( '_', $_orderby, 2 );
-				if ( ! isset( $this->join[ $address_type ] )) {
+				if ( ! isset( $this->join[ $address_type ] ) ) {
 					$this->join_address_table( $address_type );
 				}
 
@@ -1526,7 +1526,9 @@ class OrdersTableQuery {
 	private function join_address_table( $address_type = 'billing' ): void {
 		global $wpdb;
 
-		if ( isset( $this->join[ $address_type ] ) ) return;
+		if ( isset( $this->join[ $address_type ] ) ) {
+			return;
+		}
 
 		$this->join(
 			$this->tables['addresses'],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
With these changes I want to add a feature to sort by address fields (phone, etc.). This is only implemented for HPOS order query for now but if needed, I can extend it to legacy order querying. 

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59066.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this PR and use it as the plugin.
2. Query for orders: 
```php
$orders = wc_get_orders( [
    'limit'   => 5,
    'orderby' => 'billing_phone',
] );
```
3. Loop over orders and check the `billing_phone` or other fields:
```php
foreach ( $orders as $order ) {
    error_log( $order->get_billing_phone() );
}
```

<!-- End testing instructions -->

### Testing that has already taken place:

I already tested this locally and on our staging environments of our shops and the sorting works as expected.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Enhances query ordering to also sort by address fields such as billing and shipping

</details>
