### PR TITLE
Fix edge case scenario with subsequent aborted requests

### DIFF
--- a/plugins/woocommerce/changelog/lstr-fix-edge-case-when-selecting-shipping-rate
+++ b/plugins/woocommerce/changelog/lstr-fix-edge-case-when-selecting-shipping-rate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix edge case when selecting shipping/pickup location on slow network

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -484,13 +484,11 @@ export const selectShippingRate =
 
 			dispatch.receiveCart( rest );
 			dispatch.shippingRatesBeingSelected( false );
-			return response as CartResponse;
+			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
 			dispatch.shippingRatesBeingSelected( false );
 			return Promise.reject( error );
-		} finally {
-			abortController = null;
 		}
 	};
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Related to https://github.com/woocommerce/woocommerce/issues/57542

Screen recording presenting the problem

https://github.com/user-attachments/assets/453a0d40-6aff-40ce-849f-b906b83c9a17

Steps I did in the recording while throttling network significantly:
1. Very quickly select the 2nd option
2. Very quickly select the 3rd option
3. Very quickly go back to the 1st option

**Expected**: 1st option stays selected
**What happens**: selection moves to the 3rd option

#### Explanation

Short version: this is caused by incorrectly resetting the `AbortController` that makes it impossible to abort a request to change selection in some cases. The fix removes this reset.

<details>
<summary>Long version will be a journey. So I will hide it for the brave souls.</summary>

Let's imagine you have 3 shipping rates, let's call them "A", "B" and "C". The initial state in the data store looks like this:
```
A - selected
B
C
```

You click B, and we call a thunk to update B to selected. The state changes to:

```
A - still selected in the store (although we update UI optimistically, so user sees B selected)
B - start request to change selection to B, create abort controller to cancel it
C
```

Then before the request has time to finish, you click C. What happens is:

A - still selected in the store (optimistic update, user sees C selected)

We need to look a bit closer to the flow in thunk:
1. Abort the request for request B ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L456-L458))
2. Sets abort controller to request C ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L459-L462))
3. Request to change selection to C ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L464-L475))
4. Abort controller is set to null ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L493)) - this might be challenging to get, it happens in `finally` that we wrapped the request to change selection to B. Since steps 1-3 from this flow are happening synchronously, this is the first time some async code has opportunity to run.

At this point, we have an ongoing request to C, but without a way to properly cancel it. An interesting thing happens when you click A now.

A - still selected in the store (we do optimistic update, so user sees A selected, great for now)

The flow in thunk:
1. We see that the request is to change the value that is already in the store, since we don't need to do any work, let's exit the function early and call it a day ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L440-L448))
2. Before returning, let's try aborting whatever is in flight though ([source](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts#L444-L446))
3. There's nothing in flight, as abort controller is set to `null` (this happened in step 4. in the previous section)
4. Return early
5. Request to change selection to C is finally complete, we didn't have a way of stopping it in-flight, so we update state to select C (ups)

</details>


### How to test the changes in this Pull Request:

You need to have at least 3 pickup locations or shipping rates.

1. Add some items to your cart and open checkout
2. Fill the fields necessary to display shipping options/local pickup
3. Go to the network tab in your dev tools and enable throttling set to Slow 4G
4. Try reproducing what I did in the screen recording attached at the beginning of this description
5. Apart from the above, just click randomly on available options (vary the timing of your clicks) to verify whether you can break it in any way

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
