### PR TITLE
Add job to refresh docs site post release

### DIFF
--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -78,3 +78,15 @@ jobs:
             --base trunk \
             --head "$branch_name" \
             --reviewer "${{ github.actor }}"
+
+  refresh-sites:
+    name: Refresh doc sites after release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ ! contains( github.event.release.tag_name, 'wc-beta-tester' ) && ! contains( github.event.release.tag_name, '-rc' )  }}
+    steps:
+      - name: Refresh Code reference
+        env:
+          GH_TOKEN: ${{ secrets.CODE_REFERENCE_SITE_TOKEN }}
+        run: |
+          gh workflow run deploy.yml --repo "$GITHUB_REPOSITORY_OWNER/code-reference"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR adds a step to the post-release workflow to trigger the regenerating of the [code reference site](https://woocommerce.github.io/code-reference/) after a stable release is published.

🙏🏻 Please review https://github.com/woocommerce/code-reference/pull/28 as part of this PR as well.

> [!WARNING]
> This functionality requires an access token, which is similar to other access tokens we use in our workflows (such as `REPORTS_TOKEN`). For the time being, in case we want to consolidate some tokens, I have marked the job as `continue-on-error: true` so it doesn't fail the full post-release job if the token is not configured as a secret in the repo.

Closes #57960.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the relevant repositories:
   - Fork the `woocommerce/code-reference` repository and make sure branch `deploy-job-fixes` is merged into `trunk`. Include all branches, not just `trunk`.
   - Fork the `woocommerce/woocommerce` repository and make sure this branch (`fix/57960)` is merged into `trunk`.
1. Go to your fork of `code-reference` and ensure that:
   - Actions are enabled in the **Actions** tab.
   - In **Settings > Pages**, **Source** is set to deploy from the `gh-pages` branch.
1. Inside https://github.com/settings/personal-access-tokens, create a **Fine-grained** token with access to just the `<your username>/code-reference` repository and **Read and write** permission to use **Actions**. No other permission is needed. Take note of the generated token.
1. Go to `https://<your username>.github.io/code-reference/classes/WooCommerce.html#property_version` and confirm that you see that `$version` is said to be set to `9.8.5`.
1. Go to **Settings > Secrets and variables > Actions** in your fork of the `woocommerce` repository and add a new secret named `CODE_REFERENCE_SITE_TOKEN` with value the token from the previous step.
1. Go to **Releases** (in your fork of the `woocommerce` repo) and publish a new release with these settings:
   - Tag name `9.9.5`.
   - Upload https://downloads.wordpress.org/plugin/woocommerce.9.9.5.zip as `woocommerce.zip`.
   - Set as the "latest" release.
   - Target set to `trunk` (so the new workflow runs after it gets published).
1. Confirm in **Actions** (in your fork of the `woocommerce` repo) that the _Release: Post-release published flows_ workflow runs after the release is published. Wait until it completes.
1. Confirm in **Actions** (in your fork of the `code-reference` repo) that _GitHub Pages deploy_ was run or is running. Wait until it completes if necessary.
1. Go to `https://<your username>.github.io/code-reference/classes/WooCommerce.html#property_version` and confirm that you see that `$version` is now said to be set to `9.9.5`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
