### PR TITLE
[NOX In-Context] Update the “Ready to test payments” screen for clarity

### DIFF
--- a/plugins/woocommerce/changelog/59076-update-new-copy-for-test-step-nox
+++ b/plugins/woocommerce/changelog/59076-update-new-copy-for-test-step-nox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the “Ready to test payments” screen for clarity

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -500,6 +500,39 @@ const TestAccountStep = () => {
 										</div>
 									</div>
 								</div>
+								<Button
+									variant="primary"
+									onClick={ () => {
+										recordPaymentsOnboardingEvent(
+											'woopayments_onboarding_modal_click',
+											{
+												step:
+													currentStep?.id ||
+													'unknown',
+												action: 'continue_store_setup',
+											}
+										);
+
+										// Navigate to wc-admin page
+										navigateTo( {
+											url: getNewPath( {}, '', {
+												page: 'wc-admin',
+											} ),
+										} );
+									} }
+								>
+									{ __(
+										'Continue store setup',
+										'woocommerce'
+									) }
+								</Button>
+
+								<div className="woocommerce-payments-test-account-step__success_content_or-divider">
+									<hr />
+									{ __( 'OR', 'woocommerce' ) }
+									<hr />
+								</div>
+
 								<div className="woocommerce-woopayments-modal__content__item-flex">
 									<img
 										src={
@@ -537,42 +570,15 @@ const TestAccountStep = () => {
 										</div>
 									</div>
 								</div>
+								<Button
+									variant="secondary"
+									isBusy={ isContinueButtonLoading }
+									disabled={ isContinueButtonLoading }
+									onClick={ handleContinue }
+								>
+									{ __( 'Activate payments', 'woocommerce' ) }
+								</Button>
 							</div>
-							<Button
-								variant="primary"
-								onClick={ () => {
-									recordPaymentsOnboardingEvent(
-										'woopayments_onboarding_modal_click',
-										{
-											step: currentStep?.id || 'unknown',
-											action: 'continue_store_setup',
-										}
-									);
-
-									// Navigate to wc-admin page
-									navigateTo( {
-										url: getNewPath( {}, '', {
-											page: 'wc-admin',
-										} ),
-									} );
-								} }
-							>
-								{ __( 'Continue store setup', 'woocommerce' ) }
-							</Button>
-							<div className="woocommerce-payments-test-account-step__success_content_or-divider">
-								<hr />
-								{ __( 'OR', 'woocommerce' ) }
-								<hr />
-							</div>
-
-							<Button
-								variant="secondary"
-								isBusy={ isContinueButtonLoading }
-								disabled={ isContinueButtonLoading }
-								onClick={ handleContinue }
-							>
-								{ __( 'Activate payments', 'woocommerce' ) }
-							</Button>
 						</div>
 					</div>
 				</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -488,13 +488,13 @@ const TestAccountStep = () => {
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>
 											{ __(
-												'Continue your store setup',
+												'Continue setting up your store',
 												'woocommerce'
 											) }
 										</h3>
 										<div>
 											{ __(
-												'Finish completing the tasks required to launch your store.',
+												'Test payments and finish off any other tasks required to launch your store.',
 												'woocommerce'
 											) }
 										</div>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -511,7 +511,7 @@ const TestAccountStep = () => {
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>
 											{ __(
-												'Activate payments',
+												'Activate real payments',
 												'woocommerce'
 											) }
 										</h3>
@@ -519,7 +519,7 @@ const TestAccountStep = () => {
 											<p>
 												{ interpolateComponents( {
 													mixedString: __(
-														'Provide some additional details about your business so you can begin accepting real payments. {{link}}Learn more{{/link}}',
+														'Provide additional details about your business so you can begin accepting real payments. {{link}}Learn more{{/link}}',
 														'woocommerce'
 													),
 													components: {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/style.scss
@@ -96,8 +96,9 @@
 	&__success-whats-next {
 		display: flex;
 		flex-direction: column;
-		gap: $gap-small;
+		gap: $gap-smaller * 2;
 		border: 1px solid $gray-200;
+		border-radius: 2px;
 		padding: $gap-large;
 
 		.woocommerce-woopayments-modal__content__item h2 {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces some changes to the Ready to test payments screen for clarity following design changes.

Closes WOOPRD-581

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     ![CleanShot 2025-06-23 at 13 28 58@2x](https://github.com/user-attachments/assets/3d5aaeb7-69e6-4d11-801f-07cf3d0782b7)   |    ![CleanShot 2025-06-23 at 13 33 58@2x](https://github.com/user-attachments/assets/3aab639f-4bbb-4e8a-9f29-441f380a1248)   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR locally
2. Reset any connected account from WooCommerce > Settings > Payments
3. Select UK (for quick test account creation) and click Complete Setup
4. Select some PMs and click next. The test account creation step should start.
5. Once finished, make sure it's showing as expected:

![CleanShot 2025-06-23 at 13 33 58@2x](https://github.com/user-attachments/assets/3aab639f-4bbb-4e8a-9f29-441f380a1248)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update the “Ready to test payments” screen for clarity

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
