### PR TITLE
Make sure Add to Cart button state updates when changing variations in the Add to Cart + Options block (10.0)

### DIFF
--- a/plugins/woocommerce/changelog/fix-59117-add-to-cart-with-options-variable-product-form-valid-10.0
+++ b/plugins/woocommerce/changelog/fix-59117-add-to-cart-with-options-variable-product-form-valid-10.0
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Make sure Add to Cart button state updates when changing variation in the Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -18,7 +18,6 @@ export type Context = {
 	productId: number;
 	productType: string;
 	selectedAttributes: CartVariationItem[];
-	variationId: number | null;
 	availableVariations: AvailableVariation[];
 	quantity: Record< number, number >;
 	tempQuantity: number;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -147,11 +147,16 @@ const addToCartWithOptionsStore = store(
 	{
 		state: {
 			get isFormValid(): boolean {
-				const { productType } = getContext< Context >();
+				const { availableVariations, selectedAttributes, productType } =
+					getContext< Context >();
 				if ( productType !== 'variable' ) {
 					return true;
 				}
-				return !! addToCartWithOptionsStore.state.variationId;
+				const matchedVariation = getMatchedVariation(
+					availableVariations,
+					selectedAttributes
+				);
+				return !! matchedVariation?.variation_id;
 			},
 			get variationId(): number | null {
 				const context = getContext< Context >();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -187,7 +187,14 @@ class AddToCartWithOptions extends AbstractBlock {
 			wp_interactivity_state(
 				'woocommerce/add-to-cart-with-options',
 				array(
-					'isFormValid' => ! $product->is_type( 'variable' ),
+					'isFormValid' => function () {
+						$context = wp_interactivity_get_context();
+						$product = wc_get_product( $context['productId'] );
+						if ( $product instanceof \WC_Product && $product->is_type( 'variable' ) ) {
+							return false;
+						}
+						return true;
+					},
 					'variationId' => null,
 				)
 			);
@@ -464,7 +471,6 @@ class AddToCartWithOptions extends AbstractBlock {
 					<input type="hidden" name="product_id" value="' . esc_attr( $product_id ) . '" />
 					<input type="hidden"
 						name="variation_id"
-						data-wp-interactive="woocommerce/add-to-cart-with-options"
 						data-wp-bind--value="state.variationId"
 					/>
 				</div>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/59158 but for WooCommerce 10.0 so we can create a CFE (https://github.com/woocommerce/woocommerce/issues/59179).

### How to test the changes in this Pull Request:

#### Preparation

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.

#### Reproducing the issue

1. Go to a variable product page.
2. Select the attributes and hover the Add to Cart button.
3. Verify the cursor is not `not-allowed`.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/868ea81b-d43d-45df-903d-3165d4146ea3) | ![imatge](https://github.com/user-attachments/assets/02d292e3-3727-44da-9f2a-7f05866a4c71)
