### PR TITLE
Add to Cart + Options e2e test: wait for variation to load before adding to cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-58838-flaky-test-ii
+++ b/plugins/woocommerce/changelog/fix-58838-flaky-test-ii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix Add to Cart + Options 'allows adding variable products to cart' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -143,12 +143,20 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await logoNoOption.click();
 			await colorGreenOption.click();
-			await addToCartButton.click();
+
+			// Wait until the variation is found and the button becomes visually
+			// enabled.
+			// Note: The button is always enabled for accessibility reasons.
+			// Instead, we check directly for the "disabled" class, which grays
+			// out the button.
+			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
 
 			await expect( productPrice ).toHaveText( '$45.00' );
 		} );
 
 		await test.step( 'successfully adds to cart when attributes are selected', async () => {
+			await addToCartButton.click();
+
 			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
 		} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/58838.

This PR makes it so in the _Add to Cart + Options_ 'allows adding variable products to cart' test, we wait until the matching variation has been found before clicking on the _Add to cart_ button. I ran the test 20 times locally, and it seemed to pass consistently.

### How to test the changes in this Pull Request:

1. Make sure the 'allows adding variable products to cart' test passes and is not flaky ([Blocks e2e tests 1/10](https://github.com/woocommerce/woocommerce/actions/runs/16113791899/job/45463044680?pr=59472))