### PR TITLE
Product Filter: Add taxonomy filter support for product queries

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4916-register-url-param
+++ b/plugins/woocommerce/changelog/wooplug-4916-register-url-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Filters: Add taxonomy filter support for product queries.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -28,7 +28,6 @@ final class ProductFilterAttribute extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 		add_action( 'deleted_transient', array( $this, 'delete_default_attribute_id_transient' ) );
 		add_action( 'wp_loaded', array( $this, 'register_block_patterns' ) );
@@ -60,27 +59,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 		}
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$attribute_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return strpos( $param, 'filter_' ) === 0 || strpos( $param, 'query_type_' ) === 0;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$attribute_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -34,7 +34,6 @@ final class ProductFilterPrice extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
@@ -86,27 +85,7 @@ final class ProductFilterPrice extends AbstractBlock {
 		return $items;
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$price_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::MIN_PRICE_QUERY_VAR === $param || self::MAX_PRICE_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$price_param_keys
-		);
-	}
 
 	/**
 	 * Render the block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -32,31 +32,10 @@ final class ProductFilterRating extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$rating_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::RATING_FILTER_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$rating_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -29,31 +29,10 @@ final class ProductFilterStatus extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$stock_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::STOCK_STATUS_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$stock_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -36,19 +36,23 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array
 	 */
 	private function get_taxonomies() {
-		$taxonomies    = get_object_taxonomies( 'product', 'objects' );
+		$public_product_taxonomies = get_taxonomies(
+			array(
+				'public'      => true,
+				'object_type' => array( 'product' ),
+			),
+			'objects'
+		);
 		$taxonomy_data = array();
 
-		foreach ( $taxonomies as $taxonomy ) {
-			if ( $taxonomy->public && 'product_shipping_class' !== $taxonomy->name ) {
-				$taxonomy_data[] = array(
-					'label'  => $taxonomy->label,
-					'name'   => $taxonomy->name,
-					'labels' => array(
-						'singular_name' => $taxonomy->labels->singular_name,
-					),
-				);
-			}
+		foreach ( $public_product_taxonomies as $taxonomy ) {
+			$taxonomy_data[] = array(
+				'label'  => $taxonomy->label,
+				'name'   => $taxonomy->name,
+				'labels' => array(
+					'singular_name' => $taxonomy->labels->singular_name,
+				),
+			);
 		}
 
 		return $taxonomy_data;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -36,7 +36,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array
 	 */
 	private function get_taxonomies() {
-		$public_product_taxonomies = get_taxonomies(
+		$taxonomies    = get_taxonomies(
 			array(
 				'public'      => true,
 				'object_type' => array( 'product' ),
@@ -45,7 +45,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		);
 		$taxonomy_data = array();
 
-		foreach ( $public_product_taxonomies as $taxonomy ) {
+		foreach ( $taxonomies as $taxonomy ) {
 			$taxonomy_data[] = array(
 				'label'  => $taxonomy->label,
 				'name'   => $taxonomy->name,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
 
 /**
  * ProductFilters class.
@@ -226,17 +227,7 @@ class ProductFilters extends AbstractBlock {
 
 		parse_str( $parsed_url['query'], $url_query_params );
 
-		/**
-		 * Filters the active filter data provided by filter blocks.
-		 *
-		 * @since 11.7.0
-		 *
-		 * @param array $filter_param_keys The active filters data
-		 * @param array $url_param_keys    The query param parsed from the URL.
-		 *
-		 * @return array Active filters params.
-		 */
-		$filter_param_keys = array_unique( apply_filters( 'woocommerce_blocks_product_filters_param_keys', array(), array_keys( $url_query_params ) ) );
+		$filter_param_keys = wc_get_container()->get( Params::class )->get_param_keys();
 
 		return array_filter(
 			$url_query_params,

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -16,6 +16,8 @@ class CacheController implements RegisterHooksInterface {
 
 	/**
 	 * Hook into actions and filters.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function register() {
 		add_action( 'woocommerce_after_product_object_save', array( $this, 'clear_filter_data_cache' ) );

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -10,14 +10,14 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Hooks into WooCommerce actions to register cache invalidation.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class CacheController implements RegisterHooksInterface {
 	const CACHE_GROUP = 'filter_data';
 
 	/**
 	 * Hook into actions and filters.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function register() {
 		add_action( 'woocommerce_after_product_object_save', array( $this, 'clear_filter_data_cache' ) );
@@ -26,8 +26,6 @@ class CacheController implements RegisterHooksInterface {
 
 	/**
 	 * Invalidate all cache under filter data group.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function clear_filter_data_cache() {
 		WC_Cache_Helper::get_transient_version( self::CACHE_GROUP, true );

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class for filter counts.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class FilterData {
 	/**
@@ -31,8 +33,6 @@ class FilterData {
 
 	/**
 	 * Get price data for current products.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return object
@@ -108,8 +108,6 @@ class FilterData {
 	/**
 	 * Get stock status counts for the current products.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @param array $statuses   Array of stock status values to count.
 	 * @return array status=>count pairs.
@@ -172,8 +170,6 @@ class FilterData {
 	/**
 	 * Get rating counts for the current products.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return array rating=>count pairs.
 	 */
@@ -232,8 +228,6 @@ class FilterData {
 
 	/**
 	 * Get attribute counts for the current products.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array  $query_vars         The WP_Query arguments.
 	 * @param string $attribute_to_count Attribute taxonomy name.
@@ -299,8 +293,6 @@ class FilterData {
 
 	/**
 	 * Get taxonomy counts for the current products.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array  $query_vars The WP_Query arguments.
 	 * @param string $taxonomy_to_count   Taxonomy name.

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -32,6 +32,8 @@ class FilterData {
 	/**
 	 * Get price data for current products.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return object
 	 */
@@ -106,6 +108,8 @@ class FilterData {
 	/**
 	 * Get stock status counts for the current products.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @param array $statuses   Array of stock status values to count.
 	 * @return array status=>count pairs.
@@ -168,6 +172,8 @@ class FilterData {
 	/**
 	 * Get rating counts for the current products.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return array rating=>count pairs.
 	 */
@@ -226,6 +232,8 @@ class FilterData {
 
 	/**
 	 * Get attribute counts for the current products.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array  $query_vars         The WP_Query arguments.
 	 * @param string $attribute_to_count Attribute taxonomy name.
@@ -291,6 +299,8 @@ class FilterData {
 
 	/**
 	 * Get taxonomy counts for the current products.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array  $query_vars The WP_Query arguments.
 	 * @param string $taxonomy_to_count   Taxonomy name.

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
@@ -25,6 +25,8 @@ class FilterDataProvider {
 	/**
 	 * Get the data provider with desired query clauses generator.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param QueryClausesGenerator $query_clauses_generator The query clauses generator instance.
 	 */
 	public function with( QueryClausesGenerator $query_clauses_generator ) {

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
@@ -13,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Provider class.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class FilterDataProvider {
 	/**
@@ -24,8 +26,6 @@ class FilterDataProvider {
 
 	/**
 	 * Get the data provider with desired query clauses generator.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param QueryClausesGenerator $query_clauses_generator The query clauses generator instance.
 	 */

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Internal\ProductFilters\Interfaces;
 
 /**
  * Interface for filter URL parameters.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 interface FilterUrlParam {
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
@@ -1,0 +1,24 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\ProductFilters\Interfaces;
+
+/**
+ * Interface for filter URL parameters.
+ */
+interface FilterUrlParam {
+	/**
+	 * Get the param keys.
+	 *
+	 * @return array
+	 */
+	public function get_param_keys(): array;
+
+	/**
+	 * Get the param.
+	 *
+	 * @param string $type The type of param to get.
+	 * @return array
+	 */
+	public function get_param( string $type ): array;
+}

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * MainQueryClausesGenerator interface file.
+ */
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFilters\Interfaces;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * MainQueryClausesGenerator interface.
+ */
+interface MainQueryClausesGenerator {
+
+	/**
+	 * Add conditional query clauses for main query based on the filter params in query vars.
+	 *
+	 * @param array     $args     Query args.
+	 * @param \WP_Query $wp_query WP_Query object.
+	 * @return array
+	 */
+	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query );
+}

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
@@ -21,12 +21,5 @@ interface MainQueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query );
-
-	/**
-	 * Get the filter URL params for the product filters.
-	 *
-	 * @return array
-	 */
-	public function get_filter_url_params();
+	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query ): array;
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * MainQueryClausesGenerator interface.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 interface MainQueryClausesGenerator {
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
@@ -22,4 +22,11 @@ interface MainQueryClausesGenerator {
 	 * @return array
 	 */
 	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query );
+
+	/**
+	 * Get the filter URL params for the product filters.
+	 *
+	 * @return array
+	 */
+	public function get_filter_url_params();
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/QueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/QueryClausesGenerator.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * QueryClausesGenerator interface.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 interface QueryClausesGenerator {
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/QueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/QueryClausesGenerator.php
@@ -21,5 +21,5 @@ interface QueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( array $args, \WP_Query $wp_query );
+	public function add_query_clauses( array $args, \WP_Query $wp_query ): array;
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
@@ -33,36 +33,39 @@ class MainQueryController implements RegisterHooksInterface {
 
 	/**
 	 * Hook into actions and filters.
-	 */
-	public function register() {
-		add_filter( 'posts_clauses', array( $this, 'main_query_filter' ), 10, 2 );
-	}
-
-	/**
-	 * Filter the posts clauses of the main query to suport global filters.
 	 *
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
-	 * @param array     $args     Query args.
-	 * @param \WP_Query $wp_query WP_Query object.
+	 * @return void
+	 */
+	public function register() {
+		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses_for_main_query' ), 10, 2 );
+		add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
+	}
+
+	/**
+	 * Register custom query vars for our filters. Price, stock status, and attribute query vars are
+	 * already registered at WC_Query.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
+	 * @param array $query_vars Query vars.
 	 * @return array
 	 */
-	public function main_query_filter( $args, $wp_query ) {
-		if (
-			! $wp_query->is_main_query() ||
-			'product_query' !== $wp_query->get( 'wc_query' )
-		) {
-			return $args;
+	public function add_query_vars( $query_vars ) {
+		$custom_query_vars = array(
+			'filter_stock_status',
+		);
+
+		$public_product_taxonomies = get_taxonomies( array(
+			'public' => true,
+			'object_type' => array( 'product' ),
+		) );
+
+		foreach( $public_product_taxonomies as $taxonomy ) {
+			$custom_query_vars[] = 'filter_' . $taxonomy;
 		}
 
-		if ( $wp_query->get( 'filter_stock_status' ) ) {
-			$stock_statuses = trim( $wp_query->get( 'filter_stock_status' ) );
-			$stock_statuses = explode( ',', $stock_statuses );
-			$stock_statuses = array_filter( $stock_statuses );
-
-			$args = $this->query_clauses->add_stock_clauses( $args, $stock_statuses );
-		}
-
-		return $args;
+		return array_merge( $query_vars, $custom_query_vars );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
@@ -53,19 +53,6 @@ class MainQueryController implements RegisterHooksInterface {
 	 * @return array
 	 */
 	public function add_query_vars( $query_vars ) {
-		$custom_query_vars = array(
-			'filter_stock_status',
-		);
-
-		$public_product_taxonomies = get_taxonomies( array(
-			'public' => true,
-			'object_type' => array( 'product' ),
-		) );
-
-		foreach( $public_product_taxonomies as $taxonomy ) {
-			$custom_query_vars[] = 'filter_' . $taxonomy;
-		}
-
-		return array_merge( $query_vars, $custom_query_vars );
+		return array_merge( $query_vars, $this->query_clauses->get_filter_url_params() );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
@@ -19,16 +19,25 @@ class MainQueryController implements RegisterHooksInterface {
 	private $query_clauses;
 
 	/**
+	 * Hold the filter params.
+	 *
+	 * @var Params
+	 */
+	private $params;
+
+	/**
 	 * Initialize dependencies.
 	 *
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param QueryClauses $query_clauses Instance of QueryClauses.
+	 * @param Params       $params        Instance of Params.
 	 *
 	 * @return void
 	 */
-	final public function init( QueryClauses $query_clauses ): void {
+	final public function init( QueryClauses $query_clauses, Params $params ): void {
 		$this->query_clauses = $query_clauses;
+		$this->params        = $params;
 	}
 
 	/**
@@ -38,7 +47,7 @@ class MainQueryController implements RegisterHooksInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		add_filter( 'posts_clauses', array( $this->query_clauses, 'add_query_clauses_for_main_query' ), 10, 2 );
 		add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
 	}
@@ -52,7 +61,7 @@ class MainQueryController implements RegisterHooksInterface {
 	 * @param array $query_vars Query vars.
 	 * @return array
 	 */
-	public function add_query_vars( $query_vars ) {
-		return array_merge( $query_vars, $this->query_clauses->get_filter_url_params() );
+	public function add_query_vars( array $query_vars ): array {
+		return array_merge( $query_vars, $this->params->get_param_keys() );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
@@ -30,6 +30,7 @@ class MainQueryController implements RegisterHooksInterface {
 	/**
 	 * Initialize dependencies.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 * @param QueryClauses $query_clauses Instance of QueryClauses.
 	 * @param Params       $params        Instance of Params.
 	 *

--- a/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/MainQueryController.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\Internal\RegisterHooksInterface;
 defined( 'ABSPATH' ) || exit;
 /**
  * Hooks into WordPress filters to handle product filters for the main query.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class MainQueryController implements RegisterHooksInterface {
 
@@ -28,8 +30,6 @@ class MainQueryController implements RegisterHooksInterface {
 	/**
 	 * Initialize dependencies.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @param QueryClauses $query_clauses Instance of QueryClauses.
 	 * @param Params       $params        Instance of Params.
 	 *
@@ -43,8 +43,6 @@ class MainQueryController implements RegisterHooksInterface {
 	/**
 	 * Hook into actions and filters.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @return void
 	 */
 	public function register(): void {
@@ -55,8 +53,6 @@ class MainQueryController implements RegisterHooksInterface {
 	/**
 	 * Register custom query vars for our filters. Price, stock status, and attribute query vars are
 	 * already registered at WC_Query.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $query_vars Query vars.
 	 * @return array

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFilters;
+
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\FilterUrlParam;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Single source of truth for managing all filter params.
+ */
+class Params implements FilterUrlParam {
+	/**
+	 * Hold the filter params.
+	 *
+	 * @var array
+	 */
+	private static $params = array();
+
+	/**
+	 * Get the param keys.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @return array
+	 */
+	public function get_param_keys(): array {
+		if ( empty( self::$params ) ) {
+			$this->init_params();
+		}
+
+		$keys = array();
+		foreach ( self::$params as $taxonomy => $params ) {
+			$keys = array_merge( $keys, array_values( $params ) );
+			if ( 'attribute' === $taxonomy ) {
+				$query_type_params = array_map(
+					function( $param ) {
+						return 'query_type_' . $param;
+					},
+					array_keys( $params )
+				);
+				$keys = array_merge( $keys, $query_type_params );
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Get the param.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @param string $type The type of param to get.
+	 * @return array
+	 */
+	public function get_param( string $type ): array {
+		if ( empty( self::$params ) ) {
+			$this->init_params();
+		}
+
+		return self::$params[ $type ] ?? array();
+	}
+
+	/**
+	 * Initialize the params.
+	 *
+	 * @return void
+	 */
+	private function init_params(): void {
+		self::$params = array(
+			'price' => array(
+				'min_price',
+				'max_price',
+			),
+			'rating' => array(
+				'rating_filter',
+			),
+			'status' => array(
+				'filter_stock_status',
+			),
+			'attribute' => $this->get_attribute_params(),
+			'taxonomy' => $this->get_taxonomy_params(),
+		);
+	}
+
+	/**
+	 * Get the attribute params.
+	 *
+	 * @return array
+	 */
+	private function get_attribute_params(): array {
+		$params = array();
+		foreach ( wc_get_attribute_taxonomies() as $attribute ) {
+			$params[ $attribute->attribute_name ] = "filter_$attribute->attribute_name";
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Get the taxonomy params.
+	 *
+	 * @return array
+	 */
+	private function get_taxonomy_params(): array {
+		$public_product_taxonomies = get_taxonomies(
+			array(
+				'public'      => true,
+				'object_type' => array( 'product' ),
+			),
+			'objects'
+		);
+
+		$params = array();
+		foreach ( $public_product_taxonomies as $taxonomy ) {
+			$params[ $taxonomy->name ] = "filter_$taxonomy->name";
+		}
+
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -112,11 +112,18 @@ class Params implements FilterUrlParam {
 			'objects'
 		);
 
-		$params = array();
-		foreach ( $public_product_taxonomies as $taxonomy ) {
-			$params[ $taxonomy->name ] = "filter_$taxonomy->name";
-		}
+		// We have control over built-in taxonomies, so we can use prettier names.
+		$map = array(
+			'product_cat'   => 'categories',
+			'product_tag'   => 'tags',
+			'product_brand' => 'brands',
+		);
 
-		return $params;
+		return array_map(
+			function ( $taxonomy ) use ( $map ) {
+				return $map[ $taxonomy->name ] ?? "filter_$taxonomy->name";
+			},
+			$public_product_taxonomies
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -35,12 +35,12 @@ class Params implements FilterUrlParam {
 			$keys = array_merge( $keys, array_values( $params ) );
 			if ( 'attribute' === $taxonomy ) {
 				$query_type_params = array_map(
-					function( $param ) {
+					function ( $param ) {
 						return 'query_type_' . $param;
 					},
 					array_keys( $params )
 				);
-				$keys = array_merge( $keys, $query_type_params );
+				$keys              = array_merge( $keys, $query_type_params );
 			}
 		}
 
@@ -69,18 +69,18 @@ class Params implements FilterUrlParam {
 	 */
 	private function init_params(): void {
 		self::$params = array(
-			'price' => array(
+			'price'     => array(
 				'min_price',
 				'max_price',
 			),
-			'rating' => array(
+			'rating'    => array(
 				'rating_filter',
 			),
-			'status' => array(
+			'status'    => array(
 				'filter_stock_status',
 			),
 			'attribute' => $this->get_attribute_params(),
-			'taxonomy' => $this->get_taxonomy_params(),
+			'taxonomy'  => $this->get_taxonomy_params(),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -106,8 +106,8 @@ class Params implements FilterUrlParam {
 	private function get_taxonomy_params(): array {
 		$public_product_taxonomies = get_taxonomies(
 			array(
-				'public'      => true,
-				'object_type' => array( 'product' ),
+				'public'  => true,
+				'show_ui' => true,
 			),
 			'objects'
 		);
@@ -119,11 +119,14 @@ class Params implements FilterUrlParam {
 			'product_brand' => 'brands',
 		);
 
-		return array_map(
-			function ( $taxonomy ) use ( $map ) {
-				return $map[ $taxonomy->name ] ?? "filter_$taxonomy->name";
-			},
-			$public_product_taxonomies
-		);
+		$params = array();
+
+		foreach ( $public_product_taxonomies as $taxonomy ) {
+			if ( is_array( $taxonomy->object_type ) && in_array( 'product', $taxonomy->object_type, true ) ) {
+				$params[ $taxonomy->name ] = $map[ $taxonomy->name ] ?? "filter_$taxonomy->name";
+			}
+		}
+
+		return $params;
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -10,6 +10,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Single source of truth for managing all filter params.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class Params implements FilterUrlParam {
 	/**
@@ -22,7 +24,6 @@ class Params implements FilterUrlParam {
 	/**
 	 * Get the param keys.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 * @return array
 	 */
 	public function get_param_keys(): array {
@@ -50,7 +51,6 @@ class Params implements FilterUrlParam {
 	/**
 	 * Get the param.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 * @param string $type The type of param to get.
 	 * @return array
 	 */

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -29,6 +29,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	/**
 	 * Initialize the query clauses.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param Params $params The filter params.
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -335,6 +335,10 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 			)
 		);
 
+		if ( is_wp_error( $all_terms ) ) {
+			return $args;
+		}
+
 		$term_ids_by_taxonomy = array();
 
 		foreach ( $all_terms as $term ) {

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -328,6 +328,13 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		);
 
 		if ( is_wp_error( $all_terms ) ) {
+			$logger = wc_get_logger();
+			$logger->error(
+				$all_terms->get_error_message(),
+				array(
+					'taxonomies' => $chosen_taxonomies,
+				)
+			);
 			return $args;
 		}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -374,6 +374,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		if ( ! empty( $tax_queries ) ) {
 			$args['where'] .= ' AND (' . implode( ' AND ', $tax_queries ) . ')';
+		} else {
+			$args['where'] .= ' AND 1=0';
 		}
 
 		return $args;

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -19,6 +19,22 @@ defined( 'ABSPATH' ) || exit;
  * Class for filter clauses.
  */
 class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
+	/**
+	 * Hold the filter params.
+	 *
+	 * @var Params
+	 */
+	private $params;
+
+	/**
+	 * Initialize the query clauses.
+	 *
+	 * @param Params $params The filter params.
+	 * @return void
+	 */
+	final public function init( Params $params ): void {
+		$this->params = $params;
+	}
 
 	/**
 	 * Add conditional query clauses based on the filter params in query vars.
@@ -30,7 +46,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( $args, $wp_query ) {
+	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		if ( $wp_query->get( 'filter_stock_status' ) ) {
 			$stock_statuses = trim( $wp_query->get( 'filter_stock_status' ) );
 			$stock_statuses = explode( ',', $stock_statuses );
@@ -71,7 +87,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses_for_main_query( $args, $wp_query ) {
+	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query ): array {
 		if (
 			! $wp_query->is_main_query() ||
 			'product_query' !== $wp_query->get( 'wc_query' )
@@ -102,7 +118,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param array $stock_statuses Stock statuses to be queried.
 	 * @return array
 	 */
-	public function add_stock_clauses( $args, $stock_statuses ) {
+	public function add_stock_clauses( array $args, array $stock_statuses ): array {
 		$stock_statuses = array_filter( $stock_statuses );
 
 		if ( empty( $stock_statuses ) ) {
@@ -132,7 +148,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * }
 	 * @return array
 	 */
-	public function add_price_clauses( $args, $price_range ) {
+	public function add_price_clauses( array $args, array $price_range ): array {
 		if ( ! isset( $price_range['min_price'] ) && ! isset( $price_range['max_price'] ) ) {
 			return $args;
 		}
@@ -180,7 +196,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 *
 	 * @return array
 	 */
-	public function add_attribute_clauses( $args, $chosen_attributes ) {
+	public function add_attribute_clauses( array $args, array $chosen_attributes ): array {
 		if ( empty( $chosen_attributes ) ) {
 			return $args;
 		}
@@ -293,7 +309,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * }
 	 * @return array
 	 */
-	public function add_taxonomy_clauses( $args, $chosen_taxonomies ) {
+	public function add_taxonomy_clauses( array $args, array $chosen_taxonomies ): array {
 		if ( empty( $chosen_taxonomies ) ) {
 			return $args;
 		}
@@ -366,7 +382,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 *                                   taxonomy, return all terms.
 	 * @return mixed
 	 */
-	private function get_current_attribute_terms( $all_terms, $taxonomy, $taxonomy_count ) {
+	private function get_current_attribute_terms( array $all_terms, string $taxonomy, int $taxonomy_count ): array {
 		if ( 1 === $taxonomy_count ) {
 			return $all_terms;
 		}
@@ -385,7 +401,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param string $sql SQL join.
 	 * @return string
 	 */
-	private function append_product_sorting_table_join( $sql ) {
+	private function append_product_sorting_table_join( string $sql ): string {
 		global $wpdb;
 
 		if ( ! strstr( $sql, 'wc_product_meta_lookup' ) ) {
@@ -402,7 +418,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 *
 	 * @return boolean
 	 */
-	private function should_adjust_price_filters_for_displayed_taxes() {
+	private function should_adjust_price_filters_for_displayed_taxes(): bool {
 		$display  = get_option( 'woocommerce_tax_display_shop' );
 		$database = wc_prices_include_tax() ? 'incl' : 'excl';
 
@@ -417,7 +433,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param string $operator Comparison operator for column. Accepts '>=' or '<='.
 	 * @return string Constructed query.
 	 */
-	private function get_price_filter_query_for_displayed_taxes( $price_filter, $column = 'min_price', $operator = '>=' ) {
+	private function get_price_filter_query_for_displayed_taxes( float $price_filter, string $column = 'min_price', string $operator = '>=' ): string {
 		global $wpdb;
 
 		if ( ! in_array( $operator, array( '>=', '<=' ), true ) ) {
@@ -469,7 +485,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param string $tax_class Tax class for adjustment.
 	 * @return float
 	 */
-	private function adjust_price_filter_for_tax_class( $price_filter, $tax_class ) {
+	private function adjust_price_filter_for_tax_class( float $price_filter, string $tax_class ): float {
 		$tax_display    = get_option( 'woocommerce_tax_display_shop' );
 		$tax_rates      = WC_Tax::get_rates( $tax_class );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $tax_class );
@@ -506,7 +522,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return array
 	 */
-	private function get_chosen_attributes( $query_vars ) {
+	private function get_chosen_attributes( array $query_vars ): array {
 		$chosen_attributes = array();
 
 		if ( empty( $query_vars ) ) {
@@ -538,69 +554,20 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return array
 	 */
-	private function get_chosen_taxonomies( $query_vars ) {
+	private function get_chosen_taxonomies( array $query_vars ): array {
 		$chosen_taxonomies = array();
 
 		if ( empty( $query_vars ) ) {
 			return $chosen_taxonomies;
 		}
 
-		foreach ( $this->get_taxonomy_url_params_mapping() as $taxonomy => $param ) {
+		foreach ( $this->params->get_param( 'taxonomy' ) as $taxonomy => $param ) {
 			if ( isset( $query_vars[ $param ] ) ) {
 				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) );
 			}
 		}
 
-		return $chosen_taxonomies;
-	}
-
-	/**
-	 * Get the filter URL params for the product filters.
-	 *
-	 * @return array
-	 */
-	public function get_filter_url_params() {
-		return array_values(
-			array_merge(
-				array(
-					'filter_stock_status',
-				),
-				array_values( $this->get_taxonomy_url_params_mapping() ),
-			)
-		);
-	}
-
-	/**
-	 * Get the taxonomy URL params for the product filters.
-	 *
-	 * @return array
-	 */
-	private function get_taxonomy_url_params_mapping() {
-		$public_product_taxonomies = get_taxonomies(
-			array(
-				'public'      => true,
-				'object_type' => array( 'product' ),
-			),
-			'objects'
-		);
-
-		// We have control over these built-in taxonomies.
-		$map = array(
-			'product_cat'   => 'category',
-			'product_tag'   => 'tag',
-			'product_brand' => 'brand',
-		);
-
-		return array_map(
-			function ( $taxonomy ) use ( $map ) {
-				if ( isset( $map[ $taxonomy->name ] ) ) {
-					return $map[ $taxonomy->name ];
-				}
-
-				return $taxonomy->name;
-			},
-			$public_product_taxonomies
-		);
+		return array_filter( $chosen_taxonomies );
 	}
 
 	/**
@@ -608,7 +575,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 *
 	 * @return string
 	 */
-	private function get_lookup_table_name() {
+	private function get_lookup_table_name(): string {
 		return wc_get_container()->get( LookupDataStore::class )->get_lookup_table_name();
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -302,10 +302,12 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		$tax_queries = array();
 
-		$all_terms = get_terms( array(
-			'taxonomy'   => array_keys( $chosen_taxonomies ),
-			'slug'       => array_merge( ...array_values( $chosen_taxonomies ) ),
-		) );
+		$all_terms = get_terms(
+			array(
+				'taxonomy' => array_keys( $chosen_taxonomies ),
+				'slug'     => array_merge( ...array_values( $chosen_taxonomies ) ),
+			)
+		);
 
 		$term_ids_by_taxonomy = array();
 
@@ -335,6 +337,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 			 * 4. Efficient combination: Multiple taxonomy filters can be combined with AND
 			 *    without complex GROUP BY logic or performance degradation.
 			 */
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 			$tax_queries[] = $wpdb->prepare(
 				"EXISTS (
 					SELECT 1 FROM {$wpdb->term_relationships} tr
@@ -542,22 +545,66 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 			return $chosen_taxonomies;
 		}
 
-		$public_product_taxonomies = get_taxonomies( array(
-			'public' => true,
-			'object_type' => array( 'product' ),
-		) );
-
-		$taxonomy_filter_keys = array_map( function( $taxonomy ) {
-			return 'filter_' . $taxonomy;
-		}, $public_product_taxonomies );
-
-		foreach( $taxonomy_filter_keys as $taxonomy => $param_key ) {
-			if ( isset( $query_vars[ $param_key ] ) ) {
-				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param_key ] ) );
+		foreach ( $this->get_taxonomy_url_params_mapping() as $taxonomy => $param ) {
+			if ( isset( $query_vars[ $param ] ) ) {
+				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) );
 			}
 		}
 
 		return $chosen_taxonomies;
+	}
+
+	/**
+	 * Get the filter URL params for the product filters.
+	 *
+	 * @return array
+	 */
+	public function get_filter_url_params() {
+		return array_values(
+			array_merge(
+				array(
+					'filter_stock_status',
+				),
+				array_values( $this->get_taxonomy_url_params_mapping() ),
+			)
+		);
+	}
+
+	/**
+	 * Get the taxonomy URL params for the product filters.
+	 *
+	 * @return array
+	 */
+	private function get_taxonomy_url_params_mapping() {
+		$public_product_taxonomies = get_taxonomies(
+			array(
+				'public'      => true,
+				'object_type' => array( 'product' ),
+			),
+			'objects'
+		);
+
+		// We have control over these built-in taxonomies.
+		$map = array(
+			'product_cat'   => 'category',
+			'product_tag'   => 'tag',
+			'product_brand' => 'brand',
+		);
+
+		return array_map(
+			function ( $taxonomy ) use ( $map ) {
+				if ( isset( $map[ $taxonomy->name ] ) ) {
+						return $map[ $taxonomy->name ];
+				}
+
+				if ( ! empty( $taxonomy->rewrite['slug'] ) ) {
+					return $taxonomy->rewrite['slug'];
+				}
+
+				return $taxonomy->name;
+			},
+			$public_product_taxonomies
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -31,6 +31,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	/**
 	 * Initialize the query clauses.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 * @param Params $params The filter params.
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -556,7 +556,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		foreach ( $this->params->get_param( 'taxonomy' ) as $taxonomy => $param ) {
 			if ( isset( $query_vars[ $param ] ) && ! empty( trim( $query_vars[ $param ] ) ) ) {
-				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) );
+				$chosen_taxonomies[ $taxonomy ] = array_filter( array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -114,6 +114,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	/**
 	 * Add query clauses for stock filter.
 	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
 	 * @param array $args           Query args.
 	 * @param array $stock_statuses Stock statuses to be queried.
 	 * @return array
@@ -138,6 +140,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for price filter.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args        Query args.
 	 * @param array $price_range {
@@ -183,6 +187,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for filtering products by attributes.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args              Query args.
 	 * @param array $chosen_attributes {
@@ -298,6 +304,8 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for taxonomy filter (e.g., product_cat, product_tag).
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args           Query args.
 	 * @param array $chosen_taxonomies {

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -594,11 +594,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		return array_map(
 			function ( $taxonomy ) use ( $map ) {
 				if ( isset( $map[ $taxonomy->name ] ) ) {
-						return $map[ $taxonomy->name ];
-				}
-
-				if ( ! empty( $taxonomy->rewrite['slug'] ) ) {
-					return $taxonomy->rewrite['slug'];
+					return $map[ $taxonomy->name ];
 				}
 
 				return $taxonomy->name;

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -321,8 +321,9 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		$all_terms = get_terms(
 			array(
-				'taxonomy' => array_keys( $chosen_taxonomies ),
-				'slug'     => array_merge( ...array_values( $chosen_taxonomies ) ),
+				'taxonomy'   => array_keys( $chosen_taxonomies ),
+				'slug'       => array_merge( ...array_values( $chosen_taxonomies ) ),
+				'hide_empty' => false,
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -576,12 +576,12 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		}
 
 		foreach ( $this->params->get_param( 'taxonomy' ) as $taxonomy => $param ) {
-			if ( isset( $query_vars[ $param ] ) ) {
+			if ( isset( $query_vars[ $param ] ) && ! empty( trim( $query_vars[ $param ] ) ) ) {
 				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) );
 			}
 		}
 
-		return array_filter( $chosen_taxonomies );
+		return $chosen_taxonomies;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -17,6 +17,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class for filter clauses.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	/**
@@ -28,8 +30,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Initialize the query clauses.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param Params $params The filter params.
 	 * @return void
@@ -83,8 +83,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	 * WooCommerce handles attribute, price, and rating filters in the main query.
 	 * This method is used to add stock status and taxonomy filters to the main query.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @param array     $args     Query args.
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
@@ -116,8 +114,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	/**
 	 * Add query clauses for stock filter.
 	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
-	 *
 	 * @param array $args           Query args.
 	 * @param array $stock_statuses Stock statuses to be queried.
 	 * @return array
@@ -142,8 +138,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for price filter.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args        Query args.
 	 * @param array $price_range {
@@ -189,8 +183,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for filtering products by attributes.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args              Query args.
 	 * @param array $chosen_attributes {
@@ -306,8 +298,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add query clauses for taxonomy filter (e.g., product_cat, product_tag).
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 *
 	 * @param array $args           Query args.
 	 * @param array $chosen_taxonomies {

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -302,20 +302,18 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		$tax_queries = array();
 
-		foreach ( $chosen_taxonomies as $taxonomy => $terms ) {
-			if ( empty( $terms ) ) {
-				continue;
-			}
+		$all_terms = get_terms( array(
+			'taxonomy'   => array_keys( $chosen_taxonomies ),
+			'slug'       => array_merge( ...array_values( $chosen_taxonomies ) ),
+		) );
 
-			// Get term IDs from slugs
-			$term_ids = array();
-			foreach ( $terms as $term_slug ) {
-				$term = get_term_by( 'slug', $term_slug, $taxonomy );
-				if ( $term && ! is_wp_error( $term ) ) {
-					$term_ids[] = $term->term_id;
-				}
-			}
+		$term_ids_by_taxonomy = array();
 
+		foreach ( $all_terms as $term ) {
+			$term_ids_by_taxonomy[ $term->taxonomy ][] = $term->term_id;
+		}
+
+		foreach ( $term_ids_by_taxonomy as $taxonomy => $term_ids ) {
 			if ( empty( $term_ids ) ) {
 				continue;
 			}
@@ -553,9 +551,9 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 			return 'filter_' . $taxonomy;
 		}, $public_product_taxonomies );
 
-		foreach( $taxonomy_filter_keys as $taxonomy => $key ) {
-			if ( isset( $query_vars[ $key ] ) ) {
-				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $key ] ) );
+		foreach( $taxonomy_filter_keys as $taxonomy => $param_key ) {
+			if ( isset( $query_vars[ $param_key ] ) ) {
+				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $param_key ] ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -388,28 +388,6 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 	}
 
 	/**
-	 * Get all the term for current attribute.
-	 *
-	 * @param \WP_Term[] $all_terms      Aggreated terms array.
-	 * @param string     $taxonomy       Attribute taxonomy name.
-	 * @param int        $taxonomy_count Taxonomy count. If there is only one
-	 *                                   taxonomy, return all terms.
-	 * @return mixed
-	 */
-	private function get_current_attribute_terms( array $all_terms, string $taxonomy, int $taxonomy_count ): array {
-		if ( 1 === $taxonomy_count ) {
-			return $all_terms;
-		}
-
-		return array_filter(
-			$all_terms,
-			function ( $term ) use ( $taxonomy ) {
-				return $term->taxonomy === $taxonomy;
-			}
-		);
-	}
-
-	/**
 	 * Join wc_product_meta_lookup to posts if not already joined.
 	 *
 	 * @param string $sql SQL join.

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Internal\ProductFilters;
 
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\MainQueryClausesGenerator;
 use WC_Tax;
 use WC_Cache_Helper;
 
@@ -17,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class for filter clauses.
  */
-class QueryClauses implements QueryClausesGenerator {
+class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 	/**
 	 * Add conditional query clauses based on the filter params in query vars.
@@ -49,6 +50,46 @@ class QueryClauses implements QueryClausesGenerator {
 		$args = $this->add_attribute_clauses(
 			$args,
 			$this->get_chosen_attributes( $wp_query->query_vars )
+		);
+
+		$args = $this->add_taxonomy_clauses(
+			$args,
+			$this->get_chosen_taxonomies( $wp_query->query_vars )
+		);
+
+		return $args;
+	}
+
+	/**
+	 * Add query clauses for main query.
+	 * WooCommerce handles attribute, price, and rating filters in the main query.
+	 * This method is used to add stock status and taxonomy filters to the main query.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
+	 * @param array     $args     Query args.
+	 * @param \WP_Query $wp_query WP_Query object.
+	 * @return array
+	 */
+	public function add_query_clauses_for_main_query( $args, $wp_query ) {
+		if (
+			! $wp_query->is_main_query() ||
+			'product_query' !== $wp_query->get( 'wc_query' )
+		) {
+			return $args;
+		}
+
+		if ( $wp_query->get( 'filter_stock_status' ) ) {
+			$stock_statuses = trim( $wp_query->get( 'filter_stock_status' ) );
+			$stock_statuses = explode( ',', $stock_statuses );
+			$stock_statuses = array_filter( $stock_statuses );
+
+			$args = $this->add_stock_clauses( $args, $stock_statuses );
+		}
+
+		$args = $this->add_taxonomy_clauses(
+			$args,
+			$this->get_chosen_taxonomies( $wp_query->query_vars )
 		);
 
 		return $args;
@@ -240,6 +281,104 @@ class QueryClauses implements QueryClausesGenerator {
 	}
 
 	/**
+	 * Add query clauses for taxonomy filter (e.g., product_cat, product_tag).
+	 *
+	 * @param array $args           Query args.
+	 * @param array $chosen_taxonomies {
+	 *     Chosen taxonomies array.
+	 *
+	 *     @type array {$taxonomy: Taxonomy name} {
+	 *         @type string[] $terms Chosen terms' slug.
+	 *     }
+	 * }
+	 * @return array
+	 */
+	public function add_taxonomy_clauses( $args, $chosen_taxonomies ) {
+		if ( empty( $chosen_taxonomies ) ) {
+			return $args;
+		}
+
+		global $wpdb;
+
+		$tax_queries = array();
+
+		foreach ( $chosen_taxonomies as $taxonomy => $terms ) {
+			if ( empty( $terms ) ) {
+				continue;
+			}
+
+			// Get term IDs from slugs
+			$term_ids = array();
+			foreach ( $terms as $term_slug ) {
+				$term = get_term_by( 'slug', $term_slug, $taxonomy );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$term_ids[] = $term->term_id;
+				}
+			}
+
+			if ( empty( $term_ids ) ) {
+				continue;
+			}
+
+			$term_ids_list = '(' . implode( ',', array_map( 'absint', $term_ids ) ) . ')';
+
+			/*
+			 * Use EXISTS subquery for taxonomy filtering for several key benefits:
+			 *
+			 * 1. Performance: EXISTS stops execution as soon as the first matching row is found,
+			 *    making it faster than JOIN approaches that need to process all matches.
+			 *
+			 * 2. No duplicate rows: Unlike JOINs, EXISTS doesn't create duplicate rows when
+			 *    a product has multiple matching terms, eliminating the need for DISTINCT.
+			 *
+			 * 3. Clean boolean logic: We only care IF a product has the terms, not HOW MANY
+			 *    or which specific ones, making EXISTS semantically correct.
+			 *
+			 * 4. Efficient combination: Multiple taxonomy filters can be combined with AND
+			 *    without complex GROUP BY logic or performance degradation.
+			 */
+			$tax_queries[] = $wpdb->prepare(
+				"EXISTS (
+					SELECT 1 FROM {$wpdb->term_relationships} tr
+					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+					WHERE tr.object_id = {$wpdb->posts}.ID
+					AND tt.taxonomy = %s
+					AND tt.term_id IN {$term_ids_list}
+				)",
+				$taxonomy
+			);
+		}
+
+		if ( ! empty( $tax_queries ) ) {
+			$args['where'] .= ' AND (' . implode( ' AND ', $tax_queries ) . ')';
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get all the term for current attribute.
+	 *
+	 * @param \WP_Term[] $all_terms      Aggreated terms array.
+	 * @param string     $taxonomy       Attribute taxonomy name.
+	 * @param int        $taxonomy_count Taxonomy count. If there is only one
+	 *                                   taxonomy, return all terms.
+	 * @return mixed
+	 */
+	private function get_current_attribute_terms( $all_terms, $taxonomy, $taxonomy_count ) {
+		if ( 1 === $taxonomy_count ) {
+			return $all_terms;
+		}
+
+		return array_filter(
+			$all_terms,
+			function ( $term ) use ( $taxonomy ) {
+				return $term->taxonomy === $taxonomy;
+			}
+		);
+	}
+
+	/**
 	 * Join wc_product_meta_lookup to posts if not already joined.
 	 *
 	 * @param string $sql SQL join.
@@ -390,6 +529,37 @@ class QueryClauses implements QueryClausesGenerator {
 		}
 
 		return $chosen_attributes;
+	}
+
+	/**
+	 * Get an array of taxonomies and terms selected from query arguments.
+	 *
+	 * @param array $query_vars The WP_Query arguments.
+	 * @return array
+	 */
+	private function get_chosen_taxonomies( $query_vars ) {
+		$chosen_taxonomies = array();
+
+		if ( empty( $query_vars ) ) {
+			return $chosen_taxonomies;
+		}
+
+		$public_product_taxonomies = get_taxonomies( array(
+			'public' => true,
+			'object_type' => array( 'product' ),
+		) );
+
+		$taxonomy_filter_keys = array_map( function( $taxonomy ) {
+			return 'filter_' . $taxonomy;
+		}, $public_product_taxonomies );
+
+		foreach( $taxonomy_filter_keys as $taxonomy => $key ) {
+			if ( isset( $query_vars[ $key ] ) ) {
+				$chosen_taxonomies[ $taxonomy ] = array_map( 'sanitize_title', explode( ',', $query_vars[ $key ] ) );
+			}
+		}
+
+		return $chosen_taxonomies;
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -350,7 +350,7 @@ class ProductQuery implements QueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( array $args, \WP_Query $wp_query ) {
+	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
 
 		if ( $wp_query->get( 'search' ) ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
@@ -263,6 +263,22 @@ class FixtureData {
 	}
 
 	/**
+	 * Create a product tag and return the result.
+	 *
+	 * @param array $props Tag props.
+	 * @return array
+	 */
+	public function get_product_tag( $props ) {
+		$tag_name = $props['name'] ?? 'Test Tag';
+
+		return wp_insert_term(
+			$tag_name,
+			'product_tag',
+			$props
+		);
+	}
+
+	/**
 	 * Create a product brand and return the result.
 	 *
 	 * @param array $props Product props.

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
@@ -101,9 +101,24 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 		);
 
 		$this->product_tags = array(
-			'tag-1' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 1', 'slug' => 'tag-1' ) ),
-			'tag-2' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 2', 'slug' => 'tag-2' ) ),
-			'tag-3' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 3', 'slug' => 'tag-3' ) ),
+			'tag-1' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 1',
+					'slug' => 'tag-1',
+				)
+			),
+			'tag-2' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 2',
+					'slug' => 'tag-2',
+				)
+			),
+			'tag-3' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 3',
+					'slug' => 'tag-3',
+				)
+			),
 		);
 
 		$this->products_data = array(
@@ -141,8 +156,8 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 			array(
 				'name'         => 'Product 5',
 				'stock_status' => ProductStockStatus::IN_STOCK,
-				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
-				'tag_ids'       => array( $this->product_tags['tag-2']['term_id'] ),
+				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'      => array( $this->product_tags['tag-2']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(
@@ -167,8 +182,8 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 			array(
 				'name'         => 'Product 6',
 				'stock_status' => ProductStockStatus::IN_STOCK,
-				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
-				'tag_ids'       => array( $this->product_tags['tag-3']['term_id'] ),
+				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'      => array( $this->product_tags['tag-3']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
@@ -41,6 +41,13 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 	protected $product_categories;
 
 	/**
+	 * Product tags.
+	 *
+	 * @var array
+	 */
+	protected $product_tags;
+
+	/**
 	 * Backup options.
 	 *
 	 * @var array
@@ -93,18 +100,26 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 			'cat-3' => $this->fixture_data->get_product_category( array( 'name' => 'Cat 3' ) ),
 		);
 
+		$this->product_tags = array(
+			'tag-1' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 1', 'slug' => 'tag-1' ) ),
+			'tag-2' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 2', 'slug' => 'tag-2' ) ),
+			'tag-3' => $this->fixture_data->get_product_tag( array( 'name' => 'Tag 3', 'slug' => 'tag-3' ) ),
+		);
+
 		$this->products_data = array(
 			array(
 				'name'          => 'Product 1',
 				'regular_price' => 10,
 				'stock_status'  => ProductStockStatus::ON_BACKORDER,
 				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-1']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 2',
 				'regular_price' => 20,
 				'stock_status'  => ProductStockStatus::IN_STOCK,
 				'category_ids'  => array( $this->product_categories['cat-2']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-2']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 3',
@@ -114,17 +129,20 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 					$this->product_categories['cat-2']['term_id'],
 					$this->product_categories['cat-3']['term_id'],
 				),
+				'tag_ids'       => array( $this->product_tags['tag-3']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 4',
 				'regular_price' => 40,
 				'stock_status'  => ProductStockStatus::IN_STOCK,
 				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-1']['term_id'] ),
 			),
 			array(
 				'name'         => 'Product 5',
 				'stock_status' => ProductStockStatus::IN_STOCK,
-				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-2']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(
@@ -149,7 +167,8 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 			array(
 				'name'         => 'Product 6',
 				'stock_status' => ProductStockStatus::IN_STOCK,
-				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-3']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(
@@ -188,6 +207,7 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 		$this->remove_all_attributes();
 		$this->remove_all_products();
 		$this->remove_all_product_categories();
+		$this->remove_all_product_tags();
 		$this->empty_lookup_tables();
 
 		foreach ( $this->backup_options as $option => $value ) {
@@ -263,6 +283,15 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 	private function remove_all_product_categories() {
 		foreach ( $this->product_categories as $term ) {
 			wp_delete_term( $term['term_id'], 'product_cat' );
+		}
+	}
+
+	/**
+	 * Remove all product tags.
+	 */
+	private function remove_all_product_tags() {
+		foreach ( $this->product_tags as $term ) {
+			wp_delete_term( $term['term_id'], 'product_tag' );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/ParamsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/ParamsTest.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductFilters;
+
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
+
+require_once WC_ABSPATH . '/includes/class-wc-brands.php';
+
+/**
+ * Tests for the Params class.
+ */
+class ParamsTest extends AbstractProductFiltersTest {
+	/**
+	 * The system under test.
+	 *
+	 * @var Params
+	 */
+	private $sut;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Ensure brands taxonomy is registered for testing.
+		\WC_Brands::init_taxonomy();
+
+		$container = wc_get_container();
+		$this->sut = $container->get( Params::class );
+		$this->clear_params_cache();
+	}
+
+	/**
+	 * Test that get_param_keys returns all expected parameter types.
+	 */
+	public function test_get_param_keys_returns_all_parameter_types() {
+		$param_keys = $this->sut->get_param_keys();
+
+		// Should contain price parameters.
+		$this->assertContains( 'min_price', $param_keys );
+		$this->assertContains( 'max_price', $param_keys );
+
+		// Should contain rating parameters.
+		$this->assertContains( 'rating_filter', $param_keys );
+
+		// Should contain status parameters.
+		$this->assertContains( 'filter_stock_status', $param_keys );
+
+		// Should contain taxonomy parameters with prettier names.
+		$this->assertContains( 'categories', $param_keys );
+		$this->assertContains( 'tags', $param_keys );
+		$this->assertContains( 'brands', $param_keys );
+
+		// Should contain attribute parameters created in setup.
+		$this->assertContains( 'filter_color', $param_keys );
+		$this->assertContains( 'query_type_color', $param_keys );
+	}
+
+
+	/**
+	 * Test get_param method with different parameter types.
+	 *
+	 * @dataProvider param_type_provider
+	 * @param string $type The parameter type to test.
+	 * @param array  $expected_structure The expected structure for the parameter type.
+	 */
+	public function test_get_param_with_different_types( $type, $expected_structure ) {
+		$params = $this->sut->get_param( $type );
+
+		$this->assertIsArray( $params );
+
+		if ( ! empty( $expected_structure ) ) {
+			foreach ( $expected_structure as $expected_param ) {
+				$this->assertContains( $expected_param, $params );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for parameter types.
+	 */
+	public function param_type_provider() {
+		return array(
+			'price parameters'     => array(
+				'price',
+				array( 'min_price', 'max_price' ),
+			),
+			'rating parameters'    => array(
+				'rating',
+				array( 'rating_filter' ),
+			),
+			'status parameters'    => array(
+				'status',
+				array( 'filter_stock_status' ),
+			),
+			'taxonomy parameters'  => array(
+				'taxonomy',
+				array( 'categories', 'tags', 'brands' ),
+			),
+			'attribute parameters' => array(
+				'attribute',
+				array( 'filter_color' ), // Color attribute is created in setup.
+			),
+			'non-existent type'    => array(
+				'non_existent',
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * Test taxonomy parameter mapping for built-in taxonomies.
+	 */
+	public function test_taxonomy_parameter_mapping() {
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Test built-in taxonomy mappings.
+		$this->assertContains( 'categories', $taxonomy_params );
+		$this->assertContains( 'tags', $taxonomy_params );
+		$this->assertContains( 'brands', $taxonomy_params );
+	}
+
+	/**
+	 * Test that custom taxonomies use filter_ prefix.
+	 */
+	public function test_custom_taxonomy_parameter_generation() {
+		// Register a custom taxonomy.
+		register_taxonomy(
+			'product_custom_tax',
+			'product',
+			array(
+				'label'  => 'Custom Taxonomy',
+				'public' => true,
+			)
+		);
+
+		// Clear cached params to force re-initialization.
+		$this->clear_params_cache();
+
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Should contain custom taxonomy with filter_ prefix.
+		$this->assertContains( 'filter_product_custom_tax', $taxonomy_params );
+
+		// Clean up.
+		unregister_taxonomy( 'product_custom_tax' );
+	}
+
+	/**
+	 * Test static caching behavior.
+	 */
+	public function test_static_caching_behavior() {
+		// Clear cache to start fresh.
+		$this->clear_params_cache();
+
+		// First call should initialize params.
+		$first_call = $this->sut->get_param_keys();
+
+		// Modify the cached params to test if caching is working.
+		$reflection      = new \ReflectionClass( Params::class );
+		$params_property = $reflection->getProperty( 'params' );
+		$params_property->setAccessible( true );
+		$cached_params = $params_property->getValue();
+
+		// Add a test parameter to the cached data.
+		$cached_params['test_type'] = array( 'test_param' );
+		$params_property->setValue( $cached_params );
+
+		// Second call should return the modified cached data (proving caching works).
+		$second_call = $this->sut->get_param_keys();
+
+		// If caching works, the second call should include our test parameter.
+		$this->assertContains( 'test_param', $second_call, 'Second call should return modified cached data, proving caching works' );
+
+		// Test that get_param also uses the modified cached data.
+		$test_params = $this->sut->get_param( 'test_type' );
+		$this->assertEquals( array( 'test_param' ), $test_params, 'get_param should return modified cached data' );
+	}
+
+
+	/**
+	 * Test edge cases and error handling.
+	 */
+	public function test_edge_cases_and_error_handling() {
+		// Test with empty string parameter type.
+		$empty_params = $this->sut->get_param( '' );
+		$this->assertIsArray( $empty_params );
+		$this->assertEmpty( $empty_params );
+
+		// Test with non-existent parameter type.
+		$non_existent_params = $this->sut->get_param( 'non_existent_type' );
+		$this->assertIsArray( $non_existent_params );
+		$this->assertEmpty( $non_existent_params );
+	}
+
+	/**
+	 * Test that param keys are unique.
+	 */
+	public function test_param_keys_are_unique() {
+		$param_keys  = $this->sut->get_param_keys();
+		$unique_keys = array_unique( $param_keys );
+
+		$this->assertEquals( count( $param_keys ), count( $unique_keys ), 'Parameter keys should be unique' );
+	}
+
+	/**
+	 * Test that taxonomy parameters only include public taxonomies with UI.
+	 */
+	public function test_taxonomy_parameters_only_include_public_taxonomies_with_ui() {
+		// Register a private taxonomy.
+		register_taxonomy(
+			'product_private_tax',
+			'product',
+			array(
+				'label'   => 'Private Taxonomy',
+				'public'  => false,
+				'show_ui' => true,
+			)
+		);
+
+		// Register a public taxonomy without UI.
+		register_taxonomy(
+			'product_no_ui_tax',
+			'product',
+			array(
+				'label'   => 'No UI Taxonomy',
+				'public'  => true,
+				'show_ui' => false,
+			)
+		);
+
+		// Clear cached params.
+		$this->clear_params_cache();
+
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Should not contain private taxonomy.
+		$this->assertNotContains( 'filter_product_private_tax', $taxonomy_params );
+
+		// Should not contain public taxonomy without UI.
+		$this->assertNotContains( 'filter_product_no_ui_tax', $taxonomy_params );
+
+		// Clean up.
+		unregister_taxonomy( 'product_private_tax' );
+		unregister_taxonomy( 'product_no_ui_tax' );
+	}
+
+	/**
+	 * Helper method to clear params cache for testing.
+	 */
+	private function clear_params_cache() {
+		$reflection      = new \ReflectionClass( Params::class );
+		$params_property = $reflection->getProperty( 'params' );
+		$params_property->setAccessible( true );
+		$params_property->setValue( array() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
@@ -182,4 +182,54 @@ class QueryClausesTest extends AbstractProductFiltersTest {
 
 		$this->assertEqualsCanonicalizing( $expected_products_name, $received_products_name );
 	}
+
+	/**
+	 * Test the product query with post clauses containing taxonomy clauses.
+	 *
+	 * @testWith ["product_cat", ["cat-1"]]
+	 *           ["product_cat", ["cat-2"]]
+	 *           ["product_cat", ["cat-1", "cat-2"]]
+	 *           ["product_tag", ["tag-1"]]
+	 *           ["product_tag", ["tag-2", "tag-3"]]
+	 *
+	 * @param string   $taxonomy Taxonomy name.
+	 * @param string[] $terms    Chosen terms' slug.
+	 */
+	public function test_taxonomy_clauses_with( $taxonomy, $terms ) {
+		$chosen_taxonomies = array(
+			$taxonomy => $terms,
+		);
+		$filter_callback   = function ( $args ) use ( $chosen_taxonomies ) {
+			return $this->sut->add_taxonomy_clauses( $args, $chosen_taxonomies );
+		};
+
+		add_filter( 'posts_clauses', $filter_callback );
+		$received_products_name = $this->get_data_from_products_array(
+			wc_get_products( array() )
+		);
+		remove_filter( 'posts_clauses', $filter_callback );
+
+		$expected_products_name = $this->get_data_from_products_array(
+			array_filter(
+				$this->products,
+				function ( \WC_Product $product ) use ( $chosen_taxonomies ) {
+					foreach ( $chosen_taxonomies as $taxonomy => $terms ) {
+						$product_terms = wp_get_post_terms( $product->get_id(), $taxonomy, array( 'fields' => 'slugs' ) );
+
+						if ( is_wp_error( $product_terms ) ) {
+							return false;
+						}
+
+						// Check if product has any of the requested terms (OR logic)
+						if ( empty( array_intersect( $terms, $product_terms ) ) ) {
+							return false;
+						}
+					}
+					return true;
+				}
+			)
+		);
+
+		$this->assertEqualsCanonicalizing( $expected_products_name, $received_products_name );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/QueryClausesTest.php
@@ -220,7 +220,7 @@ class QueryClausesTest extends AbstractProductFiltersTest {
 							return false;
 						}
 
-						// Check if product has any of the requested terms (OR logic)
+						// Check if product has any of the requested terms (OR logic).
 						if ( empty( array_intersect( $terms, $product_terms ) ) ) {
 							return false;
 						}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds support for filtering products by public taxonomies using `filter_*` parameters in the main query and product collection queries. This enables taxonomy filtering alongside existing attribute filters.

- Added automatic registration of `filter_*` query vars for all public product taxonomies.
- Added `add_taxonomy_clauses()` method in `QueryClauses` class that uses efficient EXISTS subqueries.
- Uses EXISTS subqueries instead of JOINs to avoid duplicate rows and improve query performance
- Refactored `QueryClauses` to implement new `MainQueryClausesGenerator` interface for using in `MainQueryController`.
- I take this chance to refactor how we manage filter URL parameters to make it more manageable by having a single source of truth for all parameters we use.

Closes WOOPLUG-4916. Closes https://github.com/woocommerce/woocommerce/issues/59463.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters to the Product Catalog template.
2. Enable Product Counts for all filters which have that setting.
3. On the frontend, manually add taxonomy filter parameter to the URL, verify the count and product result are correct.
  - Try different category
  - Try adding taxonomy filter param to filtered URL.

From our internal conversation, we agreed to use these params for built in taxonomy:
- `categories` for product categories.
- `tags` for product tags.
- `brands` for product brands.

For custom taxonomy, the param name format is `filter_<taxonomy_name>`. We can consider adding a filter later enabling 3PDs to change the param name of custom taxonomy, but only when we see real demand.

<details><summary>Screenshots</summary>
<p>

<img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/ccbd5fd0-144d-4972-b2af-a402478c4e4b" />
<img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/4b9a6203-d5e4-43d1-b91d-b9f52768527f" />
<img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/13446fad-1aa2-45a5-bc69-31f8fb25433d" />


</p>
</details> 