### PR TITLE
Add back not-allowed cursor to invalid Add to Cart + Options form

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-disabled-button-cursor
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-disabled-button-cursor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add back not-allowed cursor to invalid Add to Cart + Options form
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -68,7 +68,9 @@
 	}
 }
 
-:where(.wc-block-add-to-cart-with-options.is-invalid .wp-block-woocommerce-product-button .add_to_cart_button) {
+// `cursor` needs to override some styles from WordPress core, that's why we
+// need extra specificity.
+:where(.wc-block-add-to-cart-with-options.is-invalid) .wp-block-woocommerce-product-button .add_to_cart_button {
 	cursor: not-allowed;
 	opacity: 0.5;
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -34,8 +34,11 @@ class AddToCartWithOptions extends AbstractBlock {
 	 */
 	protected function enqueue_data( array $attributes = array() ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'productTypes', wc_get_product_types() );
-		$this->asset_data_registry->add( 'addToCartWithOptionsTemplatePartIds', $this->get_template_part_ids() );
+
+		if ( is_admin() && ! WC()->is_rest_api_request() ) {
+			$this->asset_data_registry->add( 'productTypes', wc_get_product_types() );
+			$this->asset_data_registry->add( 'addToCartWithOptionsTemplatePartIds', $this->get_template_part_ids() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59364.

Fixes a regression caused by https://github.com/woocommerce/woocommerce/pull/59364 where we decrease the specificity of the selector that was adding the `not-allowed` cursor to the Add to Cart + Options button when the form was invalid, causing it to be overridden by a WordPress core CSS rule.

I also took the opportunity to move the `productTypes` and `addToCartWithOptionsTemplatePartIds` settings to be loaded in the admin only.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Debug switching product types and verify template parts are loaded correctly.
4. Go to the frontend of a variable product. Make sure not to select all attributes.
5. Verify hovering the _Add to cart_ button shows a `not-allowed` cursor.

Before | After
--- | ---
![imatge](https://github.com/user-attachments/assets/11df9578-0894-4f94-bf32-4f5bd9fc9271) | ![imatge](https://github.com/user-attachments/assets/7a84aabe-81b2-42ca-801f-55ade66baa1a)