### PR TITLE
Refactor Product selection in E2E Tests for Bulk Editing

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/product-edit.spec.js
@@ -32,6 +32,21 @@ async function saveBulkProductChanges( page ) {
 	).toBeVisible();
 }
 
+async function selectProduct( page, product ) {
+	await page
+		.getByLabel( `Select ${ product.name }` )
+		.and(
+			page.locator( `input[type="checkbox"][value="${ product.id }"]` )
+		)
+		.click();
+}
+
+async function selectAllProducts( page, products ) {
+	for ( const product of products ) {
+		await selectProduct( page, product );
+	}
+}
+
 const test = baseTest.extend( {
 	storageState: ADMIN_STATE_PATH,
 	products: async ( { restApi }, use ) => {
@@ -123,16 +138,7 @@ test( 'can bulk edit products', async ( { page, products } ) => {
 	const stockQtyIncrease = 10;
 
 	await test.step( 'select and bulk edit the products', async () => {
-		for ( const product of products ) {
-			await page
-				.getByLabel( `Select ${ product.name }` )
-				.and(
-					page.locator(
-						`input[type="checkbox"][value="${ product.id }"]`
-					)
-				)
-				.click();
-		}
+		await selectAllProducts( page, products );
 
 		await page
 			.locator( '#bulk-action-selector-top' )
@@ -223,9 +229,7 @@ test(
 		const salePriceDecrease = 10;
 
 		await test.step( 'select and bulk edit the products', async () => {
-			for ( const product of products ) {
-				await page.getByLabel( `Select ${ product.name }` ).click();
-			}
+			await selectAllProducts( page, products );
 
 			await page
 				.locator( '#bulk-action-selector-top' )
@@ -280,9 +284,7 @@ test(
 		await test.step( 'Update products leaving the "Sale > Change to" empty', async () => {
 			await page.goto( `wp-admin/edit.php?post_type=product` );
 
-			for ( const product of products ) {
-				await page.getByLabel( `Select ${ product.name }` ).click();
-			}
+			await selectAllProducts( page, products );
 
 			await page
 				.locator( '#bulk-action-selector-top' )
@@ -323,9 +325,7 @@ test(
 		await test.step( 'Update products with the "Sale > Decrease existing sale price" option', async () => {
 			await page.goto( `wp-admin/edit.php?post_type=product` );
 
-			for ( const product of products ) {
-				await page.getByLabel( `Select ${ product.name }` ).click();
-			}
+			await selectAllProducts( page, products );
 
 			await page
 				.locator( '#bulk-action-selector-top' )
@@ -393,7 +393,7 @@ test(
 		await test.step( 'Update products with the "Sale > Increase existing sale price" option', async () => {
 			await page.goto( `wp-admin/edit.php?post_type=product` );
 
-			await page.getByLabel( `Select ${ product.name }` ).click();
+			await selectProduct( page, product );
 
 			await page
 				.locator( '#bulk-action-selector-top' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes flaky E2E tests in the product bulk edit functionality that were failing due to strict mode violations when selecting products with duplicate names.

- Introduced `selectProduct()` and `selectAllProducts()` helper functions to centralize and improve product selection logic (there was a bunch of repeated code).
- Enhanced product selection to use both the label and a specific checkbox value selector, ensuring uniqueness and eliminating flakiness caused by duplicated names.

Closes #57464.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `product-edit.spec.js` tests multiple times.
5. Verify that all product bulk edit tests pass consistently.

### Testing that has already taken place:

- Ran the product edit test suite multiple times locally to confirm the fix resolves the flakiness.
- Verified that the new helper functions correctly select products by combining label and ID-based selectors.
- Confirmed that all existing test functionality remains intact after the refactoring.
- Tested with the standard `wp-env` environment using the default test configuration.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fixed E2E test flakiness.

</details>
