### PR TITLE
Update Product Filters blocks handlebars templates in e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-tests-filters-handlebars-templates
+++ b/plugins/woocommerce/changelog/fix-e2e-tests-filters-handlebars-templates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update Product Filters blocks handlebars templates in e2e tests
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -31,24 +31,6 @@
 	}
 }
 
-:where(.wc-block-add-to-cart-form) {
-	.quantity .qty {
-		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
-		width: 3.631em;
-		text-align: center;
-	}
-
-	div.product form.cart div.quantity {
-		display: inline-block;
-		float: none;
-		vertical-align: middle;
-	}
-
-	input {
-		height: auto;
-	}
-}
-
 .wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {
 	.wc-block-components-quantity-selector {
 		margin: 0 4px 0 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/editor.scss
@@ -31,20 +31,22 @@
 	}
 }
 
-.quantity .qty {
-	// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
-	width: 3.631em;
-	text-align: center;
-}
+:where(.wc-block-add-to-cart-form) {
+	.quantity .qty {
+		// WooCommerce core styles: https://github.com/woocommerce/woocommerce/blob/c9f62609155825cd817976c7611b9b0415e90f2f/plugins/woocommerce/client/legacy/css/woocommerce.scss/#L111-L112
+		width: 3.631em;
+		text-align: center;
+	}
 
-div.product form.cart div.quantity {
-	display: inline-block;
-	float: none;
-	vertical-align: middle;
-}
+	div.product form.cart div.quantity {
+		display: inline-block;
+		float: none;
+		vertical-align: middle;
+	}
 
-input {
-	height: auto;
+	input {
+		height: auto;
+	}
 }
 
 .wc-block-add-to-cart-form.wc-block-add-to-cart-form--stepper {

--- a/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_active-filters.handlebars
+++ b/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_active-filters.handlebars
@@ -1,11 +1,18 @@
 <!-- wp:woocommerce/product-filters -->
-<div class="wp-block-woocommerce-product-filters wc-block-product-filters">
+<div
+	class='wp-block-woocommerce-product-filters wc-block-product-filters'
+	style='--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff'
+>
 
-<!-- wp:woocommerce/product-filter-active -->
-<!-- wp:woocommerce/product-filter-removable-chips {"lock":{"remove":true}} -->
-<div class="wp-block-woocommerce-product-filter-removable-chips wc-block-product-filter-removable-chips"></div>
-<!-- /wp:woocommerce/product-filter-removable-chips -->
-<!-- /wp:woocommerce/product-filter-active -->
+	<!-- wp:woocommerce/product-filter-active -->
+	<div class='wp-block-woocommerce-product-filter-active'>
+		<!-- wp:woocommerce/product-filter-removable-chips {"lock":{"remove":true}} -->
+		<div
+			class='wp-block-woocommerce-product-filter-removable-chips wc-block-product-filter-removable-chips'
+		></div>
+		<!-- /wp:woocommerce/product-filter-removable-chips -->
+	</div>
+	<!-- /wp:woocommerce/product-filter-active -->
 </div>
 <!-- /wp:woocommerce/product-filters -->
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_attribute-filter.handlebars
+++ b/plugins/woocommerce/client/blocks/tests/e2e/content-templates/template_archive-product_attribute-filter.handlebars
@@ -1,12 +1,12 @@
 <!-- wp:woocommerce/product-filters -->
-<div class="wp-block-woocommerce-product-filters wc-block-product-filters">
+<div class="wp-block-woocommerce-product-filters wc-block-product-filters" style="--wc-product-filters-text-color:#111;--wc-product-filters-background-color:#fff">
 <!-- wp:woocommerce/product-filter-active -->
 <div class="wp-block-woocommerce-product-filter-active">
 
 <!-- wp:woocommerce/product-filter-clear-button -->
 <!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}}},"layout":{"type":"flex","verticalAlignment":"stretched"}} -->
 <div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--10)"><!-- wp:button {"textAlign":"center","width":100,"className":"wc-block-product-filter-clear-button is-style-outline","style":{"border":{"width":"1px"},"typography":{"textDecoration":"none"},"outline":"none","fontSize":"medium","spacing":{"padding":{"left":"8px","right":"8px","top":"5px","bottom":"5px"}}}} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 wc-block-product-filter-clear-button is-style-outline" style="text-decoration:none"><a class="wp-block-button__link has-text-align-center wp-element-button" style="border-width:1px;padding-top:5px;padding-right:8px;padding-bottom:5px;padding-left:8px">Clear filters</a></div>
+<div class="wp-block-button has-custom-width wp-block-button__width-100 wc-block-product-filter-clear-button is-style-outline"><a class="wp-block-button__link has-text-align-center wp-element-button" style="border-width:1px;padding-top:5px;padding-right:8px;padding-bottom:5px;padding-left:8px;text-decoration:none">Clear filters</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 <!-- /wp:woocommerce/product-filter-clear-button --></div>
@@ -15,10 +15,12 @@
 <div class="wp-block-woocommerce-product-filter-attribute"><!-- wp:group {"metadata":{"name":"Header"},"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:heading {"level":3} -->
 <h3 class="wp-block-heading">Attribute</h3>
-<!-- /wp:heading -->
+<!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:woocommerce/product-filter-checkbox-list {"lock":{"remove":true},"className":"wp-block-woocommerce-product-filter-checkbox-list"} /--></div>
+<!-- wp:woocommerce/product-filter-checkbox-list {"lock":{"remove":true}} -->
+<div class="wp-block-woocommerce-product-filter-checkbox-list wc-block-product-filter-checkbox-list"></div>
+<!-- /wp:woocommerce/product-filter-checkbox-list --></div>
 {{/ wp-block }}
 
 </div>

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts
@@ -66,6 +66,7 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 					name: 'Attribute',
 				} )
 				.locator( '..' )
+				.locator( '..' )
 				.locator( 'label' );
 
 			await expect( listItems ).toHaveCount( 5 );
@@ -177,6 +178,7 @@ test.describe( 'woocommerce/product-filter-attribute - Frontend', () => {
 				.getByRole( 'heading', {
 					name: 'Attribute',
 				} )
+				.locator( '..' )
 				.locator( '..' )
 				.locator( 'label' );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -181,7 +181,7 @@ class AddToCartWithOptions extends AbstractBlock {
 			/**
 			 * Filter the default quantity to add to cart.
 			 *
-			 * @since 10.9.0
+			 * @since 10.0.0
 			 * @param number $default_quantity The default quantity.
 			 * @param number $product_id The product id.
 			 */

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -129,7 +129,7 @@ class ProductButton extends AbstractBlock {
 			/**
 			 * Filters the change the quantity to add to cart.
 			 *
-			 * @since 10.9.0
+			 * @since 8.5.0
 			 * @param number $default_quantity The default quantity.
 			 * @param number $product_id The product id.
 			 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes several small changes:

* Updates the Product Filters e2e tests, which I think weren't up to date.
* Updates some `@since` tags that were pointing to wrong versions.
* Removes some unused styles from `add-to-cart-form/editor.scss`.

I included all of them in the same PR because they are quite small.

### How to test the changes in this Pull Request:

1. Run `pnpm test:e2e tests/e2e/tests/product-filters/attribute-filter-frontend.block_theme.spec.ts --debug`, in the browser window that opens, click on _Edit Site_. Verify there are no invalid blocks in the template.
2. Repeat the same with `pnpm test:e2e tests/e2e/tests/product-filters/active-filter-frontend.block_theme.spec.ts --debug`.