### PR TITLE
Add to Cart + Options: prevent adding below-min quantity in grouped products children

### DIFF
--- a/plugins/woocommerce/changelog/fix-59393-fix-grouped-products-min-quantity
+++ b/plugins/woocommerce/changelog/fix-59393-fix-grouped-products-min-quantity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: prevent adding below-min quantity in grouped products children

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -227,6 +227,7 @@ const addToCartWithOptionsStore = store(
 				const {
 					currentValue,
 					maxValue,
+					minValue,
 					step,
 					childProductId,
 					inputElement,
@@ -234,11 +235,12 @@ const addToCartWithOptionsStore = store(
 				const newValue = currentValue + step;
 
 				if ( maxValue === undefined || newValue <= maxValue ) {
+					const updatedValue = Math.max( minValue, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
-						newValue,
+						updatedValue,
 						childProductId
 					);
-					inputElement.value = newValue.toString();
+					inputElement.value = updatedValue.toString();
 					dispatchChangeEvent( inputElement );
 				}
 			},
@@ -251,6 +253,7 @@ const addToCartWithOptionsStore = store(
 				}
 				const {
 					currentValue,
+					maxValue,
 					minValue,
 					step,
 					childProductId,
@@ -259,15 +262,19 @@ const addToCartWithOptionsStore = store(
 				const newValue = currentValue - step;
 
 				if ( newValue >= minValue ) {
+					const updatedValue = Math.min(
+						maxValue ?? Infinity,
+						newValue
+					);
 					addToCartWithOptionsStore.actions.setQuantity(
-						newValue,
+						updatedValue,
 						childProductId
 					);
-					inputElement.value = newValue.toString();
+					inputElement.value = updatedValue.toString();
 					dispatchChangeEvent( inputElement );
 				}
 			},
-			handleQuantityInputChange: (
+			handleQuantityInput: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {
 				const inputData = getInputData( event );
@@ -280,6 +287,28 @@ const addToCartWithOptionsStore = store(
 					currentValue,
 					childProductId
 				);
+			},
+			handleQuantityChange: (
+				event: HTMLElementEvent< HTMLInputElement >
+			) => {
+				const inputData = getInputData( event );
+				if ( ! inputData ) {
+					return;
+				}
+				const { childProductId, maxValue, minValue, currentValue } =
+					inputData;
+
+				const newValue = Math.min(
+					maxValue ?? Infinity,
+					Math.max( minValue, currentValue )
+				);
+
+				addToCartWithOptionsStore.actions.setQuantity(
+					newValue,
+					childProductId
+				);
+				event.target.value = newValue.toString();
+				dispatchChangeEvent( event.target );
 			},
 			handleQuantityCheckboxChange: (
 				event: HTMLElementEvent< HTMLInputElement >

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -887,7 +887,7 @@ function wc_get_product_id_by_global_unique_id( $global_unique_id ) {
 }
 
 /**
- * Get attributes/data for an individual variation from the database and maintain it's integrity.
+ * Get attributes/data for an individual variation from the database and maintain its integrity.
  *
  * @since  2.4.0
  * @param  int $variation_id Variation ID.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -50,6 +50,12 @@ class GroupedProductItemSelector extends AbstractBlock {
 		 * @param WC_Product $product   Product object.
 		 */
 		$min_value = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+
+		// By default, products have a min value of 1. In that case, we can
+		// safely override it to 0 when they are a child of a grouped product.
+		// The main benefit is that the the decrease quantity button will be
+		// enabled even when the quantity is 1, which is a small quality of life
+		// enhancement for shoppers.
 		if ( 1 === $min_value ) {
 			$min_value = 0;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -25,6 +25,15 @@ class GroupedProductItemSelector extends AbstractBlock {
 	protected $block_name = 'add-to-cart-with-options-grouped-product-item-selector';
 
 	/**
+	 * Set the quantity input type to number.
+	 *
+	 * @return string The quantity input type.
+	 */
+	public function set_quantity_input_type() {
+		return 'number';
+	}
+
+	/**
 	 * Gets the quantity selector markup for a product.
 	 *
 	 * @param \WC_Product $product The product object.
@@ -33,27 +42,38 @@ class GroupedProductItemSelector extends AbstractBlock {
 	private function get_quantity_selector_markup( $product ) {
 		ob_start();
 
+		/**
+		 * Filter the minimum quantity value allowed for the product.
+		 *
+		 * @since 10.1.0
+		 * @param int        $min_value Minimum quantity value.
+		 * @param WC_Product $product   Product object.
+		 */
+		$min_value = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+		if ( 1 === $min_value ) {
+			$min_value = 0;
+		}
+
+		/**
+		 * Filter the maximum quantity value allowed for the product.
+		 *
+		 * @since 10.1.0
+		 * @param int        $max_value Maximum quantity value.
+		 * @param WC_Product $product   Product object.
+		 */
+		$max_value = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
+
+		if ( $min_value === $max_value && $min_value > 0 ) {
+			add_filter( 'woocommerce_quantity_input_type', array( $this, 'set_quantity_input_type' ) );
+		}
+
 		woocommerce_quantity_input(
 			array(
 				'input_name'  => 'quantity[' . $product->get_id() . ']',
 				'input_id'    => 'quantity_' . $product->get_id(),
 				'input_value' => isset( $_POST['quantity'][ $product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $product->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				/**
-				 * Filter the minimum quantity value allowed for the product.
-				 *
-				 * @since 2.0.0
-				 * @param int        $min_value Minimum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
-				/**
-				 * Filter the maximum quantity value allowed for the product.
-				 *
-				 * @since 2.0.0
-				 * @param int        $max_value Maximum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'min_value'   => $min_value,
+				'max_value'   => $max_value,
 				/**
 				 * Filter the placeholder value allowed for the product.
 				 *
@@ -64,6 +84,10 @@ class GroupedProductItemSelector extends AbstractBlock {
 				'placeholder' => apply_filters( 'woocommerce_quantity_input_placeholder', 0, $product ),
 			)
 		);
+
+		if ( $min_value === $max_value && $min_value > 0 ) {
+			remove_filter( 'woocommerce_quantity_input_type', array( $this, 'set_quantity_input_type' ) );
+		}
 
 		$quantity_html = ob_get_clean();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -68,7 +68,8 @@ class Utils {
 			$processor->get_attribute( 'type' ) === 'number' &&
 			strpos( $processor->get_attribute( 'name' ), 'quantity' ) !== false
 		) {
-			$processor->set_attribute( 'data-wp-on--input', 'actions.handleQuantityInputChange' );
+			$processor->set_attribute( 'data-wp-on--input', 'actions.handleQuantityInput' );
+			$processor->set_attribute( 'data-wp-on--change', 'actions.handleQuantityChange' );
 		}
 
 		$quantity_html = $processor->get_updated_html();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59393.

In the _Grouped Product Item Selector_ block, we were overriding the product minimum quantity setting it to 0, that was required to make it possible to add only a subset of products to cart. However, this also allowed adding fewer products than the minimum quantity allowed for a product. This PR fixes that.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Add this code snippet to your site (changing the product ID to match one of the products):

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 3;
	}
	return $default;
}, 10, 2 );
```

4. Add that product as a child of a grouped product.
5. Visit that grouped product page on the frontend.
6. Verify you are not allowed to add 1 or 2 items to the cart. The minimum is respected.
7. Update the code snippet to this:

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 3;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 3;
	}
	return $default;
}, 10, 2 );
```

8. Verify the layout doesn't look broken.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/e7206256-e800-4aff-9466-54b6e597262c) | ![imatge](https://github.com/user-attachments/assets/46c20e2d-0759-4523-8118-c71cd0308983)

9. Verify you can add 3 units of that product to cart.