### PR TITLE
Reduce number of session updates in Session Handler

### DIFF
--- a/plugins/woocommerce/changelog/fix-prevent-recalculation-on-empty-cart
+++ b/plugins/woocommerce/changelog/fix-prevent-recalculation-on-empty-cart
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: Cart and Session hardening to prevent edge case errors
+Comment: Small improvement to prevent excessive session updates
 
 

--- a/plugins/woocommerce/changelog/fix-prevent-recalculation-on-empty-cart
+++ b/plugins/woocommerce/changelog/fix-prevent-recalculation-on-empty-cart
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Cart and Session hardening to prevent edge case errors
+
+

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -282,8 +282,8 @@ final class WC_Cart_Session {
 		$cart_for_session = $this->get_cart_for_session();
 
 		if ( empty( $cart_for_session ) ) {
-			WC()->session->set( 'cart', null );
-			$update_cart_session = true;
+			$wc_session->set( 'cart', null );
+			$wc_session->set( 'cart_totals', null );
 		}
 
 		if ( $update_cart_session ) {

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -79,7 +79,6 @@ final class WC_Cart_Session {
 
 		// Update session when the cart is updated.
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ), 1000 );
-		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
 
 		// Cookie events - cart cookies need to be set before headers are sent.
@@ -283,12 +282,14 @@ final class WC_Cart_Session {
 		$cart_for_session = $this->get_cart_for_session();
 
 		if ( empty( $cart_for_session ) ) {
-			$wc_session->set( 'cart', null );
-			$wc_session->set( 'cart_totals', null );
-		}
-
-		if ( $update_cart_session ) {
+			// If the cart is empty, clear the cart session directly.
+			$this->destroy_cart_session();
+		} elseif ( $update_cart_session ) {
+			// If the cart is not empty, and the cart session needs to be updated, calculate totals. Session will update after this.
 			$this->cart->calculate_totals();
+		} else {
+			// Otherwise, just set the session. This was previously hooked into `woocommerce_cart_loaded_from_session` but that resulted in multiple session updates.
+			$this->set_session();
 		}
 
 		// If this is a re-order, redirect to the cart page to get rid of the `order_again` query string.

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -101,14 +101,15 @@ final class WC_Cart_Session {
 		 */
 		do_action( 'woocommerce_load_cart_from_session' );
 
-		$cart        = (array) array_filter( WC()->session->get( 'cart', array() ) );
-		$cart_totals = WC()->session->get( 'cart_totals', null );
+		$wc_session  = WC()->session;
+		$cart        = (array) array_filter( $wc_session->get( 'cart', array() ) );
+		$cart_totals = $wc_session->get( 'cart_totals', null );
 
 		$this->cart->set_totals( $cart_totals );
-		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
-		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
-		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
-		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
+		$this->cart->set_applied_coupons( $wc_session->get( 'applied_coupons', array() ) );
+		$this->cart->set_coupon_discount_totals( $wc_session->get( 'coupon_discount_totals', array() ) );
+		$this->cart->set_coupon_discount_tax_totals( $wc_session->get( 'coupon_discount_tax_totals', array() ) );
+		$this->cart->set_removed_cart_contents( $wc_session->get( 'removed_cart_contents', array() ) );
 
 		// Flag to indicate the stored cart should be updated. If cart totals are null, this will be true to calculate totals.
 		$update_cart_session = is_null( $cart_totals );
@@ -117,8 +118,8 @@ final class WC_Cart_Session {
 		$order_again = false;
 
 		// Populate cart from order.
-		if ( isset( $_GET['order_again'], $_GET['_wpnonce'] ) && is_user_logged_in() && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-order_again' ) ) { // WPCS: input var ok, sanitization ok.
-			$cart                = $this->populate_cart_from_order( absint( $_GET['order_again'] ), $cart ); // WPCS: input var ok.
+		if ( isset( $_GET['order_again'], $_GET['_wpnonce'] ) && is_user_logged_in() && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-order_again' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$cart                = $this->populate_cart_from_order( absint( $_GET['order_again'] ), $cart );
 			$order_again         = true;
 			$update_cart_session = true;
 		}
@@ -303,13 +304,15 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function destroy_cart_session() {
-		WC()->session->set( 'cart', null );
-		WC()->session->set( 'cart_totals', null );
-		WC()->session->set( 'applied_coupons', null );
-		WC()->session->set( 'coupon_discount_totals', null );
-		WC()->session->set( 'coupon_discount_tax_totals', null );
-		WC()->session->set( 'removed_cart_contents', null );
-		WC()->session->set( 'order_awaiting_payment', null );
+		$wc_session = WC()->session;
+
+		$wc_session->set( 'cart', null );
+		$wc_session->set( 'cart_totals', null );
+		$wc_session->set( 'applied_coupons', null );
+		$wc_session->set( 'coupon_discount_totals', null );
+		$wc_session->set( 'coupon_discount_tax_totals', null );
+		$wc_session->set( 'removed_cart_contents', null );
+		$wc_session->set( 'order_awaiting_payment', null );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -137,12 +137,8 @@ final class WC_Cart_Totals {
 			throw new Exception( 'A valid WC_Cart object is required' );
 		}
 
-		// Check if customer is VAT exempt, if customer is defined.
-		$customer               = $cart->get_customer();
-		$is_customer_vat_exempt = $customer && $customer->get_is_vat_exempt();
-
 		$this->cart          = $cart;
-		$this->calculate_tax = wc_tax_enabled() && ! $is_customer_vat_exempt;
+		$this->calculate_tax = wc_tax_enabled() && ! $cart->get_customer()->get_is_vat_exempt();
 		$this->calculate();
 	}
 
@@ -726,8 +722,7 @@ final class WC_Cart_Totals {
 		$merged_subtotal_taxes = array(); // Taxes indexed by tax rate ID for storage later.
 
 		$adjust_non_base_location_prices = apply_filters( 'woocommerce_adjust_non_base_location_prices', true );
-		$customer                        = $this->cart->get_customer();
-		$is_customer_vat_exempt          = $customer && $customer->get_is_vat_exempt();
+		$is_customer_vat_exempt          = $this->cart->get_customer()->get_is_vat_exempt();
 
 		foreach ( $this->items as $item_key => $item ) {
 			if ( $item->price_includes_tax ) {

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -137,8 +137,12 @@ final class WC_Cart_Totals {
 			throw new Exception( 'A valid WC_Cart object is required' );
 		}
 
+		// Check if customer is VAT exempt, if customer is defined.
+		$customer               = $cart->get_customer();
+		$is_customer_vat_exempt = $customer && $customer->get_is_vat_exempt();
+
 		$this->cart          = $cart;
-		$this->calculate_tax = wc_tax_enabled() && ! $cart->get_customer()->get_is_vat_exempt();
+		$this->calculate_tax = wc_tax_enabled() && ! $is_customer_vat_exempt;
 		$this->calculate();
 	}
 
@@ -722,7 +726,8 @@ final class WC_Cart_Totals {
 		$merged_subtotal_taxes = array(); // Taxes indexed by tax rate ID for storage later.
 
 		$adjust_non_base_location_prices = apply_filters( 'woocommerce_adjust_non_base_location_prices', true );
-		$is_customer_vat_exempt          = $this->cart->get_customer()->get_is_vat_exempt();
+		$customer                        = $this->cart->get_customer();
+		$is_customer_vat_exempt          = $customer && $customer->get_is_vat_exempt();
 
 		foreach ( $this->items as $item_key => $item ) {
 			if ( $item->price_includes_tax ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This was originally for https://github.com/woocommerce/woocommerce/pull/59397, but I've split that to raise a CFE.

While investigating #59397 I found some session related code that could be optimised to reduce the number of calculations ran. This may or may not be related to the cart totals issue above, but has been touched recently so I improved it.

### How to test the changes in this Pull Request:

Smoke testing and CI will suffice. Ensure that no errors are raised and cart functionality is intact when:

- Logged in with empty cart
- Logged in with a cart
- Logged out with empty cart
- Logged out with a cart

CI should cover critical functionality such as order placement.

### Testing that has already taken place:

The above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
