### PR TITLE
Wait for confirmation notice when removing a coupon in E2E test

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/tests/coupons/cart-block-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/coupons/cart-block-coupons.spec.js
@@ -207,6 +207,15 @@ test.describe(
 						.getByLabel( `Remove coupon "${ coupons[ i ].code }"` )
 						.click();
 					await expect(
+						page
+							.locator(
+								'.wc-block-components-notice-banner__content'
+							)
+							.getByText(
+								`Coupon code "${ coupons[ i ].code }" has been removed from your cart.`
+							)
+					).toBeVisible();
+					await expect(
 						page.locator(
 							'.wc-block-components-totals-footer-item > .wc-block-components-totals-item__value'
 						)


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding a different way of waiting for confirmation that the coupon was removed. This is now aligned with the way we're waiting for confirmation that the coupon was added. Hope it helps 🤞 

Closes https://github.com/woocommerce/woocommerce/issues/50591

### How to test the changes in this Pull Request:

Code review and green CI 🙏 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

E2E test improvement

</details>
