### PR TITLE
Ensure add-to-cart URLs respect the current URL and its arguments when AJAX mode is off

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-673
+++ b/plugins/woocommerce/changelog/wooplug-673
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updated add-to-cart URLs to maintain current URL and arguments when AJAX mode is disabled.

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -47,7 +47,7 @@ class WC_Product_Simple extends WC_Product {
 				array(
 					'add-to-cart' => $this->get_id(),
 				),
-				( function_exists( 'is_feed' ) && is_feed() ) || ( function_exists( 'is_404' ) && is_404() ) ? $this->get_permalink() : ''
+				( function_exists( 'is_feed' ) && is_feed() ) || ( function_exists( 'is_404' ) && is_404() ) ? $this->get_permalink() : false
 			)
 		) : $this->get_permalink();
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPLUG-673: Add to cart button redirects to homepage when plain permalinks is used and ajax add to cart is turned off](https://linear.app/a8c/issue/WOOPLUG-673/add-to-cart-button-redirects-to-homepage-when-plain-permalinks-is-used)
Closes #32642

This issue seems to be a regression of #24545, where we fixed the case for permalinks in the feed context. It appears that the fallback to an empty string was intended to cover the "current URL" case, which does not align with how the `add_query_arg()` helper works. To allow for the "current" URL, the second argument must either be (1) omitted or (2) set to `false`. This PR does exactly that.

(For Bug Fixes) Bug introduced in PR #24545

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|![Screenshot 2025-07-08 at 4 25 15 PM](https://github.com/user-attachments/assets/7a27e96b-5ac6-4c61-ae9a-dc0657344a72)|![Screenshot 2025-07-08 at 4 24 50 PM](https://github.com/user-attachments/assets/e97d9dc5-f428-4cda-b861-51876fcbb1f2)|

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites
1.  Ensure the "Enable AJAX add to cart buttons on archives" setting is turned off under **WooCommerce > Settings > Products > General**.
2. Make sure you have a few products in the catalog, ideally enough to return more than one product when searching for a keyword, e.g., 'Beanie'.
3. Set permalinks to "Plain" under **Tools > Permalinks**.

#### Testing steps
1. Search for a product using the search bar at the top right.
4. Click the add-to-cart button for a Simple product in the search results.
5. Notice that this redirects you to the homepage. 
6. Apply this fix.
7. Search again and click the same add-to-cart button.
8. Confirm that you remain on the current URL while the product is successfully added to the cart.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
