### PR TITLE
Cache bust resource hints transient when site URL changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-59049
+++ b/plugins/woocommerce/changelog/fix-59049
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update cached block resource asset hints when the site URL is updated

--- a/plugins/woocommerce/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/src/Blocks/AssetsController.php
@@ -266,6 +266,7 @@ final class AssetsController {
 		$current_version = array(
 			'woocommerce' => WOOCOMMERCE_VERSION,
 			'wordpress'   => get_bloginfo( 'version' ),
+			'site_url'    => wp_guess_url(),
 		);
 
 		if ( isset( $cache['version'] ) && $cache['version'] === $current_version ) {
@@ -288,6 +289,7 @@ final class AssetsController {
 			'version' => array(
 				'woocommerce' => WOOCOMMERCE_VERSION,
 				'wordpress'   => get_bloginfo( 'version' ),
+				'site_url'    => wp_guess_url(),
 			),
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -227,11 +227,13 @@ class AssetsController extends \WP_UnitTestCase {
 	 * Tests that the additional resource hints don't use the cache when the version is invalid.
 	 *
 	 * @dataProvider resource_hints_invalid_cache_provider
+	 * @param string $key   The cache key to set to an invalid value.
+	 * @param string $value The cache value to set.
 	 *
 	 * @return void
 	 */
 	public function test_additional_resource_hints_invalid_cache( string $key, string $value ) {
-		$mock_version        = array(
+		$mock_version         = array(
 			'woocommerce' => WOOCOMMERCE_VERSION,
 			'wordpress'   => get_bloginfo( 'version' ),
 			'site_url'    => wp_guess_url(),

--- a/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/AssetsController.php
@@ -197,6 +197,7 @@ class AssetsController extends \WP_UnitTestCase {
 			'version' => array(
 				'woocommerce' => WOOCOMMERCE_VERSION,
 				'wordpress'   => get_bloginfo( 'version' ),
+				'site_url'    => wp_guess_url(),
 			),
 		);
 		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
@@ -210,11 +211,33 @@ class AssetsController extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for invalid cache.
+	 *
+	 * @return array[] Test cases with invalid cache keys and values.
+	 */
+	public function resource_hints_invalid_cache_provider(): array {
+		return array(
+			array( 'woocommerce', WOOCOMMERCE_VERSION . '-old' ),
+			array( 'wordpress', get_bloginfo( 'version' ) . '-old' ),
+			array( 'site_url', 'http://old-url.local' ),
+		);
+	}
+
+	/**
 	 * Tests that the additional resource hints don't use the cache when the version is invalid.
+	 *
+	 * @dataProvider resource_hints_invalid_cache_provider
 	 *
 	 * @return void
 	 */
-	public function test_additional_resource_hints_invalid_cache() {
+	public function test_additional_resource_hints_invalid_cache( string $key, string $value ) {
+		$mock_version        = array(
+			'woocommerce' => WOOCOMMERCE_VERSION,
+			'wordpress'   => get_bloginfo( 'version' ),
+			'site_url'    => wp_guess_url(),
+		);
+		$mock_version[ $key ] = $value;
+
 		$this->api->expects( $this->once() )
 			->method( 'get_script_data' )
 			->willReturn(
@@ -232,10 +255,7 @@ class AssetsController extends \WP_UnitTestCase {
 					'as'   => 'script',
 				),
 			),
-			'version' => array(
-				'woocommerce' => WOOCOMMERCE_VERSION,
-				'wordpress'   => '0.1.0-old',
-			),
+			'version' => $mock_version,
 		);
 		set_site_transient( 'woocommerce_block_asset_resource_hints', $mock_cache );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When sites change their base URL, there is a small window where the cached resource hint URLs for the site may be different than those from the actual site.

This PR adds cache busting by verifying that the site URL has not changed.

Closes #59049 .

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

1. Add a product to your cart
2. Visit the cart page on the frontend of your site
3. Using your favorite DB tool, check the value of the `_site_transient_woocommerce_block_asset_resource_hints` transient in the `wp_options` table
4. Note that the URLs include the current site URL
5. Update the current site URL by defining `WP_SITEURL` and `WP_HOME` in your `wp-config.php` and make any changes necessary to your hosting configuration to reflect the new site URL
6. Visit the cart page again
7. Using your favorite DB tool, check the value of the `_site_transient_woocommerce_block_asset_resource_hints` transient in the `wp_options` table
8. Note that the URLs include the updated site URL and not the previous site URL

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
