### PR TITLE
E2E: verify block style loading on classic themes

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/style.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/style.classic_theme.spec.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Page } from '@playwright/test';
 import {
 	expect,
 	test as base,
@@ -8,6 +9,24 @@ import {
 } from '@woocommerce/e2e-utils';
 
 const test = base.extend( {} );
+
+async function getStylesheets( page: Page ) {
+	const styleLocators = page.locator(
+		'link[rel="stylesheet"][href*="assets/client/blocks"]:not([href*="wc-blocks.css"])'
+	);
+	return await styleLocators.evaluateAll( ( links ) =>
+		links.map( ( link ) => ( link as HTMLLinkElement ).href )
+	);
+}
+
+async function getInlineStyles( page: Page ) {
+	const styleLocators = page.locator(
+		'style[id^="woocommerce-"][id$="-style-inline-css"]'
+	);
+	return await styleLocators.evaluateAll( ( styles ) =>
+		styles.map( ( style ) => style.id )
+	);
+}
 
 test.describe( 'Block Style Loading in Classic Themes', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
@@ -20,13 +39,11 @@ test.describe( 'Block Style Loading in Classic Themes', () => {
 		admin,
 		editor,
 	} ) => {
-		// Create a page without WooCommerce blocks
 		await admin.createNewPost( { postType: 'page' } );
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Test Page Without Blocks' );
 
-		// Add regular content (no WooCommerce blocks)
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: {
@@ -34,34 +51,12 @@ test.describe( 'Block Style Loading in Classic Themes', () => {
 			},
 		} );
 
-		// Publish and visit the page on frontend
 		await editor.publishAndVisitPost();
 
-		// Check for file-based stylesheets
-		const specificBlockStylesheets = await page.$$eval(
-			'link[rel="stylesheet"]',
-			( links ) =>
-				links
-					.map( ( link ) => ( link as HTMLLinkElement ).href )
-					.filter(
-						( href ) =>
-							href.includes( 'assets/client/blocks' ) &&
-							! href.includes( 'wc-blocks.css' )
-					)
-		);
+		const blockStylesheets = await getStylesheets( page );
+		const inlineBlockStyles = await getInlineStyles( page );
 
-		// Check for inline styles with WooCommerce block IDs
-		const inlineBlockStyles = await page.$$eval( 'style', ( styles ) =>
-			styles
-				.map( ( style ) => style.id )
-				.filter(
-					( id ) =>
-						id.startsWith( 'woocommerce-' ) &&
-						id.endsWith( '-style-inline-css' )
-				)
-		);
-
-		expect( specificBlockStylesheets ).toHaveLength( 0 );
+		expect( blockStylesheets ).toHaveLength( 0 );
 		expect( inlineBlockStyles ).toHaveLength( 0 );
 	} );
 
@@ -70,43 +65,19 @@ test.describe( 'Block Style Loading in Classic Themes', () => {
 		admin,
 		editor,
 	} ) => {
-		// Create a page with a WooCommerce block
 		await admin.createNewPost( { postType: 'page' } );
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Test Page With WooCommerce Block' );
 
-		// Add a WooCommerce product button block
 		await editor.insertBlock( {
 			name: 'woocommerce/product-filters',
 		} );
 
-		// Publish and visit the page on frontend
 		await editor.publishAndVisitPost();
 
-		// Check for file-based stylesheets
-		const blockStylesheets = await page.$$eval(
-			'link[rel="stylesheet"]',
-			( links ) =>
-				links
-					.map( ( link ) => ( link as HTMLLinkElement ).href )
-					.filter(
-						( href ) =>
-							href.includes( 'assets/client/blocks' ) &&
-							! href.includes( 'wc-blocks.css' )
-					)
-		);
-
-		// Check for inline styles with WooCommerce block IDs
-		const inlineBlockStyles = await page.$$eval( 'style', ( styles ) =>
-			styles
-				.map( ( style ) => style.id )
-				.filter(
-					( id ) =>
-						id.startsWith( 'woocommerce-' ) &&
-						id.endsWith( '-style-inline-css' )
-				)
-		);
+		const blockStylesheets = await getStylesheets( page );
+		const inlineBlockStyles = await getInlineStyles( page );
 
 		// Ensure styles are loaded (either as files or inline)
 		const hasFileStyles = blockStylesheets.length > 0;
@@ -115,10 +86,10 @@ test.describe( 'Block Style Loading in Classic Themes', () => {
 		expect( hasFileStyles || hasInlineStyles ).toBeTruthy();
 
 		const hasProductFilterStyle = blockStylesheets.some( ( href ) =>
-			href.includes( 'woocommerce' )
+			href.includes( 'product-filters' )
 		);
 		const hasProductFilterInlineStyle = inlineBlockStyles.some( ( id ) =>
-			id.includes( 'woocommerce' )
+			id.includes( 'product-filters' )
 		);
 		expect(
 			hasProductFilterStyle || hasProductFilterInlineStyle

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/style.classic_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/style.classic_theme.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import {
+	expect,
+	test as base,
+	CLASSIC_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
+
+const test = base.extend( {} );
+
+test.describe( 'Block Style Loading in Classic Themes', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		// Activate classic theme for all tests
+		await requestUtils.activateTheme( CLASSIC_THEME_SLUG );
+	} );
+
+	test( 'should not load unnecessary block styles on pages without WooCommerce blocks', async ( {
+		page,
+		admin,
+		editor,
+	} ) => {
+		// Create a page without WooCommerce blocks
+		await admin.createNewPost( { postType: 'page' } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Test Page Without Blocks' );
+
+		// Add regular content (no WooCommerce blocks)
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'This is a regular page with no WooCommerce blocks.',
+			},
+		} );
+
+		// Publish and visit the page on frontend
+		await editor.publishAndVisitPost();
+
+		// Check for file-based stylesheets
+		const specificBlockStylesheets = await page.$$eval(
+			'link[rel="stylesheet"]',
+			( links ) =>
+				links
+					.map( ( link ) => ( link as HTMLLinkElement ).href )
+					.filter(
+						( href ) =>
+							href.includes( 'assets/client/blocks' ) &&
+							! href.includes( 'wc-blocks.css' )
+					)
+		);
+
+		// Check for inline styles with WooCommerce block IDs
+		const inlineBlockStyles = await page.$$eval( 'style', ( styles ) =>
+			styles
+				.map( ( style ) => style.id )
+				.filter(
+					( id ) =>
+						id.startsWith( 'woocommerce-' ) &&
+						id.endsWith( '-style-inline-css' )
+				)
+		);
+
+		expect( specificBlockStylesheets ).toHaveLength( 0 );
+		expect( inlineBlockStyles ).toHaveLength( 0 );
+	} );
+
+	test( 'should load base WooCommerce styles when blocks are present', async ( {
+		page,
+		admin,
+		editor,
+	} ) => {
+		// Create a page with a WooCommerce block
+		await admin.createNewPost( { postType: 'page' } );
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Test Page With WooCommerce Block' );
+
+		// Add a WooCommerce product button block
+		await editor.insertBlock( {
+			name: 'woocommerce/product-filters',
+		} );
+
+		// Publish and visit the page on frontend
+		await editor.publishAndVisitPost();
+
+		// Check for file-based stylesheets
+		const blockStylesheets = await page.$$eval(
+			'link[rel="stylesheet"]',
+			( links ) =>
+				links
+					.map( ( link ) => ( link as HTMLLinkElement ).href )
+					.filter(
+						( href ) =>
+							href.includes( 'assets/client/blocks' ) &&
+							! href.includes( 'wc-blocks.css' )
+					)
+		);
+
+		// Check for inline styles with WooCommerce block IDs
+		const inlineBlockStyles = await page.$$eval( 'style', ( styles ) =>
+			styles
+				.map( ( style ) => style.id )
+				.filter(
+					( id ) =>
+						id.startsWith( 'woocommerce-' ) &&
+						id.endsWith( '-style-inline-css' )
+				)
+		);
+
+		// Ensure styles are loaded (either as files or inline)
+		const hasFileStyles = blockStylesheets.length > 0;
+		const hasInlineStyles = inlineBlockStyles.length > 0;
+
+		expect( hasFileStyles || hasInlineStyles ).toBeTruthy();
+
+		const hasProductFilterStyle = blockStylesheets.some( ( href ) =>
+			href.includes( 'woocommerce' )
+		);
+		const hasProductFilterInlineStyle = inlineBlockStyles.some( ( id ) =>
+			id.includes( 'woocommerce' )
+		);
+		expect(
+			hasProductFilterStyle || hasProductFilterInlineStyle
+		).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In https://github.com/woocommerce/woocommerce/pull/58971, we fix the block style loading behavior for classic themes, this PR adds test to cover that case.

I add E2E instead of PHP unit test case because we need to be as close to reality as possible to catch the regression. I only add 2 case with minimal steps.

Closes wooplug-4788 (https://github.com/woocommerce/woocommerce/issues/59176)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

See CI passing.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
E2E: Verify the block style loading behavior for classic theme added in https://github.com/woocommerce/woocommerce/pull/58971.
</details>
