### PR TITLE
Restore `DiscountMeta` slot in Cart when coupons missing and improve CSS specificity

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-discount-meta
+++ b/plugins/woocommerce/changelog/fix-cart-discount-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure discount meta slot fill shows when no coupons are applied to the cart.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/sidebar-layout/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/sidebar-layout/style.scss
@@ -53,6 +53,9 @@
 	.wc-block-components-sidebar {
 		.wc-block-components-totals-item,
 		.wc-block-components-panel,
+		// Increase specificity to override the rule from the totals-wrapper component
+		// https://github.com/woocommerce/woocommerce/blob/74e823c0324289cff7361629ff8cc677c45dce0f/plugins/woocommerce/client/blocks/packages/components/totals-wrapper/style.scss#L24
+		.slot-wrapper .wc-block-components-panel,
 		.wc-block-components-totals-coupon {
 			padding-left: $gap;
 			padding-right: $gap;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/sidebar-layout/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/sidebar-layout/style.scss
@@ -53,7 +53,7 @@
 	.wc-block-components-sidebar {
 		.wc-block-components-totals-item,
 		.wc-block-components-panel,
-		// Increase specificity to override the rule from the totals-wrapper component
+		// Increase specificity to overwrite the rule from the TotalsWrapper component
 		// https://github.com/woocommerce/woocommerce/blob/74e823c0324289cff7361629ff8cc677c45dce0f/plugins/woocommerce/client/blocks/packages/components/totals-wrapper/style.scss#L24
 		.slot-wrapper .wc-block-components-panel,
 		.wc-block-components-totals-coupon {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/block.tsx
@@ -27,9 +27,9 @@ const Block = ( { className }: { className: string } ) => {
 	const { cartTotals, cartCoupons } = useStoreCart();
 	const { removeCoupon, isRemovingCoupon } = useStoreCartCoupons( 'wc/cart' );
 
-	// Hide if there are no coupons to show.
+	// Hide all but the slot/fill if there are no coupons to show.
 	if ( ! cartCoupons.length ) {
-		return null;
+		return <DiscountSlotFill />;
 	}
 
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
@@ -3,8 +3,6 @@
  */
 import { render, screen } from '@testing-library/react';
 import { SlotFillProvider } from '@wordpress/components';
-import { dispatch } from '@wordpress/data';
-import { CART_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -18,7 +16,10 @@ jest.mock( '@woocommerce/base-context/hooks', () => ( {
 } ) );
 
 // Import mocked hooks
-import { useStoreCart, useStoreCartCoupons } from '@woocommerce/base-context/hooks';
+import {
+	useStoreCart,
+	useStoreCartCoupons,
+} from '@woocommerce/base-context/hooks';
 
 // Mock the ExperimentalDiscountsMeta to track when slot is rendered
 const mockSlotRender = jest.fn();
@@ -70,11 +71,7 @@ describe( 'Cart Order Summary Discount Block', () => {
 	} );
 
 	const renderWithProviders = ( ui: React.ReactElement ) => {
-		return render(
-			<SlotFillProvider>
-				{ ui }
-			</SlotFillProvider>
-		);
+		return render( <SlotFillProvider>{ ui }</SlotFillProvider> );
 	};
 
 	it( 'renders only the DiscountSlotFill when there are no coupons', () => {
@@ -100,21 +97,21 @@ describe( 'Cart Order Summary Discount Block', () => {
 		);
 
 		// Verify receiveCart was not passed to the slot
-		const slotProps = mockSlotRender.mock.calls[0][0];
+		const slotProps = mockSlotRender.mock.calls[ 0 ][ 0 ];
 		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
 	} );
 
 	it( 'renders both TotalsDiscount and DiscountSlotFill when there are coupons', () => {
 		const mockCoupons = [
-			{ 
+			{
 				code: 'TEST10',
 				label: 'TEST10', // The label is what gets displayed
-				discount_type: 'percent', 
+				discount_type: 'percent',
 				amount: '10',
 				totals: {
 					total_discount: '1000',
 					total_discount_tax: '0',
-				}
+				},
 			},
 		];
 
@@ -131,7 +128,7 @@ describe( 'Cart Order Summary Discount Block', () => {
 
 		// With real components, look for the discount text/coupon code
 		expect( screen.getByText( 'TEST10' ) ).toBeInTheDocument();
-		
+
 		// Verify the slot is still rendered
 		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
 
@@ -148,7 +145,9 @@ describe( 'Cart Order Summary Discount Block', () => {
 
 	it( 'always renders the ExperimentalDiscountsMeta.Slot regardless of coupon state', () => {
 		// Test with no coupons
-		const { rerender } = renderWithProviders( <Block className="test-class" /> );
+		const { rerender } = renderWithProviders(
+			<Block className="test-class" />
+		);
 		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
 		expect( mockSlotRender ).toHaveBeenCalledTimes( 1 );
 
@@ -158,14 +157,16 @@ describe( 'Cart Order Summary Discount Block', () => {
 		// Test with coupons
 		( useStoreCart as jest.Mock ).mockReturnValue( {
 			...mockCartData,
-			cartCoupons: [ { 
-				code: 'TEST',
-				label: 'TEST', // Add label for display
-				totals: {
-					total_discount: '500',
-					total_discount_tax: '0',
-				}
-			} ],
+			cartCoupons: [
+				{
+					code: 'TEST',
+					label: 'TEST', // Add label for display
+					totals: {
+						total_discount: '500',
+						total_discount_tax: '0',
+					},
+				},
+			],
 		} );
 
 		rerender(
@@ -173,13 +174,13 @@ describe( 'Cart Order Summary Discount Block', () => {
 				<Block className="test-class" />
 			</SlotFillProvider>
 		);
-		
+
 		// Should still have the slot
 		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
-		
+
 		// Verify it was called with correct props both times
 		expect( mockSlotRender ).toHaveBeenCalledTimes( 1 );
-		
+
 		// Check the props structure
 		expect( mockSlotRender ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -190,23 +191,25 @@ describe( 'Cart Order Summary Discount Block', () => {
 				} ),
 			} )
 		);
-		
+
 		// Verify receiveCart is not passed
-		const slotProps = mockSlotRender.mock.calls[0][0];
+		const slotProps = mockSlotRender.mock.calls[ 0 ][ 0 ];
 		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
 	} );
 
 	it( 'handles missing className prop gracefully', () => {
 		( useStoreCart as jest.Mock ).mockReturnValue( {
 			...mockCartData,
-			cartCoupons: [ { 
-				code: 'TEST',
-				label: 'TEST', // Add label for display
-				totals: {
-					total_discount: '500',
-					total_discount_tax: '0',
-				}
-			} ],
+			cartCoupons: [
+				{
+					code: 'TEST',
+					label: 'TEST', // Add label for display
+					totals: {
+						total_discount: '500',
+						total_discount_tax: '0',
+					},
+				},
+			],
 		} );
 
 		// @ts-expect-error Testing without required prop

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
@@ -3,6 +3,10 @@
  */
 import { render, screen } from '@testing-library/react';
 import { SlotFillProvider } from '@wordpress/components';
+import {
+	useStoreCart,
+	useStoreCartCoupons,
+} from '@woocommerce/base-context/hooks';
 
 /**
  * Internal dependencies
@@ -14,12 +18,6 @@ jest.mock( '@woocommerce/base-context/hooks', () => ( {
 	useStoreCart: jest.fn(),
 	useStoreCartCoupons: jest.fn(),
 } ) );
-
-// Import mocked hooks
-import {
-	useStoreCart,
-	useStoreCartCoupons,
-} from '@woocommerce/base-context/hooks';
 
 // Mock the ExperimentalDiscountsMeta to track when slot is rendered
 const mockSlotRender = jest.fn();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
@@ -1,0 +1,219 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { SlotFillProvider } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+
+// We only need to mock the hooks since we're using real components
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	useStoreCart: jest.fn(),
+	useStoreCartCoupons: jest.fn(),
+} ) );
+
+// Import mocked hooks
+import { useStoreCart, useStoreCartCoupons } from '@woocommerce/base-context/hooks';
+
+// Mock the ExperimentalDiscountsMeta to track when slot is rendered
+const mockSlotRender = jest.fn();
+jest.mock( '@woocommerce/blocks-checkout', () => {
+	const actual = jest.requireActual( '@woocommerce/blocks-checkout' );
+	return {
+		...actual,
+		ExperimentalDiscountsMeta: {
+			...actual.ExperimentalDiscountsMeta,
+			Slot: ( props: any ) => {
+				mockSlotRender( props );
+				// Return a testable element that represents the slot
+				return <div data-testid="discount-slot" />;
+			},
+		},
+	};
+} );
+
+const mockCartTotals = {
+	currency_code: 'USD',
+	currency_symbol: '$',
+	currency_minor_unit: 2,
+	currency_decimal_separator: '.',
+	currency_thousand_separator: ',',
+	currency_prefix: '$',
+	currency_suffix: '',
+	total_discount: '0',
+	total_discount_tax: '0',
+};
+
+const mockCartData = {
+	cartTotals: mockCartTotals,
+	cartCoupons: [],
+	extensions: { some: 'data' },
+	receiveCart: jest.fn(),
+	otherCartData: { test: 'value' },
+};
+
+const mockCouponHooks = {
+	removeCoupon: jest.fn(),
+	isRemovingCoupon: false,
+};
+
+describe( 'Cart Order Summary Discount Block', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useStoreCart as jest.Mock ).mockReturnValue( mockCartData );
+		( useStoreCartCoupons as jest.Mock ).mockReturnValue( mockCouponHooks );
+	} );
+
+	const renderWithProviders = ( ui: React.ReactElement ) => {
+		return render(
+			<SlotFillProvider>
+				{ ui }
+			</SlotFillProvider>
+		);
+	};
+
+	it( 'renders only the DiscountSlotFill when there are no coupons', () => {
+		renderWithProviders( <Block className="test-class" /> );
+
+		// Verify the slot is rendered
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+
+		// Since we're using real TotalsWrapper, it won't render when there are no children
+		// TotalsDiscount should not be present when there are no coupons
+		expect( screen.queryByText( /discount/i ) ).not.toBeInTheDocument();
+
+		// Verify the slot was called with correct props
+		expect( mockSlotRender ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: 'woocommerce/cart',
+				extensions: { some: 'data' },
+				cart: expect.objectContaining( {
+					cartTotals: mockCartTotals,
+					otherCartData: { test: 'value' },
+				} ),
+			} )
+		);
+
+		// Verify receiveCart was not passed to the slot
+		const slotProps = mockSlotRender.mock.calls[0][0];
+		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
+	} );
+
+	it( 'renders both TotalsDiscount and DiscountSlotFill when there are coupons', () => {
+		const mockCoupons = [
+			{ 
+				code: 'TEST10',
+				label: 'TEST10', // The label is what gets displayed
+				discount_type: 'percent', 
+				amount: '10',
+				totals: {
+					total_discount: '1000',
+					total_discount_tax: '0',
+				}
+			},
+		];
+
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			...mockCartData,
+			cartCoupons: mockCoupons,
+			cartTotals: {
+				...mockCartTotals,
+				total_discount: '1000',
+			},
+		} );
+
+		renderWithProviders( <Block className="test-class" /> );
+
+		// With real components, look for the discount text/coupon code
+		expect( screen.getByText( 'TEST10' ) ).toBeInTheDocument();
+		
+		// Verify the slot is still rendered
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+
+		// The wrapper should have the provided class
+		const wrapper = screen.getByText( 'TEST10' ).closest( '.test-class' );
+		expect( wrapper ).toBeInTheDocument();
+	} );
+
+	it( 'calls useStoreCartCoupons with correct context', () => {
+		renderWithProviders( <Block className="test-class" /> );
+
+		expect( useStoreCartCoupons ).toHaveBeenCalledWith( 'wc/cart' );
+	} );
+
+	it( 'always renders the ExperimentalDiscountsMeta.Slot regardless of coupon state', () => {
+		// Test with no coupons
+		const { rerender } = renderWithProviders( <Block className="test-class" /> );
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+		expect( mockSlotRender ).toHaveBeenCalledTimes( 1 );
+
+		// Clean up
+		jest.clearAllMocks();
+
+		// Test with coupons
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			...mockCartData,
+			cartCoupons: [ { 
+				code: 'TEST',
+				label: 'TEST', // Add label for display
+				totals: {
+					total_discount: '500',
+					total_discount_tax: '0',
+				}
+			} ],
+		} );
+
+		rerender(
+			<SlotFillProvider>
+				<Block className="test-class" />
+			</SlotFillProvider>
+		);
+		
+		// Should still have the slot
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+		
+		// Verify it was called with correct props both times
+		expect( mockSlotRender ).toHaveBeenCalledTimes( 1 );
+		
+		// Check the props structure
+		expect( mockSlotRender ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				context: 'woocommerce/cart',
+				extensions: expect.any( Object ),
+				cart: expect.objectContaining( {
+					cartTotals: expect.any( Object ),
+				} ),
+			} )
+		);
+		
+		// Verify receiveCart is not passed
+		const slotProps = mockSlotRender.mock.calls[0][0];
+		expect( slotProps.cart ).not.toHaveProperty( 'receiveCart' );
+	} );
+
+	it( 'handles missing className prop gracefully', () => {
+		( useStoreCart as jest.Mock ).mockReturnValue( {
+			...mockCartData,
+			cartCoupons: [ { 
+				code: 'TEST',
+				label: 'TEST', // Add label for display
+				totals: {
+					total_discount: '500',
+					total_discount_tax: '0',
+				}
+			} ],
+		} );
+
+		// @ts-expect-error Testing without required prop
+		renderWithProviders( <Block /> );
+
+		// Should still render without errors
+		expect( screen.getByText( 'TEST' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'discount-slot' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/test/block.tsx
@@ -27,7 +27,7 @@ jest.mock( '@woocommerce/blocks-checkout', () => {
 		...actual,
 		ExperimentalDiscountsMeta: {
 			...actual.ExperimentalDiscountsMeta,
-			Slot: ( props: any ) => {
+			Slot: ( props: unknown ) => {
 				mockSlotRender( props );
 				// Return a testable element that represents the slot
 				return <div data-testid="discount-slot" />;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Increase CSS specificity to ensure Fills rendered in the Checkout order summary sidebar continue to receive the same styles they did in 9.9
- Restore the `<ExperimentalDiscountsMeta>` slot fill to the coupons area on the Cart block


Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="402" alt="image" src="https://github.com/user-attachments/assets/ce477a45-9b79-451f-bd3b-7ec5188519ed" /> | <img width="376" alt="image" src="https://github.com/user-attachments/assets/dfd6a4e6-135c-414b-92a1-e643f4d3208a" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Points and Rewards
2. Enable partial points redemption, and a minimum redemption amount set (Go to WC -> Points and Rewards -> Settings)
3. As a logged in user with points (Go to WC -> Points and Rewards and add points to a user) go to the Checkout block
4. Ensure the panel displays with correct padding
5. Repeat on the Cart block.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
