### PR TITLE
Add documentation for block registration in the WooCommerce Email Editor

### DIFF
--- a/docs/contribution/releases/building-and-publishing.md
+++ b/docs/contribution/releases/building-and-publishing.md
@@ -47,8 +47,8 @@ sidebar_label: Building and Publishing
 ### Step 3: Verify Release Availability
 
 - Confirm the new release appears at:
-   - [https://plugins.svn.wordpress.org/woocommerce/tags/](https://plugins.svn.wordpress.org/woocommerce/tags/)
-   - The "Previous versions" dropdown on the [Advanced Options screen](https://wordpress.org/plugins/woocommerce/advanced/).
+    - [https://plugins.svn.wordpress.org/woocommerce/tags/](https://plugins.svn.wordpress.org/woocommerce/tags/)
+    - The "Previous versions" dropdown on the [Advanced Options screen](https://wordpress.org/plugins/woocommerce/advanced/).
 
 ### Step 4: Test and Validate the Release
 
@@ -58,18 +58,18 @@ sidebar_label: Building and Publishing
 ### Step 5: Update Stable Tag
 
 - **Condition:** Only perform this step if:
-   - The release is **not** an RC, **and**
-   - No major issues were found during testing and validation (Step 4).
+    - The release is **not** an RC, **and**
+    - No major issues were found during testing and validation (Step 4).
 - **Action:** Run the ["Release: Update stable tag" workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-update-stable-tag.yml) from `trunk`, set the version, and select the option to update the stable tag as part of the workflow input.
-   - Review and merge the pull requests for both the release branch and trunk.
+    - Review and merge the pull requests for both the release branch and trunk.
 
 ### Step 6: Publish GitHub Release Tag
 
 - **Action:** Publish the [previously created GitHub draft release tag](https://github.com/woocommerce/woocommerce/releases).
 - **When setting release status:**
-   - If releasing an RC, check "Set as a pre-release."
-   - If the version was marked as stable in Step 5, check "Set as the latest release."
-   - If the version was **not** marked as stable in Step 5, do **not** set as the latest release.
+    - If releasing an RC, check "Set as a pre-release."
+    - If the version was marked as stable in Step 5, check "Set as the latest release."
+    - If the version was **not** marked as stable in Step 5, do **not** set as the latest release.
 
 ## Decision Table
 

--- a/packages/php/email-editor/changelog/wooplug-4705-block-registration-api-add-instructions-how-to-register
+++ b/packages/php/email-editor/changelog/wooplug-4705-block-registration-api-add-instructions-how-to-register
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add documentation for block registration in the WooCommerce Email Editor

--- a/packages/php/email-editor/docs/README.md
+++ b/packages/php/email-editor/docs/README.md
@@ -2,5 +2,6 @@
 
 ## Documentation
 
+-   [Block Registration](block-registration.md) - Guide to registering WordPress blocks for email editor support, including configuration, rendering, and best practices.
 -   [Email Rendering](rendering.md) - Guide to the email rendering system, including renderer classes, bootstrapping, and core blocks integration.
 -   [Personalization Tags](personalization-tags.md) - Guide to the personalization tags system, including tag registration, usage, and integration with the email editor.

--- a/packages/php/email-editor/docs/block-registration.md
+++ b/packages/php/email-editor/docs/block-registration.md
@@ -69,7 +69,9 @@ The render callback should accept three parameters:
 
 ### Method 1: Using block_type_metadata_settings Filter
 
-The recommended approach is to use the `block_type_metadata_settings` filter to modify block settings during registration:
+The recommended approach is to add the `supports.email` to the block.json file or the JS client-side registration.
+
+Another approach is to use the `block_type_metadata_settings` filter to modify block settings during registration:
 
 ```php
 /**

--- a/packages/php/email-editor/docs/block-registration.md
+++ b/packages/php/email-editor/docs/block-registration.md
@@ -1,0 +1,455 @@
+# Block Registration for Email Editor
+
+This guide explains how to register WordPress blocks to support email rendering in the WooCommerce Email Editor. The email editor extends WordPress Gutenberg blocks with email-specific rendering capabilities, allowing blocks to generate HTML that is compatible with email clients.
+
+## Table of Contents
+
+-   [Overview](#overview)
+-   [Block Configuration](#block-configuration)
+    -   [Email Support Property](#email-support-property)
+    -   [Email Render Callback](#email-render-callback)
+-   [Registering Blocks for Email Support](#registering-blocks-for-email-support)
+    -   [Method 1: Using block_type_metadata_settings Filter](#method-1-using-block_type_metadata_settings-filter)
+    -   [Method 2: Direct Block Registration](#method-2-direct-block-registration)
+-   [Creating Email Block Renderers](#creating-email-block-renderers)
+    -   [Abstract Block Renderer](#abstract-block-renderer)
+    -   [Rendering Context](#rendering-context)
+    -   [Table Wrapper Helper](#table-wrapper-helper)
+-   [Complete Example](#complete-example)
+-   [Best Practices](#best-practices)
+-   [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The WooCommerce Email Editor allows WordPress blocks to be rendered in email-compatible HTML. To make a block compatible with email rendering, you need to:
+
+1. **Enable email support** by setting `supports.email = true` in the block configuration
+2. **Provide an email render callback** that generates email-compatible HTML
+3. **Implement the rendering logic** that converts block content to email-friendly markup
+
+The email editor automatically detects blocks with email support and uses their custom render callbacks instead of the default WordPress block rendering.
+
+## Block Configuration
+
+### Email Support Property
+
+To indicate that a block supports email rendering, set the `email` property to `true` in the block's `supports` configuration:
+
+```php
+$block_settings = array(
+    'name'     => 'my-plugin/custom-block',
+    'title'    => 'Custom Block',
+    'supports' => array(
+        'email' => true,  // Enable email support
+        // ... other supports
+    ),
+    // ... other settings
+);
+```
+
+### Email Render Callback
+
+Provide a custom render callback specifically for email rendering:
+
+```php
+$block_settings = array(
+    'name'                  => 'my-plugin/custom-block',
+    'render_email_callback' => array( $this, 'render_block_for_email' ),
+    // ... other settings
+);
+```
+
+The render callback should accept three parameters:
+- `string $block_content` - The original block HTML content
+- `array $parsed_block` - The parsed block data including attributes
+- `Rendering_Context $rendering_context` - Email rendering context
+
+## Registering Blocks for Email Support
+
+### Method 1: Using block_type_metadata_settings Filter
+
+The recommended approach is to use the `block_type_metadata_settings` filter to modify block settings during registration:
+
+```php
+/**
+ * Add email support to custom blocks.
+ */
+function add_email_support_to_blocks( $settings ) {
+    // List of blocks that should support email rendering
+    $email_supported_blocks = array(
+        'my-plugin/custom-block',
+        'my-plugin/another-block',
+    );
+
+    if ( in_array( $settings['name'], $email_supported_blocks, true ) ) {
+        // Enable email support
+        $settings['supports']['email'] = true;
+        
+        // Set email render callback
+        $settings['render_email_callback'] = array( 
+            'My_Plugin_Email_Renderer', 
+            'render_block' 
+        );
+    }
+
+    return $settings;
+}
+add_filter( 'block_type_metadata_settings', 'add_email_support_to_blocks', 10, 1 );
+```
+
+### Method 2: Direct Block Registration
+
+You can also register blocks directly with email support:
+
+```php
+/**
+ * Register a custom block with email support.
+ */
+function register_custom_email_block() {
+    register_block_type( 'my-plugin/custom-block', array(
+        'title'       => __( 'Custom Email Block', 'my-plugin' ),
+        'description' => __( 'A custom block with email support.', 'my-plugin' ),
+        'category'    => 'widgets',
+        'supports'    => array(
+            'email' => true,
+            // ... other supports
+        ),
+        'attributes'  => array(
+            'content' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
+            // ... other attributes
+        ),
+        'render_email_callback' => 'my_plugin_render_email_block',
+    ) );
+}
+add_action( 'init', 'register_custom_email_block' );
+```
+
+## Creating Email Block Renderers
+
+### Abstract Block Renderer
+
+For more complex blocks, you can create a dedicated renderer class that extends the abstract block renderer:
+
+```php
+<?php
+
+namespace My_Plugin\Email\Renderer;
+
+use Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Abstract_Block_Renderer;
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+
+/**
+ * Email renderer for custom block.
+ */
+class Custom_Block_Renderer extends Abstract_Block_Renderer {
+
+    /**
+     * Render the block content for email.
+     *
+     * @param string            $block_content Block content.
+     * @param array             $parsed_block Parsed block data.
+     * @param Rendering_Context $rendering_context Rendering context.
+     * @return string
+     */
+    public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+        $attributes = $parsed_block['attrs'] ?? array();
+        
+        // Extract block attributes
+        $content    = $attributes['content'] ?? '';
+        $text_color = $attributes['textColor'] ?? '';
+        $bg_color   = $attributes['backgroundColor'] ?? '';
+        
+        // Build email-compatible HTML
+        $styles = array();
+        if ( $text_color ) {
+            $styles[] = "color: {$text_color}";
+        }
+        if ( $bg_color ) {
+            $styles[] = "background-color: {$bg_color}";
+        }
+        
+        $style_attr = ! empty( $styles ) ? ' style="' . implode( '; ', $styles ) . '"' : '';
+        
+        $html = sprintf(
+            '<div%s>%s</div>',
+            $style_attr,
+            wp_kses_post( $content )
+        );
+        
+        // Wrap in email-compatible table structure
+        return Table_Wrapper_Helper::render_table_wrapper( $html );
+    }
+}
+```
+
+### Rendering Context
+
+The `Rendering_Context` object provides access to theme settings and other rendering context:
+
+```php
+public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
+    // Get theme settings
+    $theme = $rendering_context->get_theme_settings();
+    
+    // Access theme colors, fonts, etc.
+    $theme_settings = $theme->get_theme_styles();
+
+    // Get the theme json
+    $theme_settings = $theme->get_theme_json();
+    
+    // Use theme values in your rendering logic
+    // ...
+    
+    return $rendered_html;
+}
+```
+
+### Table Wrapper Helper
+
+Email clients have limited CSS support, so using table-based layouts is recommended. The `Table_Wrapper_Helper` provides utilities for creating email-compatible table structures:
+
+```php
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+
+// Basic table wrapper
+$html = Table_Wrapper_Helper::render_table_wrapper( $content );
+
+// Table wrapper with custom attributes
+$html = Table_Wrapper_Helper::render_table_wrapper(
+    $content,
+    array( 'width' => '100%' ),           // Table attributes
+    array( 'style' => 'padding: 20px;' ), // Cell attributes
+    array(),                              // Row attributes
+    true                                  // Render cell wrapper
+);
+```
+
+## Complete Example
+
+Here's a complete example of registering a custom block with email support:
+
+```php
+<?php
+/**
+ * Plugin Name: Custom Email Block
+ * Description: A newsletter signup block with email editor support
+ * Version: 1.0.0
+ * Author: Your Name
+ * Text Domain: my-plugin
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+
+/**
+ * Custom Email Block Plugin
+ */
+class My_Custom_Email_Block {
+
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_block' ) );
+    }
+
+    /**
+     * Register the custom block using direct registration.
+     */
+    public function register_block() {
+        // Enqueue the block JavaScript
+        wp_register_script(
+            'newsletter-signup-block',
+            plugin_dir_url( __FILE__ ) . 'simple-block.js',
+            array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+            '1.0.0'
+        );
+
+        // Register the block type
+        register_block_type( 'my-plugin/newsletter-signup', array(
+            'editor_script'   => 'newsletter-signup-block',
+            'render_callback' => array( $this, 'render_frontend_block' ),
+            'render_email_callback' => array( $this, 'render_email_block' ),
+        ) );
+    }
+
+    /**
+     * Render the block for frontend (non-email contexts).
+     */
+    public function render_frontend_block( $attributes ) {
+        $title       = $attributes['title'] ?? 'Subscribe to our newsletter';
+        $description = $attributes['description'] ?? 'Get the latest updates delivered to your inbox.';
+        $button_text = $attributes['buttonText'] ?? 'Subscribe';
+        $button_url  = $attributes['buttonUrl'] ?? '';
+
+        $html = '<div class="newsletter-signup-block">';
+        $html .= '<h3>' . esc_html( $title ) . '</h3>';
+        $html .= '<p>' . esc_html( $description ) . '</p>';
+
+        if ( $button_url && $button_text ) {
+            $html .= '<a href="' . esc_url( $button_url ) . '">' . esc_html( $button_text ) . '</a>';
+        }
+
+        $html .= '</div>';
+
+        return $html;
+    }
+
+    /**
+     * Render the block for email.
+     */
+    public function render_email_block( $block_content, $parsed_block, $rendering_context ) {
+        $attributes = $parsed_block['attrs'] ?? array();
+
+        $title       = $attributes['title'] ?? 'Default Email Title';
+        $description = $attributes['description'] ?? 'Default Email: Get the latest updates delivered to your inbox.';
+        $button_text = $attributes['buttonText'] ?? 'Default Email: Subscribe';
+        $button_url  = $attributes['buttonUrl'] ?? '';
+
+        // Create email-compatible HTML
+        $html = '<table role="presentation" cellpadding="0" cellspacing="0" style="width: 100%;">
+            <tr>
+                <td style="padding: 20px; text-align: center; background-color: #f8f9fa;">
+                    <h2 style="margin: 0 0 15px 0; font-family: Arial, sans-serif; color: #333;">' . esc_html( $title ) . '</h2>
+                    <p style="margin: 0 0 20px 0; font-family: Arial, sans-serif; color: #666; line-height: 1.5;">' . esc_html( $description ) . '</p>';
+
+        if ( $button_url && $button_text ) {
+            $html .= '<a href="' . esc_url( $button_url ) . '" style="display: inline-block; padding: 12px 24px; background-color: #007cba; color: #ffffff; text-decoration: none; border-radius: 4px; font-family: Arial, sans-serif;">' . esc_html( $button_text ) . '</a>';
+        }
+
+        $html .= '</td>
+            </tr>
+        </table>';
+
+        return $html;
+    }
+}
+
+// Initialize the plugin
+new My_Custom_Email_Block();
+```
+
+JS
+
+```javascript
+/**
+ * Simple test version of the newsletter block
+ */
+(function() {
+    console.log('Newsletter block JavaScript is loading...');
+
+    // Check if WordPress dependencies are available
+    if (typeof wp === 'undefined') {
+        console.error('WordPress dependencies not available');
+        return;
+    }
+
+    const { __ } = wp.i18n;
+    const { createElement } = wp.element;
+    const { registerBlockType } = wp.blocks;
+    const { useBlockProps } = wp.blockEditor;
+
+    console.log('Registering newsletter-signup block...');
+
+    registerBlockType('my-plugin/newsletter-signup', {
+        title: __('Newsletter Signup', 'my-plugin'),
+        icon: 'email-alt',
+        category: 'widgets',
+        description: __('A newsletter signup form for emails.', 'my-plugin'),
+		supports: {
+			email: true,
+		},
+        attributes: {
+            title: {
+                type: 'string',
+                default: 'Subscribe to our newsletter'
+            }
+        },
+
+        edit: function(props) {
+            const blockProps = useBlockProps();
+
+            return createElement(
+                'div',
+                blockProps,
+                createElement(
+                    'div',
+                    {
+                        style: {
+                            padding: '20px',
+                            border: '1px solid #ccc',
+                            textAlign: 'center'
+                        }
+                    },
+                    createElement('h3', null, props.attributes.title),
+                    createElement('p', null, 'Newsletter signup block - working!')
+                )
+            );
+        },
+
+        save: function() {
+            return null; // Server-side rendering
+        }
+    });
+
+    console.log('Newsletter signup block registered successfully!');
+})();
+```
+
+## Best Practices
+
+### Email-Compatible HTML
+
+1. **Use table-based layouts** - Email clients have inconsistent CSS support
+2. **Inline CSS styles** - External stylesheets are often blocked
+3. **Avoid complex CSS** - Stick to basic properties like color, background-color, padding
+4. **Use web-safe fonts** - Arial, Helvetica, Times New Roman, etc.
+5. **Test across email clients** - Use tools like Litmus or Email on Acid
+
+### Block Design
+
+1. **Keep it simple** - Complex layouts may not render consistently
+2. **Use semantic HTML** - Helps with accessibility and rendering
+3. **Provide fallbacks** - Graceful degradation for unsupported features
+4. **Consider mobile** - Many emails are read on mobile devices
+
+### Code Quality
+
+1. **Escape output** - Use `esc_html()`, `esc_url()`, `wp_kses_post()` appropriately
+2. **Validate input** - Check attributes and provide sensible defaults
+3. **Handle errors gracefully** - Return original content if rendering fails
+4. **Follow WordPress coding standards** - Consistent code style
+
+## Troubleshooting
+
+### Block Not Rendering in Email
+
+1. **Check email support** - Ensure `supports.email` is set to `true`
+2. **Verify callback** - Confirm `render_email_callback` is properly set
+3. **Hook timing** - Make sure filters are added before block registration
+4. **Check block name** - Ensure the block name matches exactly
+
+### Email Display Issues
+
+1. **Test in multiple clients** - Different email clients handle HTML differently
+2. **Validate HTML** - Use an HTML validator to check for errors
+3. **Check CSS support** - Some CSS properties are not supported in emails
+4. **Use tables for layout** - More reliable than CSS flexbox/grid in emails
+
+### Debug Information
+
+Enable debug logging to troubleshoot issues:
+
+```php
+// Add this to wp-config.php for debugging
+define( 'WP_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );
+
+// The email editor logs to the WordPress debug log
+```
+
+Check the WordPress debug log (`/wp-content/debug.log`) for email editor related messages. 

--- a/packages/php/email-editor/docs/block-registration.md
+++ b/packages/php/email-editor/docs/block-registration.md
@@ -60,6 +60,7 @@ $block_settings = array(
 ```
 
 The render callback should accept three parameters:
+
 - `string $block_content` - The original block HTML content
 - `array $parsed_block` - The parsed block data including attributes
 - `Rendering_Context $rendering_context` - Email rendering context
@@ -74,7 +75,7 @@ The recommended approach is to use the `block_type_metadata_settings` filter to 
 /**
  * Add email support to custom blocks.
  */
-function add_email_support_to_blocks( $settings ) {
+function add_email_support_to_blocks( $settings, $metadata ) {
     // List of blocks that should support email rendering
     $email_supported_blocks = array(
         'my-plugin/custom-block',
@@ -94,7 +95,7 @@ function add_email_support_to_blocks( $settings ) {
 
     return $settings;
 }
-add_filter( 'block_type_metadata_settings', 'add_email_support_to_blocks', 10, 1 );
+add_filter( 'block_type_metadata_settings', 'add_email_support_to_blocks', 10, 2 );
 ```
 
 ### Method 2: Direct Block Registration
@@ -166,10 +167,10 @@ class Custom_Block_Renderer extends Abstract_Block_Renderer {
         // Build email-compatible HTML
         $styles = array();
         if ( $text_color ) {
-            $styles[] = "color: {$text_color}";
+            $styles[] = 'color: ' . esc_attr( sanitize_hex_color( $text_color ) );
         }
         if ( $bg_color ) {
-            $styles[] = "background-color: {$bg_color}";
+            $styles[] = 'background-color: ' . esc_attr( sanitize_hex_color( $bg_color ) );
         }
         
         $style_attr = ! empty( $styles ) ? ' style="' . implode( '; ', $styles ) . '"' : '';
@@ -193,13 +194,13 @@ The `Rendering_Context` object provides access to theme settings and other rende
 ```php
 public function render( string $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
     // Get theme settings
-    $theme = $rendering_context->get_theme_settings();
+    $theme_settings = $rendering_context->get_theme_settings();
     
-    // Access theme colors, fonts, etc.
-    $theme_settings = $theme->get_theme_styles();
+    // Theme style values
+    $theme_styles = $rendering_context->get_theme_styles();
 
     // Get the theme json
-    $theme_settings = $theme->get_theme_json();
+    $theme_json = $rendering_context->get_theme_json();
     
     // Use theme values in your rendering logic
     // ...
@@ -361,7 +362,7 @@ JS
         category: 'widgets',
         description: __('A newsletter signup form for emails.', 'my-plugin'),
 		supports: {
-			email: true,
+			email: true, // required for the email editor.
 		},
         attributes: {
             title: {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR implements the block registration documentation and examples as requested in [Issue #58996](https://github.com/woocommerce/woocommerce/issues/58996).

 **Why**

The WooCommerce Email Editor introduced new features where blocks are loaded by the `blockType` property `supports.email` and can set callbacks for email rendering. However, there were no instructions for third-party developers and contributors on how to configure new block types to support this functionality.

This documentation addresses that gap by providing:
1. **Clear instructions** on how to register blocks with email support
2. **Practical examples** showing real-world implementation
3. **Best practices** for email-compatible block development
4. **Troubleshooting guidance** to help developers debug common issues

Closes #58996 WOOPLUG-4705

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

N/A - Documentation only


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to `packages/php/email-editor/docs/`
2. Verify the new `block-registration.md` file exists and contains comprehensive documentation
3. Check that `README.md` includes a link to the new documentation
4. Review the code examples in the documentation for accuracy
5. Test the provided newsletter signup block example in a WordPress environment

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
