### PR TITLE
Fix email preview settings not supporting custom plugin id in emails

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4868-email-preview-settings-do-not-load-using-a-custom-plugin-id
+++ b/plugins/woocommerce/changelog/wooplug-4868-email-preview-settings-do-not-load-using-a-custom-plugin-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Ensure email previews uses the plugin_id for transients

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1469,8 +1469,9 @@ class WC_Email extends WC_Settings_API {
 		 */
 		$is_email_preview = apply_filters( 'woocommerce_is_email_preview', false );
 		if ( $is_email_preview ) {
+			$plugin_id = $this->plugin_id;
 			$email_id  = $this->id;
-			$transient = get_transient( "woocommerce_{$email_id}_{$key}" );
+			$transient = get_transient( "{$plugin_id}{$email_id}_{$key}" );
 			if ( false !== $transient ) {
 				$option = $transient ? $transient : $empty_value;
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes a bug where email preview settings do not load correctly when using custom emails with a non-default plugin ID. The issue occurs because transients containing email setting values are saved with a key that uses the plugin ID as a prefix, but when loading the transient values, the prefix was hardcoded as "woocommerce_".

**Why this change is needed:**
- Third-party plugins creating custom emails with overridden plugin IDs (e.g., `$plugin_id = 'x_'`) were unable to see updated email settings in the preview functionality
- Email previews would always use default values instead of the actual configured values for these custom emails
- This inconsistency created a poor developer experience when building email extensions

**What this PR does:**
- Updates the `get_option_or_transient()` method in `WC_Email` class to use the email's actual `plugin_id` property instead of hardcoded "woocommerce_" when loading transients during email preview
- Ensures transient key generation matches between saving and loading operations for all emails regardless of their plugin ID
- Maintains backward compatibility for core WooCommerce emails (which use "woocommerce_" as plugin_id)

Closes #59359 WOOPLUG-4868 

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Set up a custom email with non-default plugin ID:** 
   - Create a custom email class that extends a WooCommerce email (e.g., `WC_Email_Customer_Completed_Order`)
   - Override the `plugin_id` property to use a custom value (e.g., `public $plugin_id = 'x_';`)
   - Register the email using the `woocommerce_email_classes` filter
   - Add the email's heading setting to the preview settings using `woocommerce_email_preview_email_content_setting_ids` filter
   
```php
function register_my_custom_test_email_class( array $emails ) {

	if(class_exists('My_Custom_Test_Email')) {
		return $emails;
	}

	class My_Custom_Test_Email extends \WC_Email_Customer_Completed_Order {
		public $plugin_id = 'x_';

		public function __construct() {
			$this->id = 'my_custom_test_email';
			$this->title = 'My Custom Test Email';
			$this->description = 'This is a custom test email';

			$this->heading = 'My Custom Test Email Heading';
			$this->subject = 'My Custom Test Email Subject';

			add_filter( 'woocommerce_email_preview_email_content_setting_ids', function( $setting_ids ) {
				$setting_ids[] = 'x_customer_completed_order_heading';
				return $setting_ids;
			} );
			parent::__construct();
		}

		public function get_default_subject() {
			return $this->subject;
		}

		public function get_default_heading() {
			return $this->heading;
		}
	}

	$emails['Test_Email'] = new My_Custom_Test_Email();

	return $emails;
}
add_filter( 'woocommerce_email_classes', 'register_my_custom_test_email_class' );
```   

2. **Test email preview functionality:**
   - Navigate to WooCommerce > Settings > Emails
   - Click on your custom email to open its settings
   - Open the email preview (if available) or use the preview functionality
   - Modify the "heading" field or other email settings
   - Verify that the preview updates with the new settings values instead of showing default values

3. **Verify backward compatibility:**
   - Test core WooCommerce emails (which use default "woocommerce_" plugin_id)
   - Confirm that their preview functionality continues to work as expected
   - Change settings like email heading, subject, etc. and verify previews update correctly

4. **Edge case testing:**
   - Test with multiple custom emails having different plugin IDs
   - Verify each email's preview uses its own settings independently

### Testing that has already taken place:

- Manual testing with custom email implementation using non-default plugin ID
- Verified that email previews now correctly display updated setting values for custom plugin IDs
- Confirmed backward compatibility with core WooCommerce emails
- Tested transient key generation logic to ensure consistency between save and load operations

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
