### PR TITLE
Fix performance issue in withSidebarNotices

### DIFF
--- a/plugins/woocommerce/changelog/fix-sidebar-notices-performance-issue
+++ b/plugins/woocommerce/changelog/fix-sidebar-notices-performance-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Improves performance when editing site templates.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a performance issue in the `withSidebarNotices` higher-order component.

The `withSidebarNotices` HoC uses `useSelect` to perform some expensive operations on every single block in the block editor store. This can result in significant lag when hovering over or otherwise interacting with blocks in the editor, particularly in complex templates.

This PR keeps the original HoC approach, but moves the notice rendering logic to a separate component. This allows us to remove the store-using logic from the original component, while keeping the early checks it already did. The end result is that we use the store much less often, greatly improving performance.

The PR also adds a dependency array to the `useSelect` call, as [best practices suggest](https://developer.wordpress.org/news/2024/03/how-to-work-effectively-with-the-useselect-hook/#always-declare-useselect-dependencies:~:text=from%20multiple%20stores-,Always%20declare%20useSelect%20dependencies,-The).

### How to test the changes in this Pull Request:

First, confirm the presence of a performance issue in trunk:

1. Check out trunk and build
2. In wp-admin, open a template such as "Single Product" for editing
3. In the editor, quickly move your mouse over multiple blocks. Keep moving it between blocks. Notice how the UI lags in showing the highlighting frame around the block. You can also verify CPU usage is high.

Then, validate this fix:

1. Check out this branch and build
2. In wp-admin, open the same template for editing
3. In the editor, quickly move your mouse over multiple blocks. Keep moving it between blocks. Notice how the UI is now fast in showing the highlighting frame around the block. You can also verify CPU usage is lower than before.

Also, validate that the functionality in question still works:

1. Select a non-WooCommerce block and ensure that sidebar notices are NOT shown.
2. Select a WooCommerce block which isn't cart or checkout and ensure that sidebar notices are NOT shown.
3. Select the cart or checkout block and ensure that sidebar notices ARE shown. Depending on the template you're editing, you may need to add it first.

Here is what the sidebar notices look like for me:
<img width="276" alt="image" src="https://github.com/user-attachments/assets/13f932aa-8fc3-4e93-a654-8e921f3accfa" />

### Testing that has already taken place:

Ad-hoc testing during development of this fix.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [X] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [X] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Improves performance when editing site templates.

</details>
