### PR TITLE
Preserve personalization tags in email text version

### DIFF
--- a/packages/php/email-editor/changelog/59478-wooplug-4793-text-version-of-email-generated-by-renderer-misses-the
+++ b/packages/php/email-editor/changelog/59478-wooplug-4793-text-version-of-email-generated-by-renderer-misses-the
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Preserve personalization tags in email text version

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -157,7 +157,7 @@ class Renderer {
 	}
 
 	/**
-	 * Renders the text version of the email template
+	 * Renders the text version of the email template.
 	 *
 	 * @param string $template HTML template.
 	 * @return string
@@ -165,7 +165,7 @@ class Renderer {
 	private function render_text_version( $template ) {
 		$template = ( mb_detect_encoding( $template, 'UTF-8', true ) ) ? $template : mb_convert_encoding( $template, 'UTF-8', mb_list_encodings() );
 
-		// Preserve personalization tags by temporarily replacing them with unique placeholders
+		// Preserve personalization tags by temporarily replacing them with unique placeholders.
 		$template = $this->preserve_personalization_tags( $template );
 
 		$result = Html2Text::convert( (string) $template );
@@ -173,38 +173,38 @@ class Renderer {
 			return '';
 		}
 
-		// Restore personalization tags from placeholders
+		// Restore personalization tags from placeholders.
 		$result = $this->restore_personalization_tags( $result );
 
 		return $result;
 	}
 
 	/**
-	 * Preserves personalization tags by replacing them with unique placeholders
+	 * Preserves personalization tags by replacing them with unique placeholders.
 	 *
 	 * @param string $template HTML template.
 	 * @return string
 	 */
 	private function preserve_personalization_tags( string $template ): string {
-		$all_tags = $this->personalization_tags_registry->get_all();
+		$all_tags                               = $this->personalization_tags_registry->get_all();
 		$this->personalization_tag_placeholders = array();
-		$counter = 0;
+		$counter                                = 0;
 
 		foreach ( $all_tags as $tag ) {
 			$token = $tag->get_token();
-			// Create a unique placeholder for each personalization tag
+			// Create a unique placeholder for each personalization tag.
 			$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter . '_' . md5( $token );
-			// Store the full HTML comment format
+			// Store the full HTML comment format.
 			$this->personalization_tag_placeholders[ $placeholder ] = '<!--' . $token . '-->';
-			$counter++;
+			++$counter;
 		}
 
-		// Replace all personalization tags with placeholders
+		// Replace all personalization tags with placeholders.
 		foreach ( $this->personalization_tag_placeholders as $placeholder => $html_comment ) {
-			// Escape the HTML comment for safe regex usage
+			// Escape the HTML comment for safe regex usage.
 			$escaped_html_comment = preg_quote( $html_comment, '/' );
-			// Match the exact HTML comment format
-			$pattern = '/' . $escaped_html_comment . '/';
+			// Match the exact HTML comment format.
+			$pattern  = '/' . $escaped_html_comment . '/';
 			$template = preg_replace( $pattern, $placeholder, $template );
 		}
 

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -191,15 +191,14 @@ class Renderer {
 	 * @return string
 	 */
 	private function preserve_personalization_tags( string $template ): string {
-		$all_registered_tags = $this->personalization_tags_registry->get_all();
+		$all_registered_tags                    = $this->personalization_tags_registry->get_all();
 		$this->personalization_tag_placeholders = array();
-		$counter = 0;
+		$counter                                = 0;
 
-
-		$base_tokens = array(); // all the tokens used in the email, e.g. [woocommerce/customer-username]
-		$token_prefixes = array(); // all the used prefixes, e.g. woocommerce, mailpoet, etc.
+		$base_tokens    = array(); // All the tokens used in the email, e.g. [woocommerce/customer-username].
+		$token_prefixes = array(); // All the used prefixes, e.g. woocommerce, mailpoet, etc.
 		foreach ( $all_registered_tags as $tag ) {
-			$token = $tag->get_token(); // e.g. [woocommerce/customer-username]
+			$token                 = $tag->get_token(); // E.g. [woocommerce/customer-username].
 			$base_tokens[ $token ] = true;
 			// Remove brackets for regex matching, escape for regex.
 			$token_prefixes[] = preg_quote( substr( $token, 1, -1 ), '/' );
@@ -228,7 +227,7 @@ class Renderer {
 			$template
 		);
 
-		return $template;
+		return $template ?? '';
 	}
 
 	/**

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Engine\Renderer;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Content_Renderer;
 use Automattic\WooCommerce\EmailEditor\Engine\Templates\Templates;
 use Automattic\WooCommerce\EmailEditor\Engine\Theme_Controller;
+use Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry;
 use Soundasleep\Html2Text;
 use WP_Style_Engine;
 
@@ -46,6 +47,20 @@ class Renderer {
 	 */
 	private Css_Inliner $css_inliner;
 
+	/**
+	 * Personalization tags registry
+	 *
+	 * @var Personalization_Tags_Registry
+	 */
+	private Personalization_Tags_Registry $personalization_tags_registry;
+
+	/**
+	 * Map of placeholders to full HTML comment tags for restoration.
+	 *
+	 * @var array
+	 */
+	private array $personalization_tag_placeholders = array();
+
 	const TEMPLATE_FILE        = 'template-canvas.php';
 	const TEMPLATE_STYLES_FILE = 'template-canvas.css';
 
@@ -53,21 +68,24 @@ class Renderer {
 	/**
 	 * Renderer constructor.
 	 *
-	 * @param Content_Renderer $content_renderer Content renderer.
-	 * @param Templates        $templates Templates.
-	 * @param Css_Inliner      $css_inliner CSS Inliner.
-	 * @param Theme_Controller $theme_controller Theme controller.
+	 * @param Content_Renderer              $content_renderer Content renderer.
+	 * @param Templates                     $templates Templates.
+	 * @param Css_Inliner                   $css_inliner CSS Inliner.
+	 * @param Theme_Controller              $theme_controller Theme controller.
+	 * @param Personalization_Tags_Registry $personalization_tags_registry Personalization tags registry.
 	 */
 	public function __construct(
 		Content_Renderer $content_renderer,
 		Templates $templates,
 		Css_Inliner $css_inliner,
-		Theme_Controller $theme_controller
+		Theme_Controller $theme_controller,
+		Personalization_Tags_Registry $personalization_tags_registry
 	) {
-		$this->content_renderer = $content_renderer;
-		$this->templates        = $templates;
-		$this->theme_controller = $theme_controller;
-		$this->css_inliner      = $css_inliner;
+		$this->content_renderer              = $content_renderer;
+		$this->templates                     = $templates;
+		$this->theme_controller              = $theme_controller;
+		$this->css_inliner                   = $css_inliner;
+		$this->personalization_tags_registry = $personalization_tags_registry;
 	}
 
 	/**
@@ -146,11 +164,66 @@ class Renderer {
 	 */
 	private function render_text_version( $template ) {
 		$template = ( mb_detect_encoding( $template, 'UTF-8', true ) ) ? $template : mb_convert_encoding( $template, 'UTF-8', mb_list_encodings() );
-		$result   = Html2Text::convert( (string) $template );
+
+		// Preserve personalization tags by temporarily replacing them with unique placeholders
+		$template = $this->preserve_personalization_tags( $template );
+
+		$result = Html2Text::convert( (string) $template );
 		if ( ! $result ) {
 			return '';
 		}
 
+		// Restore personalization tags from placeholders
+		$result = $this->restore_personalization_tags( $result );
+
 		return $result;
+	}
+
+	/**
+	 * Preserves personalization tags by replacing them with unique placeholders
+	 *
+	 * @param string $template HTML template.
+	 * @return string
+	 */
+	private function preserve_personalization_tags( string $template ): string {
+		$all_tags = $this->personalization_tags_registry->get_all();
+		$this->personalization_tag_placeholders = array();
+		$counter = 0;
+
+		foreach ( $all_tags as $tag ) {
+			$token = $tag->get_token();
+			// Create a unique placeholder for each personalization tag
+			$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter . '_' . md5( $token );
+			// Store the full HTML comment format
+			$this->personalization_tag_placeholders[ $placeholder ] = '<!--' . $token . '-->';
+			$counter++;
+		}
+
+		// Replace all personalization tags with placeholders
+		foreach ( $this->personalization_tag_placeholders as $placeholder => $html_comment ) {
+			// Escape the HTML comment for safe regex usage
+			$escaped_html_comment = preg_quote( $html_comment, '/' );
+			// Match the exact HTML comment format
+			$pattern = '/' . $escaped_html_comment . '/';
+			$template = preg_replace( $pattern, $placeholder, $template );
+		}
+
+		return $template;
+	}
+
+	/**
+	 * Restores personalization tags from placeholders
+	 *
+	 * @param string $text Text content.
+	 * @return string
+	 */
+	private function restore_personalization_tags( string $text ): string {
+		if ( empty( $this->personalization_tag_placeholders ) ) {
+			return $text;
+		}
+		foreach ( $this->personalization_tag_placeholders as $placeholder => $html_comment ) {
+			$text = str_replace( $placeholder, $html_comment, $text );
+		}
+		return $text;
 	}
 }

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -192,21 +192,19 @@ class Renderer {
 
 		foreach ( $all_tags as $tag ) {
 			$token = $tag->get_token();
-			// Create a unique placeholder for each personalization tag.
-			$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter . '_' . md5( $token );
+			// Create a unique placeholder for each personalization tag (counter is sufficient).
+			$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter;
 			// Store the full HTML comment format.
 			$this->personalization_tag_placeholders[ $placeholder ] = '<!--' . $token . '-->';
 			++$counter;
 		}
 
-		// Replace all personalization tags with placeholders.
-		foreach ( $this->personalization_tag_placeholders as $placeholder => $html_comment ) {
-			// Escape the HTML comment for safe regex usage.
-			$escaped_html_comment = preg_quote( $html_comment, '/' );
-			// Match the exact HTML comment format.
-			$pattern  = '/' . $escaped_html_comment . '/';
-			$template = preg_replace( $pattern, $placeholder, $template );
-		}
+		// Replace all personalization tags with placeholders (exact string replacement).
+		$template = str_replace(
+			array_values( $this->personalization_tag_placeholders ),
+			array_keys( $this->personalization_tag_placeholders ),
+			$template
+		);
 
 		return $template;
 	}

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -185,29 +185,46 @@ class Renderer {
 	}
 
 	/**
-	 * Preserves personalization tags by replacing them with unique placeholders.
+	 * Preserves personalization tags by replacing them with unique placeholders (not inside comments).
 	 *
 	 * @param string $template HTML template.
 	 * @return string
 	 */
 	private function preserve_personalization_tags( string $template ): string {
-		$all_tags                               = $this->personalization_tags_registry->get_all();
+		$all_registered_tags = $this->personalization_tags_registry->get_all();
 		$this->personalization_tag_placeholders = array();
-		$counter                                = 0;
+		$counter = 0;
 
-		foreach ( $all_tags as $tag ) {
-			$token = $tag->get_token();
-			// Create a unique placeholder for each personalization tag (counter is sufficient).
-			$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter;
-			// Store the full HTML comment format.
-			$this->personalization_tag_placeholders[ $placeholder ] = '<!--' . $token . '-->';
-			++$counter;
+
+		$base_tokens = array(); // all the tokens used in the email, e.g. [woocommerce/customer-username]
+		$token_prefixes = array(); // all the used prefixes, e.g. woocommerce, mailpoet, etc.
+		foreach ( $all_registered_tags as $tag ) {
+			$token = $tag->get_token(); // e.g. [woocommerce/customer-username]
+			$base_tokens[ $token ] = true;
+			// Remove brackets for regex matching, escape for regex.
+			$token_prefixes[] = preg_quote( substr( $token, 1, -1 ), '/' );
 		}
 
-		// Replace all personalization tags with placeholders (exact string replacement).
-		$template = str_replace(
-			array_values( $this->personalization_tag_placeholders ),
-			array_keys( $this->personalization_tag_placeholders ),
+		if ( empty( $token_prefixes ) ) {
+			return $template;
+		}
+
+		// Match all of the code comments that look like a personalization tags.
+		$pattern = '/<!--\[(' . implode( '|', $token_prefixes ) . ')(?:\s+[^\]]*)?\]-->/';
+
+		$template = preg_replace_callback(
+			$pattern,
+			function ( $matches ) use ( &$counter, $base_tokens ) {
+				// $matches[1] is the token without brackets, add brackets for lookup.
+				$base_token = '[' . $matches[1] . ']';
+				if ( isset( $base_tokens[ $base_token ] ) ) {
+					$placeholder = 'PERSONALIZATION_TAG_PLACEHOLDER_' . $counter;
+					$this->personalization_tag_placeholders[ $placeholder ] = $matches[0];
+					++$counter;
+					return $placeholder;
+				}
+				return $matches[0];
+			},
 			$template
 		);
 

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -165,6 +165,11 @@ class Renderer {
 	private function render_text_version( $template ) {
 		$template = ( mb_detect_encoding( $template, 'UTF-8', true ) ) ? $template : mb_convert_encoding( $template, 'UTF-8', mb_list_encodings() );
 
+		// Ensure template is a string before processing.
+		if ( ! is_string( $template ) ) {
+			return '';
+		}
+
 		// Preserve personalization tags by temporarily replacing them with unique placeholders.
 		$template = $this->preserve_personalization_tags( $template );
 

--- a/packages/php/email-editor/src/class-email-editor-container.php
+++ b/packages/php/email-editor/src/class-email-editor-container.php
@@ -197,6 +197,7 @@ class Email_Editor_Container {
 					$container->get( Templates::class ),
 					new Email_Css_Inliner(),
 					$container->get( Theme_Controller::class ),
+					$container->get( Personalization_Tags_Registry::class ),
 				);
 			}
 		);

--- a/packages/php/email-editor/tests/integration/Email_Editor_Integration_Test_Case.php
+++ b/packages/php/email-editor/tests/integration/Email_Editor_Integration_Test_Case.php
@@ -244,6 +244,7 @@ abstract class Email_Editor_Integration_Test_Case extends \WP_UnitTestCase {
 					$container->get( Templates::class ),
 					$container->get( Email_Css_Inliner::class ),
 					$container->get( Theme_Controller::class ),
+					$container->get( Personalization_Tags_Registry::class ),
 				);
 			}
 		);

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -241,7 +241,12 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		);
 
 		$this->email_post->post_content = '<!-- wp:paragraph --><p><!--[woocommerce/customer-username]--></p><!-- /wp:paragraph -->';
-		wp_update_post( $this->email_post );
+		wp_update_post(
+			array(
+				'ID'           => $this->email_post->ID,
+				'post_content' => $this->email_post->post_content,
+			)
+		);
 		$rendered = $this->renderer->render(
 			$this->email_post,
 			'Subject',

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -63,10 +63,15 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$theme_controller_mock->method( 'get_styles' )->willReturn( $styles );
 		$theme_controller_mock->method( 'get_layout_settings' )->willReturn( array( 'contentSize' => '660px' ) );
 
+		// Create a mock for Personalization_Tags_Registry
+		$personalization_tags_registry_mock = $this->createMock( \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry::class );
+		$personalization_tags_registry_mock->method( 'get_all' )->willReturn( array() );
+
 		$this->renderer = $this->getServiceWithOverrides(
 			Renderer::class,
 			array(
 				'theme_controller' => $theme_controller_mock,
+				'personalization_tags_registry' => $personalization_tags_registry_mock,
 			)
 		);
 
@@ -206,6 +211,43 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			'test-email-template-extra'
 		);
 		$this->assertStringContainsString( 'test-template-class-extra', $rendered['html'] );
+	}
+
+	/**
+	 * Test that rendering preserves personalization tags.
+	 */
+	public function testItPreservesPersonalizationTags(): void {
+		// Use the real Personalization_Tags_Registry and Personalization_Tag
+		$registry = new \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry(
+			$this->di_container->get(\Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger::class)
+		);
+		$registry->register(
+			new \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag(
+				'Customer Username',
+				'[woocommerce/customer-username]',
+				'Customer',
+				function () { return ''; }
+			)
+		);
+
+		// Override the renderer with our real registry
+		$this->renderer = $this->getServiceWithOverrides(
+			Renderer::class,
+			array(
+				'personalization_tags_registry' => $registry,
+			)
+		);
+
+		$this->email_post->post_content = '<!-- wp:paragraph --><p><!--[woocommerce/customer-username]--></p><!-- /wp:paragraph -->';
+		wp_update_post( $this->email_post );
+		$rendered = $this->renderer->render(
+			$this->email_post,
+			'Subject',
+			'Preheader content',
+			'en'
+		);
+		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['html'] );
+		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['text'] );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -240,7 +240,7 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			)
 		);
 
-		$this->email_post->post_content = '<!-- wp:paragraph --><p><!--[woocommerce/customer-username]--></p><!-- /wp:paragraph -->';
+		$this->email_post->post_content = '<!-- wp:paragraph --><p><!--[woocommerce/customer-username]--><!--[woocommerce/customer-username default="john"]--></p><!-- /wp:paragraph -->';
 		wp_update_post(
 			array(
 				'ID'           => $this->email_post->ID,
@@ -253,8 +253,15 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			'Preheader content',
 			'en'
 		);
+		// Debug output for rendered text and html if assertion fails.
+		if (strpos($rendered['text'], '<!--[woocommerce/customer-username]-->') === false) {
+			fwrite(STDERR, "\n[DEBUG] Rendered text version:\n" . $rendered['text'] . "\n");
+			fwrite(STDERR, "\n[DEBUG] Rendered HTML version:\n" . $rendered['html'] . "\n");
+		}
 		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['html'] );
+		$this->assertStringContainsString( '<!--[woocommerce/customer-username default="john"]-->', $rendered['html'] );
 		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['text'] );
+		$this->assertStringContainsString( '<!--[woocommerce/customer-username default="john"]-->', $rendered['text'] );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -63,14 +63,14 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 		$theme_controller_mock->method( 'get_styles' )->willReturn( $styles );
 		$theme_controller_mock->method( 'get_layout_settings' )->willReturn( array( 'contentSize' => '660px' ) );
 
-		// Create a mock for Personalization_Tags_Registry
+		// Create a mock for Personalization_Tags_Registry.
 		$personalization_tags_registry_mock = $this->createMock( \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry::class );
 		$personalization_tags_registry_mock->method( 'get_all' )->willReturn( array() );
 
 		$this->renderer = $this->getServiceWithOverrides(
 			Renderer::class,
 			array(
-				'theme_controller' => $theme_controller_mock,
+				'theme_controller'              => $theme_controller_mock,
 				'personalization_tags_registry' => $personalization_tags_registry_mock,
 			)
 		);
@@ -217,20 +217,22 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	 * Test that rendering preserves personalization tags.
 	 */
 	public function testItPreservesPersonalizationTags(): void {
-		// Use the real Personalization_Tags_Registry and Personalization_Tag
+		// Use the real Personalization_Tags_Registry and Personalization_Tag.
 		$registry = new \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry(
-			$this->di_container->get(\Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger::class)
+			$this->di_container->get( \Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger::class )
 		);
 		$registry->register(
 			new \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tag(
 				'Customer Username',
 				'[woocommerce/customer-username]',
 				'Customer',
-				function () { return ''; }
+				function () {
+					return '';
+				}
 			)
 		);
 
-		// Override the renderer with our real registry
+		// Override the renderer with our real registry.
 		$this->renderer = $this->getServiceWithOverrides(
 			Renderer::class,
 			array(

--- a/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Engine/Renderer/Renderer_Test.php
@@ -217,7 +217,6 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	 * Test that rendering preserves personalization tags.
 	 */
 	public function testItPreservesPersonalizationTags(): void {
-		// Use the real Personalization_Tags_Registry and Personalization_Tag.
 		$registry = new \Automattic\WooCommerce\EmailEditor\Engine\PersonalizationTags\Personalization_Tags_Registry(
 			$this->di_container->get( \Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger::class )
 		);
@@ -232,7 +231,6 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			)
 		);
 
-		// Override the renderer with our real registry.
 		$this->renderer = $this->getServiceWithOverrides(
 			Renderer::class,
 			array(
@@ -253,11 +251,6 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 			'Preheader content',
 			'en'
 		);
-		// Debug output for rendered text and html if assertion fails.
-		if (strpos($rendered['text'], '<!--[woocommerce/customer-username]-->') === false) {
-			fwrite(STDERR, "\n[DEBUG] Rendered text version:\n" . $rendered['text'] . "\n");
-			fwrite(STDERR, "\n[DEBUG] Rendered HTML version:\n" . $rendered['html'] . "\n");
-		}
 		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['html'] );
 		$this->assertStringContainsString( '<!--[woocommerce/customer-username default="john"]-->', $rendered['html'] );
 		$this->assertStringContainsString( '<!--[woocommerce/customer-username]-->', $rendered['text'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Personalization tags were being stripped from the text version of emails during HTML-to-text conversion. This prevented them from being replaced with actual values later in the email sending process.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59185 WOOPLUG-4793.

### Screenshots or screen recordings:

No UI changes

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. There are no UI changes in this pull request, it can be only tested by running the Integration tests
2. Check that the build passes with this change

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Preserve personalization tags in email text version

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
