### PR TITLE
Remove `entity_type` from fulfillments

### DIFF
--- a/plugins/woocommerce/changelog/59495-add-59493-remove-entity_type-from-fulfillments-table
+++ b/plugins/woocommerce/changelog/59495-add-59493-remove-entity_type-from-fulfillments-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove entity_type column from fulfillments table as it's no longer needed

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/fulfillment-context.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/fulfillment-context.tsx
@@ -17,7 +17,6 @@ import {
 	SHIPPING_OPTION_META_KEY,
 	TRACKING_NUMBER_META_KEY,
 	TRACKING_URL_META_KEY,
-	WC_ORDER_CLASS,
 } from '../data/constants';
 
 interface FulfillmentContextProps {
@@ -94,8 +93,7 @@ export const FulfillmentProvider = ( {
 		_setFulfillment( {
 			id: fulfillment?.id ?? undefined,
 			fulfillment_id: fulfillment?.id ?? undefined,
-			entity_id: String( order.id ),
-			entity_type: WC_ORDER_CLASS,
+			order_id: order.id,
 			is_fulfilled: fulfillment?.is_fulfilled ?? false,
 			status: fulfillment?.status ?? 'unfulfilled',
 			meta_data: [

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/types.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/types.ts
@@ -133,8 +133,7 @@ export interface ShippingLineMetaDatum {
 export interface Fulfillment {
 	id?: number;
 	fulfillment_id?: number;
-	entity_type: string;
-	entity_id: string;
+	order_id: number;
 	status: string;
 	is_fulfilled: boolean;
 	date_updated?: Date;

--- a/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
@@ -36,11 +36,8 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 	 */
 	public function create( &$data ): void {
 		// Validate the fulfillment data.
-		if ( ! $data->get_entity_type() ) {
-			throw new \Exception( esc_html__( 'Invalid entity type.', 'woocommerce' ) );
-		}
-		if ( ! $data->get_entity_id() ) {
-			throw new \Exception( esc_html__( 'Invalid entity ID.', 'woocommerce' ) );
+		if ( ! $data->get_order_id() ) {
+			throw new \Exception( esc_html__( 'Invalid order ID.', 'woocommerce' ) );
 		}
 		if ( ! FulfillmentUtils::is_valid_fulfillment_status( $data->get_status() ) ) {
 			throw new \Exception( esc_html__( 'Invalid fulfillment status.', 'woocommerce' ) );
@@ -79,14 +76,13 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		$rows_inserted = $wpdb->insert(
 			$wpdb->prefix . 'wc_order_fulfillments',
 			array(
-				'entity_type'  => $data->get_entity_type(),
-				'entity_id'    => $data->get_entity_id(),
+				'order_id'     => $data->get_order_id(),
 				'status'       => $data->get_status() ?? 'unfulfilled',
 				'is_fulfilled' => $data->get_is_fulfilled() ? 1 : 0,
 				'date_updated' => $data->get_date_updated(),
 				'date_deleted' => $data->get_date_deleted(),
 			),
-			array( '%s', '%s', '%s', '%d', '%s', '%s' )
+			array( '%d', '%s', '%d', '%s', '%s' )
 		);
 
 		// Check for errors.
@@ -215,8 +211,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		$wpdb->update(
 			$wpdb->prefix . 'wc_order_fulfillments',
 			array(
-				'entity_type'  => $data->get_entity_type(),
-				'entity_id'    => $data->get_entity_id(),
+				'order_id'     => $data->get_order_id(),
 				'status'       => $data->get_status(),
 				'is_fulfilled' => $data->get_is_fulfilled() ? 1 : 0,
 				'date_updated' => current_time( 'mysql' ),
@@ -226,7 +221,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 				'fulfillment_id' => $data_id,
 				'date_deleted'   => null,
 			),
-			array( '%s', '%s', '%s', '%d', '%s', '%s' ),
+			array( '%d', '%s', '%d', '%s', '%s' ),
 			array( '%d' )
 		);
 
@@ -498,22 +493,20 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 	/**
 	 * Method to read the fulfillment data.
 	 *
-	 * @param string $entity_type The entity type.
-	 * @param string $entity_id The entity ID.
+	 * @param int $order_id The order ID.
 	 *
 	 * @return Fulfillment[] Fulfillment object.
 	 *
 	 * @throws \Exception If the fulfillment data can't be read.
 	 */
-	public function read_fulfillments( string $entity_type, string $entity_id ): array {
+	public function read_fulfillments( int $order_id ): array {
 		// Read the fulfillment data from the database.
 		global $wpdb;
 
 		$fulfillment_data = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE entity_type = %s AND entity_id = %s AND date_deleted IS NULL",
-				$entity_type,
-				$entity_id
+				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE order_id = %d AND date_deleted IS NULL",
+				$order_id
 			),
 			ARRAY_A
 		);

--- a/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreInterface.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreInterface.php
@@ -16,10 +16,9 @@ interface FulfillmentsDataStoreInterface {
 	/**
 	 * Read the fulfillment data.
 	 *
-	 * @param string $entity_type The entity type.
-	 * @param string $entity_id The entity ID.
+	 * @param int $order_id The order ID.
 	 *
 	 * @return Fulfillment[] Fulfillment object.
 	 */
-	public function read_fulfillments( string $entity_type, string $entity_id ): array;
+	public function read_fulfillments( int $order_id ): array;
 }

--- a/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
@@ -73,39 +73,21 @@ class Fulfillment extends \WC_Data {
 	}
 
 	/**
-	 * Get the entity type.
+	 * Get the order ID.
 	 *
-	 * @return string|null Entity type.
+	 * @return int|null Order ID.
 	 */
-	public function get_entity_type(): ?string {
-		return $this->data['entity_type'] ?? null;
+	public function get_order_id(): ?int {
+		return $this->data['order_id'] ?? null;
 	}
 
 	/**
-	 * Set the entity type.
+	 * Set the order ID.
 	 *
-	 * @param class-string|null $entity_type Entity type.
+	 * @param class-int|null $order_id Order ID.
 	 */
-	public function set_entity_type( ?string $entity_type ): void {
-		$this->data['entity_type'] = $entity_type;
-	}
-
-	/**
-	 * Get the entity ID.
-	 *
-	 * @return string|null Entity ID.
-	 */
-	public function get_entity_id(): ?string {
-		return $this->data['entity_id'] ?? null;
-	}
-
-	/**
-	 * Set the entity ID.
-	 *
-	 * @param class-string|null $entity_id Entity ID.
-	 */
-	public function set_entity_id( ?string $entity_id ): void {
-		$this->data['entity_id'] = $entity_id;
+	public function set_order_id( ?int $order_id ): void {
+		$this->data['order_id'] = $order_id;
 	}
 
 	/**
@@ -269,27 +251,18 @@ class Fulfillment extends \WC_Data {
 	/**
 	 * Get the order associated with this fulfillment.
 	 *
-	 * This method retrieves the order based on the entity type and entity ID.
-	 * If the entity type is `WC_Order`, it returns the order object.
+	 * This method retrieves the order based on the order ID.
 	 *
 	 * @return \WC_Order|null The order object or null if not found.
 	 */
 	public function get_order(): ?\WC_Order {
-		$entity_type = $this->get_entity_type();
-		$entity_id   = $this->get_entity_id();
-
-		if ( ! $entity_type || ! $entity_id ) {
+		$order_id = $this->get_order_id();
+		if ( ! $order_id ) {
 			return null;
 		}
 
-		if ( \WC_Order::class === $entity_type ) {
-			$order = wc_get_order( (int) $entity_id );
-			if ( $order instanceof \WC_Order ) {
-				return $order;
-			}
-		}
-
-		return null;
+		$order = wc_get_order( $order_id );
+		return $order instanceof \WC_Order ? $order : null;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
@@ -104,7 +104,7 @@ class FulfillmentUtils {
 	}
 
 	/**
-	 * Get the fulfillment status of the entity. This runs like a computed property, where
+	 * Get the fulfillment status of the order. This runs like a computed property, where
 	 * it checks the fulfillment status of each fulfillment attached to the order,
 	 * and computes the overall fulfillment status of the order.
 	 *

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
@@ -99,14 +99,13 @@ class FulfillmentsController {
 
 		$schema = "CREATE TABLE {$wpdb->prefix}wc_order_fulfillments (
 			fulfillment_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-			entity_type varchar(255) NOT NULL,
-			entity_id bigint(20) unsigned NOT NULL,
+			order_id bigint(20) unsigned NOT NULL,
 			status varchar(255) NOT NULL,
 			is_fulfilled tinyint(1) NOT NULL DEFAULT 0,
 			date_updated datetime NOT NULL,
 			date_deleted datetime NULL,
 			PRIMARY KEY (fulfillment_id),
-			KEY entity_type_id (entity_type({$max_index_length}), entity_id)
+			KEY order_id (order_id)
 		) $collate;
 		CREATE TABLE {$wpdb->prefix}wc_order_fulfillment_meta (
 			meta_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -116,7 +116,7 @@ class FulfillmentsManager {
 		 */
 		$fulfillments_data_store = wc_get_container()->get( FulfillmentsDataStore::class );
 		// Read all fulfillments for the order.
-		$fulfillments = $fulfillments_data_store->read_fulfillments( \WC_Order::class, (string) $order->get_id() );
+		$fulfillments = $fulfillments_data_store->read_fulfillments( $order->get_id() );
 
 		// Update the fulfillment status of the order.
 		$last_status = FulfillmentUtils::calculate_order_fulfillment_status( $order, $fulfillments );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -284,8 +284,7 @@ class FulfillmentsRenderer {
 
 				if ( 0 < count( $remaining_items ) ) {
 					$fulfillment = new Fulfillment();
-					$fulfillment->set_entity_type( WC_Order::class );
-					$fulfillment->set_entity_id( (string) $order->get_id() );
+					$fulfillment->set_order_id( $order->get_id() );
 					$fulfillment->set_status( 'fulfilled' );
 					$fulfillment->set_items( $remaining_items );
 					$fulfillment->save();
@@ -578,7 +577,7 @@ class FulfillmentsRenderer {
 
 		// If not, fetch them and cache them.
 		$data_store                                   = wc_get_container()->get( FulfillmentsDataStore::class );
-		$fulfillments                                 = $data_store->read_fulfillments( WC_Order::class, '' . $order->get_id() );
+		$fulfillments                                 = $data_store->read_fulfillments( $order->get_id() );
 		$this->fulfillments_cache[ $order->get_id() ] = $fulfillments;
 
 		return $fulfillments;

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
@@ -142,8 +142,7 @@ class FulfillmentsSettings {
 
 		if ( ! empty( $auto_fulfill_items ) ) {
 			$fulfillment = new Fulfillment();
-			$fulfillment->set_entity_type( WC_Order::class );
-			$fulfillment->set_entity_id( (string) $order_id );
+			$fulfillment->set_order_id( $order_id );
 			$fulfillment->set_status( 'fulfilled' );
 			$fulfillment->set_items(
 				array_map(
@@ -180,7 +179,7 @@ class FulfillmentsSettings {
 		}
 
 		// If fulfillments already exist, skip auto-fulfillment.
-		$fulfillments = wc_get_container()->get( FulfillmentsDataStore::class )->read_fulfillments( \WC_Order::class, (string) $order_id );
+		$fulfillments = wc_get_container()->get( FulfillmentsDataStore::class )->read_fulfillments( $order_id );
 		if ( ! empty( $fulfillments ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -19,11 +19,6 @@ use WP_REST_Server;
 /**
  * OrderFulfillmentsRestController class file.
  *
- * !> Note: This REST controller is only created for `WC_Order` type of entities, that allow
- * !> managing fulfillments only for admins. Regular users can only view their fulfillments.
- * !>
- * !> If you are using another entity type for your fulfillments, you should create a new controller.
- *
  * @package Automattic\WooCommerce\Internal\Fulfillments
  */
 class OrderFulfillmentsRestController extends RestApiControllerBase {
@@ -217,7 +212,7 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 		// Fetch fulfillments for the order.
 		try {
 			$datastore    = wc_get_container()->get( FulfillmentsDataStore::class );
-			$fulfillments = $datastore->read_fulfillments( WC_Order::class, "$order_id" );
+			$fulfillments = $datastore->read_fulfillments( $order_id );
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),
@@ -254,8 +249,7 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			$fulfillment = new Fulfillment();
 			$fulfillment->set_props( $request->get_json_params() );
 			$fulfillment->set_meta_data( $request->get_json_params()['meta_data'] );
-			$fulfillment->set_entity_type( WC_Order::class );
-			$fulfillment->set_entity_id( "$order_id" );
+			$fulfillment->set_order_id( $order_id );
 
 			$fulfillment->save();
 
@@ -1014,15 +1008,9 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'entity_type'    => array(
-				'description' => __( 'The type of entity for which the fulfillment is created.', 'woocommerce' ),
-				'type'        => 'string',
-				'required'    => true,
-				'context'     => array( 'view', 'edit' ),
-			),
-			'entity_id'      => array(
-				'description' => __( 'Unique identifier for the entity.', 'woocommerce' ),
-				'type'        => 'string',
+			'order_id'       => array(
+				'description' => __( 'Unique identifier for the order.', 'woocommerce' ),
+				'type'        => 'integer',
 				'required'    => true,
 				'context'     => array( 'view', 'edit' ),
 			),
@@ -1177,7 +1165,7 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 	 * @throws \Exception If the fulfillment ID is invalid.
 	 */
 	private function validate_fulfillment( Fulfillment $fulfillment, int $fulfillment_id, int $order_id ) {
-		if ( $fulfillment->get_id() !== $fulfillment_id || $fulfillment->get_entity_type() !== WC_Order::class || $fulfillment->get_entity_id() !== "$order_id" ) {
+		if ( $fulfillment->get_id() !== $fulfillment_id || $fulfillment->get_order_id() !== $order_id ) {
 			throw new \Exception( esc_html__( 'Invalid fulfillment ID.', 'woocommerce' ), );
 		}
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -73,10 +73,7 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 
 		$order       = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_id'   => $order->get_id(),
-				'entity_type' => 'WC_Order',
-			)
+			array( 'order_id' => $order->get_id() )
 		);
 
 		add_filter(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -83,7 +83,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$this->store->create( $this->get_test_fulfillment( $this->order->get_id() ) );
 		$this->assertTrue( $hook_called, 'The fulfillment before create hook was not called.' );
-		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$fulfillments = $this->store->read_fulfillments( $this->order->get_id() );
 		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
 	}
 
@@ -108,7 +108,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $hook_called, 'The fulfillment before create hook was not called.' );
 
 		// Check that no fulfillment was created.
-		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$fulfillments = $this->store->read_fulfillments( $this->order->get_id() );
 		$this->assertCount( 0, $fulfillments, 'Fulfillment was created.' );
 	}
 
@@ -134,8 +134,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		// Compare the received fulfillment with the expected data.
 		$sent_data = $this->get_test_fulfillment_data( $this->order->get_id() );
-		$this->assertEquals( $received_fulfillment->get_entity_type(), $sent_data['entity_type'], );
-		$this->assertEquals( $received_fulfillment->get_entity_id(), $sent_data['entity_id'], );
+		$this->assertEquals( $received_fulfillment->get_order_id(), (int) $sent_data['order_id'], );
 		$this->assertEquals( $received_fulfillment->get_status(), $sent_data['status'], );
 		$this->assertEquals( $received_fulfillment->get_is_fulfilled(), $sent_data['is_fulfilled'], );
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key' ), $sent_data['meta_data'][0]['value'] );
@@ -144,7 +143,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$this->assertNotNull( $received_fulfillment->get_id(), 'Fulfillment ID should not be null.' );
 		$this->assertGreaterThan( 0, $received_fulfillment->get_id(), 'Fulfillment ID should be greater than 0.' );
 
-		$fulfillments = $this->store->read_fulfillments( WC_Order::class, (string) $this->order->get_id() );
+		$fulfillments = $this->store->read_fulfillments( $this->order->get_id() );
 		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
 	}
 
@@ -235,8 +234,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		// Compare the received fulfillment with the expected data.
 		$this->assertEquals( $received_fulfillment->get_id(), $fulfillment->get_id() );
-		$this->assertEquals( $received_fulfillment->get_entity_type(), $fulfillment->get_entity_type() );
-		$this->assertEquals( $received_fulfillment->get_entity_id(), $fulfillment->get_entity_id() );
+		$this->assertEquals( $received_fulfillment->get_order_id(), $fulfillment->get_order_id() );
 		$this->assertEquals( $received_fulfillment->get_status(), $fulfillment->get_status() );
 		$this->assertEquals( $received_fulfillment->get_is_fulfilled(), $fulfillment->get_is_fulfilled() );
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key' ), $fulfillment->get_meta( 'test_meta_key' ) );
@@ -430,8 +428,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		// Compare the received fulfillment with the expected data.
 		$this->assertEquals( $received_fulfillment->get_id(), $fulfillment->get_id() );
-		$this->assertEquals( $received_fulfillment->get_entity_type(), $fulfillment->get_entity_type() );
-		$this->assertEquals( $received_fulfillment->get_entity_id(), $fulfillment->get_entity_id() );
+		$this->assertEquals( $received_fulfillment->get_order_id(), $fulfillment->get_order_id() );
 		$this->assertEquals( $received_fulfillment->get_status(), $fulfillment->get_status() );
 		$this->assertEquals( $received_fulfillment->get_is_fulfilled(), $fulfillment->get_is_fulfilled() );
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key' ), $fulfillment->get_meta( 'test_meta_key' ) );
@@ -527,8 +524,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$this->assertNotNull( $received_fulfillment, 'Received fulfillment should not be null.' );
 		$this->assertInstanceOf( Fulfillment::class, $received_fulfillment, 'Received fulfillment should be an instance of Fulfillment.' );
 		$this->assertEquals( $received_fulfillment->get_id(), $fulfillment_clone->get_id() );
-		$this->assertEquals( $received_fulfillment->get_entity_type(), $fulfillment_clone->get_entity_type() );
-		$this->assertEquals( $received_fulfillment->get_entity_id(), $fulfillment_clone->get_entity_id() );
+		$this->assertEquals( $received_fulfillment->get_order_id(), $fulfillment_clone->get_order_id() );
 		$this->assertEquals( $received_fulfillment->get_status(), $fulfillment_clone->get_status() );
 		$this->assertEquals( $received_fulfillment->get_is_fulfilled(), $fulfillment_clone->get_is_fulfilled() );
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key' ), $fulfillment_clone->get_meta( 'test_meta_key' ) );
@@ -561,8 +557,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 	 */
 	private function get_test_fulfillment_data( $order_id ): array {
 		return array(
-			'entity_type'  => WC_Order::class,
-			'entity_id'    => $order_id,
+			'order_id'     => $order_id,
 			'status'       => 'unfulfilled',
 			'is_fulfilled' => false,
 			'meta_data'    => array(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -44,8 +44,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_create_fulfillment() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -66,12 +65,11 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests the create method of the order fulfillment data store with invalid entity type.
+	 * Tests the create method of the order fulfillment data store with invalid order ID.
 	 */
-	public function test_create_fulfillment_throws_error_on_invalid_entity_type() {
+	public function test_create_fulfillment_throws_error_on_invalid_order_id() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( '' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( null );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -83,30 +81,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Invalid entity type.' );
-
-		self::$order_fulfillment_data_store->create( $fulfillment );
-	}
-
-	/**
-	 * Tests the create method of the order fulfillment data store with invalid entity ID.
-	 */
-	public function test_create_fulfillment_throws_error_on_invalid_entity_id() {
-		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '' );
-		$fulfillment->set_status( 'unfulfilled' );
-		$fulfillment->set_items(
-			array(
-				array(
-					'item_id' => 1,
-					'qty'     => 2,
-				),
-			)
-		);
-
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Invalid entity ID.' );
+		$this->expectExceptionMessage( 'Invalid order ID.' );
 
 		self::$order_fulfillment_data_store->create( $fulfillment );
 	}
@@ -116,8 +91,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_create_fulfillment_throws_error_on_invalid_items() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_props( array( 'meta_data' => array( '_items' => null ) ) );
 
@@ -132,8 +106,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_create_fulfillment_throws_error_on_empty_items() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( array() );
 
@@ -148,8 +121,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_create_fulfillment_throws_error_on_invalid_item() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -175,8 +147,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_read_fulfillment() {
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -209,8 +180,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public function test_update_fulfillment() {
 		$fulfillment = new Fulfillment();
 		$fulfillment->set_id( 1 );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -226,7 +196,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 		self::$order_fulfillment_data_store->create( $fulfillment );
 
-		$fulfillment->set_entity_id( '456' );
+		$fulfillment->set_order_id( 456 );
 		$fulfillment->set_items(
 			array(
 				array(
@@ -252,8 +222,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public function test_delete_fulfillment() {
 		$fulfillment = new Fulfillment();
 		$fulfillment->set_id( 1 );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
-		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -281,8 +250,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		self::$order_fulfillment_data_store->delete( $fulfillment );
 		// The fulfillment should be reset to it's initial state.
 		$this->assertEquals( 0, $fulfillment->get_id() );
-		$this->assertEquals( null, $fulfillment->get_entity_type() );
-		$this->assertEquals( null, $fulfillment->get_entity_id() );
+		$this->assertEquals( null, $fulfillment->get_order_id() );
 		$this->assertEquals( array(), $fulfillment->get_items() );
 		$this->assertEquals( array(), $fulfillment->get_meta_data() );
 		$this->assertEquals( null, $fulfillment->get_date_updated() );
@@ -307,8 +275,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_id( '123' );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( $items );
 		$fulfillment->save();
@@ -342,8 +309,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_id( '123' );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( $items );
 		$fulfillment->save();
@@ -384,8 +350,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_id( '123' );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( $items );
 		$fulfillment->save();
@@ -439,8 +404,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_id( '123' );
-		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_order_id( 123 );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( $items );
 		$fulfillment->save();
@@ -471,10 +435,9 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_read_fulfillments() {
 		$this->prepare_db_for_test();
-		$fulfillments = self::$order_fulfillment_data_store->read_fulfillments( 'order-fulfillment', '123' );
+		$fulfillments = self::$order_fulfillment_data_store->read_fulfillments( 123 );
 		$this->assertCount( 2, $fulfillments );
-		$this->assertEquals( '123', $fulfillments[0]->get_entity_id() );
-		$this->assertEquals( 'order-fulfillment', $fulfillments[0]->get_entity_type() );
+		$this->assertEquals( 123, $fulfillments[0]->get_order_id() );
 		$this->assertEquals(
 			array(
 				array(
@@ -485,8 +448,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			),
 			$fulfillments[0]->get_items(),
 		);
-		$this->assertEquals( '123', $fulfillments[1]->get_entity_id() );
-		$this->assertEquals( 'order-fulfillment', $fulfillments[1]->get_entity_type() );
+		$this->assertEquals( 123, $fulfillments[1]->get_order_id() );
 		$this->assertEquals(
 			array(
 				array(
@@ -501,17 +463,15 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	/**
 	 * Create a test fulfillment and save it to the database.
 	 *
-	 * @param string $entity_type The entity type.
-	 * @param string $entity_id The entity ID.
-	 * @param array  $items The items to fulfill.
+	 * @param int   $order_id The order ID.
+	 * @param array $items The items to fulfill.
 	 *
 	 * @return Fulfillment The created fulfillment object.
 	 */
-	private function create_test_fulfillment( string $entity_type, string $entity_id, array $items ) {
+	private function create_test_fulfillment( int $order_id, array $items ) {
 		$fulfillment = new Fulfillment();
 		$fulfillment->set_id( 0 );
-		$fulfillment->set_entity_type( $entity_type );
-		$fulfillment->set_entity_id( $entity_id );
+		$fulfillment->set_order_id( $order_id );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items( $items );
 		$fulfillment->save();
@@ -530,8 +490,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	private function prepare_db_for_test() {
 		$this->create_test_fulfillment(
-			'order-fulfillment',
-			'123',
+			123,
 			array(
 				array(
 					'item_id' => 1,
@@ -540,8 +499,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 		$this->create_test_fulfillment(
-			'order-fulfillment',
-			'456',
+			456,
 			array(
 				array(
 					'item_id' => 2,
@@ -550,8 +508,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 		$this->create_test_fulfillment(
-			'order-fulfillment',
-			'789',
+			789,
 			array(
 				array(
 					'item_id' => 3,
@@ -560,8 +517,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 		$this->create_test_fulfillment(
-			'order-fulfillment',
-			'123',
+			123,
 			array(
 				array(
 					'item_id' => 4,
@@ -570,8 +526,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 		$this->create_test_fulfillment(
-			'order-fulfillment',
-			'456',
+			456,
 			array(
 				array(
 					'item_id' => 5,
@@ -601,8 +556,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 
 		if ( ! $is_deleted ) {
 			$this->assertNotNull( $record );
-			$this->assertEquals( $fulfillment->get_entity_type(), $record->entity_type );
-			$this->assertEquals( $fulfillment->get_entity_id(), $record->entity_id );
+			$this->assertEquals( $fulfillment->get_order_id(), $record->order_id );
 			$this->assertEquals( $fulfillment->get_date_updated(), $record->date_updated );
 			$this->assertEquals( $fulfillment->get_date_deleted(), $record->date_deleted );
 		} else {

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
@@ -41,17 +41,12 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_fulfillment_object_with_id_fetches_data_and_metadata() {
 		$order          = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$db_fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_id' => $order->get_id(),
-			)
-		);
+		$db_fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => $order->get_id() ) );
 		$fulfillment    = new Fulfillment( $db_fulfillment->get_id() );
 
 		$this->assertInstanceOf( Fulfillment::class, $fulfillment );
 		$this->assertEquals( $db_fulfillment->get_id(), $fulfillment->get_id() );
-		$this->assertEquals( $db_fulfillment->get_entity_type(), $fulfillment->get_entity_type() );
-		$this->assertEquals( $db_fulfillment->get_entity_id(), $fulfillment->get_entity_id() );
+		$this->assertEquals( $db_fulfillment->get_order_id(), $fulfillment->get_order_id() );
 		$this->assertEquals( $db_fulfillment->get_date_updated(), $fulfillment->get_date_updated() );
 		$this->assertEquals( $db_fulfillment->get_date_deleted(), $fulfillment->get_date_deleted() );
 		$this->assertEquals( $db_fulfillment->get_items(), $fulfillment->get_items() );
@@ -62,31 +57,18 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that Fulfillment object can be updated.
 	 */
 	public function test_fulfillment_object_update() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
-
-		$fulfillment->set_entity_type( 'updated-entity-type' );
-		$fulfillment->set_entity_id( '456' );
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
+		$fulfillment->set_order_id( 456 );
 		$fulfillment->save();
 
-		$this->assertEquals( 'updated-entity-type', $fulfillment->get_entity_type() );
-		$this->assertEquals( 456, $fulfillment->get_entity_id() );
+		$this->assertEquals( 456, $fulfillment->get_order_id() );
 	}
 
 	/**
 	 * Test that Fulfillment object can be soft deleted.
 	 */
 	public function test_fulfillment_object_soft_delete() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotEquals( 0, $fulfillment_id );
@@ -102,12 +84,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that Fulfillment object can be created with items.
 	 */
 	public function test_fulfillment_object_with_items() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$items = array(
 			array(
@@ -134,12 +111,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that Fulfillment object can be created with metadata.
 	 */
 	public function test_fulfillment_object_with_metadata() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$fulfillment->add_meta_data( 'test_meta_key', 'test_meta_value', true );
 		$fulfillment->save();
@@ -151,12 +123,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that metadata can be updated.
 	 */
 	public function test_fulfillment_object_update_metadata() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$fulfillment->add_meta_data( 'test_meta_key', 'test_meta_value', true );
 		$fulfillment->save();
@@ -171,12 +138,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that metadata can be deleted.
 	 */
 	public function test_fulfillment_object_delete_metadata() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$fulfillment->add_meta_data( 'test_meta_key', 'test_meta_value', true );
 		$fulfillment->save();
@@ -192,12 +154,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_get_order() {
 		$order       = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => WC_Order::class,
-				'entity_id'   => $order->get_id(),
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => $order->get_id() ) );
 
 		$this->assertInstanceOf( \WC_Order::class, $fulfillment->get_order() );
 		$this->assertEquals( $order->get_id(), $fulfillment->get_order()->get_id() );
@@ -207,12 +164,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test fulfillment locking functionality.
 	 */
 	public function test_fulfillment_locking() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 
 		$this->assertFalse( $fulfillment->is_locked() );
 
@@ -229,12 +181,7 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	 * Test that the fulfillment status is validated correctly, and the fallback doesn't change is_fulfilled flag.
 	 */
 	public function test_fulfillment_status_validation() {
-		$fulfillment = FulfillmentsHelper::create_fulfillment(
-			array(
-				'entity_type' => 'order-fulfillment',
-				'entity_id'   => 123,
-			)
-		);
+		$fulfillment = FulfillmentsHelper::create_fulfillment( array( 'order_id' => 123 ) );
 		$fulfillment->set_status( 'unfulfilled' );
 		$this->assertEquals( 'unfulfilled', $fulfillment->get_status() );
 		$this->assertEquals( false, $fulfillment->get_is_fulfilled() );

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
@@ -169,8 +169,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 
 		$fulfillments[] = FulfillmentsHelper::create_fulfillment(
 			array(
-				'entity_type'  => WC_Order::class,
-				'entity_id'    => $order->get_id(),
+				'order_id'     => $order->get_id(),
 				'status'       => 'unfulfilled',
 				'is_fulfilled' => false,
 			),

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererTest.php
@@ -137,8 +137,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 		$order->save();
 
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( WC_Order::class );
-		$fulfillment->set_entity_id( (string) $order->get_id() );
+		$fulfillment->set_order_id( $order->get_id() );
 		$fulfillment->add_meta_data( '_tracking_number', '123456789' );
 		$fulfillment->add_meta_data( '_tracking_url', 'https://example.com/track/123456789' );
 		$fulfillment->add_meta_data( '_shipment_provider', 'UPS' );
@@ -243,7 +242,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		$fulfillments = wc_get_container()
 		->get( FulfillmentsDataStore::class )
-		->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		->read_fulfillments( $order->get_id() );
 
 		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
 		$this->assertEquals( 'fulfilled', $fulfillments[0]->get_status(), 'Fulfillment status is not set to Fulfilled.' );
@@ -275,8 +274,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		// Create an initial fulfillment with only one item.
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( WC_Order::class );
-		$fulfillment->set_entity_id( (string) $order->get_id() );
+		$fulfillment->set_order_id( $order->get_id() );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array(
@@ -293,7 +291,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		$fulfillments = wc_get_container()
 		->get( FulfillmentsDataStore::class )
-		->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		->read_fulfillments( $order->get_id() );
 
 		$this->assertCount( 2, $fulfillments, 'Fulfillment was not created.' );
 		foreach ( $fulfillments as $fulfillment ) {
@@ -320,8 +318,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		// Fulfill the order without calling the bulk action first.
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( WC_Order::class );
-		$fulfillment->set_entity_id( (string) $order->get_id() );
+		$fulfillment->set_order_id( $order->get_id() );
 		$fulfillment->set_status( 'unfulfilled' );
 		$fulfillment->set_items(
 			array_map(
@@ -341,7 +338,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		$fulfillments = wc_get_container()
 		->get( FulfillmentsDataStore::class )
-		->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		->read_fulfillments( $order->get_id() );
 
 		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
 		$this->assertEquals( $fulfillment->get_id(), $fulfillments[0]->get_id(), 'Fulfillment ID does not match.' );
@@ -367,8 +364,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		// Fulfill the order without calling the bulk action first.
 		$fulfillment = new Fulfillment();
-		$fulfillment->set_entity_type( WC_Order::class );
-		$fulfillment->set_entity_id( (string) $order->get_id() );
+		$fulfillment->set_order_id( $order->get_id() );
 		$fulfillment->set_status( 'fulfilled' );
 		$fulfillment->set_items(
 			array_map(
@@ -388,7 +384,7 @@ class FulfillmentsRendererTest extends \WC_Unit_Test_Case {
 
 		$fulfillments = wc_get_container()
 		->get( FulfillmentsDataStore::class )
-		->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		->read_fulfillments( $order->get_id() );
 
 		$this->assertCount( 1, $fulfillments, 'Fulfillment was not created.' );
 		$this->assertEquals( $fulfillment->get_id(), $fulfillments[0]->get_id(), 'Fulfillment ID does not match.' );

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsSettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsSettingsTest.php
@@ -205,7 +205,7 @@ class FulfillmentsSettingsTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $hook_called, 'Hook should be called if there are items.' );
 
 		$data_store   = new FulfillmentsDataStore();
-		$fulfillments = $data_store->read_fulfillments( WC_Order::class, '123' );
+		$fulfillments = $data_store->read_fulfillments( 123 );
 		$this->assertCount( $fulfillments_expected, $fulfillments, 'Fulfillments count does not match expected.' );
 
 		if ( $fulfillments_expected > 0 ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/Helpers/FulfillmentsHelper.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/Helpers/FulfillmentsHelper.php
@@ -27,8 +27,7 @@ class FulfillmentsHelper {
 			array_merge(
 				array(
 					'id'           => 0,
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => 123,
+					'order_id'     => 123,
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 				),

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
@@ -61,12 +61,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 			$order                     = WC_Helper_Order::create_order( get_current_user_id() );
 			self::$created_order_ids[] = $order->get_id();
 			for ( $fulfillment = 1; $fulfillment <= 10; $fulfillment++ ) {
-				FulfillmentsHelper::create_fulfillment(
-					array(
-						'entity_type' => WC_Order::class,
-						'entity_id'   => $order->get_id(),
-					)
-				);
+				FulfillmentsHelper::create_fulfillment( array( 'order_id' => $order->get_id() ) );
 			}
 		}
 	}
@@ -108,8 +103,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 10, count( $fulfillments ) );
 
 		foreach ( $fulfillments as $fulfillment ) {
-			$this->assertEquals( WC_Order::class, $fulfillment['entity_type'] );
-			$this->assertEquals( self::$created_order_ids[0], $fulfillment['entity_id'] );
+			$this->assertEquals( self::$created_order_ids[0], $fulfillment['order_id'] );
 		}
 	}
 
@@ -195,8 +189,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => '' . $order->get_id(),
+					'order_id'     => $order->get_id(),
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 					'meta_data'    => array(
@@ -254,8 +247,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => '' . $order->get_id(),
+					'order_id'     => $order->get_id(),
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 					'meta_data'    => array(
@@ -297,8 +289,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertIsArray( $fulfillment );
 		$this->assertArrayHasKey( 'fulfillment_id', $fulfillment );
 		$this->assertNotNull( $fulfillment['fulfillment_id'] );
-		$this->assertEquals( WC_Order::class, $fulfillment['entity_type'] );
-		$this->assertEquals( $order->get_id(), $fulfillment['entity_id'] );
+		$this->assertEquals( $order->get_id(), $fulfillment['order_id'] );
 		$this->assertEquals( 'unfulfilled', $fulfillment['status'] );
 		$this->assertEquals( false, $fulfillment['is_fulfilled'] );
 		$this->assertIsArray( $fulfillment['meta_data'] );
@@ -343,8 +334,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => '' . $order->get_id(),
+					'order_id'     => $order->get_id(),
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 					'meta_data'    => array(
@@ -395,8 +385,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => '' . $order->get_id(),
+					'order_id'     => $order->get_id(),
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 					'meta_data'    => array(
@@ -427,10 +416,6 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 	 * Test creating a fulfillment with an invalid order ID.
 	 */
 	public function test_create_fulfillment_invalid_order_id() {
-		// Create a new order.
-		$order = WC_Helper_Order::create_order( get_current_user_id() );
-		$this->assertInstanceOf( WC_Order::class, $order );
-
 		// Set the current user to an admin.
 		wp_set_current_user( 1 );
 
@@ -440,8 +425,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$request->set_body(
 			wp_json_encode(
 				array(
-					'entity_type'  => WC_Order::class,
-					'entity_id'    => '' . $order->get_id(),
+					'order_id'     => '999999',
 					'status'       => 'unfulfilled',
 					'is_fulfilled' => false,
 					'meta_data'    => array(
@@ -512,8 +496,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'fulfillment', $response->get_data() );
 		$fulfillment = $response->get_data()['fulfillment'];
 		$this->assertEquals( $fulfillments[0]['fulfillment_id'], $fulfillment['fulfillment_id'] );
-		$this->assertEquals( $fulfillments[0]['entity_type'], $fulfillment['entity_type'] );
-		$this->assertEquals( $fulfillments[0]['entity_id'], $fulfillment['entity_id'] );
+		$this->assertEquals( $fulfillments[0]['order_id'], $fulfillment['order_id'] );
 		$this->assertEquals( $fulfillments[0]['status'], $fulfillment['status'] );
 		$this->assertEquals( $fulfillments[0]['is_fulfilled'], $fulfillment['is_fulfilled'] );
 		$this->assertEquals( $fulfillments[0]['meta_data'], $fulfillment['meta_data'] );
@@ -788,8 +771,7 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'fulfillment_id', $fulfillment );
 		$this->assertNotNull( $fulfillment['fulfillment_id'] );
 
-		$this->assertEquals( WC_Order::class, $fulfillment['entity_type'] );
-		$this->assertEquals( $order_id, $fulfillment['entity_id'] );
+		$this->assertEquals( $order_id, $fulfillment['order_id'] );
 		$this->assertEquals( 'fulfilled', $fulfillment['status'] );
 		$this->assertEquals( true, $fulfillment['is_fulfilled'] );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
 
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsManager;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 use Automattic\WooCommerce\Internal\Fulfillments\Providers as ShippingProviders;
 
@@ -15,6 +16,8 @@ class ShippingProvidersTest extends \WP_UnitTestCase {
 	 * Test that the shipping providers configuration returns the correct classes.
 	 */
 	public function test_shipping_providers_configuration(): void {
+		new FulfillmentsManager(); // Ensure the FulfillmentsManager is initialized to load the shipping providers.
+
 		$shipping_providers = FulfillmentUtils::get_shipping_providers();
 
 		foreach ( $shipping_providers as $key => $provider_class ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR removes the `entity_type` column from the fulfillments table as it's no longer needed in the current implementation. The entity type information is now handled through other means in the fulfillments system.

Fixes #59493 WOOPLUG-4930

### How to test the changes in this Pull Request:

**Important**: Before testing, remove the `woocommerce_fulfillments_db_tables_created` option to have the DB recreated before testing changes. This can be done by running:

```sql
DELETE FROM wp_options WHERE option_name = 'woocommerce_fulfillments_db_tables_created';
```

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure the fulfillments feature flag is enabled, if not, you can set it enabled with setting the `woocommerce_feature_fulfillments_enabled` option to `yes`.
2. Verify that fulfillments functionality works correctly without the entity_type column
3. Test creating new fulfillments
4. Test updating existing fulfillments
5. Verify that the database schema is correctly updated

### Testing that has already taken place:

- Database migration tested to ensure proper removal of entity_type column
- Fulfillments functionality verified to work without entity_type dependency
- No breaking changes identified in existing fulfillments workflows

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Dev - Development related task

#### Message

Remove entity_type column from fulfillments table as it's no longer needed

</details>