### PR TITLE
[e2e tests] Update expected heading in connect to woocommerce.com test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-dotcom-connect-test
+++ b/plugins/woocommerce/changelog/e2e-fix-dotcom-connect-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+e2e tests: fix broken test

--- a/plugins/woocommerce/tests/e2e-pw/tests/onboarding/setup-checklist.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/onboarding/setup-checklist.spec.js
@@ -150,7 +150,7 @@ test( 'Can connect to WooCommerce.com', async ( { page } ) => {
 		await expect( page.url() ).toContain( 'wordpress.com/log-in' );
 		await expect(
 			page.getByRole( 'heading', {
-				name: 'Log in to your account',
+				name: 'Log in to Woo with WordPress.com',
 			} )
 		).toBeVisible( { timeout: 30000 } );
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix [broken test](https://github.com/woocommerce/woocommerce/actions/runs/15823506760/job/44602394936?pr=58755#step:9:204) `Can connect to WooCommerce.com`

With https://github.com/Automattic/wp-calypso/pull/104104 merged the test `onboarding/setup-checklist.spec.js > Can connect to WooCommerce.com` started failing. The test was checking for the page heading which was updated.

### How to test the changes in this Pull Request:

CI is green.

