### PR TITLE
Ensure quantity inputs update if receiving new props from server

### DIFF
--- a/plugins/woocommerce/changelog/fix-quantity-not-updating
+++ b/plugins/woocommerce/changelog/fix-quantity-not-updating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent issue where quantity would not update correctly after being edited on the client and receiving an update from the data store.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/index.tsx
@@ -115,6 +115,8 @@ const QuantitySelector = ( {
 	 */
 	useLayoutEffect( () => {
 		if ( quantity === expectedQuantityRef.current ) {
+			// Reset expected quantity type to 'input' if the prop matches the current state.
+			expectedQuantityTypeRef.current = 'input';
 			return;
 		}
 		if (

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/test/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/quantity-selector/test/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -42,5 +43,54 @@ describe( 'QuantitySelector', () => {
 				`Reduce quantity of ${ defaults.itemName }`
 			)
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'resets expected quantity type after successful prop update', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		const { rerender } = render(
+			<QuantitySelector
+				{ ...defaults }
+				quantity={ 10 }
+				onChange={ onChange }
+			/>
+		);
+
+		// Click increase button
+		const decreaseButton = screen.getByLabelText(
+			`Reduce quantity of ${ defaults.itemName }`
+		);
+		await act( () => user.click( decreaseButton ) );
+
+		// Verify onChange was called with new quantity
+		expect( onChange ).toHaveBeenCalledWith( 9 );
+		rerender(
+			<QuantitySelector
+				{ ...defaults }
+				quantity={ 9 }
+				onChange={ onChange }
+			/>
+		);
+
+		// The input should reflect the new quantity (3)
+		let input = screen.getByLabelText(
+			`Quantity of ${ defaults.itemName } in your cart.`
+		);
+		expect( input ).toHaveValue( 9 );
+		// Now test that a subsequent prop change is not blocked
+		rerender(
+			<QuantitySelector
+				{ ...defaults }
+				quantity={ 30 }
+				onChange={ onChange }
+			/>
+		);
+
+		// The input should reflect the new quantity (3)
+		input = screen.getByLabelText(
+			`Quantity of ${ defaults.itemName } in your cart.`
+		);
+		expect( input ).toHaveValue( 30 );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When updating a product quantity on the client, the quantity input component tracks the expected next value when increasing/decreasing or changing the value in the input field (e.g. if you are on 9, and press + the expected next value is 10). If the server updates the quantity prop in an unexpected way, then it is ignored, because this likely means the shopper is in the middle of changing the value. The method by which the shopper is updating (increase, decrease, or input) is also tracked, specifically so we can avoid overwriting shoppers' inputs while in the middle of typing a quantity into the box.

If the _updated_ quantity (which comes from the server) matches the expected quantity, then the value is applied and the expected "method" is reset.

There was a bug where the "method" of this update was not cleared, so valid server updates were not applied to the input field.

This PR ensures that expected method is reset after successful quantity application to allow updates from the prop to apply again.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPLUG-4949](https://linear.app/a8c/issue/WOOPLUG-4949/quantity-inputs-do-not-update-with-new-props-from-server)

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58693

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/42e1e0dfeec844aea00ddc76c20d2948 | https://www.loom.com/share/997183ab5e6741189e4bece0f42600fb |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your have product bundled installed along with the changes of latest trunk.
2. Create a bundled product with a child product, and set the individual price of the child product. Do not set the price for the parent product for simplicity.
3. Add that bundled product to the cart. Goto cart.
4. Increase the quantity of the parent item, you'll see the child item quantity updates as expected.
5. Now reduce the quantity of the child item.
6. Try again to increase the quantity of the parent item, ensure the child item quantity updates as expected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
