### PR TITLE
Prevent Settings tab bar from breaking into two lines when not needed

### DIFF
--- a/plugins/woocommerce/changelog/fix-wooplug-4749-nav-tab-wrapper-clearfix
+++ b/plugins/woocommerce/changelog/fix-wooplug-4749-nav-tab-wrapper-clearfix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent Settings tab bar breaking into two lines when not needed

--- a/plugins/woocommerce/changelog/fix-wooplug-4749-nav-tab-wrapper-clearfix
+++ b/plugins/woocommerce/changelog/fix-wooplug-4749-nav-tab-wrapper-clearfix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent Settings tab bar breaking into two lines when not needed
+Prevent Settings tab bar from breaking into two lines when not needed

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8991,6 +8991,19 @@ body.woocommerce_page_wc-settings {
 		list-style: none;
 		padding-left: 30px;
 		gap: 24px;
+
+		/*
+		 * Hides the ::after clearfix from nav-tab-wrapper to avoid the list
+		 * of tasks breaking into two lines in some cases.
+		 * The clearfix is added by WordPress core in
+		 * https://github.com/WordPress/wordpress-develop/blob/512f8052f00932bfab512e40400d80f62c9e6854/src/wp-admin/css/common.css#L2378-L2383
+		 * but it is not needed in our implementation because we use display: flex;
+		 * @see https://github.com/woocommerce/woocommerce/pull/39600
+		 */
+		&:not(.wp-clearfix)::after {
+			display: none;
+		}
+
 		a {
 			float: none;
 			font-family: $font-sf-pro-display;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8990,6 +8990,7 @@ body.woocommerce_page_wc-settings {
 		flex-wrap: wrap;
 		list-style: none;
 		padding-left: 30px;
+		padding-right: 24px;
 		gap: 24px;
 
 		/*


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPLUG-4749.

This PR removes the clearfix added by WordPress core to the WooCommerce Settings tabs so they don't break into two lines unnecessarily. It also adds some extra right padding, to make sure there is some space between the last tab and the window border.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings.
2. Slowly change the width of the window (make it narrower).
3. Verify there is never empty space below the tabs when they are all on the same line.
4. Verify there is always some space between the last tab and the window border.

#### Before 

https://github.com/user-attachments/assets/317d2e3c-bf8f-4c7d-8da8-2223a5361d54

#### After

https://github.com/user-attachments/assets/f2174420-7999-45d4-b69f-e7a2a8fd5c9e