### PR TITLE
Interactivity API powered mini cart - Add  "Stock left" badge

### DIFF
--- a/plugins/woocommerce/changelog/59399-wooplug-4710-interactivity-api-powered-mini-cart-show-stock-left-badge
+++ b/plugins/woocommerce/changelog/59399-wooplug-4710-interactivity-api-powered-mini-cart-show-stock-left-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Add "Stock left" badge to the iAPI powered minicart.
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -391,7 +391,7 @@ const { state: cartItemState } = store(
 
 			get isLowInStockVisible(): boolean {
 				return (
-					! cartItemState.isAvailableOnBackorder &&
+					! cartItemState.cartItem.show_backorder_badge &&
 					!! cartItemState.cartItem.low_stock_remaining
 				);
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -34,6 +34,7 @@ const {
 	increaseQuantityLabel,
 	quantityDescriptionLabel,
 	removeFromCartLabel,
+	lowInStockLabel,
 } = getConfig( 'woocommerce/mini-cart-items-block' );
 const { singularItemsText, pluralItemsText } = getConfig(
 	'woocommerce/mini-cart-title-items-counter-block'
@@ -385,6 +386,20 @@ const { state: cartItemState } = store(
 				return (
 					catalogVisibility === 'hidden' ||
 					catalogVisibility === 'search'
+				);
+			},
+
+			get isLowInStockVisible(): boolean {
+				return (
+					! cartItemState.isAvailableOnBackorder &&
+					!! cartItemState.cartItem.low_stock_remaining
+				);
+			},
+
+			get lowInStockLabel(): string {
+				return lowInStockLabel.replace(
+					'%d',
+					cartItemState.cartItem.low_stock_remaining
 				);
 			},
 		},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -107,7 +107,6 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 											class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
 											data-wp-bind--hidden="!state.isLowInStockVisible"
 											data-wp-text="state.lowInStockLabel"
-											hidden
 										>
 										</div>
 										<div class="wc-block-cart-item__prices">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -59,6 +59,9 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 
 		$available_on_backorder_label = __( 'Available on backorder', 'woocommerce' );
 
+		/* translators: %d stock amount (number of items in stock for product) */
+		$low_in_stock_label = __( '%d left in stock', 'woocommerce' );
+
 		wp_interactivity_config(
 			$this->get_full_block_name(),
 			array(
@@ -66,6 +69,7 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 				'increaseQuantityLabel'    => $increase_quantity_label,
 				'quantityDescriptionLabel' => $quantity_description_label,
 				'removeFromCartLabel'      => $remove_from_cart_label,
+				'lowInStockLabel'          => $low_in_stock_label,
 			)
 		);
 
@@ -98,6 +102,13 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 										<a data-wp-bind--hidden="state.isProductHiddenFromCatalog" data-wp-text="state.cartItemName" data-wp-bind--href="state.cartItem.permalink" class="wc-block-components-product-name"></a>
 										<div data-wp-bind--hidden="!state.cartItem.show_backorder_badge" class="wc-block-components-product-badge wc-block-components-product-backorder-badge">
 											<?php echo esc_html( $available_on_backorder_label ); ?>
+										</div>
+										<div 
+											class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
+											data-wp-bind--hidden="!state.isLowInStockVisible"
+											data-wp-text="state.lowInStockLabel"
+											hidden
+										>
 										</div>
 										<div class="wc-block-cart-item__prices">
 											<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price" hidden>


### PR DESCRIPTION
**This PR is built on top of https://github.com/woocommerce/woocommerce/pull/59388 because it needs to read the backorder status.**

### Changes proposed in this Pull Request:

It adds support for the "Stock left" badge in the minicart powered by the iAPI. It replicates [this conditional ](https://github.com/woocommerce/woocommerce/blob/7cbfd3e1b09cfa0b0915d51cbaeabddcaed511c9/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx#L247-L256) and the HTML returned by `ProductLowStockBadge`.

Closes #59010.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
|---------------|------------------|
| ![Image](https://github.com/user-attachments/assets/ff90a1b0-9a7a-4b5a-9aeb-4324108d17e3) |  ![Image](https://github.com/user-attachments/assets/39a7281a-e6a7-486e-9b99-1ed165f70e34)  | 


### How to test the changes in this Pull Request:

> To test the experimental block, make sure `experimental-iapi-mini-cart` and `experimental-iapi-runtime` are set to `true` in the `development.json` file: [link](https://github.com/woocommerce/woocommerce/blob/c9cc094885a0351dd2cb550a5739f5980e0a5e6c/plugins/woocommerce/client/admin/config/development.json#L8-L9).

1. Edit a product -> Inventory -> Set Quantity to 2.
2. Select "Track stock quantity for this product" and "Allow, but notify customer".
3. Add that product to the cart.
4. Check that the stock left badge is shown.
5. Reduce the quantity to 0 and check that the "Available in backorder" badge is shown instead.
6. You can also increase it to 10 to check it doesn't show anything in that case.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Add "Stock left" badge to the iAPI powered minicart.

</details>
