### PR TITLE
Add block transform from `Add to Cart with Options` to `Add to Cart + Options` block

### DIFF
--- a/plugins/woocommerce/changelog/feat-issue-59287
+++ b/plugins/woocommerce/changelog/feat-issue-59287
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add block transform from "Add to Cart with Options" block to the "Add to Cart + Options" block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/index.tsx
@@ -4,6 +4,7 @@
 import { registerProductBlockType } from '@woocommerce/atomic-utils';
 import { Icon, button } from '@wordpress/icons';
 import type { BlockConfiguration } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -28,6 +29,16 @@ const blockConfig = {
 		),
 	},
 	ancestor: [ 'woocommerce/single-product' ],
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'woocommerce/add-to-cart-with-options' ],
+				transform: () =>
+					createBlock( 'woocommerce/add-to-cart-with-options' ),
+			},
+		],
+	},
 	save() {
 		return null;
 	},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a block transform to allow users to convert the non-blockified `Add to Cart with Options` block to the new blockified `Add to Cart + Options` block.
The transform is implemented using the `createBlock` API and does not pass any attributes, as the new blockified block does not currently use any attributes from the classic block.

Closes #59287 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/8a143283-9086-48ed-8532-2bca3048ebb8

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to _Appearance > Editor > Templates > Single Product_.
2. Select the classic `Add to Cart with Options` block in the template.
3. Click the block icon and open the `Transform to` menu.
4. Verify that `Add to Cart + Options` is available as a transform target.
5. Click the transform option and confirm that the block is replaced with the new blockified `Add to Cart + Options` block.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
