### PR TITLE
Remove Mini Cart template part from block inserter

### DIFF
--- a/plugins/woocommerce/changelog/fix-43316
+++ b/plugins/woocommerce/changelog/fix-43316
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove Mini Cart template part from block inserter.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/index.tsx
@@ -48,14 +48,14 @@ registerBlockType( metadata, {
 // Remove the Mini Cart template part from the block inserter.
 addFilter(
 	'blocks.registerBlockType',
-	'woocommerce/mini-cart',
+	'woocommerce/area_mini-cart',
 	function ( blockSettings, blockName ) {
 		if ( blockName === 'core/template-part' ) {
 			return {
 				...blockSettings,
 				variations: blockSettings.variations.map(
 					( variation: { name: string } ) => {
-						if ( variation.name === 'mini-cart' ) {
+						if ( variation.name === 'area_mini-cart' ) {
 							return {
 								...variation,
 								scope: [],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the removal logic of the Mini Cart template part from the block inserter by conditionally filtering it's block variation in the `Mini-Cart` block using the variation name `area_mini-cart`.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #43316

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/3284a790-b507-47ea-9412-ce73e72ac238

| Before | After |
| ------ | ----- |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/215aee6b-e761-48c9-9160-ff58b2beac80" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/8a36f2b3-4afb-4953-acc8-1f7a679491f4" /> |



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Appearance > Site Editor.
2. Edit any template and type `/mini` so the quick inserter appears.
3. Notice only single option appears: the Mini-Cart block
4. The Mini-Cart template part not not present in the inserter menu.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
