### PR TITLE
Add to Cart + Options block: remove hardcoded right margin from Product Quantity block

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-59284
+++ b/plugins/woocommerce/changelog/fix-issue-59284
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Removed hardcoded right margin to fix layout inconsistency from Quantity Selector.
+Removed hard-coded right margin from Quantity Selector to resolve layout inconsistency.

--- a/plugins/woocommerce/changelog/fix-issue-59284
+++ b/plugins/woocommerce/changelog/fix-issue-59284
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed hardcoded right margin to fix layout inconsistency from Quantity Selector.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -26,7 +26,6 @@
 
 		display: inline-flex;
 		width: unset;
-		margin-right: 0.5em;
 		margin-bottom: 0;
 
 		.input-text {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses a layout issue caused by a hardcoded `margin-right` style applied to the Quantity Selector. The issue was resolved by removing this margin from the block-level styles.

This fix ensures consistent spacing without causing any regressions in other blocks, including:
- Mini-Cart
- Cart
- Checkout
- Add to Cart form (stepper styles remain unaffected)

Closes #59284 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="825" alt="image" src="https://github.com/user-attachments/assets/9b73a768-fc9d-4c3f-ba54-fe9f82d63b1e" /> | <img width="832" alt="image" src="https://github.com/user-attachments/assets/ebe62245-425a-4bd0-99df-3de40f3002b3" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to _Appearance > Editor > Templates > Single product_.
2. Update the `Add to Cart with Options` block to the blockified version.
3. Edit the `Variable Product` template part, so the quantity selector is right-aligned:
4. Open the page in the frontend. Notice the quantity selector **is** fully aligned to the right.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
