### PR TITLE
Avoid order creation E2E test case failures caused by locator conflicts during QIT test

### DIFF
--- a/plugins/woocommerce/changelog/dev-wc-e2e-avoid-create-order-test-conflict
+++ b/plugins/woocommerce/changelog/dev-wc-e2e-avoid-create-order-test-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Change to use a more specific locator to click on the Customer field when creating an order, as the current method fails the QIT woo-e2e test due to a plugin resolving multiple elements with the text "Guest".

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
@@ -424,7 +424,7 @@ test.describe(
 			order.id = await getOrderIdFromPage( page );
 
 			// Select customer
-			await page.getByText( 'Guest' ).click();
+			await page.locator( '#select2-customer_user-container' ).click();
 			await page
 				.locator( 'input[aria-owns="select2-customer_user-results"]' )
 				.fill( customer.username );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The following locator can cause failures in QIT woo e2e test because it resolves multiple elements.

https://github.com/woocommerce/woocommerce/blob/71571fe59d6f65e0db91c02adff7e5f5c0db1fce/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js#L427

For example, AutomateWoo adds a "Guests" admin menu.

![1](https://github.com/user-attachments/assets/47d07df6-909f-45a1-9b99-a1eb2b815457)

![image](https://github.com/user-attachments/assets/8dec32e6-c803-419f-9906-e3aba44f5e73)

This PR changes to use a more specific locator to click on the Customer field when creating an order, as the current method fails the QIT woo e2e test due to a plugin resolving multiple elements with the text "Guest".

The updated locator refers to:
https://github.com/woocommerce/woocommerce/blob/e43d6403ba535ca21f5c1f33f0770c2e864f7da1/plugins/woocommerce/tests/e2e-pw/tests/order/order-edit.spec.js#L266

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start a local env for E2E test.
   - https://github.com/woocommerce/woocommerce/tree/71571fe59d6f65e0db91c02adff7e5f5c0db1fce/plugins/woocommerce/tests/e2e-pw#introduction
2. Run E2E test to see if it can pass.
3. Log in to the E2E test site. Install and activate AutomateWoo.
4. Run E2E test again to see if it can pass as well.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
