### PR TITLE
Support remaining editable text to be saved in experimental mini cart

### DIFF
--- a/plugins/woocommerce/changelog/59144-dev-save-customizable-text-mini-cart
+++ b/plugins/woocommerce/changelog/59144-dev-save-customizable-text-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Experimental Mini Cart: Support remaining editable text to be saved.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.json
@@ -22,6 +22,10 @@
 				"remove": false,
 				"move": false
 			}
+		},
+		"cartButtonLabel": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"styles": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.json
@@ -22,6 +22,10 @@
 				"remove": false,
 				"move": false
 			}
+		},
+		"checkoutButtonLabel": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"styles": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -23,6 +23,10 @@
 				"remove": false,
 				"move": false
 			}
+		},
+		"startShoppingButtonLabel": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"styles": [

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-label-block/block.json
@@ -24,7 +24,8 @@
 	},
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"default": ""
 		}
 	},
 	"parent": [

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -23,9 +23,10 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
-		$view_cart_text = __( 'View my cart', 'woocommerce' );
-		$cart_page_id   = wc_get_page_id( 'cart' );
-		$cart_page_url  = get_permalink( $cart_page_id );
+		$default_view_cart_text = __( 'View my cart', 'woocommerce' );
+		$view_cart_text         = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
+		$cart_page_id           = wc_get_page_id( 'cart' );
+		$cart_page_url          = get_permalink( $cart_page_id );
 
 		ob_start();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -23,9 +23,10 @@ class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
-		$go_to_checkout_text = __( 'Go to checkout', 'woocommerce' );
-		$checkout_page_id    = wc_get_page_id( 'checkout' );
-		$checkout_page_url   = get_permalink( $checkout_page_id );
+		$default_go_to_checkout_text = __( 'Go to checkout', 'woocommerce' );
+		$go_to_checkout_text         = $attributes['checkoutButtonLabel'] ? $attributes['checkoutButtonLabel'] : $default_go_to_checkout_text;
+		$checkout_page_id            = wc_get_page_id( 'checkout' );
+		$checkout_page_url           = get_permalink( $checkout_page_id );
 
 		ob_start();
 		?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -40,7 +40,9 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
 		ob_start();
-		$shop_url = get_permalink( wc_get_page_id( 'shop' ) );
+		$shop_url                     = get_permalink( wc_get_page_id( 'shop' ) );
+		$default_start_shopping_label = __( 'Start shopping', 'woocommerce' );
+		$start_shopping_label         = $attributes['startShoppingButtonLabel'] ? $attributes['startShoppingButtonLabel'] : $default_start_shopping_label;
 		?>
 		<div class="wp-block-button has-text-align-center">
 			<a
@@ -49,7 +51,7 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 				class="wc-block-components-button wp-element-button wp-block-woocommerce-mini-cart-shopping-button-block wc-block-mini-cart__shopping-button contained"
 			>
 				<div class="wc-block-components-button__text">
-					<?php esc_html_e( 'Start shopping', 'woocommerce' ); ?>
+					<?php echo esc_html( $start_shopping_label ); ?>
 				</div>
 			</a>
 		</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
@@ -38,7 +38,8 @@ class MiniCartTitleLabelBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_title_label_block( $attributes, $content, $block ) {
-		$cart_label = __( 'Your cart', 'woocommerce' );
+		$default_cart_label = __( 'Your cart', 'woocommerce' );
+		$cart_label         = $attributes['label'] ? $attributes['label'] : $default_cart_label;
 
 		ob_start();
 		?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58914 by allowing editable text in mini cart to be saved.


### Screenshots or screen recordings:

<img width="1227" alt="Screenshot 2025-06-25 at 2 11 21 PM" src="https://github.com/user-attachments/assets/ed2915ce-5c98-4cdc-b667-8940a6440f9c" />
<img width="362" alt="Screenshot 2025-06-25 at 2 11 37 PM" src="https://github.com/user-attachments/assets/2ba65222-a07a-4f83-a81f-43fbc47ff446" />
<img width="405" alt="Screenshot 2025-06-25 at 2 11 44 PM" src="https://github.com/user-attachments/assets/98f56fe0-fdc5-461e-9f5e-f1cd0ef3a5a0" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to `Appearance > Editor > Patterns > Mini Cart`
2. Select the mini cart block 
3. Inside the mini cart block select the text components that can be edited (see screenshots above)
4. Edit them with custom text and save.
5. Visit the frontend of your site, add some items to cart and open the mini cart drawer
6. Ensure that your text customizations are displayed.

<!-- End testing instructions -->


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Experimental Mini Cart: Support remaining editable text to be saved.
</details>
