### PR TITLE
CFE: Fix Product Gallery image scroll in iOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-mobile-gestures
+++ b/plugins/woocommerce/changelog/fix-product-gallery-mobile-gestures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: fix incorrectly handled swiping on mobile devices

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -44,7 +44,6 @@ const scrollImageIntoView = ( imageId: number ) => {
 		return;
 	}
 
-	// Find the closest gallery container
 	const galleryContainer = element.closest(
 		'.wp-block-woocommerce-product-gallery'
 	);
@@ -53,15 +52,34 @@ const scrollImageIntoView = ( imageId: number ) => {
 		return;
 	}
 
-	const imageElement = galleryContainer.querySelector(
-		`.wp-block-woocommerce-product-gallery-large-image img[data-image-id="${ imageId }"]`
+	// Find the scrollable container for the large image gallery
+	const scrollableContainer = galleryContainer.querySelector(
+		'.wc-block-product-gallery-large-image__container'
+	);
+
+	if ( ! scrollableContainer ) {
+		return;
+	}
+
+	const imageElement = scrollableContainer.querySelector(
+		`img[data-image-id="${ imageId }"]`
 	);
 
 	if ( imageElement ) {
-		imageElement.scrollIntoView( {
+		// Calculate the scroll position to center the image horizontally
+		const containerRect = scrollableContainer.getBoundingClientRect();
+		const imageRect = imageElement.getBoundingClientRect();
+
+		const scrollLeft =
+			scrollableContainer.scrollLeft +
+			( imageRect.left - containerRect.left ) -
+			( containerRect.width - imageRect.width ) / 2;
+
+		// Use scrollTo as scrollIntoView with inline: 'center'
+		// is not supported in iOS (Safari and Chrome).
+		scrollableContainer.scrollTo( {
+			left: scrollLeft,
 			behavior: 'smooth',
-			block: 'nearest',
-			inline: 'center',
 		} );
 	}
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -8,12 +8,11 @@ $dialog-padding: 20px;
 	position: relative;
 	flex-grow: 1;
 	aspect-ratio: 1 / 1;
+	overflow: hidden;
 
 	.wc-block-product-gallery-large-image__container {
 		display: flex;
-		overflow: hidden;
-		scroll-snap-type: x mandatory;
-		scroll-behavior: auto;
+		overflow: auto;
 		align-items: center;
 		margin: 0;
 		padding: 0;
@@ -23,12 +22,11 @@ $dialog-padding: 20px;
 		aspect-ratio: 1 / 1;
 		flex-shrink: 0;
 		max-width: 100%;
-		overflow: hidden;
 		width: 100%;
 		display: flex;
+		overflow: hidden;
 		align-items: center;
 		justify-content: center;
-		scroll-snap-align: none center;
 	}
 
 	.wc-block-components-product-image {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -12,7 +12,7 @@ $dialog-padding: 20px;
 
 	.wc-block-product-gallery-large-image__container {
 		display: flex;
-		overflow: auto;
+		overflow: hidden;
 		align-items: center;
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Originally fixed in https://github.com/woocommerce/woocommerce/pull/59307 (against `trunk`)

Till now we were testing Product Gallery in desktop browsers using mobile views (including gestures). I tested Product Gallery (Beta) in actual mobile device and the main gallery was broken on iOS (Chrome and Safari). The images changed inconsistently and not deterministically and appeared as totally broken (see videos).

This PR fixes the scrolling by:
- removing CSS snapping properties (with iAPI we scroll images using `scrollTo` method)
- switching from `scrollIntoView` to `scrollTo` since mobile Safari doesn't support `center` property for horizontal alignment (x axis) ("• No support for center option." [from caniuse](https://caniuse.com/?search=scrollintoview))
- cleaning up `overflow` properties which were conflicting on iOS.

There's one [more use of `scrollIntoView`](https://github.com/woocommerce/woocommerce/blob/fe08721005613e8d1a3f1ba85935c51df3203855/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts#L459-L462) with `block: 'center'` but it's for y axis and it works fine in iOS.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Videos are screen recordings from mobile device
Browser | Before | After |
| ------ | ----- | -- |
|  Safari      |  https://github.com/user-attachments/assets/b251824f-a5c5-4257-ade3-d520806e2864     | https://github.com/user-attachments/assets/2ceec167-5f33-4d0c-b913-3a26e1abf3d2 |
|  Chrome      |   https://github.com/user-attachments/assets/925e3f7e-4004-4e30-b405-8a7504bc50f5    | https://github.com/user-attachments/assets/c22e7097-789d-488f-8590-c62aa2edacb8 |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. To test this PR prepare an env that will be accessible on real mobile device (feel free to reach out to me to get such an env)
2. Go to Editor > Single Product template
3. Replace the Product Image Gallery block with the Product Gallery (beta) block
4. Visit some product with number of images in gallery on a real mobile device
5. Swipe images both sides
6. Use thumbnails to navigate
7. **Expected:** Make sure images are changing both ways and there's no glitches

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
