### PR TITLE
Check to see if customer object is defined before calling `get_is_vat_exempt`

### DIFF
--- a/plugins/woocommerce/changelog/fix-prevent-fatal-error-in-wc-cart-totals-class
+++ b/plugins/woocommerce/changelog/fix-prevent-fatal-error-in-wc-cart-totals-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check to see if customer object is defined before calling `get_is_vat_exempt`

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -37,14 +37,6 @@ final class WC_Cart_Totals {
 	protected $cart;
 
 	/**
-	 * Reference to customer object.
-	 *
-	 * @since 3.2.0
-	 * @var array
-	 */
-	protected $customer;
-
-	/**
 	 * Line items to calculate.
 	 *
 	 * @since 3.2.0

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -137,8 +137,12 @@ final class WC_Cart_Totals {
 			throw new Exception( 'A valid WC_Cart object is required' );
 		}
 
+		// Check if customer is VAT exempt, if customer is defined.
+		$customer               = $cart->get_customer();
+		$is_customer_vat_exempt = $customer && $customer->get_is_vat_exempt();
+
 		$this->cart          = $cart;
-		$this->calculate_tax = wc_tax_enabled() && ! $cart->get_customer()->get_is_vat_exempt();
+		$this->calculate_tax = wc_tax_enabled() && ! $is_customer_vat_exempt;
 		$this->calculate();
 	}
 
@@ -722,7 +726,8 @@ final class WC_Cart_Totals {
 		$merged_subtotal_taxes = array(); // Taxes indexed by tax rate ID for storage later.
 
 		$adjust_non_base_location_prices = apply_filters( 'woocommerce_adjust_non_base_location_prices', true );
-		$is_customer_vat_exempt          = $this->cart->get_customer()->get_is_vat_exempt();
+		$customer                        = $this->cart->get_customer();
+		$is_customer_vat_exempt          = $customer && $customer->get_is_vat_exempt();
 
 		foreach ( $this->items as $item_key => $item ) {
 			if ( $item->price_includes_tax ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hardens the `WC_Cart_Totals` class to check that customer is not null before calling `get_is_vat_exempt`. Fixes potential fatal error (couldn't reproduce, but found in logs).

### How to test the changes in this Pull Request:

Since we were unable to find the cause of the issue, there are no testing steps to replicate the problem. Given where this is called, it should be covered by CI, however you can smoke test by going through the legacy/block checkout flow while logged in, or logged out.

### Testing that has already taken place:

The above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
