### PR TITLE
First pass at passing product add to cart params via checkout-link

### DIFF
--- a/plugins/woocommerce/changelog/issues-59332-checkout-link
+++ b/plugins/woocommerce/changelog/issues-59332-checkout-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Support adding additional parameters to a product in checkout-link

--- a/plugins/woocommerce/phpstan-baseline.neon
+++ b/plugins/woocommerce/phpstan-baseline.neon
@@ -52882,12 +52882,6 @@ parameters:
 			path: src/Blocks/Domain/Services/CheckoutLink.php
 
 		-
-			message: '#^Parameter \#2 \$str of function explode expects string, array\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Blocks/Domain/Services/CheckoutLink.php
-
-		-
 			message: '#^Method Automattic\\WooCommerce\\Blocks\\Domain\\Services\\CreateAccount\:\:customer_new_account\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -88,7 +88,13 @@ class CheckoutLink {
 	/**
 	 * Get the products from the checkout link.
 	 *
-	 * @return array The products (keys) and their quantities (values).
+	 * @return array[] Array of products, each containing:
+	 * [
+	 *     'id'             => (int)    Product ID,
+	 *     'quantity'       => (int)    Quantity of the product,
+	 *     'variation'      => (array)  Variation attributes (if any),
+	 *     'cart_item_data' => (array)  Additional cart item data,
+	 * ]
 	 */
 	protected function get_products_from_checkout_link() {
 		$raw_products = array_filter( explode( ',', wc_clean( wp_unslash( $_GET['products'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -156,7 +162,8 @@ class CheckoutLink {
 				$cart_item_data
 			);
 
-			$products[ $product_id ] = [
+			$products[] = [
+				'id'             => $product_id,
 				'quantity'       => $qty,
 				'variation'      => $variation,
 				'cart_item_data' => $cart_item_data,
@@ -188,14 +195,9 @@ class CheckoutLink {
 		$products   = $this->get_products_from_checkout_link();
 		$errors     = new \WP_Error();
 
-		foreach ( $products as $product_id => $product_data ) {
+		foreach ( $products as $product_data ) {
 			try {
-				$controller->add_to_cart(
-					array_merge(
-						[ 'id' => $product_id ],
-						$product_data
-					)
-				);
+				$controller->add_to_cart( $product_data );
 			} catch ( \Exception $e ) {
 				$errors->add( 'error', $e->getMessage() );
 			}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -99,7 +99,11 @@ class CheckoutLink {
 
 			if ( strpos( $raw_product, ':' ) !== false ) {
 
-				list( $product_id, $qty, $product_data ) = array_pad( explode( ':', $raw_product, 3 ), 3, false );
+				$exploded = explode( ':', $raw_product, 3 );
+
+				$product_id   = $exploded[0] ?? 0;
+				$qty          = $exploded[1] ?? 1;
+				$product_data = $exploded[2] ?? '';
 
 				// If the quantity is not-numeric, it may be key=value pairs.
 				if ( ! is_numeric( $qty ) ) {
@@ -109,21 +113,15 @@ class CheckoutLink {
 
 				if ( $product_data ) {
 
-					// Parse key=value pairs separated by semicolons
-					$pairs = explode( ';', $product_data );
+					// Parse the product data into key=value pairs.
+					parse_str( $product_data, $pairs );
 
 					$cart_item_data = [];
 
-					foreach ( $pairs as $pair ) {
-						if ( strpos( $pair, '=' ) === false ) {
-							continue;
-						}
-						list( $key, $value ) = explode( '=', $pair, 2 );
-						$key                 = trim( $key );
-						$value               = trim( $value );
-
-						$cart_item_data[ $key ] = wc_clean( $value );
+					foreach ( $pairs as $key => $value ) {
+						$cart_item_data[ wc_clean( $key ) ] = wc_clean( $value );
 					}
+
 				}
 			} else {
 				$product_id = $raw_product;

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -94,21 +94,66 @@ class CheckoutLink {
 		$raw_products = array_filter( explode( ',', wc_clean( wp_unslash( $_GET['products'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$products     = [];
 
-		foreach ( $raw_products as $product_id_qty ) {
-			if ( strpos( $product_id_qty, ':' ) !== false ) {
-				list( $product_id, $qty ) = explode( ':', $product_id_qty );
+		foreach ( $raw_products as $raw_product ) {
+			$cart_item_data = [];
+
+			if ( strpos( $raw_product, ':' ) !== false ) {
+
+				list( $product_id, $product_data ) = explode( ':', $raw_product );
+				
+				if ( is_numeric( $product_data ) ) {
+					$qty = $product_data;
+				} else {
+					// Parse key=value pairs separated by semicolons
+					$pairs = explode( ';', $product_data );
+
+					$cart_item_data  = [];
+
+					foreach ( $pairs as $pair ) {
+						if ( strpos( $pair, '=' ) === false ) {
+							continue;
+						}
+						list( $key, $value ) = explode( '=', $pair, 2 );
+						$key   = trim( $key );
+						$value = trim( $value );
+
+						$cart_item_data[ $key ] = wc_clean( $value );
+					}
+
+					$qty = $cart_item_data['qty'] ?? 1;
+
+				}
+
 			} else {
-				$product_id = $product_id_qty;
+				$product_id = $raw_product;
 				$qty        = 1;
 			}
+			
 			$product_id = absint( $product_id );
 			$qty        = absint( $qty );
 
 			if ( ! $product_id || ! $qty ) {
 				continue;
 			}
+			
+			$variation = array_map(
+				function ( $key, $value ) {
+					return [
+						'attribute' => $key,
+						'value'     => $value,
+					];
+				},
+				array_keys( $cart_item_data ),
+				$cart_item_data
+			);
 
-			$products[ $product_id ] = $qty;
+			$products[ $product_id ] = array_merge(
+				[
+					'quantity'  => $qty,
+					'variation' => $variation,
+				],
+				$cart_item_data,
+			);
 		}
 
 		return $products;
@@ -136,13 +181,13 @@ class CheckoutLink {
 		$products   = $this->get_products_from_checkout_link();
 		$errors     = new \WP_Error();
 
-		foreach ( $products as $product_id => $qty ) {
+		foreach ( $products as $product_id => $product_data ) {
 			try {
 				$controller->add_to_cart(
-					[
-						'id'       => $product_id,
-						'quantity' => $qty,
-					]
+					array_merge( 
+						[ 'id' => $product_id ],
+						$product_data
+					)
 				);
 			} catch ( \Exception $e ) {
 				$errors->add( 'error', $e->getMessage() );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -128,6 +128,11 @@ class CheckoutLink {
 				$product_id = $raw_product;
 				$qty        = 1;
 			}
+
+			if ( ! is_numeric( $product_id ) ) {
+				// If the product ID is not numeric, it may be a SKU
+				$product_id = wc_get_product_id_by_sku( wc_clean( $product_id ) );
+			}		
 			
 			$product_id = absint( $product_id );
 			$qty        = absint( $qty );

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -99,48 +99,49 @@ class CheckoutLink {
 
 			if ( strpos( $raw_product, ':' ) !== false ) {
 
-				list( $product_id, $product_data ) = explode( ':', $raw_product );
-				
-				if ( is_numeric( $product_data ) ) {
-					$qty = $product_data;
-				} else {
+				list( $product_id, $qty, $product_data ) = array_pad( explode( ':', $raw_product, 3 ), 3, false );
+
+				// If the quantity is not-numeric, it may be key=value pairs.
+				if ( ! is_numeric( $qty ) ) {
+					$product_data = $qty;
+					$qty          = 1;
+				}
+
+				if ( $product_data ) {
+
 					// Parse key=value pairs separated by semicolons
 					$pairs = explode( ';', $product_data );
 
-					$cart_item_data  = [];
+					$cart_item_data = [];
 
 					foreach ( $pairs as $pair ) {
 						if ( strpos( $pair, '=' ) === false ) {
 							continue;
 						}
 						list( $key, $value ) = explode( '=', $pair, 2 );
-						$key   = trim( $key );
-						$value = trim( $value );
+						$key                 = trim( $key );
+						$value               = trim( $value );
 
 						$cart_item_data[ $key ] = wc_clean( $value );
 					}
-
-					$qty = $cart_item_data['qty'] ?? 1;
-
 				}
-
 			} else {
 				$product_id = $raw_product;
 				$qty        = 1;
 			}
 
 			if ( ! is_numeric( $product_id ) ) {
-				// If the product ID is not numeric, it may be a SKU
+				// If the product ID is not numeric, it may be a SKU.
 				$product_id = wc_get_product_id_by_sku( wc_clean( $product_id ) );
-			}		
-			
+			}
+
 			$product_id = absint( $product_id );
 			$qty        = absint( $qty );
 
 			if ( ! $product_id || ! $qty ) {
 				continue;
 			}
-			
+
 			$variation = array_map(
 				function ( $key, $value ) {
 					return [
@@ -152,13 +153,11 @@ class CheckoutLink {
 				$cart_item_data
 			);
 
-			$products[ $product_id ] = array_merge(
-				[
-					'quantity'  => $qty,
-					'variation' => $variation,
-				],
-				$cart_item_data,
-			);
+			$products[ $product_id ] = [
+				'quantity'       => $qty,
+				'variation'      => $variation,
+				'cart_item_data' => $cart_item_data,
+			];
 		}
 
 		return $products;
@@ -189,7 +188,7 @@ class CheckoutLink {
 		foreach ( $products as $product_id => $product_data ) {
 			try {
 				$controller->add_to_cart(
-					array_merge( 
+					array_merge(
 						[ 'id' => $product_id ],
 						$product_data
 					)

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -138,12 +138,6 @@ class CheckoutLink {
 				$qty        = 1;
 			}
 
-			// If the product ID is not numeric, it may be a SKU.
-			if ( ! is_numeric( $product_id ) ) {
-				$product_id = wc_get_product_id_by_sku( wc_clean( $product_id ) );
-			}
-
-			$product_id = absint( $product_id );
 			$qty        = absint( $qty );
 
 			if ( ! $product_id || ! $qty ) {

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -88,60 +88,33 @@ class CheckoutLink {
 	/**
 	 * Get the products from the checkout link.
 	 *
-	 * @return array[] Array of products, each containing:
-	 * [
-	 *     'id'             => (int)    Product ID,
-	 *     'quantity'       => (int)    Quantity of the product,
-	 *     'variation'      => (array)  Variation attributes (if any),
-	 *     'cart_item_data' => (array)  Additional cart item data,
-	 * ]
+	 * Products use the format `id-or-sku:quantity:variation-data:cart-item-data`. Quantity and both data groups are optional,
+	 * while an empty variation group separates cart item data. Multiple key-value pairs within a data group use semicolons.
+	 *
+	 * @return array[] Array of product data formatted for CartController::add_to_cart().
 	 */
 	protected function get_products_from_checkout_link() {
 		$raw_products = array_filter( explode( ',', wc_clean( wp_unslash( $_GET['products'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$products     = [];
 
 		foreach ( $raw_products as $raw_product ) {
-			$cart_item_data = [];
+			$segments           = explode( ':', $raw_product, 4 );
+			$product_identifier = $segments[0] ?? '';
+			$quantity           = '' !== ( $segments[1] ?? '' ) ? absint( $segments[1] ) : 1;
+			$variation_data     = $this->parse_product_data( $segments[2] ?? '' );
+			$cart_item_data     = $this->parse_product_data( $segments[3] ?? '' );
 
-			if ( strpos( $raw_product, ':' ) !== false ) {
-
-				$exploded = explode( ':', $raw_product, 3 );
-
-				$product_id   = $exploded[0] ?? 0;
-				$qty          = $exploded[1] ?? 1;
-				$product_data = $exploded[2] ?? '';
-
-				// If the quantity is not-numeric, it may be key=value pairs.
-				if ( ! is_numeric( $qty ) ) {
-					$product_data = $qty;
-					$qty          = 1;
-				}
-
-				if ( $product_data ) {
-
-					// Parse key=value pairs separated by semicolons.
-					$pairs          = explode( ';', $product_data );
-					$cart_item_data = [];
-
-					foreach ( $pairs as $pair ) {
-						if ( strpos( $pair, '=' ) === false ) {
-							continue;
-						}
-
-						list( $key, $value )                    = explode( '=', $pair, 2 );
-						$cart_item_data[ sanitize_key( $key ) ] = wc_clean( $value );
-					}
-				}
-			} else {
-				// No custom attributes provided, treat as default quantity.
-				$product_id = $raw_product;
-				$qty        = 1;
+			if ( ! $product_identifier || ! $quantity ) {
+				continue;
 			}
 
-			$qty        = absint( $qty );
-
-			if ( ! $product_id || ! $qty ) {
-				continue;
+			if ( is_numeric( $product_identifier ) ) {
+				$product_id = absint( $product_identifier );
+			} else {
+				$product_id = wc_get_product_id_by_sku( $product_identifier );
+				if ( ! $product_id ) {
+					continue;
+				}
 			}
 
 			$variation = array_map(
@@ -151,19 +124,44 @@ class CheckoutLink {
 						'value'     => $value,
 					];
 				},
-				array_keys( $cart_item_data ),
-				$cart_item_data
+				array_keys( $variation_data ),
+				$variation_data
 			);
 
 			$products[] = [
 				'id'             => $product_id,
-				'quantity'       => $qty,
+				'quantity'       => $quantity,
 				'variation'      => $variation,
 				'cart_item_data' => $cart_item_data,
 			];
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Parse a semicolon-separated list of key-value pairs.
+	 *
+	 * @param string $raw_data Raw product data from the checkout link.
+	 * @return array<string, string> Sanitized product data.
+	 */
+	protected function parse_product_data( $raw_data ) {
+		$data = [];
+
+		foreach ( explode( ';', $raw_data ) as $pair ) {
+			if ( false === strpos( $pair, '=' ) ) {
+				continue;
+			}
+
+			list( $key, $value ) = explode( '=', $pair, 2 );
+			$key                 = sanitize_key( $key );
+
+			if ( '' !== $key ) {
+				$data[ $key ] = sanitize_text_field( $value );
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -120,8 +120,7 @@ class CheckoutLink {
 				if ( $product_data ) {
 
 					// Parse key=value pairs separated by semicolons.
-					$pairs = explode( ';', $product_data );
-
+					$pairs          = explode( ';', $product_data );
 					$cart_item_data = [];
 
 					foreach ( $pairs as $pair ) {
@@ -129,18 +128,18 @@ class CheckoutLink {
 							continue;
 						}
 
-						list( $key, $value ) = explode( '=', $pair, 2 );
+						list( $key, $value )                    = explode( '=', $pair, 2 );
 						$cart_item_data[ sanitize_key( $key ) ] = wc_clean( $value );
 					}
-
 				}
 			} else {
+				// No custom attributes provided, treat as default quantity.
 				$product_id = $raw_product;
 				$qty        = 1;
 			}
 
+			// If the product ID is not numeric, it may be a SKU.
 			if ( ! is_numeric( $product_id ) ) {
-				// If the product ID is not numeric, it may be a SKU.
 				$product_id = wc_get_product_id_by_sku( wc_clean( $product_id ) );
 			}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -124,7 +124,7 @@ class CheckoutLink {
 						}
 
 						list( $key, $value ) = explode( '=', $pair, 2 );
-						$cart_item_data[ wc_clean( $key ) ] = wc_clean( $value );
+						$cart_item_data[ sanitize_key( $key ) ] = wc_clean( $value );
 					}
 
 				}

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -113,12 +113,17 @@ class CheckoutLink {
 
 				if ( $product_data ) {
 
-					// Parse the product data into key=value pairs.
-					parse_str( $product_data, $pairs );
+					// Parse key=value pairs separated by semicolons.
+					$pairs = explode( ';', $product_data );
 
 					$cart_item_data = [];
 
-					foreach ( $pairs as $key => $value ) {
+					foreach ( $pairs as $pair ) {
+						if ( strpos( $pair, '=' ) === false ) {
+							continue;
+						}
+
+						list( $key, $value ) = explode( '=', $pair, 2 );
 						$cart_item_data[ wc_clean( $key ) ] = wc_clean( $value );
 					}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -90,15 +90,23 @@ class CheckoutLink {
 	 *
 	 * Products use the format `id-or-sku:quantity:variation-data:cart-item-data`. Quantity and both data groups are optional,
 	 * while an empty variation group separates cart item data. Multiple key-value pairs within a data group use semicolons.
+	 * Prefix numeric SKUs with `sku=`. Delimiters within identifiers, keys, or values must be escaped with a tilde.
 	 *
 	 * @return array[] Array of product data formatted for CartController::add_to_cart().
 	 */
 	protected function get_products_from_checkout_link() {
-		$raw_products = array_filter( explode( ',', wc_clean( wp_unslash( $_GET['products'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$products     = [];
+		$products_query = wp_unslash( $_GET['products'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( ! is_string( $products_query ) ) {
+			return [];
+		}
+
+		$products_query = sanitize_text_field( $products_query );
+		$raw_products   = array_filter( $this->split_escaped( $products_query, ',' ) );
+		$products       = [];
 
 		foreach ( $raw_products as $raw_product ) {
-			$segments           = explode( ':', $raw_product, 4 );
+			$segments           = $this->split_escaped( $raw_product, ':', 4 );
 			$product_identifier = $segments[0] ?? '';
 			$quantity           = '' !== ( $segments[1] ?? '' ) ? absint( $segments[1] ) : 1;
 			$variation_data     = $this->parse_product_data( $segments[2] ?? '' );
@@ -108,13 +116,16 @@ class CheckoutLink {
 				continue;
 			}
 
-			if ( is_numeric( $product_identifier ) ) {
+			if ( 0 === strpos( $product_identifier, 'sku=' ) ) {
+				$product_id = wc_get_product_id_by_sku( substr( $product_identifier, 4 ) );
+			} elseif ( is_numeric( $product_identifier ) ) {
 				$product_id = absint( $product_identifier );
 			} else {
 				$product_id = wc_get_product_id_by_sku( $product_identifier );
-				if ( ! $product_id ) {
-					continue;
-				}
+			}
+
+			if ( ! $product_id ) {
+				continue;
 			}
 
 			$variation = array_map(
@@ -142,13 +153,15 @@ class CheckoutLink {
 	/**
 	 * Parse a semicolon-separated list of key-value pairs.
 	 *
+	 * @since 11.2.0
+	 *
 	 * @param string $raw_data Raw product data from the checkout link.
 	 * @return array<string, string> Sanitized product data.
 	 */
 	protected function parse_product_data( $raw_data ) {
 		$data = [];
 
-		foreach ( explode( ';', $raw_data ) as $pair ) {
+		foreach ( $this->split_escaped( $raw_data, ';' ) as $pair ) {
 			if ( false === strpos( $pair, '=' ) ) {
 				continue;
 			}
@@ -162,6 +175,36 @@ class CheckoutLink {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Split a string on unescaped delimiters.
+	 *
+	 * @param string $value     Value to split.
+	 * @param string $delimiter Single-character delimiter.
+	 * @param int    $limit     Maximum number of returned segments.
+	 * @return string[] Split values with delimiter escapes removed.
+	 */
+	private function split_escaped( $value, $delimiter, $limit = PHP_INT_MAX ) {
+		$segments = [ '' ];
+		$index    = 0;
+		$length   = strlen( $value );
+
+		for ( $position = 0; $position < $length; ++$position ) {
+			$character = $value[ $position ];
+
+			if ( '~' === $character && $position + 1 < $length && $delimiter === $value[ $position + 1 ] ) {
+				$segments[ $index ] .= $delimiter;
+				++$position;
+			} elseif ( $delimiter === $character && count( $segments ) < $limit ) {
+				$segments[] = '';
+				++$index;
+			} else {
+				$segments[ $index ] .= $character;
+			}
+		}
+
+		return $segments;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -1463,36 +1463,32 @@ class CartController {
 				continue;
 			}
 
-			// Attribute labels e.g. Size.
-			$attribute_label           = wc_attribute_label( $attribute['name'] );
-			$lowercase_attribute_label = strtolower( $attribute_label );
-			if ( isset( $variation_data[ $attribute_label ] ) || isset( $variation_data[ $lowercase_attribute_label ] ) ) {
-
-				// Check both the original and lowercase attribute label.
-				$attribute_label = isset( $variation_data[ $attribute_label ] ) ? $attribute_label : $lowercase_attribute_label;
-
+			// Attribute slug e.g. pa_size.
+			$attribute_slug = sanitize_title( $attribute['name'] );
+			if ( isset( $variation_data[ $attribute_slug ] ) ) {
 				$return[ $variation_attribute_name ] =
 					$attribute['is_taxonomy']
 						?
-						sanitize_title( $variation_data[ $attribute_label ] )
+						sanitize_title( $variation_data[ $attribute_slug ] )
 						:
 						html_entity_decode(
-							wc_clean( $variation_data[ $attribute_label ] ),
+							wc_clean( $variation_data[ $attribute_slug ] ),
 							ENT_QUOTES,
 							get_bloginfo( 'charset' )
 						);
 				continue;
 			}
 
-			// Attribute slugs e.g. pa_size.
-			if ( isset( $variation_data[ $attribute['name'] ] ) ) {
+			// Attribute key e.g. size.
+			$attribute_key = str_replace( array( 'attribute_', 'pa_' ), '', $attribute_slug );
+			if ( isset( $variation_data[ $attribute_key ] ) ) {
 				$return[ $variation_attribute_name ] =
 					$attribute['is_taxonomy']
 						?
-						sanitize_title( $variation_data[ $attribute['name'] ] )
+						sanitize_title( $variation_data[ $attribute_key ] )
 						:
 						html_entity_decode(
-							wc_clean( $variation_data[ $attribute['name'] ] ),
+							wc_clean( $variation_data[ $attribute_key ] ),
 							ENT_QUOTES,
 							get_bloginfo( 'charset' )
 						);

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -108,7 +108,8 @@ class CartController {
 			]
 		);
 
-		$request = $this->filter_request_data( $this->parse_variation_data( $request ) );
+		$request = $this->filter_request_data( $this->parse_variation_data( $this->parse_sku( $request ) ) );
+
 		$product = $this->get_product_for_cart( $request );
 		$cart_id = $cart->generate_cart_id(
 			$this->get_product_id( $product ),
@@ -1347,6 +1348,38 @@ class CartController {
 		ksort( $request['variation'] );
 
 		return $request;
+	}
+
+	/**
+	 * If product ID is found but does not match a product, check for a SKU match.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 *
+	 * @param array $request Add to cart request params.
+	 * @return array Updated request array.
+	 */
+	protected function parse_sku( $request ) {
+		$product = wc_get_product( $request['id'] );
+
+		// Get a product by SKU if no product found by ID.
+		if ( ! $product ) {
+			$product_id = wc_get_product_id_by_sku( $request['id'] );
+			if ( ! $product_id ) {
+				throw new RouteException(
+					'woocommerce_rest_cart_invalid_product',
+					sprintf(
+						/* translators: %s: product ID */
+						esc_html__( 'Product with SKU "%s" was not found and cannot be added to the cart.', 'woocommerce' ),
+						esc_html( $request['id'] )
+					),
+					400
+				);
+			}
+			$request['id'] = wc_get_product_id_by_sku( $request['id'] );
+		}
+
+		return $request;
+
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartController.php
@@ -108,8 +108,7 @@ class CartController {
 			]
 		);
 
-		$request = $this->filter_request_data( $this->parse_variation_data( $this->parse_sku( $request ) ) );
-
+		$request = $this->filter_request_data( $this->parse_variation_data( $request ) );
 		$product = $this->get_product_for_cart( $request );
 		$cart_id = $cart->generate_cart_id(
 			$this->get_product_id( $product ),
@@ -1351,38 +1350,6 @@ class CartController {
 	}
 
 	/**
-	 * If product ID is found but does not match a product, check for a SKU match.
-	 *
-	 * @throws RouteException Exception if invalid data is detected.
-	 *
-	 * @param array $request Add to cart request params.
-	 * @return array Updated request array.
-	 */
-	protected function parse_sku( $request ) {
-		$product = wc_get_product( $request['id'] );
-
-		// Get a product by SKU if no product found by ID.
-		if ( ! $product ) {
-			$product_id = wc_get_product_id_by_sku( $request['id'] );
-			if ( ! $product_id ) {
-				throw new RouteException(
-					'woocommerce_rest_cart_invalid_product',
-					sprintf(
-						/* translators: %s: product ID */
-						esc_html__( 'Product with SKU "%s" was not found and cannot be added to the cart.', 'woocommerce' ),
-						esc_html( $request['id'] )
-					),
-					400
-				);
-			}
-			$request['id'] = wc_get_product_id_by_sku( $request['id'] );
-		}
-
-		return $request;
-
-	}
-
-	/**
 	 * Try to match request data to a variation ID and return the ID.
 	 *
 	 * @throws RouteException Exception if variation cannot be found.
@@ -1463,32 +1430,36 @@ class CartController {
 				continue;
 			}
 
-			// Attribute slug e.g. pa_size.
-			$attribute_slug = sanitize_title( $attribute['name'] );
-			if ( isset( $variation_data[ $attribute_slug ] ) ) {
+			// Attribute labels e.g. Size.
+			$attribute_label           = wc_attribute_label( $attribute['name'] );
+			$lowercase_attribute_label = strtolower( $attribute_label );
+			if ( isset( $variation_data[ $attribute_label ] ) || isset( $variation_data[ $lowercase_attribute_label ] ) ) {
+
+				// Check both the original and lowercase attribute label.
+				$attribute_label = isset( $variation_data[ $attribute_label ] ) ? $attribute_label : $lowercase_attribute_label;
+
 				$return[ $variation_attribute_name ] =
 					$attribute['is_taxonomy']
 						?
-						sanitize_title( $variation_data[ $attribute_slug ] )
+						sanitize_title( $variation_data[ $attribute_label ] )
 						:
 						html_entity_decode(
-							wc_clean( $variation_data[ $attribute_slug ] ),
+							wc_clean( $variation_data[ $attribute_label ] ),
 							ENT_QUOTES,
 							get_bloginfo( 'charset' )
 						);
 				continue;
 			}
 
-			// Attribute key e.g. size.
-			$attribute_key = str_replace( array( 'attribute_', 'pa_' ), '', $attribute_slug );
-			if ( isset( $variation_data[ $attribute_key ] ) ) {
+			// Attribute slugs e.g. pa_size.
+			if ( isset( $variation_data[ $attribute['name'] ] ) ) {
 				$return[ $variation_attribute_name ] =
 					$attribute['is_taxonomy']
 						?
-						sanitize_title( $variation_data[ $attribute_key ] )
+						sanitize_title( $variation_data[ $attribute['name'] ] )
 						:
 						html_entity_decode(
-							wc_clean( $variation_data[ $attribute_key ] ),
+							wc_clean( $variation_data[ $attribute['name'] ] ),
 							ENT_QUOTES,
 							get_bloginfo( 'charset' )
 						);

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -110,6 +110,20 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( array_values( $product_ids ), array_values( $cart_product_ids ) );
+
+		// Check that the variable product in cart has the expected variations.
+		foreach ( $cart_contents as $cart_item ) {
+			if ( isset( $cart_item['variation'] ) && ! empty( $cart_item['variation'] ) ) {
+				// The first variation should have pa_size=small, pa_colour and pa_number should be empty.
+				$expected_variation = [
+					'attribute_pa_size'   => 'small',
+					'attribute_pa_colour' => '',
+					'attribute_pa_number' => '',
+				];
+				$this->assertEquals( $expected_variation, $cart_item['variation'] );
+			}
+		}
+		
 		$this->assertEquals( array_values( [ 'test-coupon' ] ), array_values( $applied_coupon_codes ) );
 		$this->assertStringContainsString( 'session=', $url );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -57,18 +57,27 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 			\WC_Helper_Product::create_simple_product(),
 			\WC_Helper_Product::create_simple_product(),
 			\WC_Helper_Product::create_simple_product(),
+			\WC_Helper_Product::create_variation_product(),
 		];
 
-		$product_ids = array_map(
-			function ( $product ) {
-				return $product->get_id();
-			},
-			$test_products
-		);
+		$product_ids = [];
+		$products    = [];
+
+		foreach ( $test_products as $product ) {
+			$product_ids[] = $product->get_id();
+			if ( $product->is_type( 'variable' ) ) {
+				$variations = $product->get_available_variations();
+				$variation  = array_shift( $variations );
+
+				$products[] = $product->get_id() . ':1:' . http_build_query( $variation['attributes'], '', ';' );
+			} else {
+				$products[] = $product->get_id();
+			}
+		}
 
 		$coupon = CouponHelper::create_coupon( 'test-coupon' );
 
-		$_GET['products'] = implode( ',', $product_ids );
+		$_GET['products'] = implode( ',', $products );
 		$_GET['coupon']   = 'test-coupon';
 
 		$service = new class() extends CheckoutLink {

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -50,35 +50,30 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that products and coupon are added and token in url.
+	 * @testdox Adds legacy products, quantities, SKUs, variations, additional data, and a coupon from a checkout link.
 	 */
-	public function test_products_and_coupon_are_added_and_token_in_url() {
-		$test_products = [
-			\WC_Helper_Product::create_simple_product(),
-			\WC_Helper_Product::create_simple_product(),
-			\WC_Helper_Product::create_simple_product(),
-			\WC_Helper_Product::create_variation_product(),
-		];
+	public function test_products_and_coupon_are_added_and_token_in_url(): void {
+		$legacy_product    = \WC_Helper_Product::create_simple_product();
+		$quantity_product  = \WC_Helper_Product::create_simple_product();
+		$sku_product       = \WC_Helper_Product::create_simple_product();
+		$variable_product  = \WC_Helper_Product::create_variation_product();
+		$available_options = $variable_product->get_available_variations();
+		$chosen_variation  = array_shift( $available_options );
 
-		$product_ids = [];
-		$products    = [];
+		$sku_product->set_sku( 'CHECKOUT-LINK-SKU' );
+		$sku_product->save();
 
-		foreach ( $test_products as $product ) {
-			$product_ids[] = $product->get_id();
-			if ( $product->is_type( 'variable' ) ) {
-				$variations = $product->get_available_variations();
-				$variation  = array_shift( $variations );
-
-				$products[] = $product->get_id() . ':1:' . http_build_query( $variation['attributes'], '', ';' );
-			} else {
-				$products[] = $product->get_id();
-			}
-		}
-
-		$coupon = CouponHelper::create_coupon( 'test-coupon' );
-
-		$_GET['products'] = implode( ',', $products );
+		$_GET['products'] = implode(
+			',',
+			[
+				(string) $legacy_product->get_id(),
+				$quantity_product->get_id() . ':2',
+				'CHECKOUT-LINK-SKU',
+				$variable_product->get_id() . ':1:' . http_build_query( $chosen_variation['attributes'], '', ';' ) . ':nyp=99',
+			]
+		);
 		$_GET['coupon']   = 'test-coupon';
+		CouponHelper::create_coupon( 'test-coupon' );
 
 		$service = new class() extends CheckoutLink {
 			/**
@@ -91,45 +86,61 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 			}
 		};
 
-		$url = $service->get_checkout_link_test();
+		$url                  = $service->get_checkout_link_test();
+		$cart_by_product      = [];
+		$expected_product_ids = [
+			$legacy_product->get_id(),
+			$quantity_product->get_id(),
+			$sku_product->get_id(),
+			$variable_product->get_id(),
+		];
 
-		$cart_contents    = WC()->cart->get_cart();
-		$cart_product_ids = array_map(
-			function ( $item ) {
-				return $item['product_id'];
-			},
-			$cart_contents
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$cart_by_product[ $cart_item['product_id'] ] = $cart_item;
+		}
+
+		$this->assertSame( $expected_product_ids, array_keys( $cart_by_product ), 'All checkout-link product identifier formats should resolve.' );
+		$this->assertSame( 1, $cart_by_product[ $legacy_product->get_id() ]['quantity'], 'A legacy product ID should default to quantity one.' );
+		$this->assertSame( 2, $cart_by_product[ $quantity_product->get_id() ]['quantity'], 'A legacy product ID and quantity should remain supported.' );
+		$this->assertSame( 1, $cart_by_product[ $sku_product->get_id() ]['quantity'], 'A SKU should resolve to its product.' );
+		$this->assertSame(
+			[
+				'attribute_pa_colour' => '',
+				'attribute_pa_number' => '',
+				'attribute_pa_size'   => 'small',
+			],
+			$cart_by_product[ $variable_product->get_id() ]['variation'],
+			'Variation data should select the requested variation.'
 		);
+		$this->assertSame( '99', $cart_by_product[ $variable_product->get_id() ]['nyp'], 'Additional product data should be retained on the cart item.' );
+		$this->assertArrayNotHasKey( 'nyp', $cart_by_product[ $variable_product->get_id() ]['variation'], 'Additional product data should not be treated as variation data.' );
+		$this->assertSame( [ 'test-coupon' ], WC()->cart->get_applied_coupons(), 'The checkout-link coupon should be applied.' );
+		$this->assertStringContainsString( 'session=', $url, 'Guest checkout links should include a cart session token.' );
+	}
 
-		$applied_coupons      = WC()->cart->get_coupons();
-		$applied_coupon_codes = array_map(
-			function ( $coupon ) {
-				return $coupon->get_code();
-			},
-			$applied_coupons
-		);
+	/**
+	 * @testdox Does not treat an unresolved numeric product ID as a numeric SKU.
+	 */
+	public function test_unresolved_numeric_product_id_does_not_resolve_as_sku(): void {
+		$product = \WC_Helper_Product::create_simple_product();
+		$product->set_sku( '999999' );
+		$product->save();
 
-		$this->assertEquals( array_values( $product_ids ), array_values( $cart_product_ids ) );
+		$_GET['products'] = '999999';
 
-		// Check that the variable product in cart has the expected variations.
-		foreach ( $cart_contents as $cart_item ) {
-			if ( isset( $cart_item['variation'] ) && ! empty( $cart_item['variation'] ) ) {
-				// The first variation should have pa_size=small, pa_colour and pa_number should be empty.
-				$expected_variation = [
-					'attribute_pa_size'   => 'small',
-					'attribute_pa_colour' => '',
-					'attribute_pa_number' => '',
-				];
-				$this->assertEquals( $expected_variation, $cart_item['variation'] );
+		$service = new class() extends CheckoutLink {
+			/**
+			 * Get the checkout link for testing.
+			 *
+			 * @return string The checkout link.
+			 */
+			public function get_checkout_link_test() {
+				return parent::get_checkout_link();
 			}
-		}
-		
-		$this->assertEquals( array_values( [ 'test-coupon' ] ), array_values( $applied_coupon_codes ) );
-		$this->assertStringContainsString( 'session=', $url );
+		};
 
-		// Clean up.
-		foreach ( $test_products as $product ) {
-			wp_delete_post( $product->get_id(), true );
-		}
+		$service->get_checkout_link_test();
+
+		$this->assertTrue( WC()->cart->is_empty(), 'An unresolved numeric ID must not add a product with the same numeric SKU.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -53,23 +53,27 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 	 * @testdox Adds legacy products, quantities, SKUs, variations, additional data, and a coupon from a checkout link.
 	 */
 	public function test_products_and_coupon_are_added_and_token_in_url(): void {
-		$legacy_product    = \WC_Helper_Product::create_simple_product();
-		$quantity_product  = \WC_Helper_Product::create_simple_product();
-		$sku_product       = \WC_Helper_Product::create_simple_product();
-		$variable_product  = \WC_Helper_Product::create_variation_product();
-		$available_options = $variable_product->get_available_variations();
-		$chosen_variation  = array_shift( $available_options );
+		$legacy_product      = \WC_Helper_Product::create_simple_product();
+		$quantity_product    = \WC_Helper_Product::create_simple_product();
+		$sku_product         = \WC_Helper_Product::create_simple_product();
+		$numeric_sku_product = \WC_Helper_Product::create_simple_product();
+		$variable_product    = \WC_Helper_Product::create_variation_product();
+		$available_options   = $variable_product->get_available_variations();
+		$chosen_variation    = array_shift( $available_options );
 
-		$sku_product->set_sku( 'CHECKOUT-LINK-SKU' );
+		$sku_product->set_sku( 'CHECKOUT,LINK:SKU' );
 		$sku_product->save();
+		$numeric_sku_product->set_sku( '999999' );
+		$numeric_sku_product->save();
 
 		$_GET['products'] = implode(
 			',',
 			[
 				(string) $legacy_product->get_id(),
 				$quantity_product->get_id() . ':2',
-				'CHECKOUT-LINK-SKU',
-				$variable_product->get_id() . ':1:' . http_build_query( $chosen_variation['attributes'], '', ';' ) . ':nyp=99',
+				'CHECKOUT~,LINK~:SKU',
+				'sku=999999',
+				$variable_product->get_id() . ':1:' . http_build_query( $chosen_variation['attributes'], '', ';' ) . ':nyp=99;note=alpha~,beta~;gamma:delta',
 			]
 		);
 		$_GET['coupon']   = 'test-coupon';
@@ -92,6 +96,7 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 			$legacy_product->get_id(),
 			$quantity_product->get_id(),
 			$sku_product->get_id(),
+			$numeric_sku_product->get_id(),
 			$variable_product->get_id(),
 		];
 
@@ -102,7 +107,8 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 		$this->assertSame( $expected_product_ids, array_keys( $cart_by_product ), 'All checkout-link product identifier formats should resolve.' );
 		$this->assertSame( 1, $cart_by_product[ $legacy_product->get_id() ]['quantity'], 'A legacy product ID should default to quantity one.' );
 		$this->assertSame( 2, $cart_by_product[ $quantity_product->get_id() ]['quantity'], 'A legacy product ID and quantity should remain supported.' );
-		$this->assertSame( 1, $cart_by_product[ $sku_product->get_id() ]['quantity'], 'A SKU should resolve to its product.' );
+		$this->assertSame( 1, $cart_by_product[ $sku_product->get_id() ]['quantity'], 'An escaped SKU should resolve to its product.' );
+		$this->assertSame( 1, $cart_by_product[ $numeric_sku_product->get_id() ]['quantity'], 'An explicitly prefixed numeric SKU should resolve to its product.' );
 		$this->assertSame(
 			[
 				'attribute_pa_colour' => '',
@@ -113,9 +119,46 @@ class CheckoutLinkTest extends \WC_Unit_Test_Case {
 			'Variation data should select the requested variation.'
 		);
 		$this->assertSame( '99', $cart_by_product[ $variable_product->get_id() ]['nyp'], 'Additional product data should be retained on the cart item.' );
+		$this->assertSame( 'alpha,beta;gamma:delta', $cart_by_product[ $variable_product->get_id() ]['note'], 'Escaped delimiters should be retained in additional product data.' );
 		$this->assertArrayNotHasKey( 'nyp', $cart_by_product[ $variable_product->get_id() ]['variation'], 'Additional product data should not be treated as variation data.' );
 		$this->assertSame( [ 'test-coupon' ], WC()->cart->get_applied_coupons(), 'The checkout-link coupon should be applied.' );
 		$this->assertStringContainsString( 'session=', $url, 'Guest checkout links should include a cart session token.' );
+	}
+
+	/**
+	 * @testdox Preserves escaped delimiters in variation and cart item data.
+	 */
+	public function test_escaped_product_data_delimiters_are_preserved(): void {
+		$_GET['products'] = '123:1:ratio=10~:20~,wide~;special:note=a~,b~;c:d';
+
+		$service = new class() extends CheckoutLink {
+			/**
+			 * Get parsed checkout-link products for testing.
+			 *
+			 * @return array[] Parsed product data.
+			 */
+			public function get_products_test() {
+				return parent::get_products_from_checkout_link();
+			}
+		};
+
+		$this->assertSame(
+			[
+				[
+					'id'             => 123,
+					'quantity'       => 1,
+					'variation'      => [
+						[
+							'attribute' => 'ratio',
+							'value'     => '10:20,wide;special',
+						],
+					],
+					'cart_item_data' => [ 'note' => 'a,b;c:d' ],
+				],
+			],
+			$service->get_products_test(),
+			'Escaped delimiters should be treated as data rather than checkout-link separators.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

Extend checkout links to pass variation attributes and additional cart item data for each product.

Products use this format:

```text
id-or-sku:quantity:variation-data:cart-item-data
```

Quantity and both data groups are optional. An empty variation-data group can be used to provide cart item data without variation attributes:

```text
123:1::nyp=120
```

Multiple key-value pairs within a data group are separated by semicolons:

```text
123:2:color=black;size=medium:nyp=120
```

The change also:

- supports nonnumeric product SKUs;
- supports numeric SKUs using an explicit `sku=` prefix, such as `sku=999999`;
- keeps numeric identifiers ID-only, preventing a deleted product ID from unexpectedly resolving to another product's numeric SKU;
- separates variation attributes from additional cart item data;
- supports commas and colons in product SKUs, and delimiters in variation and cart-item values, using `~` escaping where required;
- preserves existing `products=ID` and `products=ID:quantity` links;
- rejects malformed array-valued `products` parameters instead of producing a type error.

For example, a SKU named `ABC,123:BLUE` can be represented as:

```text
ABC~,123~:BLUE:1
```

Closes #59332.

#### Backward compatibility

Existing checkout-link product ID and quantity formats continue to work unchanged. The new variation-data and cart-item-data groups, `sku=` prefix, and `~` delimiter escaping are additive.

Numeric identifiers remain product IDs by default, preserving existing behavior and preventing unresolved product IDs from falling back to unrelated products with matching numeric SKUs.

`CheckoutLink` is externally reachable behavior. No existing hooks or method signatures are removed or reordered. The PR adds a protected parsing method; a scan of WordPress.org plugins found no inheritance collision. It does not change database schemas or existing stored-data formats, and it introduces no new multisite or installation-layout assumptions.

### How to test the changes in this Pull Request:

1. Create:
   - a simple product;
   - a simple product with a nonnumeric SKU;
   - a simple product with a numeric SKU;
   - a variable product with at least one variation.
2. Confirm a legacy link still adds a product with quantity one:
   ```text
   /checkout-link/?products=PRODUCT_ID
   ```
3. Confirm a legacy quantity still works:
   ```text
   /checkout-link/?products=PRODUCT_ID:2
   ```
4. Confirm a nonnumeric SKU works:
   ```text
   /checkout-link/?products=PRODUCT-SKU:2
   ```
5. Confirm a numeric SKU works only when explicitly prefixed:
   ```text
   /checkout-link/?products=sku=999999:2
   ```
6. Confirm variation attributes select the expected variation:
   ```text
   /checkout-link/?products=VARIABLE_PRODUCT_ID:1:size=large
   ```
7. With an extension such as Name Your Price that consumes cart item data, confirm additional data is passed separately:
   ```text
   /checkout-link/?products=PRODUCT_ID:1::nyp=120
   ```
8. Confirm multiple variation or cart-item values can be separated with semicolons.
9. Confirm commas and colons within an SKU, and commas, colons, and semicolons within an attribute value, work when escaped with `~`. For example:
   ```text
   /checkout-link/?products=SKU~,WITH~:DELIMITERS:1
   ```
10. Confirm an unresolved numeric product ID does not add a different product whose SKU happens to match that ID.

### Testing that has already taken place:

- Targeted PHPUnit suite passed: 4 tests, 16 assertions.
- PHP coding standards passed for changed files.
- Full branch PHP lint passed.
- PHPStan passed for `CheckoutLink.php`.
- Tested in the Burrito local environment with WordPress 7.1, WooCommerce 11.2.0-dev, and PHP 8.2.
- Playwright testing confirmed:
  - escaped SKUs containing commas and colons resolve correctly;
  - explicitly prefixed numeric SKUs resolve correctly;
  - requested quantities are retained;
  - escaped colons, commas, and semicolons in variation values select the expected variation;
  - checkout links redirect to checkout with a guest session token.
- Scanned 8,349 latest WordPress.org plugins tagged `woocommerce` for potential `CheckoutLink::parse_product_data()` inheritance collisions. No potential collisions or archive errors were found. This scan does not cover premium, private, or custom plugins.
- Multisite was not tested. The change does not read or write multisite-specific state.

### Milestone

<!-- milestone-target-selection -->
- [x] Automatically assign milestone for the **[next WooCommerce version](../blob/trunk/plugins/woocommerce/woocommerce.php#L6)**
<!-- /milestone-target-selection -->

### Changelog entry

A changelog entry was added manually at:

```text
plugins/woocommerce/changelog/issues-59332-checkout-link
```

### Use of AI Tools

GPT-5.6 through Pi was used to review the checkout-link parser, identify edge cases, implement delimiter and numeric-SKU handling, add regression tests, run local validation, and draft this pull request description. The resulting changes were also exercised manually locally using Playwright.

