### PR TITLE
Update email templates to remove unexpected new lines

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-4685-unexpected-new-lines-in-email-content-blocks
+++ b/packages/php/email-editor/changelog/wooplug-4685-unexpected-new-lines-in-email-content-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fixed social links block styling by adding explicit margin-right:0 to prevent unwanted spacing on social icon images

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
@@ -168,7 +168,7 @@ class Social_Links extends Abstract_Block_Renderer {
 					<tbody><tr>
 						<td style="vertical-align:middle;">
 						<a href="%2$s" %5$s class="wp-block-social-link-anchor">
-							<img height="%8$s" src="%3$s" style="display:block;margin-right:0" width="%8$s" alt="%4$s">
+							<img height="%8$s" src="%3$s" style="display:block;margin-right:0;" width="%8$s" alt="%4$s">
 						</a>
 						</td>
 					</tr>

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php
@@ -168,7 +168,7 @@ class Social_Links extends Abstract_Block_Renderer {
 					<tbody><tr>
 						<td style="vertical-align:middle;">
 						<a href="%2$s" %5$s class="wp-block-social-link-anchor">
-							<img height="%8$s" src="%3$s" style="display:block;" width="%8$s" alt="%4$s">
+							<img height="%8$s" src="%3$s" style="display:block;margin-right:0" width="%8$s" alt="%4$s">
 						</a>
 						</td>
 					</tr>

--- a/plugins/woocommerce/changelog/wooplug-4685-unexpected-new-lines-in-email-content-blocks
+++ b/plugins/woocommerce/changelog/wooplug-4685-unexpected-new-lines-in-email-content-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+This fix addresses the issue where email content blocks contained unexpected new lines due to unnecessary line breaks in PHP template files. The changes ensure clean email rendering by removing unwanted whitespace.

--- a/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.0.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,22 +22,18 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: order number */
 printf( esc_html__( 'Order cancelled: #%s,', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %1$s: Order number. %2$s: Customer full name */
 	$text = __( 'We’re getting in touch to let you know that order #%1$s from %2$s has been cancelled.', 'woocommerce' );
 	printf( esc_html( $text ), '<!--[woocommerce/order-number]-->', '<!--[woocommerce/customer-full-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->

--- a/plugins/woocommerce/templates/emails/block/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,22 +22,18 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: order number */
 printf( esc_html__( 'Order failed: #%s,', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %1$s: Order number. %2$s: Customer full name. */
 	$text = __( 'Unfortunately, the payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' );
 	printf( esc_html( $text ), '<!--[woocommerce/order-number]-->', '<!--[woocommerce/customer-full-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -45,9 +41,7 @@ printf( esc_html__( 'Order failed: #%s,', 'woocommerce' ), '<!--[woocommerce/ord
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 echo wp_kses_post( __( 'We hope they’ll be back soon! Read more about <a href="https://woocommerce.com/document/managing-orders/">troubleshooting failed payments</a>.', 'woocommerce' ) );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-failed-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-new-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.0.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -21,21 +21,17 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: order number */
 printf( esc_html__( 'New order: #%s,', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Customer full name */
 printf( esc_html__( 'You’ve received a new order from %s', 'woocommerce' ), '<!--[woocommerce/customer-full-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->

--- a/plugins/woocommerce/templates/emails/block/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/block/admin-new-order.php
@@ -18,6 +18,9 @@
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
+
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -6,7 +6,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.0.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -16,30 +16,24 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: Order number */
 printf( esc_html__( 'Order Cancelled: #%s', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Customer first name */
 printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Order number */
 printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -47,10 +41,8 @@ printf( esc_html__( 'Your order #%s has been cancelled.', 'woocommerce' ), '<!--
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'We hope to see you again soon.', 'woocommerce' ) );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-cancelled-order.php
@@ -13,6 +13,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -47,10 +45,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-completed-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -39,12 +37,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Site title */
 	printf( esc_html__( "If you'd like to continue with your purchase, please return to %s and try a different method of payment.", 'woocommerce' ), '<!--[woocommerce/site-title]-->' )
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -56,10 +52,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-failed-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/block/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,21 +22,17 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: order number */
 printf( esc_html__( 'Details for order #%s,', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -44,11 +40,9 @@ printf( esc_html__( 'Details for order #%s,', 'woocommerce' ), '<!--[woocommerce
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/block/customer-invoice.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/block/customer-new-account.php
@@ -59,8 +59,17 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 
 <!-- wp:paragraph -->
 <p><?php
-	$text = '<a data-link-href="%1$s" contenteditable="false" style="text-decoration: underline;"> %2$s </a>';
-	printf( wp_kses_post( $text ), '[woocommerce/my-account-url]', esc_html__( 'My account', 'woocommerce' ) );
+	$link_template = '<a data-link-href="%1$s" contenteditable="false" style="text-decoration: underline;">%2$s</a>';
+	printf(
+		'%s',
+		wp_kses_post(
+			sprintf(
+				$link_template,
+				esc_attr( '[woocommerce/my-account-url]' ),
+				esc_html__( 'My account', 'woocommerce' )
+			)
+		)
+	);
 ?></p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/block/customer-new-account.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->
@@ -70,7 +72,7 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 			)
 		)
 	);
-?></p>
+	?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/block/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,39 +22,31 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: Site title*/
 printf( esc_html__( 'Welcome to %s', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Site title */
 	printf( esc_html__( 'Thanks for creating an account on %s. Here’s a copy of your user details.', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Username */
 echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' ), array( 'b' => array() ) );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -66,12 +58,10 @@ echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocomm
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	$text = '<a data-link-href="%1$s" contenteditable="false" style="text-decoration: underline;"> %2$s </a>';
 	printf( wp_kses_post( $text ), '[woocommerce/my-account-url]', esc_html__( 'My account', 'woocommerce' ) );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-note.php
+++ b/plugins/woocommerce/templates/emails/block/customer-note.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Customer note email (inital block version)
+ * Customer note email (initial block content)
  *
  * This template can be overridden by editing it in the WooCommerce email editor.
  *
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-note.php
+++ b/plugins/woocommerce/templates/emails/block/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -55,10 +53,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->
@@ -47,6 +49,6 @@ defined( 'ABSPATH' ) || exit;
 <!-- wp:paragraph -->
 <p><?php
 /* translators: %s: Store admin email */
-	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
+	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
 ?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-on-hold-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -47,10 +45,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-pos-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.0.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,12 +22,10 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: Order number */
 printf( esc_html__( 'Order refunded: %s', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,12 +26,10 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -47,10 +45,8 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s,', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-processing-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -22,30 +22,24 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 /* translators: %s: Order number */
 printf( esc_html__( 'Order refunded: %s', 'woocommerce' ), '<!--[woocommerce/order-number]-->' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Site title */
 printf( esc_html__( 'Your order from %s has been refunded.', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -57,10 +51,8 @@ printf( esc_html__( 'Your order from %s has been refunded.', 'woocommerce' ), '<
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 printf( esc_html__( 'If you need any help with your order, please contact us at %s', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->

--- a/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/block/customer-refunded-order.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/block/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -26,38 +26,30 @@ defined( 'ABSPATH' ) || exit;
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer username */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Store name */
 	printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), '<!--[woocommerce/site-title]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Username */
 echo wp_kses( sprintf( __( 'Username: <b>%s</b>', 'woocommerce' ), '<!--[woocommerce/customer-username]-->' ), array( 'b' => array() ) );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	echo esc_html__( 'If you didn’t make this request, just ignore this email. If you’d like to proceed, reset your password via the link below:', 'woocommerce' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->

--- a/plugins/woocommerce/templates/emails/block/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/block/customer-reset-password.php
@@ -19,6 +19,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/default-block-content.php
+++ b/plugins/woocommerce/templates/emails/block/default-block-content.php
@@ -8,7 +8,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
@@ -18,20 +18,16 @@ defined( 'ABSPATH' ) || exit;
 ?>
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">
-<?php
+<h2 class="wp-block-heading"><?php
 esc_html_e( 'Default block content', 'woocommerce' );
-?>
-</h2>
+?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 	/* translators: %s: Customer first name */
 	printf( esc_html__( 'Hi %s,', 'woocommerce' ), '<!--[woocommerce/customer-first-name]-->' );
-?>
-</p>
+?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:woo/email-content {"lock":{"move":false,"remove":true}} -->
@@ -39,11 +35,9 @@ esc_html_e( 'Default block content', 'woocommerce' );
 <!-- /wp:woo/email-content -->
 
 <!-- wp:paragraph -->
-<p>
-<?php
+<p><?php
 /* translators: %s: Store admin email */
 	printf( esc_html__( 'Thanks again! If you need any help with your order, please contact us at %s.', 'woocommerce' ), '<!--[woocommerce/store-email]-->' );
-?>
-	</p>
+?></p>
 <!-- /wp:paragraph -->
 

--- a/plugins/woocommerce/templates/emails/block/default-block-content.php
+++ b/plugins/woocommerce/templates/emails/block/default-block-content.php
@@ -15,6 +15,8 @@ use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
 ?>
 
 <!-- wp:heading -->

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -11,6 +11,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen -- removed to prevent empty new lines.
+// phpcs:disable Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- removed to prevent empty new lines.
+
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Settings\PointOfSaleDefaultSettings;
 

--- a/plugins/woocommerce/templates/emails/block/general-block-email.php
+++ b/plugins/woocommerce/templates/emails/block/general-block-email.php
@@ -6,7 +6,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Block
- * @version 10.0.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,8 +19,7 @@ if ( 'customer_invoice' === $email->id ) :
 	// We are keeping this here until we have a better way to handle conditional content in the email editor.
 	?>
 	<?php if ( $order->needs_payment() ) { ?>
-		<p>
-		<?php
+		<p><?php
 		if ( $order->has_status( OrderStatus::FAILED ) ) {
 			printf(
 				wp_kses(
@@ -50,16 +49,13 @@ if ( 'customer_invoice' === $email->id ) :
 				'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
 			);
 		}
-		?>
-		</p>
+		?></p>
 
 	<?php } else { ?>
-		<p>
-		<?php
+		<p><?php
 		/* translators: %s Order date */
 		printf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $order->get_date_created() ) ) );
-		?>
-		</p>
+		?></p>
 		<?php
 	}
 endif;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses the issue of unexpected new lines appearing in email content blocks when WooCommerce email templates are processed. The problem was caused by unnecessary line breaks in the PHP template files that were being preserved during email rendering, leading to unwanted whitespace in the final email output.

**Why we are creating this PR:**
The issue reported in [#58954](https://github.com/woocommerce/woocommerce/issues/58954) showed that email content blocks contained unexpected new lines that were affecting the visual presentation of emails. This was happening because the PHP template files had unnecessary line breaks between PHP opening/closing tags and HTML content, which were being preserved during the email rendering process.

**Changes made:**
1. **Updated 16 email template files** to remove unnecessary line breaks between PHP tags and HTML content
2. **Fixed social links block styling** by adding explicit `margin-right:0` to prevent unwanted spacing on social icon images
3. **Updated version numbers** for all modified template files to reflect the changes

**Files modified:**
- 16 email template files in `plugins/woocommerce/templates/emails/block/` (removing unwanted new lines)
- `packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-social-links.php` (fixing social icon spacing)

Closes #58954 WOOPLUG-4685.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Email content blocks contained unexpected new lines causing unwanted whitespace | Clean email rendering without unexpected line breaks |
| <img width="706" alt="Screenshot 2025-06-26 at 7 08 14 AM" src="https://github.com/user-attachments/assets/9894bb1b-5c04-46f0-b2ca-ff01100f4c8b" /> |  <img width="663" alt="Screenshot 2025-06-26 at 7 09 07 AM" src="https://github.com/user-attachments/assets/238afc99-8930-41a3-88cb-012e902f7226" /> |
|  ![Screenshot 2025-06-26 at 2 05 12 PM](https://github.com/user-attachments/assets/61a2f96a-0f6b-4492-b5f7-3ddcaadc4b19) |  ![Screenshot 2025-06-26 at 2 05 52 PM](https://github.com/user-attachments/assets/f2363788-5dfe-470d-92fc-fb98cb684e3a) | 



### How to test the changes in this Pull Request:

1. **Set up a WooCommerce store** with the email editor feature enabled
2. **Create a test order** and trigger various email notifications (new order, completed order, cancelled order, etc.)
3. **Check the email content** in the database or by viewing the rendered emails (you can delete the email post and re-create it from the WooCommerce email listing page)
4. **Verify that no unexpected new lines** appear in the email content blocks
5. **Test social links in emails** to ensure proper spacing without unwanted margins
6. **Compare email rendering** before and after the changes to confirm the fix

### Testing that has already taken place:

- **Environment tested:** Local development environment with WooCommerce trunk
- **Email templates tested:** All 16 modified email templates
- **Social links block tested:** Verified proper spacing without unwanted margins
- **Database content verified:** Confirmed no unexpected new lines in stored email content
- **Cross-browser testing:** Verified email rendering consistency across different email clients

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
