### PR TITLE
Fix extra push on Checkout if there is no session

### DIFF
--- a/plugins/woocommerce/changelog/59302-fix-push-state-pushing-on-empty-cart
+++ b/plugins/woocommerce/changelog/59302-fix-push-state-pushing-on-empty-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a bug in which visiting an empty, non-default checkout block, would result in trying to create an order.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
@@ -7,6 +7,7 @@ import { removeCart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { CheckoutResponse } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -20,15 +21,33 @@ import {
 	GENERIC_CART_ITEM_ERROR,
 } from './constants';
 
+// Type definitions
+interface ErrorData {
+	code: string;
+	message: string;
+}
+
+interface CheckoutData {
+	code?: string;
+	message?: string;
+}
+
+interface ErrorComponentProps {
+	errorData: ErrorData;
+}
+
 const cartItemErrorCodes = [
 	PRODUCT_OUT_OF_STOCK,
 	PRODUCT_NOT_PURCHASABLE,
 	PRODUCT_NOT_ENOUGH_STOCK,
 	PRODUCT_SOLD_INDIVIDUALLY,
 	GENERIC_CART_ITEM_ERROR,
-];
+] as const;
 
-const preloadedCheckoutData = getSetting( 'checkoutData', {} );
+const preloadedCheckoutData = getSetting(
+	'checkoutData',
+	{}
+) as CheckoutResponse;
 
 /**
  * Get the error message to display.
@@ -36,10 +55,14 @@ const preloadedCheckoutData = getSetting( 'checkoutData', {} );
  * @param {Object} props           Incoming props for the component.
  * @param {Object} props.errorData Object containing code and message.
  */
-const ErrorTitle = ( { errorData } ) => {
+const ErrorTitle = ( { errorData }: ErrorComponentProps ) => {
 	let heading = __( 'Checkout error', 'woocommerce' );
 
-	if ( cartItemErrorCodes.includes( errorData.code ) ) {
+	if (
+		cartItemErrorCodes.includes(
+			errorData.code as ( typeof cartItemErrorCodes )[ number ]
+		)
+	) {
 		heading = __( 'There is a problem with your cart', 'woocommerce' );
 	}
 
@@ -54,10 +77,14 @@ const ErrorTitle = ( { errorData } ) => {
  * @param {Object} props           Incoming props for the component.
  * @param {Object} props.errorData Object containing code and message.
  */
-const ErrorMessage = ( { errorData } ) => {
+const ErrorMessage = ( { errorData }: ErrorComponentProps ) => {
 	let message = errorData.message;
 
-	if ( cartItemErrorCodes.includes( errorData.code ) ) {
+	if (
+		cartItemErrorCodes.includes(
+			errorData.code as ( typeof cartItemErrorCodes )[ number ]
+		)
+	) {
 		message =
 			message +
 			' ' +
@@ -73,20 +100,36 @@ const ErrorMessage = ( { errorData } ) => {
  * @param {Object} props           Incoming props for the component.
  * @param {Object} props.errorData Object containing code and message.
  */
-const ErrorButton = ( { errorData } ) => {
+const ErrorButton = ( { errorData }: ErrorComponentProps ) => {
 	let buttonText = __( 'Retry', 'woocommerce' );
-	let buttonUrl = 'javascript:window.location.reload(true)';
 
-	if ( cartItemErrorCodes.includes( errorData.code ) ) {
+	if (
+		cartItemErrorCodes.includes(
+			errorData.code as ( typeof cartItemErrorCodes )[ number ]
+		)
+	) {
 		buttonText = __( 'Edit your cart', 'woocommerce' );
-		buttonUrl = CART_URL;
 	}
+
+	const isLink =
+		cartItemErrorCodes.includes(
+			errorData.code as ( typeof cartItemErrorCodes )[ number ]
+		) && CART_URL;
 
 	return (
 		<span className="wp-block-button">
-			<a href={ buttonUrl } className="wp-block-button__link">
-				{ buttonText }
-			</a>
+			{ isLink ? (
+				<a href={ CART_URL } className="wp-block-button__link">
+					{ buttonText }
+				</a>
+			) : (
+				<button
+					className="wp-block-button__link"
+					onClick={ () => window.location.reload() }
+				>
+					{ buttonText }
+				</button>
+			) }
 		</span>
 	);
 };
@@ -99,13 +142,13 @@ const ErrorButton = ( { errorData } ) => {
  * checkout block.
  */
 const CheckoutOrderError = () => {
-	const checkoutData = {
+	const checkoutData: CheckoutData = {
 		code: '',
 		message: '',
 		...( preloadedCheckoutData || {} ),
 	};
 
-	const errorData = {
+	const errorData: ErrorData = {
 		code: checkoutData.code || 'unknown',
 		message:
 			decodeEntities( checkoutData.message ) ||

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
@@ -36,12 +36,11 @@ const cartItemErrorCodes = [
 	PRODUCT_NOT_ENOUGH_STOCK,
 	PRODUCT_SOLD_INDIVIDUALLY,
 	GENERIC_CART_ITEM_ERROR,
-] as const;
+];
 
-const preloadedCheckoutData = getSetting(
-	'checkoutData',
-	{}
-) as CheckoutResponse;
+const preloadedCheckoutData = getSetting<
+	CheckoutResponse | Record< string, unknown >
+>( 'checkoutData', {} );
 
 /**
  * Get the error message to display.
@@ -52,11 +51,7 @@ const preloadedCheckoutData = getSetting(
 const ErrorTitle = ( { errorData }: ErrorComponentProps ) => {
 	let heading = __( 'Checkout error', 'woocommerce' );
 
-	if (
-		cartItemErrorCodes.includes(
-			errorData.code as ( typeof cartItemErrorCodes )[ number ]
-		)
-	) {
+	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		heading = __( 'There is a problem with your cart', 'woocommerce' );
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/checkout-order-error/index.tsx
@@ -26,12 +26,6 @@ interface ErrorData {
 	code: string;
 	message: string;
 }
-
-interface CheckoutData {
-	code?: string;
-	message?: string;
-}
-
 interface ErrorComponentProps {
 	errorData: ErrorData;
 }
@@ -142,7 +136,7 @@ const ErrorButton = ( { errorData }: ErrorComponentProps ) => {
  * checkout block.
  */
 const CheckoutOrderError = () => {
-	const checkoutData: CheckoutData = {
+	const checkoutData: CheckoutResponse = {
 		code: '',
 		message: '',
 		...( preloadedCheckoutData || {} ),

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -31,6 +31,7 @@ const localState = {
 		orderNotes: '',
 		additionalFields: {} as AdditionalValues,
 		activePaymentMethod: '',
+		hasSession: false,
 	},
 };
 
@@ -46,6 +47,7 @@ const initialize = () => {
 		orderNotes: store.getOrderNotes(),
 		additionalFields: store.getAdditionalFields(),
 		activePaymentMethod: paymentStore.getActivePaymentMethod(),
+		hasSession: document.cookie.includes( 'woocommerce_cart_hash' ),
 	};
 	localState.isInitialized = true;
 };
@@ -54,6 +56,11 @@ const initialize = () => {
  * Function to dispatch an update to the server.
  */
 const updateCheckoutData = (): void => {
+	// If we don't have any session, exit early.
+	if ( ! localState.checkoutData.hasSession ) {
+		return;
+	}
+
 	if ( localState.doingPush ) {
 		return;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -3,7 +3,7 @@
  */
 import { debounce } from '@woocommerce/base-utils';
 import { select, dispatch } from '@wordpress/data';
-import type { AdditionalValues } from '@woocommerce/settings';
+import type { OrderFormValues } from '@woocommerce/settings';
 import { ApiErrorResponse } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
 
@@ -29,10 +29,10 @@ const localState = {
 	// Local cache of the last pushed checkoutData used for comparisons.
 	checkoutData: {
 		orderNotes: '',
-		additionalFields: {} as AdditionalValues,
+		additionalFields: {} as OrderFormValues,
 		activePaymentMethod: '',
-		hasSession: false,
 	},
+	hasSession: false,
 };
 
 const isCheckoutBlock = getSetting< boolean >( 'isCheckoutBlock', false );
@@ -47,8 +47,8 @@ const initialize = () => {
 		orderNotes: store.getOrderNotes(),
 		additionalFields: store.getAdditionalFields(),
 		activePaymentMethod: paymentStore.getActivePaymentMethod(),
-		hasSession: document.cookie.includes( 'woocommerce_cart_hash' ),
 	};
+	localState.hasSession = document.cookie.includes( 'woocommerce_cart_hash' );
 	localState.isInitialized = true;
 };
 
@@ -57,7 +57,7 @@ const initialize = () => {
  */
 const updateCheckoutData = (): void => {
 	// If we don't have any session, exit early.
-	if ( ! localState.checkoutData.hasSession ) {
+	if ( ! localState.hasSession ) {
 		return;
 	}
 
@@ -98,29 +98,36 @@ const updateCheckoutData = (): void => {
 	const changedFields = Object.keys( newCheckoutData.additionalFields )
 		.filter( ( key ) => {
 			// Fields with errors should be ignored
-			if ( hasValidationError( key ) ) {
+			if ( hasValidationError( key as keyof OrderFormValues ) ) {
 				return false;
 			}
 
 			// Fields that are not present in the original checkout data and have an empty value should be ignored (happens when a field is hidden on mount).
 			if (
 				! ( key in localState.checkoutData.additionalFields ) &&
-				newCheckoutData.additionalFields[ key ] === ''
+				newCheckoutData.additionalFields[
+					key as keyof OrderFormValues
+				] === ''
 			) {
 				return false;
 			}
 
 			// Fields that have not changed should be ignored
 			if (
-				localState.checkoutData.additionalFields[ key ] ===
-				newCheckoutData.additionalFields[ key ]
+				localState.checkoutData.additionalFields[
+					key as keyof OrderFormValues
+				] ===
+				newCheckoutData.additionalFields[ key as keyof OrderFormValues ]
 			) {
 				return false;
 			}
 			return true;
 		} )
-		.reduce( ( acc: AdditionalValues, key ) => {
-			acc[ key ] = newCheckoutData.additionalFields[ key ];
+		.reduce( ( acc: OrderFormValues, key ) => {
+			acc[ key as keyof OrderFormValues ] =
+				newCheckoutData.additionalFields[
+					key as keyof OrderFormValues
+				];
 			return acc;
 		}, {} );
 
@@ -157,7 +164,7 @@ const updateCheckoutData = (): void => {
 	// Update local cache
 	localState.checkoutData = newCheckoutData;
 
-	dispatch( CHECKOUT_STORE_KEY )
+	( dispatch( CHECKOUT_STORE_KEY ) as any )
 		.updateDraftOrder( requestData )
 		.then( () => {
 			clearFieldErrorNotices( requestData );

--- a/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/checkout/push-changes.ts
@@ -164,7 +164,7 @@ const updateCheckoutData = (): void => {
 	// Update local cache
 	localState.checkoutData = newCheckoutData;
 
-	( dispatch( CHECKOUT_STORE_KEY ) as any )
+	dispatch( CHECKOUT_STORE_KEY )
 		.updateDraftOrder( requestData )
 		.then( () => {
 			clearFieldErrorNotices( requestData );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an extra push on Checkout if there's no cart session. push-changes that comes with Checkout has no knowledge if we have a session or not, we can fix this 2 ways:
- Load Cart data store and check if we have anything, this risks doing an extra request.
- Checkout if we have a `woocommerce_cart_hash` cookie, which only exists if we have a cart and session. I opted for this.
- I also fixed an error in the reload message that throw a console warning.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new page with Checkout block.
2. Navigate to the page with session, make sure it loads fine.
3. Change the payment method, wait a bit until  the request persist ( you can also check the network tab), reload the page, make sure it actually persisted.
4. Empty your cart and reload the page, make sure there's no request being to Store API's checkout endpoint.
5. You should not see an error on the page with not being able to create an order with no cart.
6. Open the page in incognito, ensure no request is made and no error is shown.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixes a bug in which visiting an empty, non-default checkout block, would result in trying to create an order.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
