### PR TITLE
Update region picker empty value and label

### DIFF
--- a/plugins/woocommerce/changelog/59353-update-wooplug-4287-selecting-all-countries-in-shipping-zone-settings-doesnt
+++ b/plugins/woocommerce/changelog/59353-update-wooplug-4287-selecting-all-countries-in-shipping-zone-settings-doesnt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update region picker empty value and label to match its behaviour.

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -5,13 +5,20 @@ import { useState } from '@wordpress/element';
 import { TreeSelectControl } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
+const everywhere = '__WC_TREE_SELECT_COMPONENT_ROOT__';
+
 export const RegionPicker = ( { options, initialValues } ) => {
 	const [ selected, setSelected ] = useState(
-		initialValues.length
-			? initialValues
-			: [ '__WC_TREE_SELECT_COMPONENT_ROOT__' ]
+		initialValues.length ? initialValues : [ everywhere ]
 	);
 	const onChange = ( value ) => {
+		// Set selection to 'everywhere' when empty or when 'everywhere' is the last selected.
+		if ( value.length === 0 || value[ value.length - 1 ] === everywhere ) {
+			value = [ everywhere ];
+		} else {
+			// Remove 'everywhere' from selection when other regions are chosen.
+			value = value.filter( ( item ) => item !== everywhere );
+		}
 		document.body.dispatchEvent(
 			new CustomEvent( 'wc_region_picker_update', { detail: value } )
 		);

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -6,7 +6,11 @@ import { TreeSelectControl } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
 export const RegionPicker = ( { options, initialValues } ) => {
-	const [ selected, setSelected ] = useState( initialValues.length ? initialValues : [ '__WC_TREE_SELECT_COMPONENT_ROOT__' ] );
+	const [ selected, setSelected ] = useState(
+		initialValues.length
+			? initialValues
+			: [ '__WC_TREE_SELECT_COMPONENT_ROOT__' ]
+	);
 	const onChange = ( value ) => {
 		document.body.dispatchEvent(
 			new CustomEvent( 'wc_region_picker_update', { detail: value } )

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -6,7 +6,7 @@ import { TreeSelectControl } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
 export const RegionPicker = ( { options, initialValues } ) => {
-	const [ selected, setSelected ] = useState( initialValues );
+	const [ selected, setSelected ] = useState( initialValues.length ? initialValues : [ '__WC_TREE_SELECT_COMPONENT_ROOT__' ] );
 	const onChange = ( value ) => {
 		document.body.dispatchEvent(
 			new CustomEvent( 'wc_region_picker_update', { detail: value } )
@@ -20,7 +20,7 @@ export const RegionPicker = ( { options, initialValues } ) => {
 			onChange={ onChange }
 			options={ options }
 			placeholder={ __( 'Start typing to filter zones', 'woocommerce' ) }
-			selectAllLabel={ __( 'Select all countries', 'woocommerce' ) }
+			selectAllLabel={ __( 'Everywhere', 'woocommerce' ) }
 			individuallySelectParent
 			maxVisibleTags={ 5 }
 		/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Update `RegionPicker` to display the `selectAllLabel` when no regions are selected, to match its behaviour, which defaults to all countries. And rename the label to `Everywhere` to match the shipping zone table wording.

To do this, I've used the `TreeSelectControl` constant `__WC_TREE_SELECT_COMPONENT_ROOT__`, which the one used to reference the `AllLabel` when `individuallySelectParent` is used. Ideally, the component should expose that constant or allow us to do what I've done with a prop or by default.

Closes WOOPLUG-4287

### Screenshots or screen recordings:

https://github.com/user-attachments/assets/51ca5892-4129-45bb-b89c-f5a416e3f4f4



**Shipping zones screen as reference**
<img width="477" alt="Screenshot 2025-07-02 at 11 00 22" src="https://github.com/user-attachments/assets/32d9cd24-d314-4f53-bed1-fb38771c6d27" />


### How to test the changes in this Pull Request:
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this PR branch
2. Run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
3. Go to **WooCommerce → Settings → Shipping** edit or create a new shipping zone.
4. Select `Everywhere` for **Zone regions** and save.
5. Reload the page.
6. The **Zone regions** should keep showing `Everywhere`.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Update region picker empty value and label to match its behaviour.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
