### PR TITLE
Fix css calc related build errors

### DIFF
--- a/plugins/woocommerce/changelog/fix-css-build-warnings
+++ b/plugins/woocommerce/changelog/fix-css-build-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Silent css build calc errors

--- a/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/plugin-banner.scss
+++ b/plugins/woocommerce/client/admin/client/task-lists/fills/experimental-shipping-recommendation/components/plugin-banner.scss
@@ -49,7 +49,7 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-around;
-		gap: calc($gap-smaller + $gap-smallest / 2);
+		gap: calc($gap-smaller + ($gap-smallest / 2));
 	}
 
 	.woocommerce-task-shipping-recommendations_plugins-buttons {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/password-strength-meter/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/password-strength-meter/style.scss
@@ -17,7 +17,7 @@
 		width: 100%;
 		display: block;
 		height: $gap-smaller;
-		border-radius: #{$gap-smaller / 2};
+		border-radius: calc($gap-smaller / 2);
 		border: 0;
 		background-color: $universal-border-light;
 		color: $alert-red;
@@ -35,7 +35,7 @@
 			background: none;
 			background-color: currentColor;
 			transition: 0.2s ease;
-			border-radius: #{$gap-smaller / 2};
+			border-radius: calc($gap-smaller / 2);
 			border: 0;
 			height: $gap-smaller;
 			vertical-align: middle;
@@ -47,7 +47,7 @@
 			background: none;
 			background-color: currentColor;
 			transition: 0.2s ease;
-			border-radius: #{$gap-smaller / 2};
+			border-radius: calc($gap-smaller / 2);
 			border: 0;
 			height: $gap-smaller;
 			vertical-align: middle;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -49,7 +49,7 @@
 	}
 }
 
-@include breakpoint(">782px") {
+@include breakpoint(">781px") {
 	.wc-block-cart .wc-block-cart__submit-container--sticky {
 		display: none;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -49,7 +49,7 @@
 	}
 }
 
-@include breakpoint(">=782px") {
+@include breakpoint(">782px") {
 	.wc-block-cart .wc-block-cart__submit-container--sticky {
 		display: none;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -44,7 +44,7 @@
 		}
 		.wc-block-components-radio-control__description-group {
 			display: block;
-			width: calc(100% + em($gap-huge / 0.875));
+			width: calc(100% + em(math.div($gap-huge, 0.875)));
 			box-sizing: border-box;
 			border-radius: $universal-border-radius;
 			padding: 1px em($gap-small);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes some math operations CSS build time errors. There shouldn't be any impact in the frontend, but it does make the build output clear by eliminating deprecation warnings.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->


### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | 
| ------ | 
|  <img width="937" alt="Screenshot 2025-06-26 at 14 11 37" src="https://github.com/user-attachments/assets/b0e587c7-4a97-4364-a4e6-7987898a9f34" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

There shouldn't be any calc warning coming from Woo; There is one that is coming from Gutenberg's Form Token Field. 

```
 padding: $grid-unit-05/2 $grid-unit-05
```
This is just a syntax change, so there shouldn't be no side effects in the UI. 

But, for example, in the checkout block you can:

1. Go to the Local page radio selectors and see no change
<img width="673" alt="Screenshot 2025-06-26 at 13 58 52" src="https://github.com/user-attachments/assets/98abac87-3820-45a7-9129-8f5feba11eba" />

3. Go to the password strength indicator and see it looks as expected
<img width="854" alt="Screenshot 2025-06-26 at 14 00 34" src="https://github.com/user-attachments/assets/c72e34c6-8422-4b3a-9aa2-4b1a51b377d8" />



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
