### PR TITLE
Fix PHP Warning in Theme Controller

### DIFF
--- a/packages/php/email-editor/src/Engine/class-theme-controller.php
+++ b/packages/php/email-editor/src/Engine/class-theme-controller.php
@@ -250,9 +250,9 @@ class Theme_Controller {
 
 			if ( 'button' === $key ) {
 				$selector      = '.wp-block-button';
-				$css_elements .= wp_style_engine_get_styles( $elements_style, array( 'selector' => '.wp-block-button' ) )['css'];
+				$css_elements .= wp_style_engine_get_styles( $elements_style, array( 'selector' => '.wp-block-button' ) )['css'] ?? '';
 				// Add color to link element.
-				$css_elements .= wp_style_engine_get_styles( array( 'color' => array( 'text' => $elements_style['color']['text'] ?? '' ) ), array( 'selector' => '.wp-block-button a' ) )['css'];
+				$css_elements .= wp_style_engine_get_styles( array( 'color' => array( 'text' => $elements_style['color']['text'] ?? '' ) ), array( 'selector' => '.wp-block-button a' ) )['css'] ?? '';
 				continue;
 			}
 
@@ -265,7 +265,7 @@ class Theme_Controller {
 					break;
 			}
 
-			$css_elements .= wp_style_engine_get_styles( $elements_style, array( 'selector' => $selector ) )['css'];
+			$css_elements .= wp_style_engine_get_styles( $elements_style, array( 'selector' => $selector ) )['css'] ?? '';
 		}
 
 		$result = $css_presets . $css_blocks . $css_elements;


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes undefined array key warnings in the Email Editor's Theme Controller when accessing the 'css' key from `wp_style_engine_get_styles()` results.

The `wp_style_engine_get_styles()` function can return arrays without a 'css' key or false/null values in error cases, which was causing "Undefined array key 'css'" warnings on lines 258, 259, and 268 of `packages/php/email-editor/src/Engine/class-theme-controller.php`.

Added null coalescing operators (`?? ''`) to safely handle cases where the 'css' key doesn't exist, preventing PHP warnings and making the code more robust.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58946  WOOPLUG-4680.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/f297a556-6be8-4328-82cb-6bd900b92652/f3598814-2f03-4a3c-9288-76ca7b9c6f8f?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi9mMjk3YTU1Ni02YmU4LTQzMjgtODJjYi02YmQ5MDBiOTI2NTIvZjM1OTg4MTQtMmYwMy00YTNjLTkyODgtNzZjYTdiOWM2ZjhmIiwiaWF0IjoxNzUwMjM2OTc1LCJleHAiOjMzMzIwNzk2OTc1fQ.MWAAj4zjnFla9hHpC8ec3lWkztAQ5e2oLu8GiL6wCZY " alt="Screenshot 2025-06-18 at 10.48.19.png" width="1145" data-linear-height="407" />    |    <img width="988" alt="Screenshot 2025-06-24 at 3 43 06 PM" src="https://github.com/user-attachments/assets/5f37b112-5013-483e-b612-dd996537f7d5" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the Block email editor is enabled. (`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`)
2. Edit any email template from the email listing page. (`/wp-admin/admin.php?page=wc-settings&tab=email`)
3. Open the styles settings in the email editor  
4. Go to the colours section  
5. Click the three dots next to Elements and in the dropdown, click "Reset all"  
6. Save changes  
7. Go to preview in a new tab and observe the issue

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Minor bug fix
</details>
