### PR TITLE
Product Gallery: fix large image that may be displaying single image all over for variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-variable-products
+++ b/plugins/woocommerce/changelog/fix-product-gallery-variable-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: fix large image that may be displaying single image all over for variable products

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\ProductGalleryUtils;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
@@ -159,7 +160,7 @@ class ProductImage extends AbstractBlock {
 		}
 
 		$featured_image_id          = (int) $product->get_image_id();
-		$gallery_image_ids          = $product->get_gallery_image_ids();
+		$gallery_image_ids          = ProductGalleryUtils::get_all_image_ids( $product );
 		$available_image_ids        = array_merge( [ $featured_image_id ], $gallery_image_ids );
 		$provided_image_id_is_valid = $image_id && in_array( $image_id, $available_image_ids, true );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -12,15 +12,17 @@ use WC_Helper_Product;
 class ProductImage extends \WP_UnitTestCase {
 
 	/**
-	 * Test that the ProductImage block renders correctly for a simple product.
+	 * Helper method to create a simple product with an image.
+	 *
+	 * @param string $image_title Optional title for the image.
+	 * @return array Array containing 'product' and 'image_id'.
 	 */
-	public function test_product_image_render_simple_product() {
+	private function create_product_with_image( $image_title = 'Test Product Image' ) {
 		$product = WC_Helper_Product::create_simple_product();
 
-		// Create and set a test image.
 		$image_id = wp_insert_attachment(
 			array(
-				'post_title'     => 'Test Product Image',
+				'post_title'     => $image_title,
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image/jpeg',
 			)
@@ -28,25 +30,20 @@ class ProductImage extends \WP_UnitTestCase {
 		$product->set_image_id( $image_id );
 		$product->save();
 
-		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
-
-		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
-		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
-		$this->assertStringContainsString( 'data-image-id="' . $image_id . '"', $markup );
-
-		// Clean up.
-		$product->delete( true );
-		wp_delete_attachment( $image_id, true );
+		return array(
+			'product'  => $product,
+			'image_id' => $image_id,
+		);
 	}
 
 	/**
-	 * Test that the ProductImage block renders correctly for a variable product with variation images.
-	 * This is the main test case: if product is variable product and has some images attached to the variation
-	 * (but not in the main gallery) and the imageId of variation image is provided via context,
-	 * it still recognises the imageId as its own image.
+	 * Helper method to create a variable product with main image, gallery images, and variation images.
+	 *
+	 * @param int $gallery_count Number of gallery images to create.
+	 * @param int $variation_count Number of variations to create images for.
+	 * @return array Array containing 'product', 'main_image_id', 'gallery_image_ids', and 'variation_image_ids'.
 	 */
-	public function test_product_image_render_variable_product_with_variation_images() {
-		// Create a variable product.
+	private function create_variable_product_with_images( $gallery_count = 2, $variation_count = 1 ) {
 		$variable_product = WC_Helper_Product::create_variation_product();
 
 		// Create and set the main product image.
@@ -59,65 +56,97 @@ class ProductImage extends \WP_UnitTestCase {
 		);
 		$variable_product->set_image_id( $main_image_id );
 
-		// Create gallery images (separate from variation images).
-		$gallery_image_ids = array(
-			wp_insert_attachment(
+		// Create gallery images.
+		$gallery_image_ids = array();
+		for ( $i = 0; $i < $gallery_count; $i++ ) {
+			$gallery_image_ids[] = wp_insert_attachment(
 				array(
-					'post_title'     => 'Gallery Image 1',
+					'post_title'     => 'Gallery Image ' . ( $i + 1 ),
 					'post_type'      => 'attachment',
 					'post_mime_type' => 'image/jpeg',
 				)
-			),
-			wp_insert_attachment(
-				array(
-					'post_title'     => 'Gallery Image 2',
-					'post_type'      => 'attachment',
-					'post_mime_type' => 'image/jpeg',
-				)
-			),
-		);
+			);
+		}
 		$variable_product->set_gallery_image_ids( $gallery_image_ids );
 		$variable_product->save();
 
-		// Create a variation image that is NOT in the main gallery.
-		$variation_image_id = wp_insert_attachment(
-			array(
-				'post_title'     => 'Variation Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-
-		// Get the variations and set the variation image.
+		// Create variation images.
+		$variation_image_ids = array();
 		$variations = $variable_product->get_children();
-		$this->assertNotEmpty( $variations, 'Variable product should have variations' );
 
-		$variation = wc_get_product( $variations[0] );
-		$variation->set_image_id( $variation_image_id );
-		$variation->save();
+		for ( $i = 0; $i < min( $variation_count, count( $variations ) ); $i++ ) {
+			$variation_image_id = wp_insert_attachment(
+				array(
+					'post_title'     => 'Variation Image ' . ( $i + 1 ),
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image/jpeg',
+				)
+			);
+
+			$variation = wc_get_product( $variations[ $i ] );
+			$variation->set_image_id( $variation_image_id );
+			$variation->save();
+
+			$variation_image_ids[] = $variation_image_id;
+		}
+
+		return array(
+			'product'              => $variable_product,
+			'main_image_id'        => $main_image_id,
+			'gallery_image_ids'    => $gallery_image_ids,
+			'variation_image_ids'  => $variation_image_ids,
+		);
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly for a simple product.
+	 */
+	public function test_product_image_render_simple_product() {
+		$data = $this->create_product_with_image();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
+		$this->assertStringContainsString( 'data-image-id="' . $data['image_id'] . '"', $markup );
+
+		// Clean up.
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly for a variable product with variation images.
+	 * This is the main test case: if product is variable product and has some images attached to the variation
+	 * (but not in the main gallery) and the imageId of variation image is provided via context,
+	 * it still recognises the imageId as its own image.
+	 */
+	public function test_product_image_render_variable_product_with_variation_images() {
+		$data = $this->create_variable_product_with_images( 2, 1 );
+		$variation_image_id = $data['variation_image_ids'][0];
 
 		// Test that the ProductImage block recognizes the variation image when provided via context.
-		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $variation_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $variation_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
 
 		// The block should recognize the variation image as valid and use it.
 		$this->assertStringContainsString( 'data-image-id="' . $variation_image_id . '"', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 
 		// Test that the block falls back to the main product image when no imageId is provided.
-		$markup_no_image_id = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
-		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_no_image_id );
+		$markup_no_image_id = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
+		$this->assertStringContainsString( 'data-image-id="' . $data['main_image_id'] . '"', $markup_no_image_id );
 
 		// Test that the block rejects invalid image IDs.
 		$invalid_image_id = 99999;
-		$markup_invalid = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $invalid_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup_invalid = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $invalid_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
 		// Should fall back to main product image when invalid image ID is provided.
-		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_invalid );
+		$this->assertStringContainsString( 'data-image-id="' . $data['main_image_id'] . '"', $markup_invalid );
 
 		// Clean up.
-		$variable_product->delete( true );
-		wp_delete_attachment( $main_image_id, true );
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['main_image_id'], true );
 		wp_delete_attachment( $variation_image_id, true );
-		foreach ( $gallery_image_ids as $gallery_image_id ) {
+		foreach ( $data['gallery_image_ids'] as $gallery_image_id ) {
 			wp_delete_attachment( $gallery_image_id, true );
 		}
 	}
@@ -126,76 +155,47 @@ class ProductImage extends \WP_UnitTestCase {
 	 * Test that the ProductImage block renders correctly with different image sizing options.
 	 */
 	public function test_product_image_render_with_different_sizing() {
-		$product = WC_Helper_Product::create_simple_product();
-
-		$image_id = wp_insert_attachment(
-			array(
-				'post_title'     => 'Test Product Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-		$product->set_image_id( $image_id );
-		$product->save();
+		$data = $this->create_product_with_image();
 
 		// Test with 'single' image sizing.
-		$markup_single = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"single"} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup_single = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"single"} /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_single );
 
 		// Test with 'thumbnail' image sizing.
-		$markup_thumbnail = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"thumbnail"} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup_thumbnail = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"thumbnail"} /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_thumbnail );
 
 		// Clean up.
-		$product->delete( true );
-		wp_delete_attachment( $image_id, true );
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
 	}
 
 	/**
 	 * Test that the ProductImage block renders correctly with sale badge.
 	 */
 	public function test_product_image_render_with_sale_badge() {
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_regular_price( 10 );
-		$product->set_sale_price( 5 );
+		$data = $this->create_product_with_image();
+		$data['product']->set_regular_price( 10 );
+		$data['product']->set_sale_price( 5 );
+		$data['product']->save();
 
-		$image_id = wp_insert_attachment(
-			array(
-				'post_title'     => 'Test Product Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-		$product->set_image_id( $image_id );
-		$product->save();
-
-		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"showSaleBadge":true} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"showSaleBadge":true} /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup );
 
 		// Clean up.
-		$product->delete( true );
-		wp_delete_attachment( $image_id, true );
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
 	}
 
 	/**
 	 * Test that the ProductImage block renders correctly with inner blocks content.
 	 */
 	public function test_product_image_render_with_inner_blocks() {
-		$product = WC_Helper_Product::create_simple_product();
+		$data = $this->create_product_with_image();
 
-		$image_id = wp_insert_attachment(
-			array(
-				'post_title'     => 'Test Product Image',
-				'post_type'      => 'attachment',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-		$product->set_image_id( $image_id );
-		$product->save();
-
-		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image --><div class="custom-inner-block">Custom content</div><!-- /wp:woocommerce/product-image --><!-- /wp:woocommerce/single-product -->' );
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image --><div class="custom-inner-block">Custom content</div><!-- /wp:woocommerce/product-image --><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image__inner-container', $markup );
@@ -203,8 +203,8 @@ class ProductImage extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Custom content', $markup );
 
 		// Clean up.
-		$product->delete( true );
-		wp_delete_attachment( $image_id, true );
+		$data['product']->delete( true );
+		wp_delete_attachment( $data['image_id'], true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -1,0 +1,363 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
+
+use WC_Helper_Product;
+use WP_Block;
+
+/**
+ * Tests for the ProductImage block type
+ */
+class ProductImage extends \WP_UnitTestCase {
+
+	/**
+	 * Test that the ProductImage block renders correctly for a simple product.
+	 */
+	public function test_product_image_render_simple_product() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Create and set a test image.
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test Product Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup = $block->render();
+
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
+		$this->assertStringContainsString( 'data-image-id="' . $image_id . '"', $markup );
+
+		// Clean up.
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly for a variable product with variation images.
+	 * This is the main test case: if product is variable product and has some images attached to the variation
+	 * (but not in the main gallery) and the imageId of variation image is provided via context,
+	 * it still recognises the imageId as its own image.
+	 */
+	public function test_product_image_render_variable_product_with_variation_images() {
+		// Create a variable product.
+		$variable_product = WC_Helper_Product::create_variation_product();
+
+		// Create and set the main product image.
+		$main_image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Main Product Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$variable_product->set_image_id( $main_image_id );
+
+		// Create gallery images (separate from variation images).
+		$gallery_image_ids = array(
+			wp_insert_attachment(
+				array(
+					'post_title'     => 'Gallery Image 1',
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image/jpeg',
+				)
+			),
+			wp_insert_attachment(
+				array(
+					'post_title'     => 'Gallery Image 2',
+					'post_type'      => 'attachment',
+					'post_mime_type' => 'image/jpeg',
+				)
+			),
+		);
+		$variable_product->set_gallery_image_ids( $gallery_image_ids );
+		$variable_product->save();
+
+		// Create a variation image that is NOT in the main gallery.
+		$variation_image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Variation Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		// Get the variations and set the variation image.
+		$variations = $variable_product->get_children();
+		$this->assertNotEmpty( $variations, 'Variable product should have variations' );
+
+		$variation = wc_get_product( $variations[0] );
+		$variation->set_image_id( $variation_image_id );
+		$variation->save();
+
+		// Test that the ProductImage block recognizes the variation image when provided via context.
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId'  => $variable_product->get_id(),
+				'imageId' => $variation_image_id,
+			)
+		);
+
+		$markup = $block->render();
+
+		// The block should recognize the variation image as valid and use it.
+		$this->assertStringContainsString( 'data-image-id="' . $variation_image_id . '"', $markup );
+		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+
+		// Test that the block falls back to the main product image when no imageId is provided.
+		$block_no_image_id = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId' => $variable_product->get_id(),
+			)
+		);
+
+		$markup_no_image_id = $block_no_image_id->render();
+		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_no_image_id );
+
+		// Test that the block rejects invalid image IDs.
+		$invalid_image_id = 99999;
+		$block_invalid    = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId'  => $variable_product->get_id(),
+				'imageId' => $invalid_image_id,
+			)
+		);
+
+		$markup_invalid = $block_invalid->render();
+		// Should fall back to main product image when invalid image ID is provided.
+		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_invalid );
+
+		// Clean up.
+		$variable_product->delete( true );
+		wp_delete_attachment( $main_image_id, true );
+		wp_delete_attachment( $variation_image_id, true );
+		foreach ( $gallery_image_ids as $gallery_image_id ) {
+			wp_delete_attachment( $gallery_image_id, true );
+		}
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly with different image sizing options.
+	 */
+	public function test_product_image_render_with_different_sizing() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test Product Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		// Test with 'single' image sizing.
+		$block_single = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(
+					'imageSizing' => 'single',
+				),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup_single = $block_single->render();
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_single );
+
+		// Test with 'thumbnail' image sizing.
+		$block_thumbnail = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(
+					'imageSizing' => 'thumbnail',
+				),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup_thumbnail = $block_thumbnail->render();
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_thumbnail );
+
+		// Clean up.
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly with sale badge.
+	 */
+	public function test_product_image_render_with_sale_badge() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 10 );
+		$product->set_sale_price( 5 );
+
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test Product Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(
+					'showSaleBadge' => true,
+				),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup = $block->render();
+
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup );
+
+		// Clean up.
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+	}
+
+	/**
+	 * Test that the ProductImage block renders correctly with inner blocks content.
+	 */
+	public function test_product_image_render_with_inner_blocks() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test Product Image',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+		$product->set_image_id( $image_id );
+		$product->save();
+
+		$inner_content = '<div class="custom-inner-block">Custom content</div>';
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup = $block->render( array(), $inner_content, $block );
+
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+		$this->assertStringContainsString( 'wc-block-components-product-image__inner-container', $markup );
+		$this->assertStringContainsString( 'Custom content', $markup );
+
+		// Clean up.
+		$product->delete( true );
+		wp_delete_attachment( $image_id, true );
+	}
+
+	/**
+	 * Test that the ProductImage block handles products without images correctly.
+	 */
+	public function test_product_image_render_without_images() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId' => $product->get_id(),
+			)
+		);
+
+		$markup = $block->render();
+
+		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
+		// Should contain placeholder image.
+		$this->assertStringContainsString( 'woocommerce-placeholder', $markup );
+
+		// Clean up.
+		$product->delete( true );
+	}
+
+	/**
+	 * Test that the ProductImage block handles invalid product IDs correctly.
+	 */
+	public function test_product_image_render_with_invalid_product() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array(
+				'postId' => 99999, // Non-existent product ID.
+			)
+		);
+
+		$markup = $block->render();
+
+		$this->assertEmpty( $markup );
+	}
+
+	/**
+	 * Test that the ProductImage block handles missing postId context correctly.
+	 */
+	public function test_product_image_render_without_post_id() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'woocommerce/product-image',
+				'attrs'     => array(),
+			),
+			array()
+		);
+
+		$markup = $block->render();
+
+		$this->assertEmpty( $markup );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -107,7 +107,11 @@ class ProductImage extends \WP_UnitTestCase {
 		$variation->set_image_id( $variation_image_id );
 		$variation->save();
 
-		// Test that the ProductImage block recognizes the variation image when provided via context.
+		// Verify that the variation image is included in the available images (cast to string for comparison).
+		$available_image_ids = \Automattic\WooCommerce\Blocks\Utils\ProductGalleryUtils::get_all_image_ids( $variable_product );
+		$this->assertContains( (string) $variation_image_id, $available_image_ids, 'Variation image should be included in available images' );
+
+		// Test that the ProductImage block recognizes the variation image when provided via context (cast to string).
 		$block = new WP_Block(
 			array(
 				'blockName' => 'woocommerce/product-image',
@@ -115,7 +119,7 @@ class ProductImage extends \WP_UnitTestCase {
 			),
 			array(
 				'postId'  => $variable_product->get_id(),
-				'imageId' => $variation_image_id,
+				'imageId' => (string) $variation_image_id,
 			)
 		);
 
@@ -123,7 +127,6 @@ class ProductImage extends \WP_UnitTestCase {
 
 		// The block should recognize the variation image as valid and use it.
 		$this->assertStringContainsString( 'data-image-id="' . $variation_image_id . '"', $markup );
-		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 
 		// Test that the block falls back to the main product image when no imageId is provided.
@@ -149,7 +152,7 @@ class ProductImage extends \WP_UnitTestCase {
 			),
 			array(
 				'postId'  => $variable_product->get_id(),
-				'imageId' => $invalid_image_id,
+				'imageId' => (string) $invalid_image_id,
 			)
 		);
 
@@ -291,6 +294,7 @@ class ProductImage extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image__inner-container', $markup );
+		$this->assertStringContainsString( 'custom-inner-block', $markup );
 		$this->assertStringContainsString( 'Custom content', $markup );
 
 		// Clean up.

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -73,9 +73,9 @@ class ProductImage extends \WP_UnitTestCase {
 		// Create variation images.
 		$variation_image_ids = array();
 		$variations          = $variable_product->get_children();
-		$variations_count    = count( $variations );
+		$variations_count    = min( $variation_count, count( $variations ) );
 
-		for ( $i = 0; $i < min( $variation_count, $variations_count ); $i++ ) {
+		for ( $i = 0; $i < $variations_count; $i++ ) {
 			$variation_image_id = wp_insert_attachment(
 				array(
 					'post_title'     => 'Variation Image ' . ( $i + 1 ),

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
 use WC_Helper_Product;
-use WP_Block;
 
 /**
  * Tests for the ProductImage block type
@@ -29,17 +28,7 @@ class ProductImage extends \WP_UnitTestCase {
 		$product->set_image_id( $image_id );
 		$product->save();
 
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup = $block->render();
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'data-testid="product-image"', $markup );
@@ -107,56 +96,20 @@ class ProductImage extends \WP_UnitTestCase {
 		$variation->set_image_id( $variation_image_id );
 		$variation->save();
 
-		// Verify that the variation image is included in the available images (cast to string for comparison).
-		$available_image_ids = \Automattic\WooCommerce\Blocks\Utils\ProductGalleryUtils::get_all_image_ids( $variable_product );
-		$this->assertContains( (string) $variation_image_id, $available_image_ids, 'Variation image should be included in available images' );
-
-		// Test that the ProductImage block recognizes the variation image when provided via context (cast to string).
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId'  => $variable_product->get_id(),
-				'imageId' => (string) $variation_image_id,
-			)
-		);
-
-		$markup = $block->render();
+		// Test that the ProductImage block recognizes the variation image when provided via context.
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $variation_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
 
 		// The block should recognize the variation image as valid and use it.
 		$this->assertStringContainsString( 'data-image-id="' . $variation_image_id . '"', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 
 		// Test that the block falls back to the main product image when no imageId is provided.
-		$block_no_image_id = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId' => $variable_product->get_id(),
-			)
-		);
-
-		$markup_no_image_id = $block_no_image_id->render();
+		$markup_no_image_id = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_no_image_id );
 
 		// Test that the block rejects invalid image IDs.
 		$invalid_image_id = 99999;
-		$block_invalid    = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId'  => $variable_product->get_id(),
-				'imageId' => (string) $invalid_image_id,
-			)
-		);
-
-		$markup_invalid = $block_invalid->render();
+		$markup_invalid = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $variable_product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $invalid_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
 		// Should fall back to main product image when invalid image ID is provided.
 		$this->assertStringContainsString( 'data-image-id="' . $main_image_id . '"', $markup_invalid );
 
@@ -186,35 +139,11 @@ class ProductImage extends \WP_UnitTestCase {
 		$product->save();
 
 		// Test with 'single' image sizing.
-		$block_single = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(
-					'imageSizing' => 'single',
-				),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup_single = $block_single->render();
+		$markup_single = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"single"} /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_single );
 
 		// Test with 'thumbnail' image sizing.
-		$block_thumbnail = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(
-					'imageSizing' => 'thumbnail',
-				),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup_thumbnail = $block_thumbnail->render();
+		$markup_thumbnail = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"imageSizing":"thumbnail"} /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup_thumbnail );
 
 		// Clean up.
@@ -240,19 +169,7 @@ class ProductImage extends \WP_UnitTestCase {
 		$product->set_image_id( $image_id );
 		$product->save();
 
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(
-					'showSaleBadge' => true,
-				),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup = $block->render();
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image {"showSaleBadge":true} /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'wp-block-woocommerce-product-sale-badge', $markup );
@@ -278,19 +195,7 @@ class ProductImage extends \WP_UnitTestCase {
 		$product->set_image_id( $image_id );
 		$product->save();
 
-		$inner_content = '<div class="custom-inner-block">Custom content</div>';
-
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup = $block->render( array(), $inner_content, $block );
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image --><div class="custom-inner-block">Custom content</div><!-- /wp:woocommerce/product-image --><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		$this->assertStringContainsString( 'wc-block-components-product-image__inner-container', $markup );
@@ -309,17 +214,7 @@ class ProductImage extends \WP_UnitTestCase {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->save();
 
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId' => $product->get_id(),
-			)
-		);
-
-		$markup = $block->render();
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product->get_id() . '} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertStringContainsString( 'wc-block-components-product-image', $markup );
 		// Should contain placeholder image.
@@ -333,17 +228,7 @@ class ProductImage extends \WP_UnitTestCase {
 	 * Test that the ProductImage block handles invalid product IDs correctly.
 	 */
 	public function test_product_image_render_with_invalid_product() {
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array(
-				'postId' => 99999, // Non-existent product ID.
-			)
-		);
-
-		$markup = $block->render();
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":99999} --><!-- wp:woocommerce/product-image /--><!-- /wp:woocommerce/single-product -->' );
 
 		$this->assertEmpty( $markup );
 	}
@@ -352,15 +237,7 @@ class ProductImage extends \WP_UnitTestCase {
 	 * Test that the ProductImage block handles missing postId context correctly.
 	 */
 	public function test_product_image_render_without_post_id() {
-		$block = new WP_Block(
-			array(
-				'blockName' => 'woocommerce/product-image',
-				'attrs'     => array(),
-			),
-			array()
-		);
-
-		$markup = $block->render();
+		$markup = do_blocks( '<!-- wp:woocommerce/product-image --><!-- /wp:woocommerce/product-image -->' );
 
 		$this->assertEmpty( $markup );
 	}

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/ProductImage.php
@@ -72,9 +72,10 @@ class ProductImage extends \WP_UnitTestCase {
 
 		// Create variation images.
 		$variation_image_ids = array();
-		$variations = $variable_product->get_children();
+		$variations          = $variable_product->get_children();
+		$variations_count    = count( $variations );
 
-		for ( $i = 0; $i < min( $variation_count, count( $variations ) ); $i++ ) {
+		for ( $i = 0; $i < min( $variation_count, $variations_count ); $i++ ) {
 			$variation_image_id = wp_insert_attachment(
 				array(
 					'post_title'     => 'Variation Image ' . ( $i + 1 ),
@@ -91,10 +92,10 @@ class ProductImage extends \WP_UnitTestCase {
 		}
 
 		return array(
-			'product'              => $variable_product,
-			'main_image_id'        => $main_image_id,
-			'gallery_image_ids'    => $gallery_image_ids,
-			'variation_image_ids'  => $variation_image_ids,
+			'product'             => $variable_product,
+			'main_image_id'       => $main_image_id,
+			'gallery_image_ids'   => $gallery_image_ids,
+			'variation_image_ids' => $variation_image_ids,
 		);
 	}
 
@@ -122,7 +123,7 @@ class ProductImage extends \WP_UnitTestCase {
 	 * it still recognises the imageId as its own image.
 	 */
 	public function test_product_image_render_variable_product_with_variation_images() {
-		$data = $this->create_variable_product_with_images( 2, 1 );
+		$data               = $this->create_variable_product_with_images( 2, 1 );
 		$variation_image_id = $data['variation_image_ids'][0];
 
 		// Test that the ProductImage block recognizes the variation image when provided via context.
@@ -138,7 +139,7 @@ class ProductImage extends \WP_UnitTestCase {
 
 		// Test that the block rejects invalid image IDs.
 		$invalid_image_id = 99999;
-		$markup_invalid = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $invalid_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
+		$markup_invalid   = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $data['product']->get_id() . '} --><!-- wp:woocommerce/product-image {"imageId":' . $invalid_image_id . '} /--><!-- /wp:woocommerce/single-product -->' );
 		// Should fall back to main product image when invalid image ID is provided.
 		$this->assertStringContainsString( 'data-image-id="' . $data['main_image_id'] . '"', $markup_invalid );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In https://github.com/woocommerce/woocommerce/pull/58651 we started using Product Image inside Product Gallery block. It introduced a possible regression with variation product.

Product variations can have their own images and they can be part of product's gallery or not. New Product Gallery block renders all of the product images (including variation's). At the same time, Product Image has the logic to render product image if it belongs to product's gallery and fallback to featured image otherwise. In case the variation image WAS NOT part of product's gallery it wasn't recognised as product's image and hence, we'd see the featured image repeated rendered multiple times in a Large Image.

This PR fixes it by changing the method of checking product image ids from `$product->get_gallery_image_ids()` to `ProductGalleryUtils::get_all_image_ids( $product )` that we use in Product Gallery as well. Whole fix is covered in `plugins/woocommerce/src/Blocks/BlockTypes/ProductImage.php` file. 

In addition, I'm adding unit tests to Product Image.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58651

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    https://github.com/user-attachments/assets/37572109-8031-415c-af3b-d2ef9cb03315    |    https://github.com/user-attachments/assets/db3d60db-aa31-4234-a0b4-29c2af1d1bd7   |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create variation product and make sure there is some image in gallery (one is enough)
2. Add images to variations but make sure they're NOT included in main product gallery
3. Go to Editor > Single Product template
4. Replace the Product Image Gallery block with the Product Gallery (beta) block
5. Go to frontend of the variation product
6. Use thumbnails/arrows to change product images
7. Make sure the images are changing
8. Change attributes of product and make sure the gallery slides to variation image (see "After" video)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
