### PR TITLE
Improve the Add to Cart + Options block compatibility layer to support more extensions

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-hooks-refactor
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-hooks-refactor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve the Add to Cart + Options block compatibility layer to support more extensions

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -281,7 +281,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
 					 *
-					 * @since 2.7.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_quantity' );
 					/**
@@ -353,7 +353,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
 					 *
-					 * @since 2.7.0
+					 * @since 10.0.0
 					 */
 					do_action( 'woocommerce_before_add_to_cart_quantity' );
 				}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -270,6 +270,13 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			if ( ! $is_disabled_compatibility_layer && ! Utils::is_not_purchasable_product( $product ) ) {
 				ob_start();
+				/**
+				 * Hook: woocommerce_before_add_to_cart_form.
+				 *
+				 * @since 10.1.0
+				 */
+				do_action( 'woocommerce_before_add_to_cart_form' );
+
 				if ( ProductType::SIMPLE === $product_type ) {
 					/**
 					 * Hook: woocommerce_before_add_to_cart_quantity.
@@ -406,6 +413,14 @@ class AddToCartWithOptions extends AbstractBlock {
 					 */
 					do_action( 'woocommerce_after_variations_form' );
 				}
+
+				/**
+				 * Hook: woocommerce_after_add_to_cart_form.
+				 *
+				 * @since 10.1.0
+				 */
+				do_action( 'woocommerce_after_add_to_cart_form' );
+
 				$hooks_after = ob_get_clean();
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -252,17 +252,8 @@ class ProductButton extends AbstractBlock {
 			$args['attributes']['value'] = $product->get_id();
 		}
 
-		/**
-		 * Filters the add to cart button class.
-		 *
-		 * @since 8.7.0
-		 *
-		 * @param string $class The class.
-		 */
-		$html = apply_filters(
-			'woocommerce_loop_add_to_cart_link',
-			strtr(
-				'<div {wrapper_attributes}
+		$html = strtr(
+			'<div {wrapper_attributes}
 					{div_directives}
 				>
 					<{html_element}
@@ -275,22 +266,35 @@ class ProductButton extends AbstractBlock {
 					</{html_element}>
 					{view_cart_html}
 				</div>',
-				array(
-					'{wrapper_attributes}'     => $wrapper_attributes,
-					'{html_element}'           => $html_element,
-					'{button_classes}'         => $button_classes,
-					'{button_styles}'          => esc_attr( $styles_and_classes['styles'] ),
-					'{attributes}'             => isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
-					'{add_to_cart_text}'       => $is_ajax_button ? '' : $add_to_cart_text,
-					'{div_directives}'         => $is_ajax_button ? $div_directives : '',
-					'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
-					'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',
-					'{view_cart_html}'         => $is_ajax_button && CartCheckoutUtils::has_cart_page() ? $this->get_view_cart_html() : '',
-				)
-			),
-			$product,
-			$args
+			array(
+				'{wrapper_attributes}'     => $wrapper_attributes,
+				'{html_element}'           => $html_element,
+				'{button_classes}'         => $button_classes,
+				'{button_styles}'          => esc_attr( $styles_and_classes['styles'] ),
+				'{attributes}'             => isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
+				'{add_to_cart_text}'       => $is_ajax_button ? '' : $add_to_cart_text,
+				'{div_directives}'         => $is_ajax_button ? $div_directives : '',
+				'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
+				'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',
+				'{view_cart_html}'         => $is_ajax_button && CartCheckoutUtils::has_cart_page() ? $this->get_view_cart_html() : '',
+			)
 		);
+
+		if ( ! $is_descendant_of_add_to_cart_form ) {
+			/**
+			 * Filters the add to cart button class.
+			 *
+			 * @since 8.7.0
+			 *
+			 * @param string $class The class.
+			 */
+			$html = apply_filters(
+				'woocommerce_loop_add_to_cart_link',
+				$html,
+				$product,
+				$args
+			);
+		}
 
 		$product = $previous_product;
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -252,16 +252,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 					'woocommerce_output_related_products'  => 20,
 				),
 			),
-			'woocommerce_before_add_to_cart_form'       => array(
-				'block_names' => array( 'woocommerce/add-to-cart-with-options' ),
-				'position'    => 'before',
-				'hooked'      => array(),
-			),
-			'woocommerce_after_add_to_cart_form'        => array(
-				'block_names' => array( 'woocommerce/add-to-cart-with-options' ),
-				'position'    => 'after',
-				'hooked'      => array(),
-			),
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As I was investigating the plugin (https://github.com/woocommerce/woocommerce/discussions/44776#discussioncomment-13627825) I noticed a few improvements we could make to the _Add to Cart + Options_ block compatibility layer:

* The `woocommerce_loop_add_to_cart_link` hook was triggered in all cases in the _Add to Cart Button_, but it's only intended to be used in loops, so I updated the code so it's not triggered inside the _Add to Cart + Options_ block.
* The fact that the `woocommerce_before_add_to_cart_form` and `woocommerce_after_add_to_cart_form` hooks were triggered from the compatibility layer instead of inside the _Add to Cart + Options_ block was problematic in case data should be shared between the different hooks of the block. I moved those two hooks to be called inside the _Add to Cart + Options_ block, so it's consistent with the other hooks.
* There were a couple of `@since` version which were not up to date.

### How to test the changes in this Pull Request:

#### Preparation

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.

#### Reproducing the issue

1. Install [Extra Product Options For WooCommerce](https://wordpress.org/plugins/woo-extra-product-options/).
2. Go to _Products_ > _Extra Product Option_ and set up one option for a product.
3. In the frontend, visit that product page.
4. Add it to cart setting a value for the extra option.
5. Verify the product is correctly added to cart with that option data.

![Captura de pantalla de 2025-07-01 15-29-40](https://github.com/user-attachments/assets/792e7b76-8ebb-47c7-b890-6289c388e554)