### PR TITLE
Avoid warnings about missing a unique key prop from `SnackbarList` component when enabling script debug

### DIFF
--- a/plugins/woocommerce/changelog/dev-avoid-missing-unique-key-prop-warning
+++ b/plugins/woocommerce/changelog/dev-avoid-missing-unique-key-prop-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Avoid warnings about missing a unique key prop from `SnackbarList` component when enabling script debug.

--- a/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
+++ b/plugins/woocommerce/client/admin/client/layout/transient-notices/snackbar/list.js
@@ -57,21 +57,23 @@ function SnackbarList( {
 	return (
 		<div className={ className }>
 			{ children }
-			{ transitions( ( style, notice ) => (
-				<animated.div style={ style }>
-					<div
-						className="components-snackbar-list__notice-container"
-						ref={ ( ref ) => ref && refMap.set( notice, ref ) }
-					>
-						<Snackbar
-							{ ...omit( notice, [ 'content' ] ) }
-							onRemove={ removeNotice( notice ) }
+			<>
+				{ transitions( ( style, notice ) => (
+					<animated.div style={ style }>
+						<div
+							className="components-snackbar-list__notice-container"
+							ref={ ( ref ) => ref && refMap.set( notice, ref ) }
 						>
-							{ notice.content }
-						</Snackbar>
-					</div>
-				</animated.div>
-			) ) }
+							<Snackbar
+								{ ...omit( notice, [ 'content' ] ) }
+								onRemove={ removeNotice( notice ) }
+							>
+								{ notice.content }
+							</Snackbar>
+						</div>
+					</animated.div>
+				) ) }
+			</>
 		</div>
 	);
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR avoids warnings about missing a unique key prop from `SnackbarList` component when enabling script debug. This warning appears on almost every WooCommerce admin page, and it somewhat causes unwanted noise during development.

### Screenshots or screen recordings:

#### 📷 Before

![image](https://github.com/user-attachments/assets/762dab3a-0c24-451a-a825-ac1a1b2b85a0)

#### 📷 After

![image](https://github.com/user-attachments/assets/e5458134-b9f5-4e16-8952-e5128b348099)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add `define( 'SCRIPT_DEBUG', true );` to wp-config.php to enable script debug mode
2. Checkout revision d3a8f1c52b8bfa8df4817baa15d30fbe807f7c99 and run `pnpm --filter='@woocommerce/plugin-woocommerce' build` 
3. Open the Console tab of browser DevTool
4. Browse some WooCommerce admin pages to view the warning
   ![image](https://github.com/user-attachments/assets/be6fa6dc-7108-4c67-8c82-32b023fc5ee9)
5. Checkout this PR and run `pnpm --filter='@woocommerce/plugin-woocommerce' build`
6. Browse some WooCommerce admin pages to check if the warning no longer occurs

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
