### PR TITLE
Add to Cart + Options: don't try to remove attributes on load

### DIFF
--- a/plugins/woocommerce/changelog/fix-58838-flaky-test
+++ b/plugins/woocommerce/changelog/fix-58838-flaky-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: don't try to remove attributes on load

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/frontend.ts
@@ -51,7 +51,10 @@ function setAttribute( name: string, value: string | null ) {
 
 function setDefaultSelectedAttribute() {
 	const context = getContext< Context >();
-	setAttribute( context.name, context.selectedValue );
+
+	if ( context.selectedValue ) {
+		setAttribute( context.name, context.selectedValue );
+	}
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes it so we don't call `wooAddToCartWithOptions.removeAttribute()` on page load, as it isn't needed. I believe that's also causing this flaky test: https://github.com/woocommerce/woocommerce/issues/58838.

There is also a separate issue about unifying those Interactivity API stores, which would hopefully fix the flaky test too (https://github.com/woocommerce/woocommerce/issues/59335), but the fix in this PR would still be needed and this way we fix the flaky test earlier.

Closes https://github.com/woocommerce/woocommerce/issues/58838.

### How to test the changes in this Pull Request:

1. Make sure the 'allows adding variable products to cart' test passes and is not flaky.