### PR TITLE
Add support for querying deleted fulfillments programmatically on backend

### DIFF
--- a/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
@@ -148,7 +148,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		$data_id          = $data->get_id();
 		$fulfillment_data = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE fulfillment_id = %d AND date_deleted IS NULL",
+				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE fulfillment_id = %d",
 				$data_id
 			),
 			ARRAY_A
@@ -173,6 +173,11 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 	 * @throws \Exception If the fulfillment can't be updated.
 	 */
 	public function update( &$data ): void {
+		// If the fulfillment is deleted, do nothing.
+		if ( $data->get_date_deleted() ) {
+			return;
+		}
+
 		// Update the fulfillment in the database.
 		$data_id = $data->get_id();
 
@@ -280,6 +285,10 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 	 * @throws \Exception If the fulfillment can't be deleted.
 	 */
 	public function delete( &$data, $args = array() ): void {
+		// If the record is already deleted, do nothing.
+		if ( $data->get_date_deleted() ) {
+			return;
+		}
 
 		/**
 		 * Filter to modify the fulfillment data before it is updated.
@@ -339,10 +348,6 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 			throw new \Exception( esc_html__( 'Invalid fulfillment.', 'woocommerce' ) );
 		}
 
-		if ( $data->get_date_deleted() ) {
-			throw new \Exception( esc_html__( 'Cannot read meta from a deleted fulfillment.', 'woocommerce' ) );
-		}
-
 		// Read the metadata for the fulfillment.
 		global $wpdb;
 
@@ -378,6 +383,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		// Check if the fulfillment and meta are saved.
 		$data_id = $data->get_id();
 
+		// Prevent deletion of metadata from a deleted fulfillment.
 		if ( $data->get_date_deleted() ) {
 			throw new \Exception( esc_html__( 'Cannot delete meta from a deleted fulfillment.', 'woocommerce' ) );
 		}
@@ -416,6 +422,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		// Add the metadata for the fulfillment.
 		global $wpdb;
 
+		// Prevent adding metadata to a deleted fulfillment.
 		if ( $data->get_date_deleted() ) {
 			throw new \Exception( esc_html__( 'Cannot add meta to a deleted fulfillment.', 'woocommerce' ) );
 		}
@@ -463,6 +470,7 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 
 		$data_id = $data->get_id();
 
+		// Prevent updating metadata for a deleted fulfillment.
 		if ( $data->get_date_deleted() ) {
 			throw new \Exception( esc_html__( 'Cannot update meta for a deleted fulfillment.', 'woocommerce' ) );
 		}
@@ -500,23 +508,35 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 	 *
 	 * @param string $entity_type The entity type.
 	 * @param string $entity_id The entity ID.
+	 * @param bool   $with_deleted Whether to include deleted fulfillments in the results.
 	 *
 	 * @return Fulfillment[] Fulfillment object.
 	 *
 	 * @throws \Exception If the fulfillment data can't be read.
 	 */
-	public function read_fulfillments( string $entity_type, string $entity_id ): array {
+	public function read_fulfillments( string $entity_type, string $entity_id, bool $with_deleted = false ): array {
 		// Read the fulfillment data from the database.
 		global $wpdb;
 
-		$fulfillment_data = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE entity_type = %s AND entity_id = %s AND date_deleted IS NULL",
-				$entity_type,
-				$entity_id
-			),
-			ARRAY_A
-		);
+		if ( ! $with_deleted ) {
+			$fulfillment_data = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE entity_type = %s AND entity_id = %s AND date_deleted IS NULL",
+					$entity_type,
+					$entity_id
+				),
+				ARRAY_A
+			);
+		} else {
+			$fulfillment_data = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE entity_type = %s AND entity_id = %s",
+					$entity_type,
+					$entity_id
+				),
+				ARRAY_A
+			);
+		}
 
 		if ( is_wp_error( $fulfillment_data ) ) {
 			throw new \Exception( esc_html__( 'Failed to read fulfillment data.', 'woocommerce' ) );

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -291,6 +291,8 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response The fulfillment for the order, or an error if the request fails.
+	 *
+	 * @throws \Exception If the fulfillment is not found or is deleted.
 	 */
 	public function get_fulfillment( WP_REST_Request $request ): WP_REST_Response {
 		$order_id       = (int) $request->get_param( 'order_id' );
@@ -300,6 +302,12 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 		try {
 			$fulfillment = new Fulfillment( $fulfillment_id );
 			$this->validate_fulfillment( $fulfillment, $fulfillment_id, $order_id );
+			if ( $fulfillment->get_date_deleted() ) {
+				throw new \Exception(
+					esc_html__( 'Fulfillment not found.', 'woocommerce' ),
+					WP_Http::NOT_FOUND
+				);
+			}
 		} catch ( \Exception $e ) {
 			return $this->prepare_error_response(
 				$e->getCode(),

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -463,9 +463,9 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$this->store->delete( $fulfillment );
 		$this->assertTrue( $hook_called, 'The fulfillment before delete hook was not called.' );
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Fulfillment not found.' );
-		new Fulfillment( $fulfillment_id );
+		// Verify the fulfillment can still be read but is marked as deleted.
+		$deleted_fulfillment = new Fulfillment( $fulfillment_id );
+		$this->assertNotNull( $deleted_fulfillment->get_date_deleted(), 'Fulfillment should be marked as deleted.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -499,6 +499,173 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that deleted fulfillments can be read by ID.
+	 */
+	public function test_read_deleted_fulfillment_by_id() {
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_status( 'unfulfilled' );
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 2,
+				),
+			)
+		);
+		self::$order_fulfillment_data_store->create( $fulfillment );
+
+		$fulfillment_id = $fulfillment->get_id();
+		$this->assertNotNull( $fulfillment_id );
+
+		// Delete the fulfillment.
+		self::$order_fulfillment_data_store->delete( $fulfillment );
+
+		// Create a new fulfillment object and try to read the deleted one.
+		$deleted_fulfillment = new Fulfillment();
+		$deleted_fulfillment->set_id( $fulfillment_id );
+
+		// Should be able to read deleted fulfillment by ID.
+		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+
+		$this->assertEquals( $fulfillment_id, $deleted_fulfillment->get_id() );
+		$this->assertEquals( 'order-fulfillment', $deleted_fulfillment->get_entity_type() );
+		$this->assertEquals( '123', $deleted_fulfillment->get_entity_id() );
+		$this->assertNotNull( $deleted_fulfillment->get_date_deleted() );
+	}
+
+	/**
+	 * Tests that deleted fulfillments cannot be updated.
+	 */
+	public function test_update_deleted_fulfillment_fails() {
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_status( 'unfulfilled' );
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 2,
+				),
+			)
+		);
+		self::$order_fulfillment_data_store->create( $fulfillment );
+
+		$fulfillment_id = $fulfillment->get_id();
+		$this->assertNotNull( $fulfillment_id );
+
+		// Delete the fulfillment.
+		self::$order_fulfillment_data_store->delete( $fulfillment );
+
+		// Create a new fulfillment object and read the deleted one.
+		$deleted_fulfillment = new Fulfillment();
+		$deleted_fulfillment->set_id( $fulfillment_id );
+		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+
+		// Try to update the deleted fulfillment - should not affect any rows.
+		$deleted_fulfillment->set_entity_id( '456' );
+		$deleted_fulfillment->set_status( 'fulfilled' );
+
+		// Update should not throw an error but should not affect any rows.
+		self::$order_fulfillment_data_store->update( $deleted_fulfillment );
+
+		// Verify the database record was not updated.
+		global $wpdb;
+		$record = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE fulfillment_id = %d",
+				$fulfillment_id
+			)
+		);
+
+		$this->assertNotNull( $record );
+		$this->assertEquals( '123', $record->entity_id ); // Should still be original value.
+		$this->assertEquals( 'unfulfilled', $record->status ); // Should still be original value.
+		$this->assertNotNull( $record->date_deleted ); // Should still be deleted.
+	}
+
+	/**
+	 * Tests that deleting an already deleted fulfillment returns early without side effects.
+	 */
+	public function test_delete_already_deleted_fulfillment_returns_early() {
+		$fulfillment = new Fulfillment();
+		$fulfillment->set_entity_type( 'order-fulfillment' );
+		$fulfillment->set_entity_id( '123' );
+		$fulfillment->set_status( 'unfulfilled' );
+		$fulfillment->set_items(
+			array(
+				array(
+					'item_id' => 1,
+					'qty'     => 2,
+				),
+			)
+		);
+		self::$order_fulfillment_data_store->create( $fulfillment );
+
+		$fulfillment_id = $fulfillment->get_id();
+		$this->assertNotNull( $fulfillment_id );
+
+		// Delete the fulfillment the first time.
+		self::$order_fulfillment_data_store->delete( $fulfillment );
+
+		// At this point, the fulfillment object should be reset.
+		$this->assertEquals( 0, $fulfillment->get_id() );
+
+		// Read the deleted fulfillment back.
+		$deleted_fulfillment = new Fulfillment();
+		$deleted_fulfillment->set_id( $fulfillment_id );
+		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+
+		$first_deletion_time = $deleted_fulfillment->get_date_deleted();
+		$this->assertNotNull( $first_deletion_time );
+
+		// Track action calls to verify hooks are not called on second delete.
+		$before_delete_called = false;
+		$after_delete_called  = false;
+
+		add_action(
+			'wc_fulfillment_before_delete',
+			function () use ( &$before_delete_called ) {
+				$before_delete_called = true;
+			}
+		);
+
+		add_action(
+			'wc_fulfillment_after_delete',
+			function () use ( &$after_delete_called ) {
+				$after_delete_called = true;
+			}
+		);
+
+		// Try to delete the already deleted fulfillment - should return early.
+		self::$order_fulfillment_data_store->delete( $deleted_fulfillment );
+
+		// Verify hooks were not called.
+		$this->assertFalse( $before_delete_called );
+		$this->assertFalse( $after_delete_called );
+
+		// Verify the fulfillment object was not reset again.
+		$this->assertEquals( $fulfillment_id, $deleted_fulfillment->get_id() );
+		$this->assertEquals( 'order-fulfillment', $deleted_fulfillment->get_entity_type() );
+		$this->assertEquals( '123', $deleted_fulfillment->get_entity_id() );
+		$this->assertEquals( $first_deletion_time, $deleted_fulfillment->get_date_deleted() );
+
+		// Verify the database record was not modified.
+		global $wpdb;
+		$record = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}wc_order_fulfillments WHERE fulfillment_id = %d",
+				$fulfillment_id
+			)
+		);
+
+		$this->assertNotNull( $record );
+		$this->assertEquals( $first_deletion_time, $record->date_deleted );
+	}
+
+	/**
 	 * Create a test fulfillment and save it to the database.
 	 *
 	 * @param string $entity_type The entity type.

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
@@ -93,9 +93,9 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 
 		$fulfillment->delete();
 
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Fulfillment not found.' );
-		new Fulfillment( $fulfillment_id );
+		// Verify the fulfillment can still be read but is marked as deleted.
+		$deleted_fulfillment = new Fulfillment( $fulfillment_id );
+		$this->assertNotNull( $deleted_fulfillment->get_date_deleted(), 'Fulfillment should be marked as deleted.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
 
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsManager;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 use Automattic\WooCommerce\Internal\Fulfillments\Providers as ShippingProviders;
 
@@ -15,6 +16,8 @@ class ShippingProvidersTest extends \WP_UnitTestCase {
 	 * Test that the shipping providers configuration returns the correct classes.
 	 */
 	public function test_shipping_providers_configuration(): void {
+		new FulfillmentsManager(); // Ensure the FulfillmentsManager is initialized to load the shipping providers.
+
 		$shipping_providers = FulfillmentUtils::get_shipping_providers();
 
 		foreach ( $shipping_providers as $key => $provider_class ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR enhances the FulfillmentsDataStore to properly support querying deleted fulfillments while maintaining appropriate access controls.

**Key Changes:**
- **Data Store Level**: Modified `read_meta()`, `update()`, and `delete()` methods to properly handle deleted fulfillments
- **Programmatic Access**: Deleted fulfillments can be read via code for internal operations and data recovery
- **REST API Protection**: REST controller separately prevents deleted fulfillments from being accessed via API
- **Optimization**: Added early returns to prevent unnecessary database operations and hook executions

**Implementation Details:**
- Allow reading metadata from deleted fulfillments (removed restriction in `read_meta()`)
- Prevent updates to deleted fulfillments (early return in `update()` method)  
- Prevent re-deleting already deleted fulfillments (early return in `delete()` method)
- Comprehensive test coverage for all deleted fulfillment scenarios

Closes #59503 WOOPLUG-4933

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. The code should make sense, and all tests should pass, check if the new tests are covering all possibilities.
2. Enable the fulfillments feature flag: `update_option('woocommerce_feature_fulfillments_enabled', 'yes' )`
3. Create a fulfillment, delete it, it shouldn't show on the UI.
4. Try to fetch the fulfillment via `new Fulfillment( [the deleted fulfillment ID] )` by adding a `var_dump` and `die` debugger on any class. 
5. It should read the fulfillment, and the fulfillment should have deleted date set. 
6. The fulfillment should contain the metadata.
7. Read the fulfillments of the order via code, and with `$with_deleted` as `true`
8. The fulfillments list should contain the deleted fulfillment, and its meta.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a part of a feature branch as a sub-issue. Sub issues don't need a changelog entry, because the feature will be merged with a single changelog item.
</details>