### PR TITLE
Disable wptexturize for WooCommerce Order Notes

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4731-disable-wptexturize-for-woocommerce-order-notes
+++ b/plugins/woocommerce/changelog/wooplug-4731-disable-wptexturize-for-woocommerce-order-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent URLs being texturized in customer and private order notes.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -587,7 +587,7 @@ class WC_Meta_Box_Order_Data {
 								}
 
 								if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $order->get_customer_note() ) { // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-									echo '<p class="order_note"><strong>' . esc_html( __( 'Customer provided note:', 'woocommerce' ) ) . '</strong> ' . wp_kses( nl2br( esc_html( $order->get_customer_note() ) ), array( 'br' => array() ) ) . '</p>';
+									echo '<p class="order_note"><strong>' . esc_html( __( 'Customer provided note:', 'woocommerce' ) ) . '</strong> ' . wp_kses( nl2br( esc_html( wc_wptexturize_order_note( $order->get_customer_note() ) ) ), array( 'br' => array() ) ) . '</p>';
 								}
 							}
 							?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
 				<div class="note_content">
 					<?php
 					$content = wp_kses_post( $note->content );
-					$content = wc_wptexturize_order_note_content( $content );
+					$content = wc_wptexturize_order_note( $content );
 					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- the content goes through wp_kses_post above.
 					echo wpautop( $content );
 					?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-notes.php
@@ -19,7 +19,12 @@ defined( 'ABSPATH' ) || exit;
 			?>
 			<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $css_class ) ); ?>">
 				<div class="note_content">
-					<?php echo wpautop( wptexturize( wp_kses_post( $note->content ) ) ); // @codingStandardsIgnoreLine ?>
+					<?php
+					$content = wp_kses_post( $note->content );
+					$content = wc_wptexturize_order_note_content( $content );
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- the content goes through wp_kses_post above.
+					echo wpautop( $content );
+					?>
 				</div>
 				<p class="meta">
 					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'Y-m-d H:i:s' ) ); ?>">

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1602,7 +1602,10 @@ class WC_AJAX {
 			?>
 			<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
 				<div class="note_content">
-					<?php echo wp_kses_post( wpautop( wptexturize( make_clickable( $note->content ) ) ) ); ?>
+					<?php
+					$content = wc_wptexturize_order_note_content( $note->content );
+					echo wp_kses_post( wpautop( make_clickable( $content ) ) );
+					?>
 				</div>
 				<p class="meta">
 					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'y-m-d h:i:s' ) ); ?>">

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1603,7 +1603,7 @@ class WC_AJAX {
 			<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
 				<div class="note_content">
 					<?php
-					$content = wc_wptexturize_order_note_content( $note->content );
+					$content = wc_wptexturize_order_note( $note->content );
 					echo wp_kses_post( wpautop( make_clickable( $content ) ) );
 					?>
 				</div>

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1286,7 +1286,7 @@ function wc_delete_order_note( $note_id ) {
  * @param string $content The order note content.
  * @return string The processed content.
  */
-function wc_wptexturize_order_note_content( $content ) {
+function wc_wptexturize_order_note( $content ) {
 	// Pattern to match URLs (http, https protocols).
 	$url_pattern = '/\b(?:https?):\/\/[^\s<>"{}|\\^`\[\]]+/i';
 
@@ -1315,13 +1315,3 @@ function wc_wptexturize_order_note_content( $content ) {
 	return str_replace( array_keys( $placeholders ), array_values( $placeholders ), $texturized_content );
 }
 
-/**
- * Apply URL-safe wptexturize to customer note content (simplified version for single content parameter).
- *
- * @since 10.1.0
- * @param string $content The customer note content.
- * @return string The processed content.
- */
-function wc_wptexturize_customer_note( $content ) {
-	return wc_wptexturize_order_note_content( $content );
-}

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1278,3 +1278,52 @@ function wc_delete_order_note( $note_id ) {
 
 	return false;
 }
+
+/**
+ * Apply wptexturize while preserving URLs to prevent their content from being altered.
+ *
+ * @since 10.1
+ * @param string $content The order note content.
+ * @return string The processed content.
+ */
+function wc_wptexturize_order_note_content( $content ) {
+	// Pattern to match URLs (http, https protocols).
+	$url_pattern = '/\b(?:https?):\/\/[^\s<>"{}|\\^`\[\]]+/i';
+
+	// Find all URLs in the content.
+	preg_match_all( $url_pattern, $content, $urls );
+
+	if ( empty( $urls[0] ) ) {
+		// No URLs found, safe to apply wptexturize.
+		return wptexturize( $content );
+	}
+
+	// Replace URLs with placeholders.
+	$placeholders        = array();
+	$placeholder_content = $content;
+
+	foreach ( $urls[0] as $index => $url ) {
+		$placeholder                  = sprintf( '___WC_URL_PLACEHOLDER_%d___', $index );
+		$placeholders[ $placeholder ] = $url;
+		$placeholder_content          = str_replace( $url, $placeholder, $placeholder_content );
+	}
+
+	// Apply wptexturize to content with placeholders.
+	$texturized_content = wptexturize( $placeholder_content );
+
+	// Restore original URLs.
+	return str_replace( array_keys( $placeholders ), array_values( $placeholders ), $texturized_content );
+}
+
+/**
+ * Apply URL-safe wptexturize to customer note content (simplified version for single content parameter).
+ *
+ * @since 9.9.6
+ * @param string $content The customer note content.
+ * @return string The processed content.
+ */
+function wc_wptexturize_customer_note( $content ) {
+	// Create a dummy note object for consistency with the main function.
+	$dummy_note = (object) array( 'content' => $content );
+	return wc_wptexturize_order_note_content( $content, $dummy_note );
+}

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1282,7 +1282,7 @@ function wc_delete_order_note( $note_id ) {
 /**
  * Apply wptexturize while preserving URLs to prevent their content from being altered.
  *
- * @since 10.1
+ * @since 10.1.0
  * @param string $content The order note content.
  * @return string The processed content.
  */
@@ -1318,7 +1318,7 @@ function wc_wptexturize_order_note_content( $content ) {
 /**
  * Apply URL-safe wptexturize to customer note content (simplified version for single content parameter).
  *
- * @since 9.9.6
+ * @since 10.1.0
  * @param string $content The customer note content.
  * @return string The processed content.
  */

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1298,11 +1298,14 @@ function wc_wptexturize_order_note( $content ) {
 		return wptexturize( $content );
 	}
 
+	// Get unique URLs to avoid issues with duplicate URLs.
+	$unique_urls = array_unique( $urls[0] );
+
 	// Replace URLs with placeholders.
 	$placeholders        = array();
 	$placeholder_content = $content;
 
-	foreach ( $urls[0] as $index => $url ) {
+	foreach ( $unique_urls as $index => $url ) {
 		$placeholder                  = sprintf( '___WC_URL_PLACEHOLDER_%d___', $index );
 		$placeholders[ $placeholder ] = $url;
 		$placeholder_content          = str_replace( $url, $placeholder, $placeholder_content );
@@ -1314,4 +1317,3 @@ function wc_wptexturize_order_note( $content ) {
 	// Restore original URLs.
 	return str_replace( array_keys( $placeholders ), array_values( $placeholders ), $texturized_content );
 }
-

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1323,7 +1323,5 @@ function wc_wptexturize_order_note_content( $content ) {
  * @return string The processed content.
  */
 function wc_wptexturize_customer_note( $content ) {
-	// Create a dummy note object for consistency with the main function.
-	$dummy_note = (object) array( 'content' => $content );
-	return wc_wptexturize_order_note_content( $content, $dummy_note );
+	return wc_wptexturize_order_note_content( $content );
 }

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -43,7 +43,7 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 
 <blockquote>
 <?php
-$safe_note = wc_wptexturize_customer_note( $customer_note );
+$safe_note = wc_wptexturize_order_note( $customer_note );
 echo wpautop( make_clickable( $safe_note ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 ?>
 </blockquote>

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -41,7 +41,10 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 </p>
 <p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
-<blockquote><?php echo wpautop( wptexturize( make_clickable( $customer_note ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></blockquote>
+<blockquote><?php 
+$safe_note = wc_wptexturize_customer_note( $customer_note );
+echo wpautop( make_clickable( $safe_note ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
+?></blockquote>
 
 <p><?php esc_html_e( 'As a reminder, here are your order details:', 'woocommerce' ); ?></p>
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -41,10 +41,12 @@ if ( ! empty( $order->get_billing_first_name() ) ) {
 </p>
 <p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
-<blockquote><?php 
+<blockquote>
+<?php
 $safe_note = wc_wptexturize_customer_note( $customer_note );
-echo wpautop( make_clickable( $safe_note ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
-?></blockquote>
+echo wpautop( make_clickable( $safe_note ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+?>
+</blockquote>
 
 <p><?php esc_html_e( 'As a reminder, here are your order details:', 'woocommerce' ); ?></p>
 <?php echo $email_improvements_enabled ? '</div>' : ''; ?>

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -124,7 +124,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				?>
 				<tr>
 					<th class="td text-align-left" scope="row" colspan="2"><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td class="td text-align-left"><?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array() ); ?></td>
+					<td class="td text-align-left"><?php echo wp_kses( nl2br( wc_wptexturize_customer_note( $order->get_customer_note() ) ), array() ); ?></td>
 				</tr>
 				<?php
 			}
@@ -133,7 +133,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				<tr class="order-customer-note">
 					<td class="td text-align-left" colspan="3">
 						<b><?php esc_html_e( 'Customer note', 'woocommerce' ); ?></b><br>
-						<?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
+						<?php echo wp_kses( nl2br( wc_wptexturize_customer_note( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
 					</td>
 				</tr>
 				<?php

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -124,7 +124,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				?>
 				<tr>
 					<th class="td text-align-left" scope="row" colspan="2"><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td class="td text-align-left"><?php echo wp_kses( nl2br( wc_wptexturize_customer_note( $order->get_customer_note() ) ), array() ); ?></td>
+					<td class="td text-align-left"><?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array() ); ?></td>
 				</tr>
 				<?php
 			}
@@ -133,7 +133,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				<tr class="order-customer-note">
 					<td class="td text-align-left" colspan="3">
 						<b><?php esc_html_e( 'Customer note', 'woocommerce' ); ?></b><br>
-						<?php echo wp_kses( nl2br( wc_wptexturize_customer_note( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
+						<?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
 					</td>
 				</tr>
 				<?php

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/plain/customer-note.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-note.php
@@ -27,7 +27,7 @@ echo esc_html__( 'The following note has been added to your order:', 'woocommerc
 
 echo "----------\n\n";
 
-echo wptexturize( $customer_note ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo wc_wptexturize_customer_note( $customer_note ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 echo "----------\n\n";
 

--- a/plugins/woocommerce/templates/emails/plain/customer-note.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-note.php
@@ -27,7 +27,7 @@ echo esc_html__( 'The following note has been added to your order:', 'woocommerc
 
 echo "----------\n\n";
 
-echo wc_wptexturize_customer_note( $customer_note ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+echo wc_wptexturize_order_note( $customer_note ) . "\n\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 echo "----------\n\n";
 

--- a/plugins/woocommerce/templates/emails/plain/customer-note.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 3.7.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -68,9 +68,9 @@ if ( $item_totals ) {
 
 if ( $order->get_customer_note() ) {
 	if ( $email_improvements_enabled ) {
-		echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+		echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wc_wptexturize_customer_note( $order->get_customer_note() ), array() ) . "\n";
 	} else {
-		echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wptexturize( $order->get_customer_note() ), array() ) . "\n";
+		echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wc_wptexturize_customer_note( $order->get_customer_note() ), array() ) . "\n";
 	}
 }
 

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/plain/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/plain/email-order-details.php
@@ -68,9 +68,9 @@ if ( $item_totals ) {
 
 if ( $order->get_customer_note() ) {
 	if ( $email_improvements_enabled ) {
-		echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wc_wptexturize_customer_note( $order->get_customer_note() ), array() ) . "\n";
+		echo "\n" . esc_html__( 'Note:', 'woocommerce' ) . "\n" . wp_kses( wc_wptexturize_order_note( $order->get_customer_note() ), array() ) . "\n";
 	} else {
-		echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wc_wptexturize_customer_note( $order->get_customer_note() ), array() ) . "\n";
+		echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses( wc_wptexturize_order_note( $order->get_customer_note() ), array() ) . "\n";
 	}
 }
 

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -128,10 +128,12 @@ if ( $show_downloads ) {
 			<?php if ( $order->get_customer_note() ) : ?>
 				<tr>
 					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td><?php 
+					<td>
+					<?php
 					$customer_note = wc_wptexturize_customer_note( $order->get_customer_note() );
-					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) ); 
-					?></td>
+					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) );
+					?>
+					</td>
 				</tr>
 			<?php endif; ?>
 		</tfoot>

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -128,7 +128,10 @@ if ( $show_downloads ) {
 			<?php if ( $order->get_customer_note() ) : ?>
 				<tr>
 					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td><?php echo wp_kses( nl2br( wptexturize( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?></td>
+					<td><?php 
+					$customer_note = wc_wptexturize_customer_note( $order->get_customer_note() );
+					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) ); 
+					?></td>
 				</tr>
 			<?php endif; ?>
 		</tfoot>

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.8.0
+ * @version 10.1.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -130,7 +130,7 @@ if ( $show_downloads ) {
 					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
 					<td>
 					<?php
-					$customer_note = wc_wptexturize_customer_note( $order->get_customer_note() );
+					$customer_note = wc_wptexturize_order_note( $order->get_customer_note() );
 					echo wp_kses( nl2br( $customer_note ), array( 'br' => array() ) );
 					?>
 					</td>

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -325,4 +325,166 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( $fully_refunded_triggered, 'Fully refunded action should be triggered' );
 		$this->assertFalse( $partially_refunded_triggered, 'Partially refunded action should not be triggered' );
 	}
+
+	/**
+	 * Test that wc_wptexturize_order_note_content() preserves URLs with double hyphens.
+	 *
+	 * @dataProvider url_protection_test_data
+	 */
+	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_en_dash, $test_description ) {
+		// Create a mock note object.
+		$note = (object) array(
+			'content'       => $input,
+			'customer_note' => 1,
+			'added_by'      => 'system',
+		);
+
+		// Test the function.
+		$result = wc_wptexturize_order_note_content( $input, $note );
+
+		// Always make at least one assertion - that we got a string result.
+		$this->assertIsString( $result, $test_description . ' - Result should be a string' );
+
+		// For empty input, result should also be empty.
+		if ( empty( $input ) ) {
+			$this->assertEmpty( $result, $test_description . ' - Empty input should produce empty result' );
+			return; // Exit early for empty input case.
+		}
+
+		// Check if URLs with double hyphens are preserved.
+		if ( $expected_contains_double_hyphens ) {
+			$this->assertStringContainsString( '--', $result, $test_description . ' - Should preserve double hyphens in URLs' );
+		} else {
+			// If we don't expect double hyphens, make sure there are none (except in URLs).
+			$url_pattern          = '/\b(?:https?):\/\/[^\s<>"{}|\\^`\[\]]+/i';
+			$content_without_urls = preg_replace( $url_pattern, '', $result );
+			$this->assertStringNotContainsString( '--', $content_without_urls, $test_description . ' - Should not contain double hyphens outside URLs' );
+		}
+
+		// Check if non-URL double hyphens are converted to en-dashes (either Unicode or HTML entity).
+		if ( $expected_contains_en_dash ) {
+			$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
+			$this->assertTrue( $contains_en_dash, $test_description . ' - Should convert non-URL double hyphens to en-dashes (found: ' . $result . ')' );
+		} else {
+			// If we don't expect en-dash, verify it's not there.
+			$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
+			$this->assertFalse( $contains_en_dash, $test_description . ' - Should not contain en-dashes (found: ' . $result . ')' );
+		}
+
+		// Ensure the result is not empty for non-empty input.
+		$this->assertNotEmpty( $result, $test_description . ' - Result should not be empty for non-empty input' );
+	}
+
+	/**
+	 * Data provider for URL protection tests.
+	 *
+	 * @return array Test data with format: [input, expected_double_hyphens, expected_en_dash, description]
+	 */
+	public function url_protection_test_data() {
+		return array(
+			// URL with double hyphens should be preserved.
+			array(
+				'Check API status at https://api.example.com/status--check for details',
+				true,  // Should contain double hyphens.
+				false, // Should not contain en-dash (no non-URL double hyphens).
+				'URL with double hyphens in path',
+			),
+			// Multiple URLs with double hyphens.
+			array(
+				'First URL: https://api.test.com/endpoint--1 and second URL: https://api.test.com/endpoint--2',
+				true,  // Should contain double hyphens.
+				false, // Should not contain en-dash.
+				'Multiple URLs with double hyphens',
+			),
+			// Text with double hyphens (not URLs) should be converted.
+			array(
+				'This is a test -- it should convert to em-dash',
+				false, // Should not contain double hyphens.
+				true,  // Should contain en-dash.
+				'Non-URL double hyphens should be converted',
+			),
+			// Mixed content: URL with double hyphens + text with double hyphens.
+			array(
+				'Check the API at https://api.example.com/status--check -- this should work properly',
+				true, // Should contain double hyphens (in URL).
+				true, // Should contain en-dash (from text).
+				'Mixed content: URL and text with double hyphens',
+			),
+			// HTTPS URL with complex path.
+			array(
+				'Visit https://example.com/path--with--multiple--hyphens/page.html',
+				true,  // Should contain double hyphens.
+				false, // Should not contain en-dash.
+				'HTTPS URL with multiple double hyphens in path',
+			),
+			// HTTP URL with double hyphens.
+			array(
+				'API endpoint: http://legacy-api.example.com/v1/status--check',
+				true,  // Should contain double hyphens.
+				false, // Should not contain en-dash.
+				'HTTP URL with double hyphens',
+			),
+			// No URLs, just regular text formatting.
+			array(
+				'Just some text -- with double hyphens -- to convert',
+				false, // Should not contain double hyphens.
+				true,  // Should contain en-dash.
+				'Text without URLs should be texturized normally',
+			),
+			// Empty content.
+			array(
+				'',
+				false, // Should not contain double hyphens.
+				false, // Should not contain en-dash.
+				'Empty content should be handled gracefully',
+			),
+			// URL at end of sentence.
+			array(
+				'Please check https://api.example.com/endpoint--status.',
+				true,  // Should contain double hyphens.
+				false, // Should not contain en-dash.
+				'URL at end of sentence with punctuation',
+			),
+		);
+	}
+
+	/**
+	 * Test that wc_wptexturize_customer_note() works correctly.
+	 */
+	public function test_wc_wptexturize_customer_note() {
+		$content = 'Check API status at https://api.example.com/status--check -- this is important';
+
+		$result = wc_wptexturize_customer_note( $content );
+
+		// Should preserve URL double hyphens.
+		$this->assertStringContainsString( 'status--check', $result, 'Should preserve double hyphens in URLs' );
+
+		// Should convert text double hyphens to en-dash (either Unicode or HTML entity).
+		$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
+		$this->assertTrue( $contains_en_dash, 'Should convert text double hyphens to en-dash (found: ' . $result . ')' );
+	}
+
+	/**
+	 * Test edge cases for URL detection regex.
+	 */
+	public function test_url_detection_edge_cases() {
+		$edge_cases = array(
+			// URL with query parameters and double hyphens.
+			'https://api.example.com/search--results?query=test&type=--advanced',
+			// URL with fragment and double hyphens.
+			'https://docs.example.com/section--a#subsection--b',
+			// Multiple protocols.
+			'Check http://old.example.com/legacy--api and https://new.example.com/modern--api',
+			// URL with port number.
+			'https://localhost:8080/dev--server/status--check',
+		);
+
+		foreach ( $edge_cases as $content ) {
+			$note   = (object) array( 'content' => $content );
+			$result = wc_wptexturize_order_note_content( $content, $note );
+
+			// All URLs should preserve their double hyphens.
+			$this->assertStringContainsString( '--', $result, "Edge case should preserve double hyphens: {$content}" );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -458,6 +458,28 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test email template processing scenarios.
+	 */
+	public function test_email_template_processing() {
+		$test_cases = array(
+			'Simple URL' => 'Visit https://api.example.com/status--check',
+			'URL with text' => 'Check https://api.example.com/status--check -- for more info',
+			'Multiple URLs' => 'API 1: https://api1.example.com/endpoint--1 API 2: https://api2.example.com/endpoint--2',
+			'URL with line breaks' => "First line\nVisit https://api.example.com/status--check\nLast line",
+		);
+
+		foreach ( $test_cases as $description => $content ) {
+			// Test HTML email processing (with nl2br)
+			$html_result = nl2br( wc_wptexturize_customer_note( $content ) );
+			$this->assertStringContainsString( '--', $html_result, $description . ' - HTML email should preserve URL double hyphens' );
+			
+			// Test plain text email processing
+			$plain_result = wc_wptexturize_customer_note( $content );
+			$this->assertStringContainsString( '--', $plain_result, $description . ' - Plain text email should preserve URL double hyphens' );
+		}
+	}
+
+	/**
 	 * Test edge cases for URL detection regex.
 	 */
 	public function test_url_detection_edge_cases() {

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -482,6 +482,44 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test handling of duplicate URLs in content.
+	 */
+	public function test_duplicate_url_handling() {
+		// Content with multiple sets of duplicate URLs.
+		$content = 'First URL: https://api.example.com/status--check appears here. ' .
+					'Second URL: https://api.example.com/health--monitor is different. ' .
+					'Third URL: https://api.example.com/debug--console is unique. ' .
+					'Now repeat first: https://api.example.com/status--check again. ' .
+					'And second: https://api.example.com/health--monitor once more. ' .
+					'And first again: https://api.example.com/status--check third time. ' .
+					'Plus some text -- that should convert to em-dash.';
+
+		$result = wc_wptexturize_order_note( $content );
+
+		// Verify each URL appears the correct number of times.
+		$status_count = substr_count( $result, 'https://api.example.com/status--check' );
+		$this->assertEquals( 3, $status_count, 'First URL should appear 3 times' );
+
+		$health_count = substr_count( $result, 'https://api.example.com/health--monitor' );
+		$this->assertEquals( 2, $health_count, 'Second URL should appear 2 times' );
+
+		$debug_count = substr_count( $result, 'https://api.example.com/debug--console' );
+		$this->assertEquals( 1, $debug_count, 'Third URL should appear 1 time' );
+
+		// All double hyphens in URLs should remain intact.
+		$this->assertStringContainsString( 'status--check', $result, 'First URL double hyphens should be preserved' );
+		$this->assertStringContainsString( 'health--monitor', $result, 'Second URL double hyphens should be preserved' );
+		$this->assertStringContainsString( 'debug--console', $result, 'Third URL double hyphens should be preserved' );
+
+		// Verify text double hyphens were converted to em-dash.
+		$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
+		$this->assertTrue( $contains_em_dash, 'Non-URL double hyphens should be converted to em-dash' );
+
+		// Ensure no placeholders leaked into final output.
+		$this->assertStringNotContainsString( '___WC_URL_PLACEHOLDER_', $result, 'No placeholders should remain in output' );
+	}
+
+	/**
 	 * Test edge cases for URL detection regex.
 	 */
 	public function test_url_detection_edge_cases() {

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -331,7 +331,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 *
 	 * @dataProvider url_protection_test_data
 	 */
-	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_en_dash, $test_description ) {
+	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_em_dash, $test_description ) {
 		// Test the function.
 		$result = wc_wptexturize_order_note_content( $input );
 
@@ -354,14 +354,14 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			$this->assertStringNotContainsString( '--', $content_without_urls, $test_description . ' - Should not contain double hyphens outside URLs' );
 		}
 
-		// Check if non-URL double hyphens are converted to en-dashes (either Unicode or HTML entity).
-		if ( $expected_contains_en_dash ) {
-			$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
-			$this->assertTrue( $contains_en_dash, $test_description . ' - Should convert non-URL double hyphens to en-dashes (found: ' . $result . ')' );
+		// Check if non-URL double hyphens are converted to em-dashes (either Unicode or HTML entity).
+		if ( $expected_contains_em_dash ) {
+			$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
+			$this->assertTrue( $contains_em_dash, $test_description . ' - Should convert non-URL double hyphens to em-dashes (found: ' . $result . ')' );
 		} else {
-			// If we don't expect en-dash, verify it's not there.
-			$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
-			$this->assertFalse( $contains_en_dash, $test_description . ' - Should not contain en-dashes (found: ' . $result . ')' );
+			// If we don't expect em-dash, verify it's not there.
+			$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
+			$this->assertFalse( $contains_em_dash, $test_description . ' - Should not contain em-dashes (found: ' . $result . ')' );
 		}
 
 		// Ensure the result is not empty for non-empty input.
@@ -371,7 +371,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Data provider for URL protection tests.
 	 *
-	 * @return array Test data with format: [input, expected_double_hyphens, expected_en_dash, description]
+	 * @return array Test data with format: [input, expected_double_hyphens, expected_em_dash, description]
 	 */
 	public function url_protection_test_data() {
 		return array(
@@ -379,63 +379,63 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			array(
 				'Check API status at https://api.example.com/status--check for details',
 				true,  // Should contain double hyphens.
-				false, // Should not contain en-dash (no non-URL double hyphens).
+				false, // Should not contain em-dash (no non-URL double hyphens).
 				'URL with double hyphens in path',
 			),
 			// Multiple URLs with double hyphens.
 			array(
 				'First URL: https://api.test.com/endpoint--1 and second URL: https://api.test.com/endpoint--2',
 				true,  // Should contain double hyphens.
-				false, // Should not contain en-dash.
+				false, // Should not contain em-dash.
 				'Multiple URLs with double hyphens',
 			),
 			// Text with double hyphens (not URLs) should be converted.
 			array(
 				'This is a test -- it should convert to em-dash',
 				false, // Should not contain double hyphens.
-				true,  // Should contain en-dash.
+				true,  // Should contain em-dash.
 				'Non-URL double hyphens should be converted',
 			),
 			// Mixed content: URL with double hyphens + text with double hyphens.
 			array(
 				'Check the API at https://api.example.com/status--check -- this should work properly',
 				true, // Should contain double hyphens (in URL).
-				true, // Should contain en-dash (from text).
+				true, // Should contain em-dash (from text).
 				'Mixed content: URL and text with double hyphens',
 			),
 			// HTTPS URL with complex path.
 			array(
 				'Visit https://example.com/path--with--multiple--hyphens/page.html',
 				true,  // Should contain double hyphens.
-				false, // Should not contain en-dash.
+				false, // Should not contain em-dash.
 				'HTTPS URL with multiple double hyphens in path',
 			),
 			// HTTP URL with double hyphens.
 			array(
 				'API endpoint: http://legacy-api.example.com/v1/status--check',
 				true,  // Should contain double hyphens.
-				false, // Should not contain en-dash.
+				false, // Should not contain em-dash.
 				'HTTP URL with double hyphens',
 			),
 			// No URLs, just regular text formatting.
 			array(
 				'Just some text -- with double hyphens -- to convert',
 				false, // Should not contain double hyphens.
-				true,  // Should contain en-dash.
+				true,  // Should contain em-dash.
 				'Text without URLs should be texturized normally',
 			),
 			// Empty content.
 			array(
 				'',
 				false, // Should not contain double hyphens.
-				false, // Should not contain en-dash.
+				false, // Should not contain em-dash.
 				'Empty content should be handled gracefully',
 			),
 			// URL at end of sentence.
 			array(
 				'Please check https://api.example.com/endpoint--status.',
 				true,  // Should contain double hyphens.
-				false, // Should not contain en-dash.
+				false, // Should not contain em-dash.
 				'URL at end of sentence with punctuation',
 			),
 		);
@@ -452,9 +452,9 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		// Should preserve URL double hyphens.
 		$this->assertStringContainsString( 'status--check', $result, 'Should preserve double hyphens in URLs' );
 
-		// Should convert text double hyphens to en-dash (either Unicode or HTML entity).
-		$contains_en_dash = strpos( $result, '–' ) !== false || strpos( $result, '&#8212;' ) !== false;
-		$this->assertTrue( $contains_en_dash, 'Should convert text double hyphens to en-dash (found: ' . $result . ')' );
+		// Should convert text double hyphens to em-dash (either Unicode or HTML entity).
+		$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
+		$this->assertTrue( $contains_em_dash, 'Should convert text double hyphens to em-dash (found: ' . $result . ')' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -462,25 +462,23 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test email template processing scenarios.
+	 * Test URL preservation with line breaks (specific to email templates).
 	 */
-	public function test_email_template_processing() {
-		$test_cases = array(
-			'Simple URL'           => 'Visit https://api.example.com/status--check',
-			'URL with text'        => 'Check https://api.example.com/status--check -- for more info',
-			'Multiple URLs'        => 'API 1: https://api1.example.com/endpoint--1 API 2: https://api2.example.com/endpoint--2',
-			'URL with line breaks' => "First line\nVisit https://api.example.com/status--check\nLast line",
-		);
-
-		foreach ( $test_cases as $description => $content ) {
-			// Test HTML email processing (with nl2br).
-			$html_result = nl2br( wc_wptexturize_customer_note( $content ) );
-			$this->assertStringContainsString( '--', $html_result, $description . ' - HTML email should preserve URL double hyphens' );
-
-			// Test plain text email processing.
-			$plain_result = wc_wptexturize_customer_note( $content );
-			$this->assertStringContainsString( '--', $plain_result, $description . ' - Plain text email should preserve URL double hyphens' );
-		}
+	public function test_url_preservation_with_line_breaks() {
+		$content_with_breaks = "Check API status:\nhttps://api.example.com/status--check\n\nThen verify the results -- everything should work.";
+		
+		// Test the core function.
+		$result = wc_wptexturize_customer_note( $content_with_breaks );
+		$this->assertStringContainsString( 'status--check', $result, 'URLs should be preserved even with line breaks' );
+		
+		// Test that nl2br() doesn't affect URL preservation (used in HTML emails).
+		$html_result = nl2br( $result );
+		$this->assertStringContainsString( 'status--check', $html_result, 'URLs should remain preserved after nl2br()' );
+		$this->assertStringContainsString( '<br />', $html_result, 'Line breaks should be converted to <br> tags' );
+		
+		// Verify em-dash conversion still works for non-URL content.
+		$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
+		$this->assertTrue( $contains_em_dash, 'Non-URL double hyphens should still be converted to em-dash' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -327,7 +327,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wc_wptexturize_order_note_content() preserves URLs with double hyphens.
+	 * Test that wc_wptexturize_order_note() preserves URLs with double hyphens.
 	 *
 	 * @dataProvider url_protection_test_data
 	 * @param string $input                            The input string to test.
@@ -335,9 +335,9 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * @param bool   $expected_contains_em_dash        Whether the result should contain em-dash.
 	 * @param string $test_description                 Description of the test case.
 	 */
-	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_em_dash, $test_description ) {
+	public function test_wc_wptexturize_order_note( $input, $expected_contains_double_hyphens, $expected_contains_em_dash, $test_description ) {
 		// Test the function.
-		$result = wc_wptexturize_order_note_content( $input );
+		$result = wc_wptexturize_order_note( $input );
 
 		// Always make at least one assertion - that we got a string result.
 		$this->assertIsString( $result, $test_description . ' - Result should be a string' );
@@ -446,12 +446,12 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wc_wptexturize_customer_note() works correctly.
+	 * Test that wc_wptexturize_order_note() works correctly with customer note content.
 	 */
-	public function test_wc_wptexturize_customer_note() {
+	public function test_wc_wptexturize_order_note_customer_note() {
 		$content = 'Check API status at https://api.example.com/status--check -- this is important';
 
-		$result = wc_wptexturize_customer_note( $content );
+		$result = wc_wptexturize_order_note( $content );
 
 		// Should preserve URL double hyphens.
 		$this->assertStringContainsString( 'status--check', $result, 'Should preserve double hyphens in URLs' );
@@ -468,7 +468,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$content_with_breaks = "Check API status:\nhttps://api.example.com/status--check\n\nThen verify the results -- everything should work.";
 
 		// Test the core function.
-		$result = wc_wptexturize_customer_note( $content_with_breaks );
+		$result = wc_wptexturize_order_note( $content_with_breaks );
 		$this->assertStringContainsString( 'status--check', $result, 'URLs should be preserved even with line breaks' );
 
 		// Test that nl2br() doesn't affect URL preservation (used in HTML emails).
@@ -497,7 +497,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		);
 
 		foreach ( $edge_cases as $content ) {
-			$result = wc_wptexturize_order_note_content( $content );
+			$result = wc_wptexturize_order_note( $content );
 
 			// All URLs should preserve their double hyphens.
 			$this->assertStringContainsString( '--', $result, "Edge case should preserve double hyphens: {$content}" );

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -332,15 +332,8 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * @dataProvider url_protection_test_data
 	 */
 	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_en_dash, $test_description ) {
-		// Create a mock note object.
-		$note = (object) array(
-			'content'       => $input,
-			'customer_note' => 1,
-			'added_by'      => 'system',
-		);
-
 		// Test the function.
-		$result = wc_wptexturize_order_note_content( $input, $note );
+		$result = wc_wptexturize_order_note_content( $input );
 
 		// Always make at least one assertion - that we got a string result.
 		$this->assertIsString( $result, $test_description . ' - Result should be a string' );
@@ -480,8 +473,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		);
 
 		foreach ( $edge_cases as $content ) {
-			$note   = (object) array( 'content' => $content );
-			$result = wc_wptexturize_order_note_content( $content, $note );
+			$result = wc_wptexturize_order_note_content( $content );
 
 			// All URLs should preserve their double hyphens.
 			$this->assertStringContainsString( '--', $result, "Edge case should preserve double hyphens: {$content}" );

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -466,16 +466,16 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_url_preservation_with_line_breaks() {
 		$content_with_breaks = "Check API status:\nhttps://api.example.com/status--check\n\nThen verify the results -- everything should work.";
-		
+
 		// Test the core function.
 		$result = wc_wptexturize_customer_note( $content_with_breaks );
 		$this->assertStringContainsString( 'status--check', $result, 'URLs should be preserved even with line breaks' );
-		
+
 		// Test that nl2br() doesn't affect URL preservation (used in HTML emails).
 		$html_result = nl2br( $result );
 		$this->assertStringContainsString( 'status--check', $html_result, 'URLs should remain preserved after nl2br()' );
 		$this->assertStringContainsString( '<br />', $html_result, 'Line breaks should be converted to <br> tags' );
-		
+
 		// Verify em-dash conversion still works for non-URL content.
 		$contains_em_dash = strpos( $result, '—' ) !== false || strpos( $result, '&#8212;' ) !== false;
 		$this->assertTrue( $contains_em_dash, 'Non-URL double hyphens should still be converted to em-dash' );

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -330,6 +330,10 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 * Test that wc_wptexturize_order_note_content() preserves URLs with double hyphens.
 	 *
 	 * @dataProvider url_protection_test_data
+	 * @param string $input                            The input string to test.
+	 * @param bool   $expected_contains_double_hyphens Whether the result should contain double hyphens.
+	 * @param bool   $expected_contains_em_dash        Whether the result should contain em-dash.
+	 * @param string $test_description                 Description of the test case.
 	 */
 	public function test_wc_wptexturize_order_note_content( $input, $expected_contains_double_hyphens, $expected_contains_em_dash, $test_description ) {
 		// Test the function.
@@ -462,18 +466,18 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_email_template_processing() {
 		$test_cases = array(
-			'Simple URL' => 'Visit https://api.example.com/status--check',
-			'URL with text' => 'Check https://api.example.com/status--check -- for more info',
-			'Multiple URLs' => 'API 1: https://api1.example.com/endpoint--1 API 2: https://api2.example.com/endpoint--2',
+			'Simple URL'           => 'Visit https://api.example.com/status--check',
+			'URL with text'        => 'Check https://api.example.com/status--check -- for more info',
+			'Multiple URLs'        => 'API 1: https://api1.example.com/endpoint--1 API 2: https://api2.example.com/endpoint--2',
 			'URL with line breaks' => "First line\nVisit https://api.example.com/status--check\nLast line",
 		);
 
 		foreach ( $test_cases as $description => $content ) {
-			// Test HTML email processing (with nl2br)
+			// Test HTML email processing (with nl2br).
 			$html_result = nl2br( wc_wptexturize_customer_note( $content ) );
 			$this->assertStringContainsString( '--', $html_result, $description . ' - HTML email should preserve URL double hyphens' );
-			
-			// Test plain text email processing
+
+			// Test plain text email processing.
 			$plain_result = wc_wptexturize_customer_note( $content );
 			$this->assertStringContainsString( '--', $plain_result, $description . ' - Plain text email should preserve URL double hyphens' );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Create a new function that will remove URLs from order notes, texturize the remaining content, then replace the URLs back, untexturized.

Closes WOOPLUG-4731

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/9a56d2e9733549959271ba24298d0ab1 | https://www.loom.com/share/3db385d9ec0d45c897f413535893e533 |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Place an order on your site
2. Go to WooCommerce -> Orders and find the order, click Edit.
3. On the order notes meta box, enter some text including a double hyphen, it should be converted into an emdash (—) i.e. it should be texturized
4. Enter the URL `https://api.example.com/some/path/booking--ABC123` and ensure the double hyphen is preserved. Reload the page and ensure the double hyphen is preserved. Note, it will not be a clickable URL. Fixing that is outside of the scope of this PR.
5. Enter both at the same time and ensure the text is texturized correctly and the URL is left alone.
6. Place an order using both shortcode and block based checkout. In the order notes, enter the url `https://api.example.com/some/path/booking--ABC123` and also some text containing a double hyphen. Ensure the notes recorded with the order are texturized correctly, but the double hyphen in the URL is preserved.
7. Note: **The order notes shown in the blockified order confirmation page are texturized right before rendering (in WP Core) so this fix will not apply there**.
8. Check the order confirmation emails you get for both admin and shopper and ensure the same texturization/preservation applies.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
