### PR TITLE
Initialize the extension class

### DIFF
--- a/docs/extensions/getting-started-extensions/how-to-design-a-simple-extension.md
+++ b/docs/extensions/getting-started-extensions/how-to-design-a-simple-extension.md
@@ -397,4 +397,6 @@ function my_extension_initialize() {
 
     $GLOBALS['my_extension'] = My_Extension::instance();
 }
+
+add_action( 'plugins_loaded', 'my_extension_initialize', 10 );
 ```


### PR DESCRIPTION
In the complete code example at the bottom, call add_action() to run 'my_extension_initialize'.

### Submission Review Guidelines:
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [PR 53252](https://github.com/woocommerce/woocommerce/pull/53252) can be closed - this is PR provides an updated commit.

### Changes proposed in this Pull Request:
The add_action() call will make the complete code example work as expected.
