### PR TITLE
Product Filters: Prevent product filter queries when no products are found

### DIFF
--- a/plugins/woocommerce/changelog/fix-bail-if-sub-query-find-no-product
+++ b/plugins/woocommerce/changelog/fix-bail-if-sub-query-find-no-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: Prevent product filter queries when no products are found.

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -62,24 +62,27 @@ class FilterData {
 			return $cached_data;
 		}
 
-		global $wpdb;
-
+		$results     = array();
 		$product_ids = $this->get_cached_product_ids( $query_vars );
 
-		$price_filter_sql = "
-		SELECT min( min_price ) as min_price, MAX( max_price ) as max_price
-		FROM {$wpdb->wc_product_meta_lookup}
-		WHERE product_id IN ( {$product_ids} )
-		";
+		if ( $product_ids ) {
+			global $wpdb;
 
-		/**
-		 * We can't use $wpdb->prepare() here because using %s with
-		 * $wpdb->prepare() for a subquery won't work as it will escape the SQL
-		 * query.
-		 * We're using the query as is, same as Core does.
-		 */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$results = (array) $wpdb->get_row( $price_filter_sql );
+			$price_filter_sql = "
+			SELECT min( min_price ) as min_price, MAX( max_price ) as max_price
+			FROM {$wpdb->wc_product_meta_lookup}
+			WHERE product_id IN ( {$product_ids} )
+			";
+
+			/**
+			* We can't use $wpdb->prepare() here because using %s with
+			* $wpdb->prepare() for a subquery won't work as it will escape the SQL
+			* query.
+			* We're using the query as is, same as Core does.
+			*/
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$results = (array) $wpdb->get_row( $price_filter_sql );
+		}
 
 		/**
 		 * Filters the product filter data before it is returned.
@@ -124,40 +127,42 @@ class FilterData {
 			return $cached_data;
 		}
 
+		$results     = array();
 		$product_ids = $this->get_cached_product_ids( $query_vars );
 
-		global $wpdb;
-		$stock_status_counts = array();
+		if ( $product_ids ) {
+			global $wpdb;
 
-		foreach ( $statuses as $status ) {
-			$stock_status_count_sql = "
-				SELECT COUNT( DISTINCT posts.ID ) as status_count
-				FROM {$wpdb->posts} as posts
-				INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
-				AND postmeta.meta_key = '_stock_status'
-				AND postmeta.meta_value = '" . esc_sql( $status ) . "'
-				WHERE posts.ID IN ( {$product_ids} )
-			";
+			foreach ( $statuses as $status ) {
+				$stock_status_count_sql = "
+					SELECT COUNT( DISTINCT posts.ID ) as status_count
+					FROM {$wpdb->posts} as posts
+					INNER JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
+					AND postmeta.meta_key = '_stock_status'
+					AND postmeta.meta_value = '" . esc_sql( $status ) . "'
+					WHERE posts.ID IN ( {$product_ids} )
+				";
 
-			/**
-			 * We can't use $wpdb->prepare() here because using %s with
-			 * $wpdb->prepare() for a subquery won't work as it will escape the
-			 * SQL query.
-			 * We're using the query as is, same as Core does.
-			 */
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$result                         = $wpdb->get_row( $stock_status_count_sql );
-			$stock_status_counts[ $status ] = $result->status_count;
+				/**
+				* We can't use $wpdb->prepare() here because using %s with
+				* $wpdb->prepare() for a subquery won't work as it will escape the
+				* SQL query.
+				* We're using the query as is, same as Core does.
+				*/
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$result             = $wpdb->get_row( $stock_status_count_sql );
+				$results[ $status ] = $result->status_count;
+			}
 		}
 
 		/**
 		 * Filter the results. @see get_filtered_price() for full documentation.
 		 */
-		$stock_status_counts = apply_filters( 'woocommerce_product_filter_data', $stock_status_counts, 'stock', $query_vars, array() ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		$results = apply_filters( 'woocommerce_product_filter_data', $results, 'stock', $query_vars, array() ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
-		$this->set_cache( $transient_key, $stock_status_counts );
+		$this->set_cache( $transient_key, $results );
 
-		return $stock_status_counts;
+		return $results;
 	}
 
 	/**
@@ -183,28 +188,31 @@ class FilterData {
 			return $cached_data;
 		}
 
-		global $wpdb;
-
+		$results     = array();
 		$product_ids = $this->get_cached_product_ids( $query_vars );
 
-		$rating_count_sql = "
-			SELECT COUNT( DISTINCT product_id ) as product_count, ROUND( average_rating, 0 ) as rounded_average_rating
-			FROM {$wpdb->wc_product_meta_lookup}
-			WHERE product_id IN ( {$product_ids} )
-			AND average_rating > 0
-			GROUP BY rounded_average_rating
-			ORDER BY rounded_average_rating DESC
-		";
+		if ( $product_ids ) {
+			global $wpdb;
 
-		/**
-		 * We can't use $wpdb->prepare() here because using %s with
-		 * $wpdb->prepare() for a subquery won't work as it will escape the
-		 * SQL query.
-		 * We're using the query as is, same as Core does.
-		 */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $rating_count_sql );
-		$results = array_map( 'absint', wp_list_pluck( $results, 'product_count', 'rounded_average_rating' ) );
+			$rating_count_sql = "
+				SELECT COUNT( DISTINCT product_id ) as product_count, ROUND( average_rating, 0 ) as rounded_average_rating
+				FROM {$wpdb->wc_product_meta_lookup}
+				WHERE product_id IN ( {$product_ids} )
+				AND average_rating > 0
+				GROUP BY rounded_average_rating
+				ORDER BY rounded_average_rating DESC
+			";
+
+			/**
+			* We can't use $wpdb->prepare() here because using %s with
+			* $wpdb->prepare() for a subquery won't work as it will escape the
+			* SQL query.
+			* We're using the query as is, same as Core does.
+			*/
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$results = $wpdb->get_results( $rating_count_sql );
+			$results = array_map( 'absint', wp_list_pluck( $results, 'product_count', 'rounded_average_rating' ) );
+		}
 
 		/**
 		 * Filter the results. @see get_filtered_price() for full documentation.
@@ -240,12 +248,14 @@ class FilterData {
 			return $cached_data;
 		}
 
-		global $wpdb;
-
+		$results     = array();
 		$product_ids = $this->get_cached_product_ids( $query_vars );
 
-		$attributes_to_count_sql = 'AND term_taxonomy.taxonomy IN ("' . esc_sql( wc_sanitize_taxonomy_name( $attribute_to_count ) ) . '")';
-		$attribute_count_sql     = "
+		if ( $product_ids ) {
+			global $wpdb;
+
+			$attributes_to_count_sql = 'AND term_taxonomy.taxonomy IN ("' . esc_sql( wc_sanitize_taxonomy_name( $attribute_to_count ) ) . '")';
+			$attribute_count_sql     = "
 			SELECT COUNT( DISTINCT posts.ID ) as term_count, terms.term_id as term_count_id
 			FROM {$wpdb->posts} AS posts
 			INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
@@ -256,15 +266,16 @@ class FilterData {
 			GROUP BY terms.term_id
 		";
 
-		/**
-		 * We can't use $wpdb->prepare() here because using %s with
-		 * $wpdb->prepare() for a subquery won't work as it will escape the
-		 * SQL query.
-		 * We're using the query as is, same as Core does.
-		 */
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $attribute_count_sql );
-		$results = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
+			/**
+			 * We can't use $wpdb->prepare() here because using %s with
+			 * $wpdb->prepare() for a subquery won't work as it will escape the
+			 * SQL query.
+			 * We're using the query as is, same as Core does.
+			 */
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$results = $wpdb->get_results( $attribute_count_sql );
+			$results = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
+		}
 
 		/**
 		 * Filter the results. @see get_filtered_price() for full documentation.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Avoids running expensive database queries in  when the initial productquery returns no results.

This change adds a check for empty  before querying for price, stock status, rating, and attribute filters, preventing unnecessary database load and warnings if no products are found. 

(For Bug Fixes) Bug introduced in PR #57078 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a page with this content: https://gist.github.com/dinhtungdu/25447263668e249272d054ecd6036c24
2. View the page on the front end, verify that you don't see warnings like the screenshot below

 
![image](https://github.com/user-attachments/assets/c47138bf-6790-4a55-8356-fdaa5f68ce88)


<!-- End testing instructions -->

