### PR TITLE
Update Add to Cart + Options store so it listens to input events (10.0)

### DIFF
--- a/plugins/woocommerce/changelog/fix-59116-add-to-cart-with-options-listen-to-input-changes-10.0
+++ b/plugins/woocommerce/changelog/fix-59116-add-to-cart-with-options-listen-to-input-changes-10.0
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update Add to Cart + Options store so it listens to input events
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -257,7 +257,7 @@ const addToCartWithOptionsStore = store(
 					dispatchChangeEvent( inputElement );
 				}
 			},
-			handleInputQuantityChange: (
+			handleQuantityInputChange: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {
 				const inputData = getInputData( event );
@@ -271,7 +271,7 @@ const addToCartWithOptionsStore = store(
 					childProductId
 				);
 			},
-			handleCheckboxQuantityChange: (
+			handleQuantityCheckboxChange: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {
 				const inputData = getInputData( event );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -257,6 +257,20 @@ const addToCartWithOptionsStore = store(
 					dispatchChangeEvent( inputElement );
 				}
 			},
+			handleInputQuantityChange: (
+				event: HTMLElementEvent< HTMLInputElement >
+			) => {
+				const inputData = getInputData( event );
+				if ( ! inputData ) {
+					return;
+				}
+				const { childProductId, currentValue } = inputData;
+
+				addToCartWithOptionsStore.actions.setQuantity(
+					currentValue,
+					childProductId
+				);
+			},
 			handleCheckboxQuantityChange: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -101,9 +101,10 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await expect( addToCartButton ).toHaveText( '3 in cart' );
 
+		await page.getByLabel( 'Product quantity' ).fill( '1' );
 		await addToCartButton.click();
 
-		await expect( addToCartButton ).toHaveText( '6 in cart' );
+		await expect( addToCartButton ).toHaveText( '4 in cart' );
 	} );
 
 	test( 'allows adding variable products to cart', async ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -109,7 +109,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				esc_html( wp_strip_all_tags( wc_price( $product->get_price() ) ) )
 			);
 		}
-		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-on--change="actions.handleCheckboxQuantityChange" />';
+		return '<input type="checkbox" name="' . esc_attr( 'quantity[' . $product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" id="' . esc_attr( 'quantity_' . $product->get_id() ) . '" data-wp-on--change="actions.handleQuantityCheckboxChange" />';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -84,13 +84,20 @@ class Utils {
 	}
 
 	/**
-	 * Make the quantity input interactive by wrapping it with the necessary data attribute.
+	 * Make the quantity input interactive by wrapping it with the necessary data attribute and adding a change event listener.
 	 *
 	 * @param string $quantity_html The quantity HTML.
 	 * @param string $wrapper_attributes Optional wrapper attributes.
 	 * @return string The quantity HTML with interactive wrapper.
 	 */
 	public static function make_quantity_input_interactive( $quantity_html, $wrapper_attributes = '' ) {
+		$html = new \WP_HTML_Tag_Processor( $quantity_html );
+		while ( $html->next_tag( 'input' ) ) {
+			$html->set_attribute( 'data-wp-on--input', 'actions.handleInputQuantityChange' );
+		}
+
+		$quantity_html = $html->get_updated_html();
+
 		if ( ! empty( $wrapper_attributes ) ) {
 			return sprintf(
 				'<div %1$s data-wp-interactive="woocommerce/add-to-cart-with-options">%2$s</div>',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -84,7 +84,7 @@ class Utils {
 	}
 
 	/**
-	 * Make the quantity input interactive by wrapping it with the necessary data attribute and adding a change event listener.
+	 * Make the quantity input interactive by wrapping it with the necessary data attribute and adding an input event listener.
 	 *
 	 * @param string $quantity_html The quantity HTML.
 	 * @param string $wrapper_attributes Optional wrapper attributes.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -92,7 +92,7 @@ class Utils {
 	public static function make_quantity_input_interactive( $quantity_html, $wrapper_attributes = '' ) {
 		$processor = new \WP_HTML_Tag_Processor( $quantity_html );
 		while ( $processor->next_tag( 'input' ) ) {
-			$processor->set_attribute( 'data-wp-on--input', 'actions.handleInputQuantityChange' );
+			$processor->set_attribute( 'data-wp-on--input', 'actions.handleQuantityInputChange' );
 		}
 
 		$quantity_html = $processor->get_updated_html();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -40,19 +40,18 @@ class Utils {
 	 * @return string The Quantity Selector HTML with classes added.
 	 */
 	public static function add_quantity_stepper_classes( $quantity_html ) {
-		$html = new \WP_HTML_Tag_Processor( $quantity_html );
+		$processor = new \WP_HTML_Tag_Processor( $quantity_html );
 
 		// Add classes to the form.
-		while ( $html->next_tag( array( 'class_name' => 'quantity' ) ) ) {
-			$html->add_class( 'wc-block-components-quantity-selector' );
+		while ( $processor->next_tag( array( 'class_name' => 'quantity' ) ) ) {
+			$processor->add_class( 'wc-block-components-quantity-selector' );
 		}
 
-		$html = new \WP_HTML_Tag_Processor( $html->get_updated_html() );
-		while ( $html->next_tag( array( 'class_name' => 'input-text' ) ) ) {
-			$html->add_class( 'wc-block-components-quantity-selector__input' );
+		while ( $processor->next_tag( array( 'class_name' => 'input-text' ) ) ) {
+			$processor->add_class( 'wc-block-components-quantity-selector__input' );
 		}
 
-		return $html->get_updated_html();
+		return $processor->get_updated_html();
 	}
 
 	/**
@@ -91,12 +90,12 @@ class Utils {
 	 * @return string The quantity HTML with interactive wrapper.
 	 */
 	public static function make_quantity_input_interactive( $quantity_html, $wrapper_attributes = '' ) {
-		$html = new \WP_HTML_Tag_Processor( $quantity_html );
-		while ( $html->next_tag( 'input' ) ) {
-			$html->set_attribute( 'data-wp-on--input', 'actions.handleInputQuantityChange' );
+		$processor = new \WP_HTML_Tag_Processor( $quantity_html );
+		while ( $processor->next_tag( 'input' ) ) {
+			$processor->set_attribute( 'data-wp-on--input', 'actions.handleInputQuantityChange' );
 		}
 
-		$quantity_html = $html->get_updated_html();
+		$quantity_html = $processor->get_updated_html();
 
 		if ( ! empty( $wrapper_attributes ) ) {
 			return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -91,7 +91,11 @@ class Utils {
 	 */
 	public static function make_quantity_input_interactive( $quantity_html, $wrapper_attributes = '' ) {
 		$processor = new \WP_HTML_Tag_Processor( $quantity_html );
-		while ( $processor->next_tag( 'input' ) ) {
+		if (
+			$processor->next_tag( 'input' ) &&
+			$processor->get_attribute( 'type' ) === 'number' &&
+			strpos( $processor->get_attribute( 'name' ), 'quantity' ) !== false
+		) {
 			$processor->set_attribute( 'data-wp-on--input', 'actions.handleQuantityInputChange' );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/59150 but for WooCommerce 10.0 so we can create a CFE (https://github.com/woocommerce/woocommerce/issues/59182).

### How to test the changes in this Pull Request:

#### Preparation

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.

#### Reproducing the issue

1. Go to the frontend of a simple product.
2. Without click on the decrease/increase quantity buttons, modify the quantity by writing a number in the input field.
3. Click directly on the _Add to Cart_ button.
4. Verify the correct quantity has been added to cart.

https://github.com/user-attachments/assets/b9d43c34-ea09-4b2d-bb34-f51037f50078

5. Repeat steps 1-4 with a grouped product, modifying the children product quantities directly writing the numbers in the input field.