### PR TITLE
Reduce quantity selector block style rules specificity 

### DIFF
--- a/plugins/woocommerce/changelog/issues-59525-quantity-input-style-specificity
+++ b/plugins/woocommerce/changelog/issues-59525-quantity-input-style-specificity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Reduce quantity selector block style rules specificity

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -15,56 +15,53 @@
 	}
 }
 
-:where(.wc-block-add-to-cart-with-options__quantity-selector),
-:where(.wc-block-add-to-cart-with-options-grouped-product-item-selector) {
-	// This resets some WC component styles, so we need it to have specificity
-	// until those stylesheets are updated.
-	.wc-block-components-quantity-selector.wc-block-components-quantity-selector {
-		display: inline-flex;
-		width: unset;
-		margin-bottom: 0;
-		margin-right: 0;
+// This resets some WC component styles, so we need it to have specificity
+// until those stylesheets are updated.
+.wc-block-components-quantity-selector.wc-block-components-quantity-selector {
+	display: inline-flex;
+	width: unset;
+	margin-bottom: 0;
+	margin-right: 0;
+}
+:where(.wc-block-components-quantity-selector) {
+	&::after {
+		border: 1px solid currentColor;
+		opacity: 0.3;
 	}
-	:where(.wc-block-components-quantity-selector) {
-		&::after {
-			border: 1px solid currentColor;
-			opacity: 0.3;
-		}
 
-		:where(.input-text) {
-			font-size: inherit;
-		}
+	:where(.input-text) {
+		font-size: inherit;
+	}
 
-		:where(input[type="number"].input-text.qty.text) {
-			-moz-appearance: textfield;
-			border: unset;
-			text-align: center;
-			order: 2;
-			font-weight: 600;
-			background-color: transparent;
-			color: currentColor;
-			margin: 0;
-			font-size: 0.8em;
-			height: 1.5em;
-			box-sizing: content-box;
-			/**
-			* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
-			*
-			* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
-			*/
-			padding: 0.9rem 0;
-			margin-right: unset;
+	:where(input[type="number"].qty) {
+		-moz-appearance: textfield;
+		border: unset;
+		text-align: center;
+		order: 2;
+		font-weight: 600;
+		background-color: transparent;
+		color: currentColor;
+		margin: 0;
+		font-size: 0.8em;
+		height: 1.5em;
+		box-sizing: content-box;
+		/**
+		* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
+		*
+		* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
+		*/
+		padding: 0.9rem 0;
+		margin-right: unset;
 
-			&:focus {
-				border-radius: unset;
-			}
+		&:focus {
+			border-radius: unset;
 		}
+	}
 
-		:where(input[type="number"]::-webkit-inner-spin-button),
-		:where(input[type="number"]::-webkit-outer-spin-button) {
-			-webkit-appearance: none;
-			margin: 0;
-		}
+	:where(input[type="number"]::-webkit-inner-spin-button),
+	:where(input[type="number"]::-webkit-outer-spin-button) {
+		-webkit-appearance: none;
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
Makes it easier to inherit style in extension plugins.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change the style targets to only 2 levels of nesting and a single `.qty` class.

Closes #59525  .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

after: ![image](https://github.com/user-attachments/assets/56d0502a-6b99-4523-92c1-09a734465e68)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review a grouped product on the front end, plus/minus buttons should look the same
2. Review a single product on the front end, plus/minus buttons should look the same


