### PR TITLE
Reduce nesting in template-customization e2e tests

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'Template customization', () => {
 				? 'template'
 				: 'template part';
 
-		test( `${ testData.templateName } template can be modified and reverted`, async ( {
+		test( `"${ testData.templateName }" template can be modified and reverted`, async ( {
 			admin,
 			frontendUtils,
 			editor,
@@ -77,7 +77,7 @@ test.describe( 'Template customization', () => {
 		} );
 
 		if ( testData.fallbackTemplate ) {
-			test( `${ testData.templateName } template defaults to the ${ testData.fallbackTemplate.templateName } template`, async ( {
+			test( `"${ testData.templateName }" template defaults to the "${ testData.fallbackTemplate.templateName }" template`, async ( {
 				admin,
 				frontendUtils,
 				requestUtils,
@@ -140,7 +140,7 @@ test.describe( 'Template customization', () => {
 		const userText = `Hello World in the ${ testData.templateName } template`;
 		const woocommerceTemplateUserText = `Hello World in the WooCommerce ${ testData.templateName } template`;
 
-		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
+		test( `user-modified "${ testData.templateName }" template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
 			page,
 			admin,
 			editor,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts
@@ -21,36 +21,85 @@ test.describe( 'Template customization', () => {
 				? 'template'
 				: 'template part';
 
-		test.describe( `${ testData.templateName } template`, () => {
-			test( 'can be modified and reverted', async ( {
+		test( `${ testData.templateName } template can be modified and reverted`, async ( {
+			admin,
+			frontendUtils,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			await admin.visitSiteEditor( {
+				postId: `woocommerce/woocommerce//${ testData.templatePath }`,
+				postType: testData.templateType,
+				canvas: 'edit',
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: userText },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+
+			// Verify template name didn't change.
+			// See: https://github.com/woocommerce/woocommerce/issues/42221
+			await expect(
+				page.getByRole( 'heading', {
+					name: templateTypeName,
+				} )
+			).toBeVisible();
+
+			await testData.visitPage( {
+				admin,
+				editor,
+				frontendUtils,
+				requestUtils,
+				page,
+			} );
+			await expect( page.getByText( userText ).first() ).toBeVisible();
+
+			// Verify the edition can be reverted.
+			await admin.visitSiteEditor( {
+				postType: testData.templateType,
+			} );
+			await editor.revertTemplate( {
+				templateName: testData.templateName,
+			} );
+			await testData.visitPage( {
+				admin,
+				editor,
+				frontendUtils,
+				requestUtils,
+				page,
+			} );
+			await expect( page.getByText( userText ) ).toBeHidden();
+		} );
+
+		if ( testData.fallbackTemplate ) {
+			test( `${ testData.templateName } template defaults to the ${ testData.fallbackTemplate.templateName } template`, async ( {
 				admin,
 				frontendUtils,
+				requestUtils,
 				editor,
 				page,
-				requestUtils,
 			} ) => {
+				// Edit fallback template and verify changes are visible.
 				await admin.visitSiteEditor( {
-					postId: `woocommerce/woocommerce//${ testData.templatePath }`,
+					postId: `woocommerce/woocommerce//${ testData.fallbackTemplate?.templatePath }`,
 					postType: testData.templateType,
 					canvas: 'edit',
 				} );
 
 				await editor.insertBlock( {
 					name: 'core/paragraph',
-					attributes: { content: userText },
+					attributes: {
+						content: fallbackTemplateUserText,
+					},
 				} );
 				await editor.saveSiteEditorEntities( {
 					isOnlyCurrentEntityDirty: true,
 				} );
-
-				// Verify template name didn't change.
-				// See: https://github.com/woocommerce/woocommerce/issues/42221
-				await expect(
-					page.getByRole( 'heading', {
-						name: templateTypeName,
-					} )
-				).toBeVisible();
-
 				await testData.visitPage( {
 					admin,
 					editor,
@@ -59,7 +108,7 @@ test.describe( 'Template customization', () => {
 					page,
 				} );
 				await expect(
-					page.getByText( userText ).first()
+					page.getByText( fallbackTemplateUserText ).first()
 				).toBeVisible();
 
 				// Verify the edition can be reverted.
@@ -67,7 +116,7 @@ test.describe( 'Template customization', () => {
 					postType: testData.templateType,
 				} );
 				await editor.revertTemplate( {
-					templateName: testData.templateName,
+					templateName: testData.fallbackTemplate?.templateName || '',
 				} );
 				await testData.visitPage( {
 					admin,
@@ -76,65 +125,11 @@ test.describe( 'Template customization', () => {
 					requestUtils,
 					page,
 				} );
-				await expect( page.getByText( userText ) ).toBeHidden();
+				await expect(
+					page.getByText( fallbackTemplateUserText )
+				).toBeHidden();
 			} );
-
-			if ( testData.fallbackTemplate ) {
-				test( `defaults to the ${ testData.fallbackTemplate.templateName } template`, async ( {
-					admin,
-					frontendUtils,
-					requestUtils,
-					editor,
-					page,
-				} ) => {
-					// Edit fallback template and verify changes are visible.
-					await admin.visitSiteEditor( {
-						postId: `woocommerce/woocommerce//${ testData.fallbackTemplate?.templatePath }`,
-						postType: testData.templateType,
-						canvas: 'edit',
-					} );
-
-					await editor.insertBlock( {
-						name: 'core/paragraph',
-						attributes: {
-							content: fallbackTemplateUserText,
-						},
-					} );
-					await editor.saveSiteEditorEntities( {
-						isOnlyCurrentEntityDirty: true,
-					} );
-					await testData.visitPage( {
-						admin,
-						editor,
-						frontendUtils,
-						requestUtils,
-						page,
-					} );
-					await expect(
-						page.getByText( fallbackTemplateUserText ).first()
-					).toBeVisible();
-
-					// Verify the edition can be reverted.
-					await admin.visitSiteEditor( {
-						postType: testData.templateType,
-					} );
-					await editor.revertTemplate( {
-						templateName:
-							testData.fallbackTemplate?.templateName || '',
-					} );
-					await testData.visitPage( {
-						admin,
-						editor,
-						frontendUtils,
-						requestUtils,
-						page,
-					} );
-					await expect(
-						page.getByText( fallbackTemplateUserText )
-					).toBeHidden();
-				} );
-			}
-		} );
+		}
 	} );
 
 	const testToRun = CUSTOMIZABLE_WC_TEMPLATES.filter(
@@ -145,91 +140,85 @@ test.describe( 'Template customization', () => {
 		const userText = `Hello World in the ${ testData.templateName } template`;
 		const woocommerceTemplateUserText = `Hello World in the WooCommerce ${ testData.templateName } template`;
 
-		test.describe( `${ testData.templateName } template`, () => {
-			test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
-				page,
+		test( `user-modified ${ testData.templateName } template based on the theme template has priority over the user-modified template based on the default WooCommerce template`, async ( {
+			page,
+			admin,
+			editor,
+			requestUtils,
+			frontendUtils,
+		} ) => {
+			// Edit the WooCommerce default template
+			await admin.visitSiteEditor( {
+				postId: `woocommerce/woocommerce//${ testData.templatePath }`,
+				postType: testData.templateType,
+				canvas: 'edit',
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: woocommerceTemplateUserText },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+
+			await requestUtils.activateTheme( BLOCK_THEME_WITH_TEMPLATES_SLUG );
+
+			// Edit the theme template. The theme template is not
+			// directly available from the UI, because the customized
+			// one takes priority, so we go directly to its URL.
+			await admin.visitSiteEditor( {
+				postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
+				postType: testData.templateType,
+				canvas: 'edit',
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: userText },
+			} );
+			await editor.saveSiteEditorEntities( {
+				isOnlyCurrentEntityDirty: true,
+			} );
+
+			// Verify the template is the one modified by the user based on the theme.
+			await testData.visitPage( {
 				admin,
 				editor,
-				requestUtils,
 				frontendUtils,
-			} ) => {
-				// Edit the WooCommerce default template
-				await admin.visitSiteEditor( {
-					postId: `woocommerce/woocommerce//${ testData.templatePath }`,
-					postType: testData.templateType,
-					canvas: 'edit',
-				} );
-
-				await editor.insertBlock( {
-					name: 'core/paragraph',
-					attributes: { content: woocommerceTemplateUserText },
-				} );
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
-
-				await requestUtils.activateTheme(
-					BLOCK_THEME_WITH_TEMPLATES_SLUG
-				);
-
-				// Edit the theme template. The theme template is not
-				// directly available from the UI, because the customized
-				// one takes priority, so we go directly to its URL.
-				await admin.visitSiteEditor( {
-					postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//${ testData.templatePath }`,
-					postType: testData.templateType,
-					canvas: 'edit',
-				} );
-
-				await editor.insertBlock( {
-					name: 'core/paragraph',
-					attributes: { content: userText },
-				} );
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
-
-				// Verify the template is the one modified by the user based on the theme.
-				await testData.visitPage( {
-					admin,
-					editor,
-					frontendUtils,
-					requestUtils,
-					page,
-				} );
-				await expect(
-					page.getByText( userText ).first()
-				).toBeVisible();
-				await expect(
-					page.getByText( woocommerceTemplateUserText )
-				).toBeHidden();
-
-				// Revert edition and verify the user-modified WC template is used.
-				// Note: we need to revert it from the admin (instead of calling
-				// `deleteAllTemplates()`). This way, we verify there are no
-				// duplicate templates with the same name.
-				// See: https://github.com/woocommerce/woocommerce/issues/42220
-				await admin.visitSiteEditor( {
-					postType: testData.templateType,
-				} );
-
-				await editor.revertTemplate( {
-					templateName: testData.templateName,
-				} );
-
-				await testData.visitPage( {
-					admin,
-					editor,
-					frontendUtils,
-					requestUtils,
-					page,
-				} );
-
-				await expect(
-					page.getByText( woocommerceTemplateUserText ).first()
-				).toBeVisible();
-				await expect( page.getByText( userText ) ).toBeHidden();
+				requestUtils,
+				page,
 			} );
+			await expect( page.getByText( userText ).first() ).toBeVisible();
+			await expect(
+				page.getByText( woocommerceTemplateUserText )
+			).toBeHidden();
+
+			// Revert edition and verify the user-modified WC template is used.
+			// Note: we need to revert it from the admin (instead of calling
+			// `deleteAllTemplates()`). This way, we verify there are no
+			// duplicate templates with the same name.
+			// See: https://github.com/woocommerce/woocommerce/issues/42220
+			await admin.visitSiteEditor( {
+				postType: testData.templateType,
+			} );
+
+			await editor.revertTemplate( {
+				templateName: testData.templateName,
+			} );
+
+			await testData.visitPage( {
+				admin,
+				editor,
+				frontendUtils,
+				requestUtils,
+				page,
+			} );
+
+			await expect(
+				page.getByText( woocommerceTemplateUserText ).first()
+			).toBeVisible();
+			await expect( page.getByText( userText ) ).toBeHidden();
 		} );
 	}
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

If you see the autogenerated flaky test issue https://github.com/woocommerce/woocommerce/issues/48185 you will see:
```
can be modified and reverted
```
as a faulty test title. Reduced nesting should help out in the future and it is also easier for me to go through all the cases in the Playwright UI mode.

### How to test the changes in this Pull Request:

Code review and green pipeline should be enough.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Minor CI change

</details>
