### PR TITLE
Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block (II)

### DIFF
--- a/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky-ii
+++ b/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky-ii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block (II)
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -242,9 +242,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		// We need to make sure the block updated before saving.
 		// @see https://github.com/woocommerce/woocommerce/issues/57718
+		// Verify that `.editor-post-publish-button__button` has an attribute
+		// `aria-haspopup="dialog"`. When https://github.com/woocommerce/woocommerce/issues/48936
+		// is fixed, we can simply check that the Save button becomes enabled.
 		await expect(
-			editor.canvas.getByLabel( 'Color', { exact: true } )
-		).toBeVisible();
+			page.getByRole( 'button', { name: 'Save', exact: true } )
+		).toHaveAttribute( 'aria-haspopup', 'dialog' );
 
 		await editor.saveSiteEditorEntities();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -251,12 +251,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		// We need to make sure the block updated before saving.
 		// @see https://github.com/woocommerce/woocommerce/issues/57718
-		// Verify that `.editor-post-publish-button__button` has an attribute
-		// `aria-haspopup="dialog"`. When https://github.com/woocommerce/woocommerce/issues/48936
-		// is fixed, we can simply check that the Save button becomes enabled.
-		await expect(
-			page.getByRole( 'button', { name: 'Save', exact: true } )
-		).toHaveAttribute( 'aria-haspopup', 'dialog' );
+		await expect( async () => {
+			await page.getByRole( 'radio', { name: 'Dropdown' } ).isChecked();
+		} ).toPass();
 
 		await editor.saveSiteEditorEntities();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -233,6 +233,15 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await pageObject.switchProductType( 'Variable Product' );
 
+		// Verify inner blocks have loaded.
+		await expect(
+			editor.canvas
+				.getByLabel(
+					'Block: Variation Selector: Attribute Options (Beta)'
+				)
+				.first()
+		).toBeVisible();
+
 		const attributeOptionsBlock = await editor.getBlockByName(
 			'woocommerce/add-to-cart-with-options-variation-selector-attribute-options'
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/57718.

Apparently, https://github.com/woocommerce/woocommerce/pull/58844 wasn't enough so this PR makes sure that:

1. After changing the product type, inner blocks are loaded before selecting them.
2. After changing the attributes, the checkbox is updated correctly.

I run the test 60 times in a row locally, and it seems to pass consistently now.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass and 'doesn't allow selecting invalid variations in dropdown mode' isn't flaky anymore.