### PR TITLE
Fix brands shortcode being empty when `show_empty` was set to `false`

### DIFF
--- a/plugins/woocommerce/changelog/59297-wooplug-4823-woocommerce-brands-product_brand_thumbnails-shortcode-breaks
+++ b/plugins/woocommerce/changelog/59297-wooplug-4823-woocommerce-brands-product_brand_thumbnails-shortcode-breaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed brands shortcode being empty when `show_empty` was set to `false`.

--- a/plugins/woocommerce/changelog/59395-cfe-59297
+++ b/plugins/woocommerce/changelog/59395-cfe-59297
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed brands shortcode being empty when `show_empty` was set to `false`.

--- a/plugins/woocommerce/changelog/59395-cfe-59297
+++ b/plugins/woocommerce/changelog/59395-cfe-59297
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed brands shortcode being empty when `show_empty` was set to `false`.

--- a/plugins/woocommerce/includes/class-wc-brands.php
+++ b/plugins/woocommerce/includes/class-wc-brands.php
@@ -567,13 +567,6 @@ class WC_Brands {
 		$alphabet       = apply_filters( 'woocommerce_brands_list_alphabet', range( 'a', 'z' ) );
 		$numbers        = apply_filters( 'woocommerce_brands_list_numbers', '0-9' );
 
-		/**
-		 * Check for empty brands and remove them from the list.
-		 */
-		if ( ! $show_empty_brands ) {
-			$terms = $this->remove_terms_with_empty_products( $terms );
-		}
-
 		foreach ( $terms as $term ) {
 			$term_letter = $this->get_brand_name_first_character( $term->name );
 
@@ -672,10 +665,6 @@ class WC_Brands {
 			return;
 		}
 
-		if ( $hide_empty ) {
-			$brands = $this->remove_terms_with_empty_products( $brands );
-		}
-
 		ob_start();
 
 		wc_get_template(
@@ -723,7 +712,7 @@ class WC_Brands {
 		$brands = get_terms(
 			'product_brand',
 			array(
-				'hide_empty' => $args['hide_empty'],
+				'hide_empty' => $hide_empty,
 				'orderby'    => $args['orderby'],
 				'exclude'    => $exclude,
 				'number'     => $args['number'],
@@ -733,10 +722,6 @@ class WC_Brands {
 
 		if ( ! $brands ) {
 			return;
-		}
-
-		if ( $hide_empty ) {
-			$brands = $this->remove_terms_with_empty_products( $brands );
 		}
 
 		ob_start();
@@ -1024,22 +1009,6 @@ class WC_Brands {
 		$term_taxonomy_ids = wp_set_object_terms( $product_id, $term_ids, 'product_brand' );
 		$product->delete_meta_data( 'duplicate_temp_brand_ids' );
 		$product->save();
-	}
-
-	/**
-	 * Remove terms with empty products.
-	 *
-	 * @param WP_Term[] $terms The terms array that needs to be removed of empty products.
-	 *
-	 * @return WP_Term[]
-	 */
-	private function remove_terms_with_empty_products( $terms ) {
-		return array_filter(
-			$terms,
-			function ( $term ) {
-				return $term->count > 0;
-			}
-		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-brands-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-brands-test.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * WooCommerce Brands Unit tests suite
+ *
+ * @package woocommerce-brands
+ */
+
+declare( strict_types = 1);
+
+require_once WC_ABSPATH . '/includes/class-wc-brands.php';
+
+/**
+ * WC Brands test
+ */
+class WC_Brands_Test extends WC_Unit_Test_Case {
+	/**
+	 * Test that `product_brand_thumbnails` shortcode's `show_empty` argument works as expected.
+	 * This test prevents regression of the issue where double filtering caused no brands to be displayed.
+	 */
+	public function test_product_brand_thumbnails_shortcode_with_show_empty_arg() {
+		$data            = $this->setup_brand_test_data();
+		$brands_instance = $data['brands_instance'];
+
+		$output = $brands_instance->output_product_brand_thumbnails( array( 'show_empty' => 'false' ) );
+
+		// Full brand is shown, empty brand is not.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringNotContainsString( 'Empty Brand', $output );
+
+		$output = $brands_instance->output_product_brand_thumbnails( array( 'show_empty' => 'true' ) );
+
+		// Both brands are shown.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringContainsString( 'Empty Brand', $output );
+	}
+
+	/**
+	 * Test that `product_brand_thumbnails_description` shortcode's `show_empty` argument works as expected.
+	 */
+	public function test_product_brand_thumbnails_description_shortcode_with_show_empty_arg() {
+		$data            = $this->setup_brand_test_data();
+		$brands_instance = $data['brands_instance'];
+
+		$output = $brands_instance->output_product_brand_thumbnails_description( array( 'show_empty' => 'false' ) );
+
+		// Full brand is shown, empty brand is not.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringNotContainsString( 'Empty Brand', $output );
+
+		$output = $brands_instance->output_product_brand_thumbnails_description( array( 'show_empty' => 'true' ) );
+
+		// Both brands are shown.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringContainsString( 'Empty Brand', $output );
+	}
+
+	/**
+	 * Test that `product_brand_list` shortcode's `show_empty_brands` argument works as expected.
+	 */
+	public function test_product_brand_list_shortcode_with_show_empty_brands_arg() {
+		$data            = $this->setup_brand_test_data();
+		$brands_instance = $data['brands_instance'];
+
+		$output = $brands_instance->output_product_brand_list( array( 'show_empty_brands' => 'false' ) );
+
+		// Full brand is shown, empty brand is not.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringNotContainsString( 'Empty Brand', $output );
+
+		$output = $brands_instance->output_product_brand_list( array( 'show_empty_brands' => 'true' ) );
+
+		// Both brands are shown.
+		$this->assertStringContainsString( 'Full Brand', $output );
+		$this->assertStringContainsString( 'Empty Brand', $output );
+	}
+
+	/**
+	 * Helper method to set up test data for brand shortcode tests.
+	 *
+	 * @return array Contains brands instance, brand term IDs and product ID.
+	 */
+	private function setup_brand_test_data() {
+		WC_Brands::init_taxonomy();
+
+		$brand_with_products = wp_insert_term( 'Full Brand', 'product_brand' );
+		$empty_brand         = wp_insert_term( 'Empty Brand', 'product_brand' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+		wp_set_object_terms( $product->get_id(), array( $brand_with_products['term_id'] ), 'product_brand' );
+
+		return array(
+			'brands_instance'     => new WC_Brands(),
+			'brand_with_products' => $brand_with_products,
+			'empty_brand'         => $empty_brand,
+			'product'             => $product,
+		);
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a regression introduced in WooCommerce 9.9.4 where the `[product_brand_thumbnails show_empty="false"]` shortcode would return no results, even when brands with products existed.

The issue was caused by PR #58797 which modified `wc_change_term_counts()`. This change resulted in brand terms having `$term->count = 0` even when they had associated products, due to how the product_brand taxonomy uses `_update_post_term_count` instead of WooCommerce’s `_wc_term_recount`.

Removed the redundant `remove_terms_with_empty_products()` calls in both shortcode methods when `hide_empty` is true, since `get_terms()` already handles this filtering correctly.

Fixes #59242

Bug introduced in PR #58797.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update to WooCommerce 9.9.4.
2. Make sure you have both brands with products assigned and empty brands.
3. Add the shortcode `[product_brand_thumbnails show_empty="false"]` to a page.
4. Verify that the output is as expected (brands with products should show, and brands without shouldn't).
5. Modify the shortcode removing `show_empty`.
6. Verify that the output is the same as (4.).
7. Modify the shortcode adding `show_empty=true`.
8. Verify that all brands show in the page, regardless of whether they have products or not.
9. Repeat steps 3–8 for `product_brand_thumbnails_description` and `product_brand_list` (taking care that for the latter, the right argument is `show_empty_brands=false`).

### Testing that has already taken place:

Performed all the testing above, and also added automated tests for the output.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Fixed brands shortcode being empty when `show_empty` was set to `false`.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
