### PR TITLE
Enhancement: Add support for conditionally hiding coupon remove button in block cart/checkout (#52436)

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
-import { RemovableChip, TotalsItem } from '@woocommerce/blocks-components';
+import { Chip, RemovableChip, TotalsItem } from '@woocommerce/blocks-components';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import { getSetting } from '@woocommerce/settings';
 import {
@@ -21,7 +21,7 @@ import './style.scss';
 export interface TotalsDiscountProps {
 	cartCoupons: LooselyMustHave<
 		CartResponseCouponItemWithLabel,
-		'code' | 'label' | 'totals'
+		'code' | 'label' | 'totals' | 'isRemovable'
 	>[];
 	currency: Currency;
 	isRemovingCoupon: boolean;
@@ -86,29 +86,45 @@ const TotalsDiscount = ( {
 						<ul className="wc-block-components-totals-discount__coupon-list">
 							{ filteredCartCoupons.map( ( cartCoupon ) => {
 								return (
-									<RemovableChip
-										key={ 'coupon-' + cartCoupon.code }
-										className="wc-block-components-totals-discount__coupon-list-item"
-										text={ cartCoupon.label }
-										screenReaderText={ sprintf(
-											/* translators: %s Coupon code. */
-											__( 'Coupon: %s', 'woocommerce' ),
-											cartCoupon.label
-										) }
-										disabled={ isRemovingCoupon }
-										onRemove={ () => {
-											removeCoupon( cartCoupon.code );
-										} }
-										radius="large"
-										ariaLabel={ sprintf(
-											/* translators: %s is a coupon code. */
-											__(
-												'Remove coupon "%s"',
-												'woocommerce'
-											),
-											cartCoupon.label
-										) }
-									/>
+									cartCoupon.isRemovable 
+									? (
+										<RemovableChip
+											key={ 'coupon-' + cartCoupon.code }
+											className="wc-block-components-totals-discount__coupon-list-item"
+											text={ cartCoupon.label }
+											screenReaderText={ sprintf(
+												/* translators: %s Coupon code. */
+												__( 'Coupon: %s', 'woocommerce' ),
+												cartCoupon.label
+											) }
+											disabled={ isRemovingCoupon }
+											onRemove={ () => {
+												removeCoupon( cartCoupon.code );
+											} }
+											radius="large"
+											ariaLabel={ sprintf(
+												/* translators: %s is a coupon code. */
+												__(
+													'Remove coupon "%s"',
+													'woocommerce'
+												),
+												cartCoupon.label
+											) }
+										/>
+									) : (
+										<Chip
+											key={ 'coupon-' + cartCoupon.code }
+											className="wc-block-components-totals-discount__coupon-list-item"
+											text={ cartCoupon.label }
+											screenReaderText={ sprintf(
+												/* translators: %s Coupon code. */
+												__( 'Coupon: %s', 'woocommerce' ),
+												cartCoupon.label
+											) }
+											radius="large"
+											element="li"
+										/>
+									)
 								);
 							} ) }
 						</ul>

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -179,6 +179,7 @@ export const useStoreCart = (
 						( coupon: CartResponseCouponItem ) => ( {
 							...coupon,
 							label: decodeEntities( coupon.code ),
+							isRemovable: true,
 						} )
 				  )
 				: EMPTY_CART_COUPONS,

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart-response.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/cart-response.ts
@@ -14,6 +14,7 @@ export interface CartResponseCouponItem {
 	code: string;
 	discount_type: string;
 	totals: CartResponseTotalsItem;
+	isRemovable: boolean;
 }
 
 export interface CartResponseCouponItemWithLabel

--- a/plugins/woocommerce/client/blocks/packages/components/chip/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/chip/style.scss
@@ -28,6 +28,9 @@
 	&.wc-block-components-chip--radius-large {
 		border-radius: 2em;
 		padding-left: 0.75em;
+		padding-right: 0.75em;
+	}
+	&.is-removable.wc-block-components-chip--radius-large {
 		padding-right: 0.25em;
 	}
 	.wc-block-components-chip__text {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

This PR introduces support for conditionally hiding the "Remove" button on coupons shown in the **Cart and Checkout Blocks**, by extending the existing [`coupons`](https://developer.woocommerce.com/docs/block-development/cart-and-checkout-blocks/available-filters/coupons/) filter available in WooCommerce Blocks.

- Adds a new optional property: `isRemovable` (boolean) to the `coupon` objects passed to the filter.
- When `isRemovable` is set to `false`, the "Remove" (×) icon/button is no longer rendered for that coupon.
- This enables developers to prevent users from removing certain coupons (e.g., auto-applied discounts).

This enhancement does **not** affect classic PHP-based coupons or templates — it is specific to the React-based Cart and Checkout blocks.

Closes #52436

---

### Screenshots or screen recordings:
<img width="408" alt="Screenshot 2025-07-04 at 10 26 30 AM" src="https://github.com/user-attachments/assets/76c7a0ee-6d81-44e0-99ba-655cff1afcd8" />
<img width="408" alt="Screenshot 2025-07-04 at 10 26 17 AM" src="https://github.com/user-attachments/assets/8482970d-35dd-4de7-8c97-e85bdc623ce0" />


| Before | After |
|--------|-------|
| All coupons show a remove button | Coupons with `isRemovable: false` do not |

---

### How to test the changes in this Pull Request:

1. Enable the WooCommerce Checkout Block (ensure you’re using block-based checkout/cart).
2. Apply a coupon like `auto` via the frontend.
3. In your custom theme or plugin, register a block filter like:

```
const modifyCoupons = ( coupons ) => {
	return coupons.map( ( coupon ) => {
		if ( 'auto' === coupon.code ) {
			return {
				...coupon,
				isRemovable: false,
			};
		}
		return coupon;
	} );
};

registerCheckoutFilters( 'custom-hide-coupon-remove-icon', {
	coupons: modifyCoupons,
} );
```

Refresh the Checkout or Cart page.

The coupon chip for `auto` should now render without a remove (×) button.

Other coupons should continue to behave as normal.

Testing that has already taken place:
Verified visually in both Cart and Checkout blocks

Confirmed only the "remove" button is affected — no unintended changes to discount logic or other UI

Ensured backward compatibility (default behavior unchanged if isRemovable is not provided)

Changelog entry
 Automatically create a changelog entry from the details below.

<details> <summary>Changelog Entry Details</summary>
Significance
 Minor

Type
 Enhancement - Improvement to existing functionality

Message
Enhancement – Added support for conditionally hiding the coupon "Remove" button in Cart and Checkout blocks using isRemovable key via the existing coupons JS filter.

</details> 