### PR TITLE
Add to Cart Blocks: Add reusable utility for min/max quantity check and blocks to use it

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-59263
+++ b/plugins/woocommerce/changelog/fix-issue-59263
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent quantity selector from rendering in Add to Cart with Options and Add to Cart + Options blocks when min and max quantity are the same.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\Utils;
 
 /**
  * CatalogSorting class.
@@ -178,10 +179,13 @@ class AddToCartForm extends AbstractBlock {
 		$managing_stock               = $product->managing_stock();
 		$stock_quantity               = $product->get_stock_quantity();
 
+		$should_hide_quantity_selector = $product->is_sold_individually() || Utils::is_min_max_quantity_same( $product ) || ( $managing_stock && $stock_quantity <= 1 );
+
 		/**
 		 * The stepper buttons don't show when the product is sold individually or stock quantity is less or equal to 1 because the quantity input field is hidden.
+		 * Additionally, if min and max purchase quantity are the same, the buttons should not be rendered at all.
 		 */
-		$is_stepper_style = 'stepper' === $attributes['quantitySelectorStyle'] && ! $product->is_sold_individually() && ( ( $managing_stock && $stock_quantity > 1 ) || ! $managing_stock ) && Features::is_enabled( 'add-to-cart-with-options-stepper-layout' );
+		$is_stepper_style = 'stepper' === $attributes['quantitySelectorStyle'] && ! $should_hide_quantity_selector && Features::is_enabled( 'add-to-cart-with-options-stepper-layout' );
 
 		if ( $is_descendent_of_single_product_block ) {
 			add_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'add_to_cart_form_action' ), 10 );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -176,7 +176,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			}
 
 			/**
-			 * Filters the change the quantity to add to cart.
+			 * Filter the default quantity to add to cart.
 			 *
 			 * @since 10.9.0
 			 * @param number $default_quantity The default quantity.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -38,6 +38,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				'input_name'  => 'quantity[' . $product->get_id() . ']',
 				'input_id'    => 'quantity_' . $product->get_id(),
 				'input_value' => isset( $_POST['quantity'][ $product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $product->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				'min_value'   => AddToCartWithOptionsUtils::is_min_max_quantity_same( $product ) ? 0 :
 				/**
 				 * Filter the minimum quantity value allowed for the product.
 				 *
@@ -45,7 +46,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				 * @param int        $min_value Minimum quantity value.
 				 * @param WC_Product $product   Product object.
 				 */
-				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+				apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
 				/**
 				 * Filter the maximum quantity value allowed for the product.
 				 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -38,7 +38,6 @@ class GroupedProductItemSelector extends AbstractBlock {
 				'input_name'  => 'quantity[' . $product->get_id() . ']',
 				'input_id'    => 'quantity_' . $product->get_id(),
 				'input_value' => isset( $_POST['quantity'][ $product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $product->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				'min_value'   => AddToCartWithOptionsUtils::is_min_max_quantity_same( $product ) ? 0 :
 				/**
 				 * Filter the minimum quantity value allowed for the product.
 				 *
@@ -46,7 +45,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				 * @param int        $min_value Minimum quantity value.
 				 * @param WC_Product $product   Product object.
 				 */
-				apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
 				/**
 				 * Filter the maximum quantity value allowed for the product.
 				 *

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -61,6 +61,11 @@ class QuantitySelector extends AbstractBlock {
 		$stock_quantity                      = $product->get_stock_quantity();
 		$allows_backorders                   = $product->backorders_allowed();
 
+		if ( AddToCartWithOptionsUtils::is_min_max_quantity_same( $product ) ) {
+			$product = $previous_product;
+			return '';
+		}
+
 		if ( $is_external_product_with_url || $can_only_be_purchased_one_at_a_time || ( $managing_stock && $stock_quantity <= 1 && ! $allows_backorders ) ) {
 			$product = $previous_product;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -150,7 +150,23 @@ class Utils {
 	 * @return bool True if min and max purchase quantity are the same, false otherwise.
 	 */
 	public static function is_min_max_quantity_same( $product ) {
+		/**
+		 * Filter the minimum quantity value allowed for the product.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param int        $min_purchase_quantity The minimum purchase quantity.
+		 * @param WC_Product $product               The product object.
+		 */
 		$min_purchase_quantity = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+		/**
+		 * Filter the maximum quantity value allowed for the product.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param int        $max_purchase_quantity The maximum purchase quantity.
+		 * @param WC_Product $product               The product object.
+		 */
 		$max_purchase_quantity = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
 		return $min_purchase_quantity === $max_purchase_quantity;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -142,4 +142,16 @@ class Utils {
 		// Render with dynamic set to false to prevent calling render_callback.
 		return $new_block->render( array( 'dynamic' => false ) );
 	}
+
+	/**
+	 * Check if min and max purchase quantity are the same for a product.
+	 *
+	 * @param \WC_Product $product The product to check.
+	 * @return bool True if min and max purchase quantity are the same, false otherwise.
+	 */
+	public static function is_min_max_quantity_same( $product ) {
+		$min_purchase_quantity = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+		$max_purchase_quantity = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
+		return $min_purchase_quantity === $max_purchase_quantity;
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Introduces a reusable utility function `is_min_max_quantity_same` in `AddToCartWithOptions/Utils.php` to check if a product's min and max purchase quantities are the same.
- Refactors both the `Add to Cart with Options` and `Add to Cart + Options` blocks to use this utility for determining whether to render the quantity selector/steppers.
- This change ensures that when min and max quantity are the same, the quantity selector and steppers are not rendered.

Closes #59263 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

In the screen recording, it shows that after adding the code to set the same minimum and maximum quantity for the product with ID 15, the steppers are not visible in either the **Add to Cart with Options** or **Add to Cart + Options** block. However, viewing a product with a different ID displays the steppers correctly.

https://github.com/user-attachments/assets/a04b5ebc-242b-413c-8f03-484eb993aefd




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add custom code to set a product's min and max quantity to the same value using the `woocommerce_quantity_input_min` and `woocommerce_quantity_input_max` filters.
2. ```
	add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
		if ( $product->get_id() === 15 ) {
			return 3;
		}
		return $default;
	}, 10, 2 );

	add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
		if ( $product->get_id() === 15 ) {
			return 3;
		}
		return $default;
	}, 10, 2 );
	```
3. Visit the frontend for a product using the `Add to Cart with Options` with stepper mode or `Add to Cart + Options` block.
4. Confirm that the quantity selector and steppers are not rendered for that product.
5. Test with products where min and max are different to ensure the selector/steppers still appear as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
