### PR TITLE
Fix 'allows switching to 3rd-party product types' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-55053-flaky-test
+++ b/plugins/woocommerce/changelog/fix-55053-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix 'allows switching to 3rd-party product types' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -35,6 +35,13 @@ class AddToCartWithOptionsPage {
 			name: 'Switch product type',
 		} );
 		await productTypeSwitcher.click();
+
+		// Wait for the menu to open.
+		const menu = this.page.getByRole( 'menu', {
+			name: 'Switch product type',
+		} );
+		await menu.waitFor( { state: 'visible' } );
+
 		const customProductTypeButton = this.page.getByRole( 'menuitem', {
 			name: productType,
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/55053.

This PR improves the 'allows switching to 3rd-party product types' e2e test of the _Add to Cart + Options_ block so we wait for the `menu` to open before trying to click on the `menuitem`.

### How to test the changes in this Pull Request:

1. Make sure the 'allows switching to 3rd-party product types' test passes and is not flaky (Blocks e2e tests 1/10).