### PR TITLE
Migrate all of Woo cron jobs to use action scheduler

### DIFF
--- a/plugins/woocommerce/changelog/59325-add-move-session-cleanup-to-AS
+++ b/plugins/woocommerce/changelog/59325-add-move-session-cleanup-to-AS
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Migrate all cron jobs (session clean up, unpaid order clean up, sale schedules, log clean up...) to use action scheduler instead.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -561,7 +561,7 @@ class WC_Install {
 		self::create_roles();
 		self::setup_environment();
 		self::create_terms();
-		self::create_cron_jobs();
+		self::clear_cron_jobs();
 		self::delete_obsolete_notes();
 		self::create_files();
 		self::maybe_create_pages();
@@ -870,20 +870,20 @@ class WC_Install {
 	 */
 	public static function cron_schedules( $schedules ) {
 		$schedules['monthly']     = array(
-			'interval' => 2635200,
+			'interval' => MONTH_IN_SECONDS,
 			'display'  => __( 'Monthly', 'woocommerce' ),
 		);
 		$schedules['fifteendays'] = array(
-			'interval' => 1296000,
+			'interval' => 15 * DAY_IN_SECONDS,
 			'display'  => __( 'Every 15 Days', 'woocommerce' ),
 		);
 		return $schedules;
 	}
 
 	/**
-	 * Create cron jobs (clear them first).
+	 * Removes old cron jobs now that we moved to Action Scheduler.
 	 */
-	private static function create_cron_jobs() {
+	private static function clear_cron_jobs() {
 		wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
@@ -892,44 +892,6 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_rate_limits' );
-
-		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
-
-		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . absint( get_option( 'gmt_offset' ) ) . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
-
-		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
-
-		if ( '' !== $held_duration ) {
-			/**
-			 * Determines the interval at which to cancel unpaid orders in minutes.
-			 *
-			 * @since 5.1.0
-			 */
-			$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
-			wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
-		}
-
-		// Delay the first run of `woocommerce_cleanup_personal_data` by 10 seconds
-		// so it doesn't occur in the same request. WooCommerce Admin also schedules
-		// a daily cron that gets lost due to a race condition. WC_Privacy's background
-		// processing instance updates the cron schedule from within a cron job.
-		wp_schedule_event( time() + 10, 'daily', 'woocommerce_cleanup_personal_data' );
-		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'woocommerce_cleanup_logs' );
-		wp_schedule_event( time() + ( 6 * HOUR_IN_SECONDS ), 'twicedaily', 'woocommerce_cleanup_sessions' );
-		wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fifteendays', 'woocommerce_geoip_updater' );
-		/**
-		 * How frequent to schedule the tracker send event.
-		 *
-		 * @since 2.3.0
-		 */
-		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
-		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'woocommerce_cleanup_rate_limits' );
-
-		if ( ! wp_next_scheduled( 'wc_admin_daily' ) ) {
-			wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
-		}
-		// Note: this is potentially redundant when the core package exists.
-		wp_schedule_single_event( time() + 10, 'generate_category_lookup_table' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -309,6 +309,12 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
+		// @todo: remove this once we have version 3.9.3 of Action Scheduler.
+		if ( function_exists( 'as_supports' ) && as_supports( 'schedule_recurring_actions_hook' ) ) {
+			add_action( 'action_scheduler_schedule_recurring_actions', array( $this, 'register_recurring_actions' ) );
+		} else {
+			add_action( 'action_scheduler_init', array( $this, 'register_recurring_actions' ) );
+		}
 
 		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );
@@ -1382,6 +1388,69 @@ final class WooCommerce {
 
 		// Always update the last change.
 		update_option( 'woocommerce_allow_tracking_last_modified', time() );
+	}
+
+	/**
+	 * Register recurring actions.
+	 */
+	public function register_recurring_actions() {
+		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
+
+		// Schedule daily sales event at midnight tomorrow.
+		$scheduled_sales_time = strtotime( '00:00 tomorrow ' . $ve . absint( get_option( 'gmt_offset' ) ) . ' HOURS' );
+
+		as_schedule_recurring_action( $scheduled_sales_time, DAY_IN_SECONDS, 'woocommerce_scheduled_sales', array(), 'woocommerce', true );
+
+		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
+
+		if ( '' !== $held_duration ) {
+			/**
+			 * Determines the interval at which to cancel unpaid orders in minutes.
+			 *
+			 * @since 5.1.0
+			 */
+			$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
+
+			as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
+
+		}
+
+		// Delay the first run of `woocommerce_cleanup_personal_data` by 10 seconds
+		// so it doesn't occur in the same request. WooCommerce Admin also schedules
+		// a daily cron that gets lost due to a race condition. WC_Privacy's background
+		// processing instance updates the cron schedule from within a cron job.
+
+		as_schedule_recurring_action( time() + 10, DAY_IN_SECONDS, 'woocommerce_cleanup_personal_data', array(), 'woocommerce', true );
+
+		// Schedule daily cleanup logs at 3 AM.
+
+		as_schedule_recurring_action( time() + ( 3 * HOUR_IN_SECONDS ), DAY_IN_SECONDS, 'woocommerce_cleanup_logs', array(), 'woocommerce', true );
+
+		// Schedule twice daily cleanup sessions at 6 AM and 6 PM.
+
+		as_schedule_recurring_action( time() + ( 6 * HOUR_IN_SECONDS ), 12 * HOUR_IN_SECONDS, 'woocommerce_cleanup_sessions', array(), 'woocommerce', true );
+
+		// Schedule geoip updater every 15 days.
+
+		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 15 * DAY_IN_SECONDS, 'woocommerce_geoip_updater', array(), 'woocommerce', true );
+
+		/**
+		 * How frequent to schedule the tracker send event.
+		 *
+		 * @since 2.3.0
+		 */
+		$tracker_recurrence = apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' );
+		$core_internals     = wp_get_schedules();
+		as_schedule_recurring_action( time() + 10, $core_internals[ $tracker_recurrence ]['interval'], 'woocommerce_tracker_send_event', array(), 'woocommerce', true );
+
+		// Schedule daily cleanup rate limits at 3 AM.
+
+		as_schedule_recurring_action( time() + ( 3 * HOUR_IN_SECONDS ), DAY_IN_SECONDS, 'woocommerce_cleanup_rate_limits', array(), 'woocommerce', true );
+
+		as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'wc_admin_daily', array(), 'woocommerce', true );
+
+		// Note: this is potentially redundant when the core package exists.
+		as_schedule_single_action( time() + 10, 'generate_category_lookup_table', array(), 'woocommerce', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -309,13 +309,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
-		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo: remove this once we have version 3.9.3 of Action Scheduler.
-		if ( function_exists( 'as_supports' ) && as_supports( 'schedule_recurring_actions_hook' ) ) {
-			add_action( 'action_scheduler_schedule_recurring_actions', array( $this, 'register_recurring_actions' ) );
-		} else {
-			add_action( 'action_scheduler_init', array( $this, 'register_recurring_actions' ) );
-		}
+		add_action( 'action_scheduler_schedule_recurring_actions', array( $this, 'register_recurring_actions' ) );
 
 		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -309,6 +309,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// @todo: remove this once we have version 3.9.3 of Action Scheduler.
 		if ( function_exists( 'as_supports' ) && as_supports( 'schedule_recurring_actions_hook' ) ) {
 			add_action( 'action_scheduler_schedule_recurring_actions', array( $this, 'register_recurring_actions' ) );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1395,6 +1395,11 @@ final class WooCommerce {
 	 * Register recurring actions.
 	 */
 	public function register_recurring_actions() {
+		// Check if Action Scheduler is available.
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+
 		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
 
 		// Schedule daily sales event at midnight tomorrow.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1238,8 +1238,7 @@ function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 		 */
 		$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $value ) );
 
-		// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
-		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
 	}
 
 	return $value;

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1226,7 +1226,11 @@ function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 	$value = ! empty( $raw_value ) ? absint( $raw_value ) : ''; // Allow > 0 or set to ''.
 
 	// Clear existing scheduled events.
-	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	if ( function_exists( 'as_unschedule_all_actions' ) ) {
+		as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	} else {
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	}
 
 	if ( '' !== $value ) {
 		/**
@@ -1238,7 +1242,11 @@ function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 		 */
 		$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $value ) );
 
-		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
+		} else {
+			wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+		}
 	}
 
 	return $value;

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1225,11 +1225,21 @@ add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_price_num_de
 function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 	$value = ! empty( $raw_value ) ? absint( $raw_value ) : ''; // Allow > 0 or set to ''.
 
-	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	// Clear existing scheduled events.
+	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
 
 	if ( '' !== $value ) {
+		/**
+		 * Filters the interval at which to cancel unpaid orders in minutes.
+		 *
+		 * @since 5.1.0
+		 *
+		 * @param int $cancel_unpaid_interval The interval at which to cancel unpaid orders in minutes.
+		 */
 		$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $value ) );
-		wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+
+		// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
+		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 	}
 
 	return $value;

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1075,7 +1075,7 @@ add_action( 'woocommerce_trash_order', 'wc_update_coupon_usage_counts' );
  * Cancel all unpaid orders after held duration to prevent stock lock for those products.
  */
 function wc_cancel_unpaid_orders() {
-	$held_duration = get_option( 'woocommerce_hold_stock_minutes' );
+	$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
 
 	// Re-schedule the event before cancelling orders
 	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry.
@@ -1089,10 +1089,18 @@ function wc_cancel_unpaid_orders() {
 	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
 
 	// Clear existing scheduled events.
+	if ( function_exists( 'as_unschedule_all_actions' ) ) {
 		as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	} else {
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	}
 
 	// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
-		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+	if ( function_exists( 'as_schedule_single_action' ) ) {
+		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
+	} else {
+		wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+	}
 
 	if ( $held_duration < 1 || 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
 		return;

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1079,9 +1079,20 @@ function wc_cancel_unpaid_orders() {
 
 	// Re-schedule the event before cancelling orders
 	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry.
-	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	/**
+	 * Filters the interval at which to cancel unpaid orders in minutes.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param int $cancel_unpaid_interval The interval at which to cancel unpaid orders in minutes.
+	 */
 	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
-	wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+
+	// Clear existing scheduled events.
+		as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+
+	// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
+		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 
 	if ( $held_duration < 1 || 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
 		return;

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -51,10 +51,6 @@ class OrderCountCacheService {
 		add_action( 'woocommerce_before_delete_order', array( $this, 'update_on_order_deleted' ), 10, 2 );
 		add_action( self::BACKGROUND_EVENT_HOOK, array( $this, 'refresh_cache' ) );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'schedule_background_actions' ) );
-		// This is a temporary fix to ensure the background actions are scheduled.
-		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// @todo: Remove this once the Action Scheduler package is updated to >= 3.9.3.
-		add_action( 'admin_init', array( $this, 'schedule_background_actions' ) );
 
 		if ( defined( 'WC_PLUGIN_BASENAME' ) ) {
 			add_action( 'deactivate_' . WC_PLUGIN_BASENAME, array( $this, 'unschedule_background_actions' ) );

--- a/plugins/woocommerce/src/Caches/OrderCountCacheService.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCacheService.php
@@ -52,6 +52,7 @@ class OrderCountCacheService {
 		add_action( self::BACKGROUND_EVENT_HOOK, array( $this, 'refresh_cache' ) );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'schedule_background_actions' ) );
 		// This is a temporary fix to ensure the background actions are scheduled.
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// @todo: Remove this once the Action Scheduler package is updated to >= 3.9.3.
 		add_action( 'admin_init', array( $this, 'schedule_background_actions' ) );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -152,7 +152,7 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 			)
 		);
 		// Verify that a second follow up action was queued.
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 		$this->assertCount(
 			2,
 			OrdersScheduler::queue()->search(
@@ -175,7 +175,7 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 			)
 		);
 		// Verify that no follow up action was queued.
-		WC_Helper_Queue::run_all_pending();
+		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
 		$this->assertCount(
 			0,
 			OrdersScheduler::queue()->search(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -82,18 +82,6 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	}
 
 	/**
-	 * By the time we hit this test method, we should have the following cron jobs.
-	 * - wc_admin_daily
-	 * - generate_category_lookup_table
-	 *
-	 * @return void
-	 */
-	public function test_cron_job_creation() {
-		$this->assertNotFalse( wp_next_scheduled( 'wc_admin_daily' ) );
-		$this->assertNotFalse( wp_next_scheduled( 'generate_category_lookup_table' ) );
-	}
-
-	/**
 	 * Data provider that returns DB Update version string and # of expected pending jobs.
 	 *
 	 * @return array[]
@@ -234,5 +222,4 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 			$this->assertNotFalse( get_option( $new_option ), $new_option );
 		}
 	}
-
 }

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -14,6 +14,7 @@ global $wpdb, $wp_version, $wc_uninstalling_plugin;
 
 $wc_uninstalling_plugin = true;
 
+// Clear WordPress cron events.
 wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
@@ -25,6 +26,21 @@ wp_clear_scheduled_hook( 'woocommerce_cleanup_rate_limits' );
 wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
+
+// Clear Action Scheduler events.
+if ( function_exists( 'as_unschedule_all_actions' ) ) {
+	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
+	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_personal_data' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_logs' );
+	as_unschedule_all_actions( 'woocommerce_geoip_updater' );
+	as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
+	as_unschedule_all_actions( 'wc_admin_daily' );
+	as_unschedule_all_actions( 'generate_category_lookup_table' );
+	as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
+}
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves all of Woo's cron jobs to action scheduler, this has some main benefits:
- cron jobs are only added on install or update, are sometimes flaky, are persisted to DB and can be deleted.
- They don't benefit from the visibility, batching, or offloading of action scheduler.

So here we move them outside of WC_Install and initiate them in WooCommerce, the logic is kept the same, AS makes it easy to migrate to it so that made it easy and safe.

Closes https://github.com/woocommerce/woocommerce/issues/29682
Closes https://github.com/woocommerce/woocommerce/issues/25722

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Status -> Scheduled actions.
2. Make sure you have the following six actions in pending:
```
woocommerce_cleanup_personal_data
woocommerce_cleanup_logs
woocommerce_cleanup_sessions
woocommerce_geoip_updater
woocommerce_tracker_send_event
woocommerce_cleanup_rate_limits
generate_category_lookup_table
```
3. Load up the database admin and go to `wp_woocommerce_sessions` and modify a row expiry date to something in the past.
4. Go to WooCommerce -> Status -> Scheduled actions -> Pending and run the session_cleanup job.
5. Make sure the sessions are deleted.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Migrate all cron jobs (session clean up, unpaid order clean up, sale schedules, log clean up...) to use action scheduler instead.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
