### PR TITLE
Fix 'too much recursion' error when interacting with the Add to Cart + Options quantity selector

### DIFF
--- a/plugins/woocommerce/changelog/fix-59523-add-to-cart-with-options-too-much-recursion
+++ b/plugins/woocommerce/changelog/fix-59523-add-to-cart-with-options-too-much-recursion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix 'too much recursion' error when interacting with the an Add to Cart + Options quantity selector
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -47,9 +47,7 @@ const getInputElementFromEvent = (
 	let inputElement = null;
 
 	if ( event.target instanceof HTMLButtonElement ) {
-		inputElement = event.target.parentElement?.querySelector(
-			'.input-text.qty.text'
-		);
+		inputElement = event.target.parentElement?.querySelector( '.qty' );
 	}
 
 	if ( event.target instanceof HTMLInputElement ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -303,12 +303,14 @@ const addToCartWithOptionsStore = store(
 					Math.max( minValue, currentValue )
 				);
 
-				addToCartWithOptionsStore.actions.setQuantity(
-					newValue,
-					childProductId
-				);
-				event.target.value = newValue.toString();
-				dispatchChangeEvent( event.target );
+				if ( event.target.value !== newValue.toString() ) {
+					addToCartWithOptionsStore.actions.setQuantity(
+						newValue,
+						childProductId
+					);
+					event.target.value = newValue.toString();
+					dispatchChangeEvent( event.target );
+				}
 			},
 			handleQuantityCheckboxChange: (
 				event: HTMLElementEvent< HTMLInputElement >

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -35,7 +35,7 @@
 			font-size: inherit;
 		}
 
-		:where(input[type="number"].input-text.qty.text) {
+		:where(input[type="number"].qty) {
 			-moz-appearance: textfield;
 			border: unset;
 			text-align: center;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59523.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59408.

Since #59408, we were updating the quantity inputs inside the _Add to Cart + Options_ block when the quantity changed. That allows us to avoid incorrect quantities being added to the cart. But I missed it was _alwasys_ triggered, even when the input and the new value were the same, causing an infinite recursion. :man_facepalming: 

Thanks @helgatheviking for reporting this issue and the potential fix.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Go to the page of a product in the frontend.
4. Click on the quantity selector buttons.
5. Verify there are no JS errors in your console.