### PR TITLE
Reliably wait for cart requests to finish before adding new items to the cart

### DIFF
--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -31,7 +31,7 @@ async function waitForFunction(
 	} while ( performance.now() - startTime < timeout );
 
 	throw new Error(
-		`Timeout reached after ${ timeout }ms waiting for cart requests to complete.`
+		`Timeout reached after ${ timeout }ms waiting for requests to complete.`
 	);
 }
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -35,6 +35,17 @@ async function waitForFunction(
 	);
 }
 
+const STORE_API_CART_WRITE_REQUEST_URLS = [
+	'/cart/add-item',
+	'/batch',
+	'/cart/remove-item',
+	'/cart/update-item',
+	'/cart/apply-coupon/',
+	'/cart/remove-coupon/',
+	'/cart/update-customer',
+	'/cart/select-shipping-rate',
+];
+
 export class FrontendUtils {
 	page: Page;
 	requestUtils: RequestUtils;
@@ -56,21 +67,38 @@ export class FrontendUtils {
 	 * Start tracking cart-related requests and return a function to wait for completion
 	 */
 	private trackCartRequests( timeout = 5000 ) {
-		const pendingRequests = new Set< string >();
+		// key: request url, value: count of pending requests with this url
+		const pendingRequests = new Map< string, number >();
 
 		const requestHandler = ( request: Request ) => {
 			const url = request.url();
 			if (
-				url.includes( '/cart' ) ||
-				url.includes( '/add_to_cart' ) ||
-				url.includes( '/batch' )
+				STORE_API_CART_WRITE_REQUEST_URLS.some( ( cartUrl ) =>
+					url.includes( cartUrl )
+				)
 			) {
-				pendingRequests.add( request.url() );
+				pendingRequests.set(
+					url,
+					( pendingRequests.get( url ) ?? 0 ) + 1
+				);
 			}
 		};
 
 		const responseHandler = ( response: Response ) => {
-			pendingRequests.delete( response.url() );
+			const url = response.url();
+			const pendingRequestCount = pendingRequests.get( url );
+
+			// means we're not dealing with cart request
+			if ( pendingRequestCount === undefined ) {
+				return;
+			}
+
+			if ( pendingRequestCount === 1 ) {
+				pendingRequests.delete( url );
+				return;
+			}
+
+			pendingRequests.set( url, pendingRequestCount - 1 );
 		};
 
 		this.page.on( 'request', requestHandler );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -30,7 +30,9 @@ async function waitForFunction(
 		await wait( interval );
 	} while ( performance.now() - startTime < timeout );
 
-	throw new Error( 'Timeout reached' );
+	throw new Error(
+		`Timeout reached after ${ timeout }ms waiting for cart requests to complete.`
+	);
 }
 
 export class FrontendUtils {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -31,7 +31,7 @@ async function waitForFunction(
 	} while ( performance.now() - startTime < timeout );
 
 	throw new Error(
-		`Timeout reached after ${ timeout }ms waiting for requests to complete.`
+		`Timeout reached after ${ timeout }ms waiting for condition to be met.`
 	);
 }
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/frontend/frontend-utils.page.ts
@@ -1,8 +1,37 @@
 /**
  * External dependencies
  */
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, Request, Response } from '@playwright/test';
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+const wait = ( time: number ) =>
+	new Promise( ( resolve ) => setTimeout( resolve, time ) );
+
+/**
+ * Custom waitForFunction implementation that runs in Node.js context.
+ *
+ * Unlike page.waitForFunction() which executes in the browser context and can
+ * only access serializable values passed as arguments, this function runs in
+ * the Node.js context and has full access to closures and local variables. This
+ * allows us to directly reference variables without serialization limitations.
+ */
+async function waitForFunction(
+	predicateFunction: () => boolean,
+	timeout = 5000,
+	interval = 100
+) {
+	// Lint is too grabby in this case, this usage is fine
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const startTime = performance.now();
+	do {
+		if ( predicateFunction() ) {
+			return true;
+		}
+		await wait( interval );
+	} while ( performance.now() - startTime < timeout );
+
+	throw new Error( 'Timeout reached' );
+}
 
 export class FrontendUtils {
 	page: Page;
@@ -22,33 +51,47 @@ export class FrontendUtils {
 	}
 
 	/**
-	 * Wait for a single cart-related request to complete
+	 * Start tracking cart-related requests and return a function to wait for completion
 	 */
-	async waitForCartRequests( timeout = 5000 ): Promise< void > {
-		try {
-			await this.page.waitForResponse(
-				( response ) => {
-					const url = response.url();
-					return (
-						( url.includes( '/cart' ) ||
-							url.includes( '/add_to_cart' ) ||
-							url.includes( '/batch' ) ) &&
-						response.status() < 400
-					);
-				},
-				{ timeout }
-			);
-		} catch ( error: unknown ) {
-			// If timeout, it means no cart requests are pending, which is fine
-			if ( error instanceof Error && error.name !== 'TimeoutError' ) {
-				throw error;
+	private trackCartRequests( timeout = 5000 ) {
+		const pendingRequests = new Set< string >();
+
+		const requestHandler = ( request: Request ) => {
+			const url = request.url();
+			if (
+				url.includes( '/cart' ) ||
+				url.includes( '/add_to_cart' ) ||
+				url.includes( '/batch' )
+			) {
+				pendingRequests.add( request.url() );
 			}
-		}
+		};
+
+		const responseHandler = ( response: Response ) => {
+			pendingRequests.delete( response.url() );
+		};
+
+		this.page.on( 'request', requestHandler );
+		this.page.on( 'response', responseHandler );
+
+		return {
+			waitForCartRequests: async () => {
+				try {
+					await waitForFunction(
+						() => pendingRequests.size === 0,
+						timeout
+					);
+				} finally {
+					this.page.off( 'request', requestHandler );
+					this.page.off( 'response', responseHandler );
+				}
+			},
+		};
 	}
 
 	async addToCart( itemName = '' ) {
-		// Wait for any pending cart requests to complete before starting
-		await this.waitForCartRequests();
+		// Start tracking cart requests before the action
+		const { waitForCartRequests } = this.trackCartRequests();
 
 		if ( itemName !== '' ) {
 			// We can't use `getByRole()` here because the Add to Cart button
@@ -61,7 +104,8 @@ export class FrontendUtils {
 		}
 
 		// Wait for the cart request triggered by this action to complete
-		await this.waitForCartRequests();
+		// We do it the complex way as there are no visual cues that we can rely on
+		await waitForCartRequests();
 	}
 
 	async goToCheckout() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow up to https://github.com/woocommerce/woocommerce/pull/58947.

I noticed that the above PR will wait for 5s before and after adding to a cart if there are no pending cart requests. I've changed the util to be more explicit in tracking pending requests. We start tracking them before adding items to cart, and then wait for all requests to finish before moving outside the `addToCart` util.

Total time before (locally): 19.1s
Total time after (locally): 9.9s

| Before | After |
|--------|-------|
| <img width="344" alt="Screenshot 2025-07-02 at 16 43 07" src="https://github.com/user-attachments/assets/889937c2-8f5e-45c6-9384-0ae5843b8723" /> | <img width="341" alt="Screenshot 2025-07-02 at 16 43 37" src="https://github.com/user-attachments/assets/6452a0a2-9882-4093-9245-1a485828d5b5" /> |

### How to test the changes in this Pull Request:

Code review and green CI 🙏 

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

E2E test tooling change

</details>
