### PR TITLE
Add documentation for email rendering

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-4751-add-documentation-for-email-rendering
+++ b/packages/php/email-editor/changelog/wooplug-4751-add-documentation-for-email-rendering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Added documentation for rendering emails and improved renderer to accept template slug
+
+

--- a/packages/php/email-editor/docs/README.md
+++ b/packages/php/email-editor/docs/README.md
@@ -1,0 +1,6 @@
+# Email Editor PHP Package
+
+## Documentation
+
+- [Email Renderering Documentation](rendering.md) - Guide to the email rendering system, including renderer classes, bootstrapping, and core blocks integration.
+

--- a/packages/php/email-editor/docs/README.md
+++ b/packages/php/email-editor/docs/README.md
@@ -2,5 +2,5 @@
 
 ## Documentation
 
-- [Email Renderering Documentation](rendering.md) - Guide to the email rendering system, including renderer classes, bootstrapping, and core blocks integration.
+- [Email Rendering Documentation](rendering.md) - Guide to the email rendering system, including renderer classes, bootstrapping, and core blocks integration.
 

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -1,0 +1,179 @@
+# Email Rendering
+
+**The email renderer classes** are designed to render WordPress posts containing block-based content (saved in a Gutenberg editor) as HTML and text suitable for sending in emails. These classes provide the core functionality for converting block editor content into email-compatible formats.
+
+The email rendering system includes **Core Blocks Integration** that provides dedicated renderers for WordPress core blocks. This integration is essential for generating email client compatible HTML output - without these block specific renderers the rendered HTML wouldn't be useful for email clients at all.
+
+## Table of Contents
+
+- [Retrieving Services via DI Container](#retrieving-services-via-di-container)
+- [Bootstrapping](#bootstrapping)
+- [Renderer Classes](#renderer-classes)
+    - [Automattic\\WooCommerce\\EmailEditor\\Engine\\Renderer\\Renderer](#automatticwoocommerceemaileditorenginerendererrenderer)
+    - [Automattic\\WooCommerce\\EmailEditor\\Engine\\Renderer\\ContentRenderer\\Content\_Renderer](#automatticwoocommerceemaileditorenginerenderercontentrenderercontent_renderer)
+- [Core Blocks Integration](#core-blocks-integration)
+- [Integration Example](#integration-example)
+
+## Retrieving Services via DI Container
+
+The easiest way to access the rendering services is via DI container. The `Automattic\WooCommerce\EmailEditor\Email_Editor_Container` class provides a dependency injection container that can be used to easily obtain renderer services.
+
+Here's how to obtain a renderer service:
+
+```php
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
+
+// Get the container instance
+$container = Email_Editor_Container::container();
+
+// Obtain renderer services
+$renderer = $container->get( Renderer::class );
+$content_renderer = $container->get( Content_Renderer::class );
+```
+
+## Bootstrapping
+
+The rendering engine requires bootstrapping using the `Automattic\WooCommerce\EmailEditor\Bootstrap` class and its `init` method.
+
+This bootstrap process registers necessary action callbacks and must be called before the WordPress `init` action is triggered. This early initialization is required because the bootstrap hooks into core blocks registration, which occurs before the `init` hook.
+
+**Example:**
+
+```php
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Bootstrap;
+
+// Get the container instance
+$container = Email_Editor_Container::container();
+
+// Get the Bootstrap service and initialize
+$bootstrap = $container->get( Bootstrap::class );
+$bootstrap->init();
+```
+
+## Renderer Classes
+
+### Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer
+
+The `Renderer` class is responsible for rendering full HTML documents including meta information in the head section and content in the body tags. This class provides a complete email template structure.
+
+**Main Method:**
+
+```php
+/**
+ * Renders the email template
+ *
+ * @param \WP_Post $post Post object.
+ * @param string   $subject Email subject.
+ * @param string   $pre_header An email preheader or preview text is the short snippet of text that follows the subject line in an inbox. See https://kb.mailpoet.com/article/418-preview-text
+ * @param string   $language Email language.
+ * @param string   $meta_robots Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
+ * @param string   $template_slug A block template slug used for cases when email doesn't have associated template.
+ * @return array
+ */
+public function render(
+    \WP_Post $post,
+    string $subject,
+    string $pre_header, 
+    string $language = 'en',
+    string $meta_robots = '', 
+    string $template_slug = ''
+): array
+```
+
+**Returns:** An array containing:
+
+-   `html`: The complete HTML email content
+-   `text`: The plain text version of the email
+
+**Example Usage:**
+
+```php
+$post           = get_post( $post_id );
+$rendered_email = $renderer->render(
+    $post,
+    'Order Confirmation',
+    'Your order has been confirmed',
+    'en'
+);
+
+$html_content = $rendered_email['html'];
+$text_content = $rendered_email['text'];
+```
+
+### Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer
+
+The `Content_Renderer` class is responsible for rendering only the HTLM of a block template content and a post. The block template has to contain `core/post-content` block.
+
+**Main Method:**
+
+```php
+/**
+ * Render the content
+ *
+ * @param WP_Post           $post Post object.
+ * @param WP_Block_Template $template Block template.
+ * @return string
+ */
+public function render(
+    WP_Post $post,
+    WP_Block_Template $template
+): string
+```
+
+**Returns:** A string containing the rendered HTML content
+
+**Example Usage:**
+
+```php
+$post        = get_post( $post_id );
+$template_id = get_stylesheet() . '//' . $template_slug;
+$template    = get_block_template( $template_id );
+$content     = $content_renderer->render( $post, $template );
+```
+
+## Core Blocks Integration
+
+The package provides specialized renderers for the most commonly used WordPress core blocks, with plans to eventually cover all core blocks. These individual block renderers are located in the [packages/php/email-editor/src/Integrations/Core/Renderer/Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks) directory.
+
+**Usage:**
+The block renderers for core blocks are linked to the core blocks when they are registered, which happens very early so the Core Blocks integration needs to be initialized early.
+
+If you use `Automattic\WooCommerce\EmailEditor\Bootstrap` class the core integration is set up for you. In case you want to set manually see the `Automattic\WooCommerce\EmailEditor\Bootstrap` init method.
+
+## Integration Example
+
+Here's how these classes work together in a typical email rendering workflow:
+
+```php
+use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
+use Automattic\WooCommerce\EmailEditor\Bootstrap;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
+
+// Get services from container
+$container = Email_Editor_Container::container();
+
+// Bootstrap the rendering engine (must be called before WordPress init action)
+$bootstrap = $container->get( Bootstrap::class );
+$bootstrap->init();
+
+// Rendering an email from a post
+
+// Get renderer services
+$renderer = $container->get( Renderer::class );
+
+// Render a complete email
+$post = get_post( $email_post_id );
+$email_data = $renderer->render(
+    $post,
+    'Welcome to our store!',
+    'Thank you for your purchase',
+    'en'
+);
+```
+
+This allows for flexible email rendering where you can either get the complete email document or just the content blocks, depending on your specific needs.
+

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -1,16 +1,16 @@
 # Email Rendering
 
-**The email renderer classes** are designed to render WordPress posts containing block-based content (saved in a Gutenberg editor) as HTML and text suitable for sending in emails. These classes provide the core functionality for converting block editor content into email-compatible formats.
+**The email renderer classes** are designed to render WordPress posts containing block-based content (saved in the Gutenberg editor) as HTML and plain-text suitable for email delivery. These classes provide the core functionality for converting block editor content into email-compatible formats.
 
-The email rendering system includes **Core Blocks Integration** that provides dedicated renderers for WordPress core blocks. This integration is essential for generating email client compatible HTML output - without these block specific renderers the rendered HTML wouldn't be useful for email clients at all.
+The email rendering system includes **Core Blocks Integration** that provides dedicated renderers for WordPress core blocks. This integration is essential for generating email client compatible HTML output - without these block-specific renderers, the rendered HTML would not be suitable for email clients.
 
 ## Table of Contents
 
 - [Retrieving Services via DI Container](#retrieving-services-via-di-container)
 - [Bootstrapping](#bootstrapping)
 - [Renderer Classes](#renderer-classes)
-    - [Automattic\\WooCommerce\\EmailEditor\\Engine\\Renderer\\Renderer](#automatticwoocommerceemaileditorenginerendererrenderer)
-    - [Automattic\\WooCommerce\\EmailEditor\\Engine\\Renderer\\ContentRenderer\\Content\_Renderer](#automatticwoocommerceemaileditorenginerenderercontentrenderercontent_renderer)
+    - [Renderer](#renderer)
+    - [Content\_Renderer](#content_renderer)
 - [Core Blocks Integration](#core-blocks-integration)
 - [Integration Example](#integration-example)
 
@@ -37,7 +37,7 @@ $content_renderer = $container->get( Content_Renderer::class );
 
 The rendering engine requires bootstrapping using the `Automattic\WooCommerce\EmailEditor\Bootstrap` class and its `init` method.
 
-This bootstrap process registers necessary action callbacks and must be called before the WordPress `init` action is triggered. This early initialization is required because the bootstrap hooks into core blocks registration, which occurs before the `init` hook.
+This bootstrap process registers necessary action callbacks. It must be called before the WordPress `init` action is triggered at or before the `plugins_loaded` action. This early initialization is required because the bootstrap hooks into core blocks registration, which occurs before the `init` hook.
 
 **Example:**
 
@@ -55,9 +55,9 @@ $bootstrap->init();
 
 ## Renderer Classes
 
-### Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer
+### Renderer
 
-The `Renderer` class is responsible for rendering full HTML documents including meta information in the head section and content in the body tags. This class provides a complete email template structure.
+The `Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer` class is responsible for rendering full HTML documents, including meta information in the head section and content in the body tags. This class provides a complete email template structure.
 
 **Main Method:**
 
@@ -69,8 +69,8 @@ The `Renderer` class is responsible for rendering full HTML documents including 
  * @param string   $subject Email subject.
  * @param string   $pre_header An email preheader or preview text is the short snippet of text that follows the subject line in an inbox. See https://kb.mailpoet.com/article/418-preview-text
  * @param string   $language Email language.
- * @param string   $meta_robots Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
- * @param string   $template_slug A block template slug used for cases when email doesn't have associated template.
+ * @param string   $meta_robots Optional string. Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
+ * @param string   $template_slug Optional block template slug used for cases when email doesn't have associated template.
  * @return array
  */
 public function render(
@@ -92,6 +92,8 @@ public function render(
 
 ```php
 $post           = get_post( $post_id );
+
+// Post has an associated block template or a fallback blank template will be used, which renders only the post contents
 $rendered_email = $renderer->render(
     $post,
     'Order Confirmation',
@@ -99,13 +101,23 @@ $rendered_email = $renderer->render(
     'en'
 );
 
+// Template is specified explicitly by passing template slug string
+$rendered_email = $renderer->render(
+    $post,
+    'Order Confirmation',
+    'Your order has been confirmed',
+    'en',
+    '',
+    'my-email-template-slug'
+);
+
 $html_content = $rendered_email['html'];
 $text_content = $rendered_email['text'];
 ```
 
-### Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer
+### Content_Renderer
 
-The `Content_Renderer` class is responsible for rendering only the HTLM of a block template content and a post. The block template has to contain `core/post-content` block.
+The `Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer` class is responsible for rendering only the HTML of block template content and a post. The block template has to contain a `core/post-content` block.
 
 **Main Method:**
 
@@ -139,9 +151,9 @@ $content     = $content_renderer->render( $post, $template );
 The package provides specialized renderers for the most commonly used WordPress core blocks, with plans to eventually cover all core blocks. These individual block renderers are located in the [packages/php/email-editor/src/Integrations/Core/Renderer/Blocks](https://github.com/woocommerce/woocommerce/tree/trunk/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks) directory.
 
 **Usage:**
-The block renderers for core blocks are linked to the core blocks when they are registered, which happens very early so the Core Blocks integration needs to be initialized early.
+The block renderers for core blocks are linked to the core blocks when they are registered, which happens very early (e.g. from a `plugins_loaded` callback), so the Core Blocks integration needs to be initialized early.
 
-If you use `Automattic\WooCommerce\EmailEditor\Bootstrap` class the core integration is set up for you. In case you want to set manually see the `Automattic\WooCommerce\EmailEditor\Bootstrap` init method.
+If you use the `Automattic\WooCommerce\EmailEditor\Bootstrap` class, the core integration is set up for you. In case you want to set manually, see the `Automattic\WooCommerce\EmailEditor\Bootstrap` init method.
 
 ## Integration Example
 
@@ -151,7 +163,6 @@ Here's how these classes work together in a typical email rendering workflow:
 use Automattic\WooCommerce\EmailEditor\Email_Editor_Container;
 use Automattic\WooCommerce\EmailEditor\Bootstrap;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\Renderer;
-use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
 
 // Get services from container
 $container = Email_Editor_Container::container();

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -78,10 +78,13 @@ class Renderer {
 	 * @param string   $pre_header Email preheader.
 	 * @param string   $language Email language.
 	 * @param string   $meta_robots Email meta robots.
+	 * @param string   $template_slug Email template slug.
 	 * @return array
 	 */
-	public function render( \WP_Post $post, string $subject, string $pre_header, string $language, $meta_robots = '' ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$template_slug = get_page_template_slug( $post ) ? get_page_template_slug( $post ) : 'email-general';
+	public function render( \WP_Post $post, string $subject, string $pre_header, string $language, string $meta_robots = '', string $template_slug = '' ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( ! $template_slug ) {
+			$template_slug = get_page_template_slug( $post ) ? get_page_template_slug( $post ) : 'email-general';
+		}
 		/** @var \WP_Block_Template $template */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort -- used for phpstan
 		$template = $this->templates->get_block_template( $template_slug );
 

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -75,10 +75,10 @@ class Renderer {
 	 *
 	 * @param \WP_Post $post Post object.
 	 * @param string   $subject Email subject.
-	 * @param string   $pre_header Email preheader.
+	 * @param string   $pre_header An email preheader or preview text is the short snippet of text that follows the subject line in an inbox. See https://kb.mailpoet.com/article/418-preview-text.
 	 * @param string   $language Email language.
-	 * @param string   $meta_robots Email meta robots.
-	 * @param string   $template_slug Email template slug.
+	 * @param string   $meta_robots Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
+	 * @param string   $template_slug A block template slug used for cases when email doesn't have associated template.
 	 * @return array
 	 */
 	public function render( \WP_Post $post, string $subject, string $pre_header, string $language, string $meta_robots = '', string $template_slug = '' ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -77,8 +77,8 @@ class Renderer {
 	 * @param string   $subject Email subject.
 	 * @param string   $pre_header An email preheader or preview text is the short snippet of text that follows the subject line in an inbox. See https://kb.mailpoet.com/article/418-preview-text.
 	 * @param string   $language Email language.
-	 * @param string   $meta_robots Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
-	 * @param string   $template_slug A block template slug used for cases when email doesn't have associated template.
+	 * @param string   $meta_robots Optional string. Can be left empty for sending, but you can provide a value (e.g. noindex, nofollow) when you want to display email html in a browser.
+	 * @param string   $template_slug Optional block template slug used for cases when email doesn't have associated template.
 	 * @return array
 	 */
 	public function render( \WP_Post $post, string $subject, string $pre_header, string $language, string $meta_robots = '', string $template_slug = '' ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -159,6 +159,56 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	}
 
 	/**
+	 * Test it renders post wrapped withing a template associated with the post via _wp_page_template post meta.
+	 */
+	public function testItRendersPostWithinAssociatedTemplate(): void {
+		// @phpstan-ignore-next-line PHPStan is not aware of the register_block_template function's side effects.
+		register_block_template(
+			'renderer-tests//test-email-template',
+			array(
+				'title'       => 'Test Email Template',
+				'description' => 'A test email template.',
+				'content'     => '<!-- wp:group --><div class="wp-block-group test-template-class"><!-- wp:post-content /--></div><!-- /wp:group -->',
+			)
+		);
+		update_post_meta( $this->email_post->ID, '_wp_page_template', 'test-email-template' );
+
+		$rendered = $this->renderer->render(
+			$this->email_post,
+			'Subject',
+			'Preheader content',
+			'en'
+		);
+		$this->assertStringContainsString( 'test-template-class', $rendered['html'] );
+	}
+
+	/**
+	 * Test it renders post wrapped withing a template passed as parameter.
+	 */
+	public function testItRendersPostWithinTemplatePassedAsParameter(): void {
+		// @phpstan-ignore-next-line PHPStan is not aware of the register_block_template function's side effects.
+		register_block_template(
+			'renderer-tests//test-email-template-extra',
+			array(
+				'title'       => 'Test Email Template',
+				'description' => 'A test email template.',
+				'content'     => '<!-- wp:group --><div class="wp-block-group test-template-class-extra"><!-- wp:post-content /--></div><!-- /wp:group -->',
+			)
+		);
+		update_post_meta( $this->email_post->ID, '_wp_page_template', 'test-email-template-extra' );
+
+		$rendered = $this->renderer->render(
+			$this->email_post,
+			'Subject',
+			'Preheader content',
+			'en',
+			'',
+			'test-email-template-extra'
+		);
+		$this->assertStringContainsString( 'test-template-class-extra', $rendered['html'] );
+	}
+
+	/**
 	 * Returns the value of the style attribute for the first tag that matches the query.
 	 *
 	 * @param string $html HTML content.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a documentation page describing the usage of the package for rendering HTML emails.
It also contains a minor enhancement of the main renderer method to cover a use case when rendering a post without an associated email template (e.g., classic post).

Closes WOOPLUG-4751

### How to test the changes in this Pull Request:

Please review the documentation to ensure it is clear and comprehensive, without any important details missing.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
