### PR TITLE
Add role dialog to the drawer to ensure that e2e tests work.

### DIFF
--- a/plugins/woocommerce/changelog/59141-wooplug-4662-interactivity-api-powered-mini-cart-explore-how-to-migrate
+++ b/plugins/woocommerce/changelog/59141-wooplug-4662-interactivity-api-powered-mini-cart-explore-how-to-migrate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Experimental iAPI Mini Cart: add role of dialog to drawer
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -52,6 +52,8 @@ type MiniCart = {
 		drawerOverlayClass: string;
 		badgeIsVisible: boolean;
 		cartIsEmpty: boolean;
+		drawerRole: string | null;
+		drawerTabIndex: string | null;
 	};
 	callbacks: {
 		openDrawer: () => void;
@@ -103,6 +105,18 @@ store< MiniCart >(
 				);
 
 				return formatPriceWithCurrency( subtotal, normalizedCurrency );
+			},
+
+			get drawerRole() {
+				const { isOpen } = getContext< MiniCartContext >();
+
+				return isOpen ? 'dialog' : null;
+			},
+
+			get drawerTabIndex() {
+				const { isOpen } = getContext< MiniCartContext >();
+
+				return isOpen ? '-1' : null;
 			},
 
 			get drawerOverlayClass() {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -537,7 +537,13 @@ class MiniCart extends AbstractBlock {
 					<?php endif; ?>
 				</button>
 				<div data-wp-on--click="callbacks.overlayCloseDrawer" data-wp-bind--class="state.drawerOverlayClass" class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden">
-					<div role="dialog" class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile">
+					<div 
+						data-wp-bind--role="state.drawerRole"
+						data-wp-bind--aria-modal="context.isOpen"
+						data-wp-bind--aria-hidden="!context.isOpen"
+						data-wp-bind--tab-index="state.drawerTabIndex"
+						class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
+					>
 						<div class="wc-block-components-drawer__content">
 							<div class="wc-block-mini-cart__template-part">
 								<?php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -537,7 +537,7 @@ class MiniCart extends AbstractBlock {
 					<?php endif; ?>
 				</button>
 				<div data-wp-on--click="callbacks.overlayCloseDrawer" data-wp-bind--class="state.drawerOverlayClass" class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden">
-					<div class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile">
+					<div role="dialog" class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile">
 						<div class="wc-block-components-drawer__content">
 							<div class="wc-block-mini-cart__template-part">
 								<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add the `dialog` role to the mini cart drawer to ensure accessibility and also allow e2e tests to pass.
Closes #59140

### Screenshots or screen recordings:

n/a


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

n/a

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Experimental iAPI Mini Cart: add role of dialog to drawer
</details>
