### PR TITLE
Limit session expiry date to 30 days

### DIFF
--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -508,7 +508,7 @@ class WC_Session_Handler extends WC_Session {
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$expiring_seconds = intval( apply_filters( 'wc_session_expiring', $default_expiring_seconds ) ) ?: $default_expiring_seconds;
+		$expiring_seconds = intval( apply_filters( 'wc_session_expiring', $default_expiring_seconds ) ) ?: $default_expiring_seconds; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		if ( $expiring_seconds > $max_expiring_seconds ) {
 			$expiring_seconds       = $max_expiring_seconds;
@@ -520,7 +520,7 @@ class WC_Session_Handler extends WC_Session {
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$expiration_seconds = intval( apply_filters( 'wc_session_expiration', $default_expiration_seconds ) ) ?: $default_expiration_seconds;
+		$expiration_seconds = intval( apply_filters( 'wc_session_expiration', $default_expiration_seconds ) ) ?: $default_expiration_seconds; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		// We limit the expiration time to 30 days to avoid performance issues and the session table growing too large.
 		if ( $expiration_seconds > $max_expiration_seconds ) {
@@ -531,7 +531,7 @@ class WC_Session_Handler extends WC_Session {
 		if ( $session_limit_exceeded ) {
 			$transient_key = 'wc_session_handler_warning';
 			if ( false === get_transient( $transient_key ) ) {
-				wc_get_logger()->warning( 'Keeping sessions for longer than 30 days results in perfomance isues, the default is 2 days for guests and 7 days for logged in users, expiry has been capped to 30 days.', array( 'source' => 'wc_session_handler' ) );
+				wc_get_logger()->warning( sprintf( 'Keeping sessions for longer than %d days results in perfomance isues, expiry has been capped.', $max_expiration_seconds / DAY_IN_SECONDS ), array( 'source' => 'wc_session_handler' ) );
 				set_transient( $transient_key, true, MONTH_IN_SECONDS );
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -496,24 +496,48 @@ class WC_Session_Handler extends WC_Session {
 	 * For guests, sessions expire in 48 hours.
 	 */
 	public function set_session_expiration() {
-		$expiring_seconds   = DAY_IN_SECONDS;
-		$expiration_seconds = is_user_logged_in() ? WEEK_IN_SECONDS : 2 * DAY_IN_SECONDS;
-
 		/**
 		 * Filters the session expiration.
 		 *
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$this->_session_expiring = time() + intval( apply_filters( 'wc_session_expiring', $expiring_seconds ) );
+		$expiring_seconds = intval( apply_filters( 'wc_session_expiring', DAY_IN_SECONDS ) );
 
+		if ( $expiring_seconds > MONTH_IN_SECONDS - DAY_IN_SECONDS ) {
+			$expiring_seconds = MONTH_IN_SECONDS - DAY_IN_SECONDS;
+			$transient_key    = 'wc_session_handler_warning';
+			if ( false === get_transient( $transient_key ) ) {
+				wc_get_logger()->warning( 'Keeping sessions for longer than 30 days results in perfomance isues, the default is 2 days for guests and 7 days for logged in users, expiry has been capped to 30 days.', array( 'source' => 'wc_session_handler' ) );
+				set_transient( $transient_key, true, MONTH_IN_SECONDS );
+			}
+		}
 		/**
 		 * Filters the session expiration.
 		 *
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$this->_session_expiration = time() + intval( apply_filters( 'wc_session_expiration', $expiration_seconds ) );
+		$expiration_seconds = intval( apply_filters( 'wc_session_expiration', is_user_logged_in() ? WEEK_IN_SECONDS : 2 * DAY_IN_SECONDS ) );
+
+		// We limit the expiration time to 30 days to avoid performance issues and the session table growing too large.
+		if ( $expiration_seconds > MONTH_IN_SECONDS ) {
+			$expiration_seconds = MONTH_IN_SECONDS;
+			$transient_key      = 'wc_session_handler_warning';
+			if ( false === get_transient( $transient_key ) ) {
+				wc_get_logger()->warning( 'Keeping sessions for longer than 30 days results in perfomance isues, the default is 2 days for guests and 7 days for logged in users, expiry has been capped to 30 days.', array( 'source' => 'wc_session_handler' ) );
+				set_transient( $transient_key, true, MONTH_IN_SECONDS );
+			}
+		}
+
+		// If the expiring time is greater than the expiration time, set the expiring time to 90% of the expiration time.
+		if ( $expiring_seconds > $expiration_seconds ) {
+			$expiring_seconds = $expiration_seconds * 0.9;
+		}
+
+		$this->_session_expiring = time() + $expiring_seconds;
+
+		$this->_session_expiration = time() + $expiration_seconds;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -531,7 +531,7 @@ class WC_Session_Handler extends WC_Session {
 		if ( $session_limit_exceeded ) {
 			$transient_key = 'wc_session_handler_warning';
 			if ( false === get_transient( $transient_key ) ) {
-				wc_get_logger()->warning( sprintf( 'Keeping sessions for longer than %d days results in perfomance isues, expiry has been capped.', $max_expiration_seconds / DAY_IN_SECONDS ), array( 'source' => 'wc_session_handler' ) );
+				wc_get_logger()->warning( sprintf( 'Keeping sessions for longer than %d days results in performance isues, expiry has been capped.', $max_expiration_seconds / DAY_IN_SECONDS ), array( 'source' => 'wc_session_handler' ) );
 				set_transient( $transient_key, true, MONTH_IN_SECONDS );
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -496,21 +496,23 @@ class WC_Session_Handler extends WC_Session {
 	 * For guests, sessions expire in 48 hours.
 	 */
 	public function set_session_expiration() {
+		$default_expiring_seconds   = DAY_IN_SECONDS;
+		$default_expiration_seconds = is_user_logged_in() ? WEEK_IN_SECONDS : 2 * DAY_IN_SECONDS;
+		$max_expiration_seconds     = MONTH_IN_SECONDS;
+		$max_expiring_seconds       = $max_expiration_seconds - DAY_IN_SECONDS;
+		$session_limit_exceeded     = false;
+
 		/**
 		 * Filters the session expiration.
 		 *
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$expiring_seconds = intval( apply_filters( 'wc_session_expiring', DAY_IN_SECONDS ) );
+		$expiring_seconds = intval( apply_filters( 'wc_session_expiring', $default_expiring_seconds ) ) ?: $default_expiring_seconds;
 
-		if ( $expiring_seconds > MONTH_IN_SECONDS - DAY_IN_SECONDS ) {
-			$expiring_seconds = MONTH_IN_SECONDS - DAY_IN_SECONDS;
-			$transient_key    = 'wc_session_handler_warning';
-			if ( false === get_transient( $transient_key ) ) {
-				wc_get_logger()->warning( 'Keeping sessions for longer than 30 days results in perfomance isues, the default is 2 days for guests and 7 days for logged in users, expiry has been capped to 30 days.', array( 'source' => 'wc_session_handler' ) );
-				set_transient( $transient_key, true, MONTH_IN_SECONDS );
-			}
+		if ( $expiring_seconds > $max_expiring_seconds ) {
+			$expiring_seconds       = $max_expiring_seconds;
+			$session_limit_exceeded = true;
 		}
 		/**
 		 * Filters the session expiration.
@@ -518,12 +520,16 @@ class WC_Session_Handler extends WC_Session {
 		 * @since 5.0.0
 		 * @param int $expiration_seconds The expiration time in seconds.
 		 */
-		$expiration_seconds = intval( apply_filters( 'wc_session_expiration', is_user_logged_in() ? WEEK_IN_SECONDS : 2 * DAY_IN_SECONDS ) );
+		$expiration_seconds = intval( apply_filters( 'wc_session_expiration', $default_expiration_seconds ) ) ?: $default_expiration_seconds;
 
 		// We limit the expiration time to 30 days to avoid performance issues and the session table growing too large.
-		if ( $expiration_seconds > MONTH_IN_SECONDS ) {
-			$expiration_seconds = MONTH_IN_SECONDS;
-			$transient_key      = 'wc_session_handler_warning';
+		if ( $expiration_seconds > $max_expiration_seconds ) {
+			$expiration_seconds     = $max_expiration_seconds;
+			$session_limit_exceeded = true;
+		}
+
+		if ( $session_limit_exceeded ) {
+			$transient_key = 'wc_session_handler_warning';
 			if ( false === get_transient( $transient_key ) ) {
 				wc_get_logger()->warning( 'Keeping sessions for longer than 30 days results in perfomance isues, the default is 2 days for guests and 7 days for logged in users, expiry has been capped to 30 days.', array( 'source' => 'wc_session_handler' ) );
 				set_transient( $transient_key, true, MONTH_IN_SECONDS );

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -532,7 +532,7 @@ class WC_Session_Handler extends WC_Session {
 			$transient_key = 'wc_session_handler_warning';
 			if ( false === get_transient( $transient_key ) ) {
 				wc_get_logger()->warning( sprintf( 'Keeping sessions for longer than %d days results in performance isues, expiry has been capped.', $max_expiration_seconds / DAY_IN_SECONDS ), array( 'source' => 'wc_session_handler' ) );
-				set_transient( $transient_key, true, MONTH_IN_SECONDS );
+				set_transient( $transient_key, true, $max_expiration_seconds );
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up to https://github.com/woocommerce/woocommerce/pull/57961, this PR limits the age of sessions to 30 days maximum, this is to prevent saving such sessions for long durations, as they can grow quite large and impact performance, we seen sites with 15-20gb session tables because sessions would expire once a year.

By default, a guest session would last 2 days and would get refreshed (pushed further) if the guest visits after the "expiring window", meaning if they visit again 24h before expiry, the session will be pushed back again.

This PR limits the maximum age for expiry to be 30 days, and the expiring date to be 29 days. It also changes expiring time to be 90% that of expiry, if it happens to be bigger than it, to keep the pushing behavior the same.

The cookies will also reflect that.

If you have code that edits session expiry date, you will see a log warning under `wc_session_handler` log file, telling you of this, such log will only trigger once a month, to avoid overloading logs.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code somewhere:
```php
add_filter(
	'wc_session_expiration',
	function ( $expiration ) {
		return YEAR_IN_SECONDS;
	}
);
```
2. Open a new incoginto window, add an item to cart.
3. Open inspector tools and go Application -> Cookies, check for the `wp_woocommerce_session_%HASH%` cookie.
4. Make sure it's expiry is 30 days from now, not a year from now.
5. Navigate around the site.
6. Open admin, WooCommerce -> Status -> Logs and open the `wc_session_handler` log file you only see a single log entry.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Limit session expiry date to be a maximum of 30 days.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
