### PR TITLE
Allow setting grouped product children quantity to 0 in Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-58990-10.0
+++ b/plugins/woocommerce/changelog/fix-58990-10.0
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Allow setting grouped product children quantity to 0 in Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -99,7 +99,11 @@ const productButtonStore = {
 					groupedProductIdsInCart?.some( ( qty ) => qty > 0 ) &&
 					hasPressedButton
 				) {
-					return state.inTheCartText;
+					const totalQuantity = groupedProductIdsInCart?.reduce((sum, qty) => sum + qty, 0) || 0;
+					return state.inTheCartText.replace(
+						'###',
+						totalQuantity.toString()
+					);
 				}
 				return addToCartText;
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -99,11 +99,7 @@ const productButtonStore = {
 					groupedProductIdsInCart?.some( ( qty ) => qty > 0 ) &&
 					hasPressedButton
 				) {
-					const totalQuantity = groupedProductIdsInCart?.reduce((sum, qty) => sum + qty, 0) || 0;
-					return state.inTheCartText.replace(
-						'###',
-						totalQuantity.toString()
-					);
+					return state.inTheCartText;
 				}
 				return addToCartText;
 			}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -180,6 +180,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			'Increase quantity of Beanie'
 		);
 		await increaseQuantityButton.click();
+		await increaseQuantityButton.click();
 
 		const addToCartButton = page.getByText( 'Add to cart' ).first();
 
@@ -187,7 +188,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await expect( page.getByText( 'Added to cart' ) ).toBeVisible();
 
-		await expect( page.getByLabel( '4 items in cart' ) ).toBeVisible();
+		await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
 	} );
 
 	test( "doesn't allow selecting invalid variations in pills mode", async ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -241,14 +241,9 @@ class AddToCartWithOptions extends AbstractBlock {
 				foreach ( $context['groupedProductIds'] as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
 					if ( $child_product ) {
-						/**
-						 * Filter the minimum quantity for a child product in a grouped product.
-						 *
-						 * @since 10.0.0
-						 * @param int $min_quantity The minimum quantity.
-						 * @param WC_Product $child_product The child product object.
-						 */
-						$default_child_quantity                   = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
+
+						$default_child_quantity = isset( $_POST['quantity'][ $child_product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $child_product->get_id() ] ) ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
 						$context['quantity'][ $child_product_id ] = $default_child_quantity;
 
 						// Check for any "sold individually" products and set their default quantity to 0.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -34,12 +34,34 @@ class GroupedProductItemSelector extends AbstractBlock {
 		ob_start();
 
 		woocommerce_quantity_input(
-			array_merge(
-				AddToCartWithOptionsUtils::get_quantity_input_args( $product ),
-				array(
-					'input_name' => 'quantity[' . $product->get_id() . ']',
-					'input_id'   => 'quantity_' . $product->get_id(),
-				)
+			array(
+				'input_name'  => 'quantity[' . $product->get_id() . ']',
+				'input_id'    => 'quantity_' . $product->get_id(),
+				'input_value' => isset( $_POST['quantity'][ $product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $product->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				/**
+				 * Filter the minimum quantity value allowed for the product.
+				 *
+				 * @since 2.0.0
+				 * @param int        $min_value Minimum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+				/**
+				 * Filter the maximum quantity value allowed for the product.
+				 *
+				 * @since 2.0.0
+				 * @param int        $max_value Maximum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				/**
+				 * Filter the placeholder value allowed for the product.
+				 *
+				 * @since 3.10.0
+				 * @param int        $max_value Maximum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				'placeholder' => apply_filters( 'woocommerce_quantity_input_placeholder', 0, $product ),
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -66,7 +66,27 @@ class QuantitySelector extends AbstractBlock {
 
 		ob_start();
 
-		woocommerce_quantity_input( AddToCartWithOptionsUtils::get_quantity_input_args( $product ) );
+		woocommerce_quantity_input(
+			array(
+				/**
+				 * Filter the minimum quantity value allowed for the product.
+				 *
+				 * @since 2.0.0
+				 * @param int        $min_value Minimum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+				/**
+				 * Filter the maximum quantity value allowed for the product.
+				 *
+				 * @since 2.0.0
+				 * @param int        $max_value Maximum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			)
+		);
 
 		$product_html = ob_get_clean();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -55,34 +55,6 @@ class Utils {
 	}
 
 	/**
-	 * Get standardized quantity input arguments for WooCommerce quantity input.
-	 *
-	 * @param \WC_Product $product The product object.
-	 * @return array Arguments for woocommerce_quantity_input().
-	 */
-	public static function get_quantity_input_args( $product ) {
-		return array(
-			/**
-			 * Filter the minimum quantity value allowed for the product.
-			 *
-			 * @since 2.0.0
-			 * @param int        $min_value Minimum quantity value.
-			 * @param WC_Product $product   Product object.
-			 */
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			/**
-			 * Filter the maximum quantity value allowed for the product.
-			 *
-			 * @since 2.0.0
-			 * @param int        $max_value Maximum quantity value.
-			 * @param WC_Product $product   Product object.
-			 */
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		);
-	}
-
-	/**
 	 * Make the quantity input interactive by wrapping it with the necessary data attribute and adding an input event listener.
 	 *
 	 * @param string $quantity_html The quantity HTML.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/58997 but for WooCommerce 10.0 so we can create a CFE (https://github.com/woocommerce/woocommerce/issues/59217).

Kudos to @helgatheviking for working on it. :raised_hands: 

### How to test the changes in this Pull Request:

#### Preparation

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.

#### Reproducing the issue

1. Go to the frontend of a grouped product.
2. Verify grouped product children default to quantity `0`.
3. Increase the quantity of one of the products while leaving another to `0` and click on _Add to cart_. Verify the product with the correct quantity was added to cart.

![image](https://github.com/user-attachments/assets/7a4d4259-5f9c-41d5-ba73-860a6dc7e60d)

Note: if you leave all products to `0`, it's still possible to click on _Add to cart_ and no error or message is displayed mentioning all products were at 0, we will work on that in a follow-up.