### PR TITLE
Restore previous `init_session_cookie` behaviour to prevent conflicts with classes extending `WC_Session_Handler`

### DIFF
--- a/plugins/woocommerce/changelog/fix-session-handler-customer-id-unset
+++ b/plugins/woocommerce/changelog/fix-session-handler-customer-id-unset
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Restore previous behaviour where init_session_cookie will create a new customer_id if no cookie exists.
+
+

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -97,12 +97,11 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Initialize the session from either the request or the cookie. If neither are present, generate a new customer ID.
+	 * Initialize the session from either the request or the cookie.
 	 */
 	private function init_session() {
-		if ( ! $this->init_session_from_request() && ! $this->init_session_from_cookie() ) {
-			$this->_customer_id = $this->generate_customer_id();
-			$this->_data        = $this->get_session_data();
+		if ( ! $this->init_session_from_request() ) {
+			$this->init_session_cookie();
 		}
 	}
 
@@ -155,16 +154,6 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Initialize the session from the cookie.
-	 *
-	 * @return bool
-	 */
-	private function init_session_from_cookie() {
-		$this->init_session_cookie();
-		return null !== $this->_customer_id;
-	}
-
-	/**
 	 * Setup cookie and customer ID.
 	 *
 	 * @since 3.6.0
@@ -173,6 +162,9 @@ class WC_Session_Handler extends WC_Session {
 		$cookie = $this->get_session_cookie();
 
 		if ( ! $cookie ) {
+			// If there is no cookie, generate a new session/customer ID.
+			$this->_customer_id = $this->generate_customer_id();
+			$this->_data        = $this->get_session_data();
 			return;
 		}
 

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -176,16 +176,16 @@ class WC_Session_Handler extends WC_Session {
 
 		$this->restore_session_data();
 
+		/**
+		 * This clears the session if the cookie is invalid.
+		 *
+		 * Previously this also cleared the session when $this->_data was empty, and the cart was not yet initialised,
+		 * however this caused a conflict with WooCommerce Payments session handler which overrides this class.
+		 *
+		 * Ref: https://github.com/woocommerce/woocommerce/pull/57652
+		 * See also: https://github.com/woocommerce/woocommerce/pull/59530
+		 */
 		if ( ! $this->is_session_cookie_valid() ) {
-			$this->destroy_session();
-		} elseif ( empty( $this->_data ) && ! isset( WC()->cart ) ) {
-			/**
-			 * Only destroy an empty session if the cart has not been previously initialized.
-			 * We cannot always safely remove the session cookie and destroy the session if the cart is already
-			 * initialized as $this->forget_session() calls `wc_empty_cart()` and can't be removed without potentially
-			 * breaking backward compatibility in cases where another extension already loaded and modified the cart
-			 * before the session.
-			 */
 			$this->destroy_session();
 		}
 

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -193,7 +193,7 @@ class CheckoutLink {
 
 		// If the user is logged in, the session is tied to the user ID. Do not use a cart token.
 		if ( ! is_user_logged_in() ) {
-			$session_token = CartTokenUtils::get_cart_token( wc()->session->get_customer_id() );
+			$session_token = CartTokenUtils::get_cart_token( (string) wc()->session->get_customer_id() );
 			$redirect_url  = add_query_arg( 'session', $session_token, $redirect_url );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -197,7 +197,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 			return null;
 		}
 
-		return CartTokenUtils::get_cart_token( wc()->session->get_customer_id() );
+		return CartTokenUtils::get_cart_token( (string) wc()->session->get_customer_id() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
@@ -232,6 +232,8 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 	 * @testdox Test that session is destroyed if the session data is empty and the cart is not yet initialized.
 	 */
 	public function test_destroy_session_data_is_empty() {
+		$this->markTestSkipped( 'This change was reverted due to a conflict in https://github.com/woocommerce/woocommerce/pull/59530' );
+
 		$customer_id        = (string) get_current_user_id();
 		$session_expiration = time() + 50000;
 		$session_expiring   = time() + 5000;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes two conflicts with the WooCommerce Payments session handler override caused by two separate changes on the core session handler.

1. `init_session_cookie` previously created a customer_id if no cookie existed, but this logic was moved. This caused issues with WooCommerce Payments which calls `init_session_cookie` and assumes customer ID will be set after doing so. The fix was to move customer_id generation back within `init_session_cookie`
2. `init_session_cookie` was modified to clear out (destroy) the session data when _data is empty and the cart is not initialised. This would result in the session cookie being wiped and the customer ID being regenerated. This broke WooCommerce Payments which needs the session and customer_id maintained to compare against data in its token. Fix was to remove the offending line and add an inline comment referencing these PRs to prevent a future regression without testing that case.

Also hardens some calls to `CartTokenUtils::get_cart_token` which expects a string. This is what was flagged in the error logs.

(For Bug Fixes) Bug introduced in PR(s): 

https://github.com/woocommerce/woocommerce/pull/58140
https://github.com/woocommerce/woocommerce/pull/57652

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Test the add to cart flow in an incognito session. Ensure you get a session and can add to cart/place order
3. Do the same logged in to ensure there are no regressions in user carts
4. Test a checkout link. e.g. https://store.local/checkout-link?products=16:1 in incognito. Ensure you're redirected to checkout with a cart. Copy the URL.
5. Start a new incognito session. Paste the URL containing the token. Ensure cart is populated and you're able to checkout.

For WooCommerce Payments:

1. Have WooPayments installed & onboarded (you can go through the guided setup by clicking on the "Payments" menu on wp-admin
2. Have Google Pay/Apple Pay active in WooPayments (you can activate them through the guided setup or through WooCommerce > Settings > Checkout > WooPayments; check the "Google Pay/Apple Pay" checkbox; save the settings)
3. Use Google Chrome, with the google chrome account logged in
4. As an anonymous customer (not a logged-in customer, but don't use an private window), navigate to a product page of a physical product
5. The Google Pay button should appear
6. Click the Google Pay button
7. No error messages visible on the product page, or the modal window from Google Pay

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
