### PR TITLE
Update quantity selectors to use the minus character instead of a hyphen

### DIFF
--- a/plugins/woocommerce/changelog/fix-use-minus-character-instead-of-hyphens-in-quantity-selectors
+++ b/plugins/woocommerce/changelog/fix-use-minus-character-instead-of-hyphens-in-quantity-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update quantity selectors to have the minus characters instead of hyphens

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/index.tsx
@@ -219,7 +219,7 @@ const QuantitySelector = ( {
 							normalizeQuantity( newQuantity );
 						} }
 					>
-						&#65293;
+						&#8722;
 					</button>
 					<button
 						ref={ increaseButtonRef }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/quantity-stepper/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/components/quantity-stepper/index.tsx
@@ -8,7 +8,7 @@ const QuantityStepper = () => {
 				readOnly
 			/>
 			<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">
-				-
+				−
 			</button>
 			<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">
 				+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -118,7 +118,7 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 									<>
 										<div className="quantity wc-block-components-quantity-selector">
 											<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">
-												-
+												−
 											</button>
 											<input
 												style={

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -77,7 +77,7 @@ class AddToCartForm extends AbstractBlock {
 		$pattern = '/(<input[^>]*id="quantity_[^"]*"[^>]*\/>)/';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.removeQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">-</button>';
+		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.removeQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
 		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.addQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -23,7 +23,7 @@ class Utils {
 		$pattern = '/(<input[^>]*id="quantity_[^"]*"[^>]*\/>)/';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
-		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.decreaseQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">-</button>';
+		$minus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Reduce quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.decreaseQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">−</button>';
 		// Replacement string to add button AFTER the matched <input> element.
 		/* translators: %s refers to the item name in the cart. */
 		$plus_button = '$1<button aria-label="' . esc_attr( sprintf( __( 'Increase quantity of %s', 'woocommerce' ), $product_name ) ) . '" type="button" data-wp-on--click="actions.increaseQuantity" class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">+</button>';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -145,7 +145,7 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 													data-wp-bind--aria-label="state.reduceQuantityLabel" 
 													class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
 												>
-													－
+													−
 												</button>
 												<button 
 													data-wp-bind--disabled="state.maximumReached" 


### PR DESCRIPTION
While working on https://github.com/woocommerce/woocommerce/pull/59364, I noticed in several places we were using the hyphen character instead of minus. While similar, that caused the minus line not to be aligned with the plus horizontal line:

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/b0d93174-3e94-4a8b-80d9-1bddc0cb76b9) | ![imatge](https://github.com/user-attachments/assets/507a2e18-4818-4398-a4a6-f7b267ac62a6)

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and select the _Stepper_ style.
3. In the frontend, verify the minus and plus are aligned.
4. Now, update the *Add to Cart with Options* block to the blockified version. Verify signs are aligned too.
5. Verify the same in the _Mini-Cart_ and _Cart_ blocks.