### PR TITLE
Prevent shipping tax fallback to standard tax rates when inheriting tax class from cart items

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4596-shipping-tax-class-based-on-cart-items-does-not-appear-to-be
+++ b/plugins/woocommerce/changelog/wooplug-4596-shipping-tax-class-based-on-cart-items-does-not-appear-to-be
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix shipping tax rate lookup when inheriting taxes from items and no matching shipping tax rates are defined.
+Shipping tax now correctly applies no tax when the inherited cart item tax class does not have shipping tax enabled, instead of falling back to standard rates.

--- a/plugins/woocommerce/changelog/wooplug-4596-shipping-tax-class-based-on-cart-items-does-not-appear-to-be
+++ b/plugins/woocommerce/changelog/wooplug-4596-shipping-tax-class-based-on-cart-items-does-not-appear-to-be
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping tax rate lookup when inheriting taxes from items and no matching shipping tax rates are defined.

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -563,80 +563,71 @@ class WC_Tax {
 			$tax_class = $shipping_tax_class;
 		}
 
-		$location          = self::get_tax_location( $tax_class, $customer );
-		$matched_tax_rates = array();
+		// If we don't have a shipping tax class yet, work out which one to use.
+		if ( is_null( $tax_class ) ) {
+			$tax_class = self::get_shipping_tax_class_from_cart_items();
+		}
 
-		if ( 4 === count( $location ) ) {
-			list( $country, $state, $postcode, $city ) = $location;
+		// If we still don't have a tax class, there must be no taxable items.
+		if ( is_null( $tax_class ) ) {
+			return array();
+		}
 
-			if ( ! is_null( $tax_class ) ) {
-				// This will be per item shipping.
-				$matched_tax_rates = self::find_shipping_rates(
-					array(
-						'country'   => $country,
-						'state'     => $state,
-						'postcode'  => $postcode,
-						'city'      => $city,
-						'tax_class' => $tax_class,
-					)
-				);
+		$location = self::get_tax_location( $tax_class, $customer );
 
-			} elseif ( WC()->cart->get_cart() ) {
+		// Check for a valid location.
+		if ( 4 !== count( $location ) ) {
+			return array();
+		}
 
-				// This will be per order shipping - loop through the order and find the highest tax class rate.
-				$cart_tax_classes = WC()->cart->get_cart_item_tax_classes_for_shipping();
+		list( $country, $state, $postcode, $city ) = $location;
 
-				// No tax classes = no taxable items.
-				if ( empty( $cart_tax_classes ) ) {
-					return array();
-				}
+		return self::find_shipping_rates(
+			array(
+				'country'   => $country,
+				'state'     => $state,
+				'postcode'  => $postcode,
+				'city'      => $city,
+				'tax_class' => $tax_class,
+			)
+		);
+	}
 
-				// If multiple classes are found, use the first one found unless a standard rate item is found. This will be the first listed in the 'additional tax class' section.
-				if ( count( $cart_tax_classes ) > 1 && ! in_array( '', $cart_tax_classes, true ) ) {
-					$tax_classes = self::get_tax_class_slugs();
+	/**
+	 * Get the shipping tax class from the cart items.
+	 *
+	 * @return string|null The shipping tax class, or null if no taxable items are found.
+	 */
+	private static function get_shipping_tax_class_from_cart_items() {
+		$default_tax_class = ''; // Standard.
 
-					foreach ( $tax_classes as $tax_class ) {
-						if ( in_array( $tax_class, $cart_tax_classes, true ) ) {
-							$matched_tax_rates = self::find_shipping_rates(
-								array(
-									'country'   => $country,
-									'state'     => $state,
-									'postcode'  => $postcode,
-									'city'      => $city,
-									'tax_class' => $tax_class,
-								)
-							);
-							break;
-						}
-					}
-				} elseif ( 1 === count( $cart_tax_classes ) ) {
-					// If a single tax class is found, use it.
-					$matched_tax_rates = self::find_shipping_rates(
-						array(
-							'country'   => $country,
-							'state'     => $state,
-							'postcode'  => $postcode,
-							'city'      => $city,
-							'tax_class' => $cart_tax_classes[0],
-						)
-					);
-				}
-			}
+		if ( ! WC()->cart->get_cart() ) {
+			return $default_tax_class;
+		}
 
-			// Get standard rate if no taxes were found.
-			if ( ! count( $matched_tax_rates ) ) {
-				$matched_tax_rates = self::find_shipping_rates(
-					array(
-						'country'  => $country,
-						'state'    => $state,
-						'postcode' => $postcode,
-						'city'     => $city,
-					)
-				);
+		$cart_tax_classes = WC()->cart->get_cart_item_tax_classes_for_shipping();
+
+		// No tax classes = no taxable items.
+		if ( empty( $cart_tax_classes ) ) {
+			return null;
+		}
+
+		// Standard tax class takes priority over any other tax class.
+		if ( in_array( $default_tax_class, $cart_tax_classes, true ) ) {
+			return $default_tax_class;
+		}
+
+		// If multiple classes are found, use the first one found using the order defined in settings.
+		$tax_classes = self::get_tax_class_slugs();
+
+		foreach ( $tax_classes as $tax_class ) {
+			if ( in_array( $tax_class, $cart_tax_classes, true ) ) {
+				return $tax_class;
 			}
 		}
 
-		return $matched_tax_rates;
+		// Default to standard tax class.
+		return $default_tax_class;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -558,11 +558,13 @@ class WC_Tax {
 	 *    - Returns empty array if cart has no taxable items
 	 *    - For multiple tax classes: prioritizes standard rate, then uses first class found in tax class hierarchy
 	 *    - For single tax class: uses that class directly
-	 * 4. Falls back to standard tax rates if no specific rates are found
+	 * 4. Returns only rates that have shipping tax enabled for the determined tax class
+	 *    - If no shipping rates exist for the tax class, returns empty array (no fallback to standard rates)
+	 *    - This ensures tax class inheritance works correctly - if a tax class doesn't apply to shipping, no shipping tax is charged
 	 *
 	 * @param string|null      $tax_class Optional. Specific tax class slug to get rates for. If null, determines from cart contents.
 	 * @param WC_Customer|null $customer Optional. Customer object to get location from. Uses current customer if null.
-	 * @return array Array of tax rate arrays, each containing 'rate', 'label', 'shipping', and 'compound' keys. Empty array if no rates found.
+	 * @return array Array of tax rate arrays, each containing 'rate', 'label', 'shipping', and 'compound' keys. Empty array if no shipping rates found for the tax class.
 	 */
 	public static function get_shipping_tax_rates( $tax_class = null, $customer = null ) {
 		// See if we have an explicitly set shipping tax class.

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -549,11 +549,20 @@ class WC_Tax {
 	}
 
 	/**
-	 * Gets an array of matching shipping tax rates for a given class.
+	 * Gets shipping tax rates based on tax class and customer location.
 	 *
-	 * @param string $tax_class Tax class to get rates for.
-	 * @param object $customer Override the customer object to get their location.
-	 * @return mixed
+	 * This method determines which tax rates to apply to shipping costs by following this priority:
+	 * 1. Uses the explicitly configured shipping tax class from WooCommerce settings if not set to 'inherit'
+	 * 2. If tax_class is provided (per-item shipping), uses that specific class
+	 * 3. If no tax_class provided (per-order shipping), analyzes cart items to determine the appropriate class:
+	 *    - Returns empty array if cart has no taxable items
+	 *    - For multiple tax classes: prioritizes standard rate, then uses first class found in tax class hierarchy
+	 *    - For single tax class: uses that class directly
+	 * 4. Falls back to standard tax rates if no specific rates are found
+	 *
+	 * @param string|null      $tax_class Optional. Specific tax class slug to get rates for. If null, determines from cart contents.
+	 * @param WC_Customer|null $customer Optional. Customer object to get location from. Uses current customer if null.
+	 * @return array Array of tax rate arrays, each containing 'rate', 'label', 'shipping', and 'compound' keys. Empty array if no rates found.
 	 */
 	public static function get_shipping_tax_rates( $tax_class = null, $customer = null ) {
 		// See if we have an explicitly set shipping tax class.
@@ -596,16 +605,22 @@ class WC_Tax {
 	/**
 	 * Get the shipping tax class from the cart items.
 	 *
-	 * @return string|null The shipping tax class, or null if no taxable items are found.
+	 * Determines the appropriate tax class for shipping based on cart contents.
+	 * Standard tax class takes priority, followed by the first non-standard class
+	 * found in the configured tax class hierarchy.
+	 *
+	 * @return string|null The shipping tax class slug, or null if no taxable items are found.
 	 */
 	private static function get_shipping_tax_class_from_cart_items() {
-		$default_tax_class = ''; // Standard.
+		$standard_tax_class = '';
+		$cart               = WC()->cart;
 
-		if ( ! WC()->cart->get_cart() ) {
-			return $default_tax_class;
+		// Check if cart has items before proceeding.
+		if ( ! $cart->get_cart() ) {
+			return $standard_tax_class;
 		}
 
-		$cart_tax_classes = WC()->cart->get_cart_item_tax_classes_for_shipping();
+		$cart_tax_classes = $cart->get_cart_item_tax_classes_for_shipping();
 
 		// No tax classes = no taxable items.
 		if ( empty( $cart_tax_classes ) ) {
@@ -613,21 +628,29 @@ class WC_Tax {
 		}
 
 		// Standard tax class takes priority over any other tax class.
-		if ( in_array( $default_tax_class, $cart_tax_classes, true ) ) {
-			return $default_tax_class;
+		if ( in_array( $standard_tax_class, $cart_tax_classes, true ) ) {
+			return $standard_tax_class;
 		}
 
-		// If multiple classes are found, use the first one found using the order defined in settings.
-		$tax_classes = self::get_tax_class_slugs();
+		// If only one tax class, use it directly.
+		if ( 1 === count( $cart_tax_classes ) ) {
+			return reset( $cart_tax_classes );
+		}
 
-		foreach ( $tax_classes as $tax_class ) {
-			if ( in_array( $tax_class, $cart_tax_classes, true ) ) {
-				return $tax_class;
+		// For multiple classes, use the first one found using the order defined in settings.
+		static $tax_class_slugs = null;
+		if ( null === $tax_class_slugs ) {
+			$tax_class_slugs = self::get_tax_class_slugs();
+		}
+
+		foreach ( $tax_class_slugs as $tax_class_slug ) {
+			if ( in_array( $tax_class_slug, $cart_tax_classes, true ) ) {
+				return $tax_class_slug;
 			}
 		}
 
-		// Default to standard tax class.
-		return $default_tax_class;
+		// Default to standard tax class if nothing else matches.
+		return $standard_tax_class;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -7,6 +7,8 @@
 
 declare( strict_types=1 );
 
+use ReflectionClass;
+
 /**
  * Unit tests for the WC_Tax class get_shipping_tax_rates method and related functionality.
  * Covers edge case bug from https://github.com/woocommerce/woocommerce/issues/58757
@@ -35,6 +37,13 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	private $created_products = array();
 
 	/**
+	 * Store the original value of woocommerce_calc_taxes.
+	 *
+	 * @var string|null
+	 */
+	private $original_calc_taxes = null;
+
+	/**
 	 * Set up test.
 	 */
 	public function setUp(): void {
@@ -43,12 +52,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		// Clear any existing tax rates and settings.
 		$this->clean_up_tax_rates();
 
-		// Set up base store location.
-		update_option( 'woocommerce_default_country', 'US:CA' );
-		update_option( 'woocommerce_store_address', '123 Test St' );
-		update_option( 'woocommerce_store_postcode', '90210' );
-
-		// Enable tax calculations.
+		// Store and set woocommerce_calc_taxes option.
+		$this->original_calc_taxes = get_option( 'woocommerce_calc_taxes', null );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 
 		// Ensure required tax classes exist for testing.
@@ -79,7 +84,13 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		// Reset tax settings.
 		delete_option( 'woocommerce_shipping_tax_class' );
 		delete_option( 'woocommerce_tax_classes' );
-		delete_option( 'woocommerce_calc_taxes' );
+
+		// Restore woocommerce_calc_taxes option to its original value.
+		if ( null !== $this->original_calc_taxes ) {
+			update_option( 'woocommerce_calc_taxes', $this->original_calc_taxes );
+		} else {
+			delete_option( 'woocommerce_calc_taxes' );
+		}
 
 		// Only clean up tax classes we created during testing.
 		if ( $this->created_reduced_rate_class ) {
@@ -98,6 +109,7 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
 		wp_cache_flush();
+		\WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 	}
 
 	/**
@@ -149,10 +161,10 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	public function test_get_shipping_tax_rates_with_standard_tax_class() {
 		// Create a standard tax rate with shipping enabled.
 		$tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '10.0000',
-			'tax_rate_name'     => 'CA Sales Tax',
+			'tax_rate_name'     => 'Test Sales Tax',
 			'tax_rate_priority' => '1',
 			'tax_rate_compound' => '0',
 			'tax_rate_shipping' => '1',
@@ -173,7 +185,7 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 
 		$this->assertArrayHasKey( $tax_rate_id, $shipping_rates );
 		$this->assertEquals( '10.0000', $shipping_rates[ $tax_rate_id ]['rate'] );
-		$this->assertEquals( 'CA Sales Tax', $shipping_rates[ $tax_rate_id ]['label'] );
+		$this->assertEquals( 'Test Sales Tax', $shipping_rates[ $tax_rate_id ]['label'] );
 		$this->assertEquals( 'yes', $shipping_rates[ $tax_rate_id ]['shipping'] );
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
@@ -185,8 +197,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	public function test_get_shipping_tax_rates_with_reduced_tax_class() {
 		// Create reduced rate tax with shipping enabled.
 		$reduced_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
 			'tax_rate_name'     => 'Reduced Tax',
 			'tax_rate_priority' => '1',
@@ -222,8 +234,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	public function test_get_shipping_tax_rates_edge_case_no_reduced_shipping_rates() {
 		// Create standard tax rate with shipping enabled.
 		$standard_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '10.0000',
 			'tax_rate_name'     => 'Standard Tax',
 			'tax_rate_priority' => '1',
@@ -235,8 +247,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 
 		// Create reduced rate tax WITHOUT shipping enabled (shipping = 0).
 		$reduced_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
 			'tax_rate_name'     => 'Reduced Tax',
 			'tax_rate_priority' => '1',
@@ -272,8 +284,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	public function test_get_shipping_tax_rates_with_explicit_shipping_tax_class() {
 		// Create reduced rate tax with shipping enabled.
 		$reduced_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
 			'tax_rate_name'     => 'Reduced Tax',
 			'tax_rate_priority' => '1',
@@ -329,8 +341,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 	public function test_get_shipping_tax_rates_mixed_tax_classes_prioritizes_standard() {
 		// Create both standard and reduced rate taxes with shipping enabled.
 		$standard_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '10.0000',
 			'tax_rate_name'     => 'Standard Tax',
 			'tax_rate_priority' => '1',
@@ -341,8 +353,8 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		);
 
 		$reduced_tax_rate = array(
-			'tax_rate_country'  => 'US',
-			'tax_rate_state'    => 'CA',
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
 			'tax_rate_name'     => 'Reduced Tax',
 			'tax_rate_priority' => '1',

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * Class WC_Tax_Test file.
+ *
+ * @package WooCommerce\Tests\Includes
+ */
+
+declare( strict_types=1 );
+
+/**
+ * Unit tests for the WC_Tax class get_shipping_tax_rates method and related functionality.
+ * Covers edge case bug from https://github.com/woocommerce/woocommerce/issues/58757
+ */
+class WC_Tax_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Track whether we created the reduced-rate tax class.
+	 *
+	 * @var bool
+	 */
+	private $created_reduced_rate_class = false;
+
+	/**
+	 * Track whether we created the zero-rate tax class.
+	 *
+	 * @var bool
+	 */
+	private $created_zero_rate_class = false;
+
+	/**
+	 * Track created products for cleanup.
+	 *
+	 * @var array
+	 */
+	private $created_products = array();
+
+	/**
+	 * Set up test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Clear any existing tax rates and settings.
+		$this->clean_up_tax_rates();
+
+		// Set up base store location.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+		update_option( 'woocommerce_store_address', '123 Test St' );
+		update_option( 'woocommerce_store_postcode', '90210' );
+
+		// Enable tax calculations.
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		// Ensure required tax classes exist for testing.
+		$this->ensure_tax_classes_exist();
+
+		// Clear cart.
+		WC()->cart->empty_cart();
+	}
+
+	/**
+	 * Clean up after test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Clear cart.
+		WC()->cart->empty_cart();
+
+		// Clean up created products.
+		foreach ( $this->created_products as $product_id ) {
+			wp_delete_post( $product_id, true );
+		}
+		$this->created_products = array();
+
+		// Clean up tax rates.
+		$this->clean_up_tax_rates();
+
+		// Reset tax settings.
+		delete_option( 'woocommerce_shipping_tax_class' );
+		delete_option( 'woocommerce_tax_classes' );
+		delete_option( 'woocommerce_calc_taxes' );
+
+		// Only clean up tax classes we created during testing.
+		if ( $this->created_reduced_rate_class ) {
+			WC_Tax::delete_tax_class_by( 'slug', 'reduced-rate' );
+		}
+		if ( $this->created_zero_rate_class ) {
+			WC_Tax::delete_tax_class_by( 'slug', 'zero-rate' );
+		}
+	}
+
+	/**
+	 * Helper method to clean up all tax rates.
+	 */
+	private function clean_up_tax_rates() {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
+		wp_cache_flush();
+	}
+
+	/**
+	 * Ensure required tax classes exist for testing.
+	 * Creates them only if they don't already exist.
+	 */
+	private function ensure_tax_classes_exist() {
+		$existing_tax_class_slugs = WC_Tax::get_tax_class_slugs();
+
+		// Check and create reduced-rate tax class if needed.
+		if ( ! in_array( 'reduced-rate', $existing_tax_class_slugs, true ) ) {
+			$reduced_class = WC_Tax::create_tax_class( 'Reduced rate', 'reduced-rate' );
+			if ( is_array( $reduced_class ) ) {
+				$this->created_reduced_rate_class = true;
+			}
+		}
+
+		// Check and create zero-rate tax class if needed.
+		if ( ! in_array( 'zero-rate', $existing_tax_class_slugs, true ) ) {
+			$zero_class = WC_Tax::create_tax_class( 'Zero rate', 'zero-rate' );
+			if ( is_array( $zero_class ) ) {
+				$this->created_zero_rate_class = true;
+			}
+		}
+	}
+
+	/**
+	 * Helper method to create a product with specified tax class.
+	 *
+	 * @param string $tax_class Tax class slug ('' for standard, 'reduced-rate', etc).
+	 * @param string $name Product name.
+	 * @return WC_Product_Simple
+	 */
+	private function create_product_with_tax_class( $tax_class = '', $name = 'Test Product' ) {
+		$product = new WC_Product_Simple();
+		$product->set_name( $name );
+		$product->set_regular_price( 10.00 );
+		$product->set_tax_class( $tax_class );
+		$product->save();
+
+		$this->created_products[] = $product->get_id();
+
+		return $product;
+	}
+
+	/**
+	 * Test get_shipping_tax_rates returns correct rates for standard tax class.
+	 */
+	public function test_get_shipping_tax_rates_with_standard_tax_class() {
+		// Create a standard tax rate with shipping enabled.
+		$tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'CA Sales Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Create product with standard tax class and add to cart.
+		$product = $this->create_product_with_tax_class( '', 'Standard Tax Product' );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		$this->assertArrayHasKey( $tax_rate_id, $shipping_rates );
+		$this->assertEquals( '10.0000', $shipping_rates[ $tax_rate_id ]['rate'] );
+		$this->assertEquals( 'CA Sales Tax', $shipping_rates[ $tax_rate_id ]['label'] );
+		$this->assertEquals( 'yes', $shipping_rates[ $tax_rate_id ]['shipping'] );
+
+		WC_Tax::_delete_tax_rate( $tax_rate_id );
+	}
+
+	/**
+	 * Test get_shipping_tax_rates with reduced rate tax class.
+	 */
+	public function test_get_shipping_tax_rates_with_reduced_tax_class() {
+		// Create reduced rate tax with shipping enabled.
+		$reduced_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'Reduced Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'reduced-rate',
+		);
+
+		$reduced_tax_rate_id = WC_Tax::_insert_tax_rate( $reduced_tax_rate );
+
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Create product with reduced rate tax class and add to cart.
+		$product = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		$this->assertArrayHasKey( $reduced_tax_rate_id, $shipping_rates );
+		$this->assertEquals( '5.0000', $shipping_rates[ $reduced_tax_rate_id ]['rate'] );
+		$this->assertEquals( 'Reduced Tax', $shipping_rates[ $reduced_tax_rate_id ]['label'] );
+
+		WC_Tax::_delete_tax_rate( $reduced_tax_rate_id );
+	}
+
+	/**
+	 * Test the correct behavior: when reduced rate items have no shipping tax rates,
+	 * it should return empty array (no shipping tax) rather than falling back to standard rates.
+	 * This tests the fix for https://github.com/woocommerce/woocommerce/issues/58757
+	 */
+	public function test_get_shipping_tax_rates_edge_case_no_reduced_shipping_rates() {
+		// Create standard tax rate with shipping enabled.
+		$standard_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'Standard Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		// Create reduced rate tax WITHOUT shipping enabled (shipping = 0).
+		$reduced_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'Reduced Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0', // This is the key - no shipping tax for reduced rate.
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'reduced-rate',
+		);
+
+		$standard_tax_rate_id = WC_Tax::_insert_tax_rate( $standard_tax_rate );
+		$reduced_tax_rate_id  = WC_Tax::_insert_tax_rate( $reduced_tax_rate );
+
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Create product with reduced rate tax class and add to cart (the problematic scenario).
+		$product = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		// The correct behavior: when reduced rate has no shipping tax enabled,
+		// no shipping tax should be applied (empty array), not fall back to standard rates.
+		$this->assertEmpty( $shipping_rates, 'Should return empty array when reduced rate has no shipping tax enabled' );
+
+		WC_Tax::_delete_tax_rate( $standard_tax_rate_id );
+		WC_Tax::_delete_tax_rate( $reduced_tax_rate_id );
+	}
+
+	/**
+	 * Test get_shipping_tax_rates with explicit shipping tax class setting.
+	 */
+	public function test_get_shipping_tax_rates_with_explicit_shipping_tax_class() {
+		// Create reduced rate tax with shipping enabled.
+		$reduced_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'Reduced Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'reduced-rate',
+		);
+
+		$reduced_tax_rate_id = WC_Tax::_insert_tax_rate( $reduced_tax_rate );
+
+		// Set explicit shipping tax class (not inherit).
+		update_option( 'woocommerce_shipping_tax_class', 'reduced-rate' );
+
+		// Create product with standard tax class - should be ignored due to explicit setting.
+		$product = $this->create_product_with_tax_class( '', 'Standard Tax Product' );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		$this->assertArrayHasKey( $reduced_tax_rate_id, $shipping_rates );
+		$this->assertEquals( '5.0000', $shipping_rates[ $reduced_tax_rate_id ]['rate'] );
+
+		WC_Tax::_delete_tax_rate( $reduced_tax_rate_id );
+	}
+
+	/**
+	 * Test get_shipping_tax_rates returns empty array when no taxable items.
+	 */
+	public function test_get_shipping_tax_rates_no_taxable_items() {
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Create product with no tax status (non-taxable) and add to cart.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Non-taxable Product' );
+		$product->set_regular_price( 10.00 );
+		$product->set_tax_status( 'none' );
+		$product->save();
+
+		$this->created_products[] = $product->get_id();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		$this->assertEmpty( $shipping_rates );
+	}
+
+	/**
+	 * Test get_shipping_tax_rates with mixed tax classes prioritizes standard.
+	 */
+	public function test_get_shipping_tax_rates_mixed_tax_classes_prioritizes_standard() {
+		// Create both standard and reduced rate taxes with shipping enabled.
+		$standard_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'Standard Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$reduced_tax_rate = array(
+			'tax_rate_country'  => 'US',
+			'tax_rate_state'    => 'CA',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'Reduced Tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'reduced-rate',
+		);
+
+		$standard_tax_rate_id = WC_Tax::_insert_tax_rate( $standard_tax_rate );
+		$reduced_tax_rate_id  = WC_Tax::_insert_tax_rate( $reduced_tax_rate );
+
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Add products with mixed tax classes to cart.
+		$standard_product = $this->create_product_with_tax_class( '', 'Standard Tax Product' );
+		$reduced_product  = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+
+		WC()->cart->add_to_cart( $standard_product->get_id(), 1 );
+		WC()->cart->add_to_cart( $reduced_product->get_id(), 1 );
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		// Should prioritize standard tax class.
+		$this->assertArrayHasKey( $standard_tax_rate_id, $shipping_rates );
+		$this->assertEquals( '10.0000', $shipping_rates[ $standard_tax_rate_id ]['rate'] );
+
+		WC_Tax::_delete_tax_rate( $standard_tax_rate_id );
+		WC_Tax::_delete_tax_rate( $reduced_tax_rate_id );
+	}
+
+	/**
+	 * Test get_shipping_tax_rates returns empty array for empty cart.
+	 */
+	public function test_get_shipping_tax_rates_empty_cart() {
+		// Set shipping tax class to inherit.
+		update_option( 'woocommerce_shipping_tax_class', 'inherit' );
+
+		// Ensure cart is empty.
+		WC()->cart->empty_cart();
+
+		$shipping_rates = WC_Tax::get_shipping_tax_rates();
+
+		$this->assertEmpty( $shipping_rates );
+	}
+
+	/**
+	 * Test get_shipping_tax_class_from_cart_items returns standard for empty cart.
+	 */
+	public function test_get_shipping_tax_class_from_cart_items_empty_cart() {
+		// Ensure cart is empty.
+		WC()->cart->empty_cart();
+
+		// Use reflection to test private method.
+		$reflection = new ReflectionClass( 'WC_Tax' );
+		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null );
+
+		$this->assertEquals( '', $result );
+	}
+
+	/**
+	 * Test get_shipping_tax_class_from_cart_items returns null for no taxable items.
+	 */
+	public function test_get_shipping_tax_class_from_cart_items_no_taxable_items() {
+		// Create non-taxable product and add to cart.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Non-taxable Product' );
+		$product->set_regular_price( 10.00 );
+		$product->set_tax_status( 'none' );
+		$product->save();
+
+		$this->created_products[] = $product->get_id();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Use reflection to test private method.
+		$reflection = new ReflectionClass( 'WC_Tax' );
+		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_shipping_tax_class_from_cart_items prioritizes standard tax class.
+	 */
+	public function test_get_shipping_tax_class_from_cart_items_prioritizes_standard() {
+		// Add products with mixed tax classes to cart.
+		$reduced_product  = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+		$standard_product = $this->create_product_with_tax_class( '', 'Standard Tax Product' );
+
+		WC()->cart->add_to_cart( $reduced_product->get_id(), 1 );
+		WC()->cart->add_to_cart( $standard_product->get_id(), 1 );
+
+		// Use reflection to test private method.
+		$reflection = new ReflectionClass( 'WC_Tax' );
+		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null );
+
+		$this->assertEquals( '', $result, 'Should prioritize standard tax class (empty string)' );
+	}
+
+	/**
+	 * Test get_shipping_tax_class_from_cart_items returns single tax class.
+	 */
+	public function test_get_shipping_tax_class_from_cart_items_single_tax_class() {
+		// Add product with reduced rate tax class to cart.
+		$product = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Use reflection to test private method.
+		$reflection = new ReflectionClass( 'WC_Tax' );
+		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null );
+
+		$this->assertEquals( 'reduced-rate', $result );
+	}
+
+	/**
+	 * Test get_shipping_tax_class_from_cart_items follows tax class hierarchy.
+	 */
+	public function test_get_shipping_tax_class_from_cart_items_follows_hierarchy() {
+		// Add products with zero-rate and reduced-rate tax classes to cart.
+		$zero_product    = $this->create_product_with_tax_class( 'zero-rate', 'Zero Rate Product' );
+		$reduced_product = $this->create_product_with_tax_class( 'reduced-rate', 'Reduced Rate Product' );
+
+		WC()->cart->add_to_cart( $zero_product->get_id(), 1 );
+		WC()->cart->add_to_cart( $reduced_product->get_id(), 1 );
+
+		// Use reflection to test private method.
+		$reflection = new ReflectionClass( 'WC_Tax' );
+		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null );
+
+		// Should return the first tax class found in the hierarchy (reduced-rate comes before zero-rate).
+		$this->assertEquals( 'reduced-rate', $result );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When shipping tax is set to "inherit from cart items" and cart contains items with a tax class that doesn't have shipping tax enabled (e.g., reduced-rate with shipping checkbox unchecked), the system was incorrectly falling back to standard shipping tax rates instead of applying no shipping tax.

Root Cause: The get_shipping_tax_rates() method had fallback logic that would use standard rates when no shipping rates were found for the inherited tax class, which defeated the purpose of tax class inheritance.

Fix: Removed the fallback logic so that when a tax class doesn't have shipping tax enabled, no shipping tax is applied (returns empty array). This ensures that the administrator's intent is respected - if they don't check the "Shipping" checkbox for a tax rate, no shipping tax should be charged for that tax class.

Impact: Fixes the bug described in GitHub issue #58757 where customers were being charged incorrect shipping tax amounts.

Fixes #58757

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a standard tax rate of 20%. Check the "shipping" box for the rate.
2. Create a reduced tax rate of 5%. Uncheck the "shipping" box for the rate.
3. No other rates defined.
4. Tax > Tax Options > Shipping tax class > Shipping tax class based on cart items
5. Create one shipping option worldwide. Flat rate.
6. Create a product with assigned tax class of reduced rate
7. Add said product to cart.
8. The product should be taxed, but the shipping should not.
9. Place order.
10. Ensure the order totals match what was in the cart.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
