### PR TITLE
Hide footer in Product Editor to correct postbox position calculations

### DIFF
--- a/plugins/woocommerce/changelog/59212-wooplug-4790-right-column-classic-editor-disappears-when-scrolling-up-and
+++ b/plugins/woocommerce/changelog/59212-wooplug-4790-right-column-classic-editor-disappears-when-scrolling-up-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Editor: fix postbox position calculation.

--- a/plugins/woocommerce/client/legacy/js/admin/product-editor.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-editor.js
@@ -3,6 +3,13 @@ jQuery( function ( $ ) {
 	$( function () {
 		var editorWrapper = $( '#postdivrich' );
 
+		/**
+		 * In the Product Editor context, the footer needs to be hidden otherwise the computation of the postbox position is wrong.
+		 * For more details,
+		 */
+		$( '#wpfooter' ).css( 'visibility', 'hidden' );
+		$( '#wpfooter' ).css( 'display', 'unset' );
+
 		if ( editorWrapper.length ) {
 			editorWrapper.addClass( 'postbox woocommerce-product-description' );
 			editorWrapper.prepend(

--- a/plugins/woocommerce/client/legacy/js/admin/product-editor.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-editor.js
@@ -7,8 +7,7 @@ jQuery( function ( $ ) {
 		 * In the Product Editor context, the footer needs to be hidden otherwise the computation of the postbox position is wrong.
 		 * For more details, see https://github.com/woocommerce/woocommerce/pull/59212.
 		 */
-		$( '#wpfooter' ).css( 'visibility', 'hidden' );
-		$( '#wpfooter' ).css( 'display', 'unset' );
+		$( '#wpfooter' ).css( { visibility: 'hidden', display: 'unset' } );
 
 		if ( editorWrapper.length ) {
 			editorWrapper.addClass( 'postbox woocommerce-product-description' );

--- a/plugins/woocommerce/client/legacy/js/admin/product-editor.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-editor.js
@@ -5,7 +5,7 @@ jQuery( function ( $ ) {
 
 		/**
 		 * In the Product Editor context, the footer needs to be hidden otherwise the computation of the postbox position is wrong.
-		 * For more details,
+		 * For more details, see https://github.com/woocommerce/woocommerce/pull/59212.
 		 */
 		$( '#wpfooter' ).css( 'visibility', 'hidden' );
 		$( '#wpfooter' ).css( 'display', 'unset' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/59180 (WOOPLUG-4790).


This PR fixes ensure that WordPress scripts can compute correctly the postbox position. 

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/7e617328-671a-4007-a365-9f830166d55a" />

([source code](https://github.com/WordPress/wordpress-develop/blob/2e4be8b47d7c536e929af86bb7d439fc241cfe83/src/js/_enqueues/wp/editor/dfw.js#L674-L691))


This happens because the `footerTop` is 0 and the `sidebarTop` returns a negative number. This happens because the footer is set to display none from the WooCommerce styles.


https://github.com/woocommerce/woocommerce/blob/54dca3828b50ca9b1b949678861231fdb7550e35/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss#L56-L58

To avoid any potential regression, I update the style of the footer only in the Product Editor context. I think that it is the safest approach, but I'm open to updating the `_reset.scss` file if you prefer.


I'm able to reproduce the issue on post classic editor if I set the display to none:




https://github.com/user-attachments/assets/2ef02bf4-6968-4a6c-92d4-7c0db4f4f281





(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/8ce12be1-38e3-4037-96b6-8736e37054f0" />        |<video src="https://github.com/user-attachments/assets/6d014ae7-04a0-44ab-8a04-c813fa651f64" />      |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout trunk.
2. Edit a product.
3. In the Product Description, add a long text.
4. Scroll down and up the page. 
5. See that the right boxes disappear. 
6. Checkout this branch.
7. Repeat 2-4.
8. See that the right boxes don't disappear anymore.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Product Editor: fix postbox position calculation.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>