### PR TITLE
Fix build errors for missing editor stylesheet declarations

### DIFF
--- a/packages/js/product-editor/changelog/59421-fix-build-warnings-missing-files
+++ b/packages/js/product-editor/changelog/59421-fix-build-warnings-missing-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove unused css declarations

--- a/packages/js/product-editor/src/blocks/generic/checkbox/block.json
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/block.json
@@ -5,11 +5,7 @@
 	"title": "Product checkbox control",
 	"category": "woocommerce",
 	"description": "A reusable checkbox for the product editor.",
-	"keywords": [
-		"products",
-		"checkbox",
-		"input"
-	],
+	"keywords": [ "products", "checkbox", "input" ],
 	"textdomain": "default",
 	"attributes": {
 		"title": {
@@ -41,8 +37,5 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css",
-	"usesContext": [
-		"postType"
-	]
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/generic/notice/block.json
+++ b/packages/js/product-editor/src/blocks/generic/notice/block.json
@@ -5,10 +5,7 @@
 	"title": "Product notice field",
 	"category": "woocommerce",
 	"description": "A notice field for use in the product editor.",
-	"keywords": [
-		"products",
-		"notice"
-	],
+	"keywords": [ "products", "notice" ],
 	"textdomain": "default",
 	"attributes": {
 		"message": {
@@ -25,8 +22,5 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css",
-	"usesContext": [
-		"postType"
-	]
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/generic/subsection/block.json
+++ b/packages/js/product-editor/src/blocks/generic/subsection/block.json
@@ -5,11 +5,7 @@
 	"title": "Product subsection",
 	"category": "woocommerce",
 	"description": "The product subsection.",
-	"keywords": [
-		"products",
-		"subsection",
-		"group"
-	],
+	"keywords": [ "products", "subsection", "group" ],
 	"textdomain": "default",
 	"attributes": {
 		"title": {
@@ -21,11 +17,7 @@
 		},
 		"blockGap": {
 			"type": "string",
-			"enum": [
-				"unit-20",
-				"unit-30",
-				"unit-40"
-			],
+			"enum": [ "unit-20", "unit-30", "unit-40" ],
 			"default": "unit-20"
 		}
 	},
@@ -37,6 +29,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-email/block.json
@@ -5,12 +5,7 @@
 	"title": "Stock level threshold",
 	"category": "widgets",
 	"description": "Stock management minimum quantity.",
-	"keywords": [
-		"products",
-		"inventory",
-		"email",
-		"minimum"
-	],
+	"keywords": [ "products", "inventory", "email", "minimum" ],
 	"textdomain": "default",
 	"attributes": {
 		"name": {
@@ -26,6 +21,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/password/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/password/block.json
@@ -5,10 +5,7 @@
 	"description": "A checkbox and an input to type a password to view a product.",
 	"title": "Product password",
 	"category": "widgets",
-	"keywords": [
-		"products",
-		"password"
-	],
+	"keywords": [ "products", "password" ],
 	"textdomain": "default",
 	"attributes": {
 		"label": {
@@ -24,6 +21,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/plugins/woocommerce/changelog/59421-fix-build-warnings-missing-files
+++ b/plugins/woocommerce/changelog/59421-fix-build-warnings-missing-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove unused css declarations

--- a/plugins/woocommerce/changelog/fix-build-warnings-missing-files
+++ b/plugins/woocommerce/changelog/fix-build-warnings-missing-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove unused css declarations


### PR DESCRIPTION
Fixes WOOPLUG-4896

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
I'm using AI to improve the output of our build process. With small PRs, the goal is to clear the warnings we see while building the project.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is removing the errors below:
```
../../packages/js/product-editor watch:build:project:bundle: Block asset file not found. /Users/raluca/Work/plugins/woocommerce/packages/js/product-editor/src/blocks/generic/checkbox/editor
../../packages/js/product-editor watch:build:project:bundle: Block asset file not found. /Users/raluca/Work/plugins/woocommerce/packages/js/product-editor/src/blocks/generic/notice/editor
../../packages/js/product-editor watch:build:project:bundle: Block asset file not found. /Users/raluca/Work/plugins/woocommerce/packages/js/product-editor/src/blocks/generic/subsection/editor
../../packages/js/product-editor watch:build:project:bundle: Block asset file not found. /Users/raluca/Work/plugins/woocommerce/packages/js/product-editor/src/blocks/product-fields/inventory-email/editor
../../packages/js/product-editor watch:build:project:bundle: Block asset file not found. /Users/raluca/Work/plugins/woocommerce/packages/js/product-editor/src/blocks/product-fields/password/edito...
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Developer only:**
Make sure these errors don't appear while running the watch command. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove unused css declarations

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
