### PR TITLE
Interactivity API powered Mini Cart - Fix display prices in cart items

### DIFF
--- a/plugins/woocommerce/changelog/59175-fix-iapi-minicart-display-prices
+++ b/plugins/woocommerce/changelog/59175-fix-iapi-minicart-display-prices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix how prices are displayed in the iAPI-powered minicart.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -328,20 +328,14 @@ const { state: cartItemState } = store(
 
 			get priceWithoutDiscount(): string {
 				return formatPriceWithCurrency(
-					parseInt(
-						cartItemState.cartItem.prices.raw_prices.regular_price,
-						10
-					),
+					parseInt( cartItemState.cartItem.prices.regular_price, 10 ),
 					cartItemState.currency
 				);
 			},
 
 			get itemPrice(): string {
 				return formatPriceWithCurrency(
-					parseInt(
-						cartItemState.cartItem.prices.raw_prices.price,
-						10
-					),
+					parseInt( cartItemState.cartItem.prices.price, 10 ),
 					cartItemState.currency
 				);
 			},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug where the cart item prices show the wrong number.

| Before | After |
| ------ | ----- |
|    <img width="476" alt="Screenshot 2025-06-26 at 09 50 09" src="https://github.com/user-attachments/assets/ced11152-438e-42c9-a276-8317ff7746a8" />    |     <img width="477" alt="Screenshot 2025-06-26 at 09 48 36" src="https://github.com/user-attachments/assets/f206830c-2385-48a4-b322-7457fd8a1280" />  |

This was included in [this refactoring](https://github.com/woocommerce/woocommerce/pull/58716/commits/d526a0eec2df9b8025d0afa631351360f44d3bf7). It seems it shouldn't use `raw_prices` in this place.

### How to test the changes in this Pull Request:

> To test the experimental block, make sure experimental-iapi-mini-cart and experimental-iapi-runtime are set to true in the development.json file: [link](https://github.com/woocommerce/woocommerce/blob/c9cc094885a0351dd2cb550a5739f5980e0a5e6c/plugins/woocommerce/client/admin/config/development.json#L8-L9).

1. Add any product to the cart.
2. Check the prices in the minicart are displayed correctly.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fix how prices are displayed in the iAPI-powered minicart.

</details>
