### PR TITLE
[dev] Monorepo: revert admin webpack cache config changes.

### DIFF
--- a/plugins/woocommerce/client/admin/webpack.config.js
+++ b/plugins/woocommerce/client/admin/webpack.config.js
@@ -89,13 +89,6 @@ require( 'fs-extra' ).ensureSymlinkSync(
 
 const webpackConfig = {
 	mode: NODE_ENV,
-	cache: ( NODE_ENV !== 'development' && { type: 'memory' } ) || {
-		type: 'filesystem',
-		cacheDirectory: path.resolve(
-			__dirname,
-			'node_modules/.cache/webpack'
-		),
-	},
 	entry: getEntryPoints(),
 	output: {
 		filename: ( data ) => {
@@ -156,7 +149,7 @@ const webpackConfig = {
 						].filter( Boolean ),
 						cacheDirectory: path.resolve(
 							__dirname,
-							'node_modules/.cache/babel-loader'
+							'../../../../node_modules/.cache/babel-loader'
 						),
 						cacheCompression: false,
 					},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Partially revert #59334 as per comments in there.

### How to test the changes in this Pull Request:

- n/a
