### PR TITLE
Wrap most Add to Cart + Options CSS selectors in :where() to decrease specificity

### DIFF
--- a/plugins/woocommerce/changelog/update-blocks-where-selectors
+++ b/plugins/woocommerce/changelog/update-blocks-where-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Wrap most Add to Cart + Options CSS selectors in :where() to decrease specificity

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/editor.scss
@@ -29,15 +29,3 @@
 		color: inherit;
 	}
 }
-
-.wc-block-add-to-cart-with-options-grouped-product-item-selector,
-.wc-block-add-to-cart-with-options__quantity-selector {
-	.quantity .qty {
-		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
-		width: 3.631em;
-	}
-
-	.wc-block-components-quantity-selector {
-		margin: 0;
-	}
-}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item-selector/style.scss
@@ -1,7 +1,5 @@
 @import "../../../../base/components/quantity-selector/style";
 
-.wc-block-add-to-cart-with-options-grouped-product-item-selector {
-	.button {
-		display: inline-flex;
-	}
+:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector .button) {
+	display: inline-flex;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/product-item/style.scss
@@ -1,4 +1,3 @@
-.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item
-	.is-layout-grid {
+:where(.wp-block-woocommerce-add-to-cart-with-options-grouped-product-item .is-layout-grid) {
 	align-items: center;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -1,5 +1,5 @@
-.wc-block-add-to-cart-with-options {
-	.quantity {
+:where(.wc-block-add-to-cart-with-options) {
+	:where(.quantity) {
 		display: inline-flex;
 		align-items: stretch;
 	}
@@ -9,30 +9,33 @@
 	*
 	* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
 	*/
-	.quantity .input-text {
+	:where(.quantity .input-text) {
 		font-size: var(--wp--preset--font-size--small);
 		padding: 0.9rem 1.1rem;
 	}
 }
 
-.wc-block-add-to-cart-with-options__quantity-selector,
-.wc-block-add-to-cart-with-options-grouped-product-item-selector {
-	// Stepper CSS
-	.wc-block-components-quantity-selector {
+:where(.wc-block-add-to-cart-with-options__quantity-selector),
+:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
+	// This resets some WC component styles, so we need it to have specificity
+	// until those stylesheets are updated.
+	.wc-block-components-quantity-selector.wc-block-components-quantity-selector {
+		display: inline-flex;
+		width: unset;
+		margin-bottom: 0;
+		margin-right: 0;
+	}
+	:where(.wc-block-components-quantity-selector) {
 		&::after {
 			border: 1px solid currentColor;
 			opacity: 0.3;
 		}
 
-		display: inline-flex;
-		width: unset;
-		margin-bottom: 0;
-
-		.input-text {
+		:where(.input-text) {
 			font-size: inherit;
 		}
 
-		input[type="number"].input-text.qty.text {
+		:where(input[type="number"].input-text.qty.text) {
 			-moz-appearance: textfield;
 			border: unset;
 			text-align: center;
@@ -57,17 +60,15 @@
 			}
 		}
 
-		input[type="number"]::-webkit-inner-spin-button,
-		input[type="number"]::-webkit-outer-spin-button {
+		:where(input[type="number"]::-webkit-inner-spin-button),
+		:where(input[type="number"]::-webkit-outer-spin-button) {
 			-webkit-appearance: none;
 			margin: 0;
 		}
 	}
 }
 
-.wc-block-add-to-cart-with-options.is-invalid
-	.wp-block-woocommerce-product-button
-	.add_to_cart_button {
+:where(.wc-block-add-to-cart-with-options.is-invalid .wp-block-woocommerce-product-button .add_to_cart_button) {
 	cursor: not-allowed;
 	opacity: 0.5;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-name/style.scss
@@ -1,4 +1,4 @@
 /* Remove the default margin added by WooCommerce core stylesheets. */
-.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name {
+:where(.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name.wp-block-woocommerce-add-to-cart-with-options-variation-selector-attribute-name) {
 	margin-bottom: 0;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/attribute-options/style.scss
@@ -19,43 +19,41 @@
 	padding: 0.25em 0.75em;
 	user-select: none;
 
-	&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled) {
+	&:where(:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled)) {
 		color: color-mix(in srgb, var(--pill-color) 40%, transparent);
 		cursor: not-allowed;
 		text-decoration: line-through;
 	}
 
-	&:hover {
-		&:not(:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled)) {
-			background-color: color-mix(
-				in srgb,
-				var(--pill-color) 10%,
-				transparent
-			);
-		}
-	
-		&:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked) {
-			background-color: color-mix(
-				in srgb,
-				var(--pill-background-color) 85%,
-				transparent
-			);
-		}
+	&:where(:hover:not(:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:disabled))) {
+		background-color: color-mix(
+			in srgb,
+			var(--pill-color) 10%,
+			transparent
+		);
 	}
 
-	&:focus-within {
+	&:where(:hover:has(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked)) {
+		background-color: color-mix(
+			in srgb,
+			var(--pill-background-color) 85%,
+			transparent
+		);
+	}
+
+	&:where(:focus-within) {
 		outline: 1px solid var(--pill-color);
 		outline-offset: 1px;
+	}
 
-		&:has(
-			.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked
-		) {
-			outline-color: var(--pill-background-color);
-		}
+	&:where(:focus-within:has(
+		.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input:checked
+	)) {
+		outline-color: var(--pill-background-color);
 	}
 
 	// We can't make it display: none, otherwise it's not focusable.
-	.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input {
+	:where(.wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill-input) {
 		height: 0;
 		width: 0;
 		opacity: 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of the _Cleaning up CSS specificity for our blocks_ task in our cooldown, I'm working on adding `:where()` to our blocks stylesheets to decrease selector specificity. I'm starting with the newly introduced blocks and this PR takes care of the _Add to Cart + Options_ block and all its inner blocks.

### How to test the changes in this Pull Request:

Testing consists of making sure there are no visual regressions.

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Using the product type selector, switch between product types and verify they all look correct.
4. Now, go to the frontend of a simple, variable and grouped products.
5. Verify there are no visual regressions. In the variable product, make sure to toggle some of the pills to verify selected, hover and focus states look good too.
