### PR TITLE
Invalidate both selectors when enabling an offline payment gateway

### DIFF
--- a/plugins/woocommerce/changelog/59155-fix-offline-pms-not-updating
+++ b/plugins/woocommerce/changelog/59155-fix-offline-pms-not-updating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix a bug where the offline payment gateways page was not updated when a gateway is enabled

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -192,10 +192,10 @@ export const EnableGatewayButton = ( {
 				}
 
 				// If no redirect occurred, the data needs to be refreshed.
+				// We need to invalidate both selectors since they share the same data source and resolver chain.
+				invalidateResolutionForStoreSelector( 'getPaymentProviders' );
 				invalidateResolutionForStoreSelector(
-					isOffline
-						? 'getOfflinePaymentGateways'
-						: 'getPaymentProviders'
+					'getOfflinePaymentGateways'
 				);
 				setIsUpdating( false );
 			} )

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/enable-gateway-button.tsx
@@ -192,11 +192,15 @@ export const EnableGatewayButton = ( {
 				}
 
 				// If no redirect occurred, the data needs to be refreshed.
-				// We need to invalidate both selectors since they share the same data source and resolver chain.
 				invalidateResolutionForStoreSelector( 'getPaymentProviders' );
-				invalidateResolutionForStoreSelector(
-					'getOfflinePaymentGateways'
-				);
+
+				if ( isOffline ) {
+					// We need to invalidate both selectors since they share the same data source and resolver chain.
+					invalidateResolutionForStoreSelector(
+						'getOfflinePaymentGateways'
+					);
+				}
+
 				setIsUpdating( false );
 			} )
 			.catch( () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a bug where enabling an offline gateway did not update the status of the providers, which kept the screen as it was. Here's a video about the issue:

https://github.com/user-attachments/assets/5bc30569-c3ff-4fc4-b56c-92be37ff37a5

This resolves the issue by constantly invalidating the provider's store and selectively invalidating the offline one only when the gateway is offline. The need to always invalidate the provider is because the offline gateways depend on it, and we need to ensure we have fresh data.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/5bc30569-c3ff-4fc4-b56c-92be37ff37a5 |   https://github.com/user-attachments/assets/b1e44628-2737-44b9-888b-ee08ecba25b0  |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Get this PR
2. Go to offline PMs
3. Make sure that when enabling one, the UI responds accordingly

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix a bug where the offline payment gateways page was not updated when a gateway is enabled
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
