### PR TITLE
OrdersTableSearchQuery: Improve HPOS full-text search performance

### DIFF
--- a/plugins/woocommerce/changelog/improve-hpos-fts-search-performance
+++ b/plugins/woocommerce/changelog/improve-hpos-fts-search-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve HPOS order search performance by optimizing full-text search queries.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -33,6 +33,16 @@ class OrdersTableSearchQuery {
 	private $search_filters;
 
 	/**
+	 * Alias used for the derived table that holds FTS product hits.
+	 */
+	private const PRODUCTS_JOIN_ALIAS = 'fts_items';
+
+	/**
+	 * Alias used for the derived table that holds FTS customer/address hits.
+	 */
+	private const CUSTOMERS_JOIN_ALIAS = 'fts_addresses';
+
+	/**
 	 * Creates the JOIN and WHERE clauses needed to execute a search of orders.
 	 *
 	 * @internal
@@ -114,6 +124,15 @@ class OrdersTableSearchQuery {
 	 * @return string JOIN clause.
 	 */
 	private function generate_join_for_search_filter( $search_filter ): string {
+		$join = '';
+
+		if ( 'products' === $search_filter ) {
+			$join = $this->maybe_get_join_for_products();
+		}
+
+		if ( 'customers' === $search_filter ) {
+			$join = $this->maybe_get_join_for_customers();
+		}
 		/**
 		 * Filter to support adding a custom order search filter.
 		 * Provide a JOIN clause for a new search filter. This should be used along with `woocommerce_hpos_admin_search_filters`
@@ -131,11 +150,87 @@ class OrdersTableSearchQuery {
 		 */
 		return apply_filters(
 			'woocommerce_hpos_generate_join_for_search_filter',
-			'',
+			$join,
 			$this->search_term,
 			$search_filter,
 			$this->query
 		);
+	}
+
+	/**
+	 * Returns a prepared JOIN fragment for products when FTS is enabled.
+	 *
+	 * @return string JOIN clause or empty string if FTS disabled.
+	 */
+	private function maybe_get_join_for_products(): string {
+		global $wpdb;
+
+		$db_util      = wc_get_container()->get( DatabaseUtil::class );
+		$items_table  = $this->query->get_table_name( 'items' );
+		$orders_table = $this->query->get_table_name( 'orders' );
+
+		$fts_enabled = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes'
+			&& get_option( CustomOrdersTableController::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION ) === 'yes';
+
+		if ( ! $fts_enabled ) {
+			return '';
+		}
+
+		$search_pattern = $wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $wpdb->prepare(
+			"LEFT JOIN (
+				SELECT DISTINCT order_id
+				FROM $items_table
+				WHERE MATCH ( order_item_name ) AGAINST ( %s IN BOOLEAN MODE )
+			) AS " . self::PRODUCTS_JOIN_ALIAS . " ON " . self::PRODUCTS_JOIN_ALIAS . ".order_id = $orders_table.id",
+			$search_pattern
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Returns a prepared JOIN fragment for customers/addresses when FTS is enabled.
+	 *
+	 * @return string JOIN clause or empty string if FTS disabled.
+	 */
+	private function maybe_get_join_for_customers(): string {
+		global $wpdb;
+
+		$db_util       = wc_get_container()->get( DatabaseUtil::class );
+		$address_table = $this->query->get_table_name( 'addresses' );
+		$orders_table  = $this->query->get_table_name( 'orders' );
+
+		$fts_enabled = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes'
+			&& get_option( CustomOrdersTableController::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION ) === 'yes';
+
+		if ( ! $fts_enabled ) {
+			return '';
+		}
+
+		$search_pattern = $wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) );
+
+		// Support for phone was added in 9.4.
+		$maybe_phone_field = '';
+		if ( version_compare( get_option( 'woocommerce_db_version' ), '9.4.0', '>=' ) ) {
+			$maybe_phone_field = ", phone";
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $wpdb->prepare(
+			"LEFT JOIN (
+				SELECT DISTINCT order_id
+				FROM $address_table
+				WHERE MATCH (
+					first_name, last_name, company,
+					address_1,  address_2, city,  state,
+					postcode,   country,   email  $maybe_phone_field
+				) AGAINST ( %s IN BOOLEAN MODE )
+			) AS " . self::CUSTOMERS_JOIN_ALIAS . " ON " . self::CUSTOMERS_JOIN_ALIAS . ".order_id = $orders_table.id",
+			$search_pattern
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -245,17 +340,7 @@ class OrdersTableSearchQuery {
 		$fts_enabled  = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes' && get_option( CustomOrdersTableController::HPOS_FTS_ORDER_ITEM_INDEX_CREATED_OPTION ) === 'yes';
 
 		if ( $fts_enabled ) {
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $orders_table and $items_table are hardcoded.
-			return $wpdb->prepare(
-				"
-$orders_table.id in (
-	SELECT order_id FROM $items_table search_query_items WHERE
-	MATCH ( search_query_items.order_item_name ) AGAINST ( %s IN BOOLEAN MODE )
-)
-",
-				$wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) ),
-			);
-			// phpcs:enable
+			return self::PRODUCTS_JOIN_ALIAS . '.order_id IS NOT NULL';
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $orders_table and $items_table are hardcoded.
@@ -286,24 +371,7 @@ $orders_table.id in (
 		$fts_enabled = get_option( CustomOrdersTableController::HPOS_FTS_INDEX_OPTION ) === 'yes' && get_option( CustomOrdersTableController::HPOS_FTS_ADDRESS_INDEX_CREATED_OPTION ) === 'yes';
 
 		if ( $fts_enabled ) {
-			$matchers = "$address_table.first_name, $address_table.last_name, $address_table.company, $address_table.address_1, $address_table.address_2, $address_table.city, $address_table.state, $address_table.postcode, $address_table.country, $address_table.email";
-
-			// Support for phone was added in 9.4.
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '9.4.0', '>=' ) ) {
-				$matchers .= ", $address_table.phone";
-			}
-
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table and $address_table are hardcoded.
-			return $wpdb->prepare(
-				"
-$order_table.id IN (
-	SELECT order_id FROM $address_table WHERE
-	MATCH( $matchers ) AGAINST ( %s IN BOOLEAN MODE )
-)
-",
-				$wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) )
-			);
-			// phpcs:enable
+			return self::CUSTOMERS_JOIN_ALIAS . '.order_id IS NOT NULL';
 		}
 
 		$meta_sub_query = $this->generate_where_for_meta_table();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -184,7 +184,7 @@ class OrdersTableSearchQuery {
 				SELECT DISTINCT order_id
 				FROM $items_table
 				WHERE MATCH ( order_item_name ) AGAINST ( %s IN BOOLEAN MODE )
-			) AS " . self::PRODUCTS_JOIN_ALIAS . " ON " . self::PRODUCTS_JOIN_ALIAS . ".order_id = $orders_table.id",
+			) AS " . self::PRODUCTS_JOIN_ALIAS . ' ON ' . self::PRODUCTS_JOIN_ALIAS . ".order_id = $orders_table.id",
 			$search_pattern
 		);
 		// phpcs:enable
@@ -214,7 +214,7 @@ class OrdersTableSearchQuery {
 		// Support for phone was added in 9.4.
 		$maybe_phone_field = '';
 		if ( version_compare( get_option( 'woocommerce_db_version' ), '9.4.0', '>=' ) ) {
-			$maybe_phone_field = ", phone";
+			$maybe_phone_field = ', phone';
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -227,7 +227,7 @@ class OrdersTableSearchQuery {
 					address_1,  address_2, city,  state,
 					postcode,   country,   email  $maybe_phone_field
 				) AGAINST ( %s IN BOOLEAN MODE )
-			) AS " . self::CUSTOMERS_JOIN_ALIAS . " ON " . self::CUSTOMERS_JOIN_ALIAS . ".order_id = $orders_table.id",
+			) AS " . self::CUSTOMERS_JOIN_ALIAS . ' ON ' . self::CUSTOMERS_JOIN_ALIAS . ".order_id = $orders_table.id",
 			$search_pattern
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -179,6 +179,7 @@ class OrdersTableSearchQuery {
 		$search_pattern = $wpdb->esc_like( $db_util->sanitise_boolean_fts_search_term( $this->search_term ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		return $wpdb->prepare(
 			"LEFT JOIN (
 				SELECT DISTINCT order_id
@@ -187,7 +188,8 @@ class OrdersTableSearchQuery {
 			) AS " . self::PRODUCTS_JOIN_ALIAS . ' ON ' . self::PRODUCTS_JOIN_ALIAS . ".order_id = $orders_table.id",
 			$search_pattern
 		);
-		// phpcs:enable
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**
@@ -218,6 +220,7 @@ class OrdersTableSearchQuery {
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		return $wpdb->prepare(
 			"LEFT JOIN (
 				SELECT DISTINCT order_id
@@ -231,6 +234,7 @@ class OrdersTableSearchQuery {
 			$search_pattern
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -278,26 +278,28 @@ class OrdersTableSearchQuery {
 
 		$order_table = $this->query->get_table_name( 'orders' );
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
 		if ( 'customer_email' === $search_filter ) {
 			return $wpdb->prepare(
-				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"`$order_table`.billing_email LIKE %s",
 				$wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}
 
 		if ( 'order_id' === $search_filter && is_numeric( $this->search_term ) ) {
 			return $wpdb->prepare(
-				"`$order_table`.id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"`$order_table`.id = %d",
 				absint( $this->search_term )
 			);
 		}
 
 		if ( 'transaction_id' === $search_filter ) {
 			return $wpdb->prepare(
-				"`$order_table`.transaction_id LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"`$order_table`.transaction_id LIKE %s",
 				'%' . $wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		if ( 'products' === $search_filter ) {
 			return $this->get_where_for_products();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -280,21 +280,21 @@ class OrdersTableSearchQuery {
 
 		if ( 'customer_email' === $search_filter ) {
 			return $wpdb->prepare(
-				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
+				"`$order_table`.billing_email LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}
 
 		if ( 'order_id' === $search_filter && is_numeric( $this->search_term ) ) {
 			return $wpdb->prepare(
-				"`$order_table`.id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
+				"`$order_table`.id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				absint( $this->search_term )
 			);
 		}
 
 		if ( 'transaction_id' === $search_filter ) {
 			return $wpdb->prepare(
-				"`$order_table`.transaction_id LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $order_table is hardcoded.
+				"`$order_table`.transaction_id LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				'%' . $wpdb->esc_like( $this->search_term ) . '%'
 			);
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -160,6 +160,7 @@ class OrdersTableSearchQuery {
 	/**
 	 * Returns a prepared JOIN fragment for products when FTS is enabled.
 	 *
+	 * @since 10.1.0
 	 * @return string JOIN clause or empty string if FTS disabled.
 	 */
 	private function maybe_get_join_for_products(): string {
@@ -195,6 +196,7 @@ class OrdersTableSearchQuery {
 	/**
 	 * Returns a prepared JOIN fragment for customers/addresses when FTS is enabled.
 	 *
+	 * @since 10.1.0
 	 * @return string JOIN clause or empty string if FTS disabled.
 	 */
 	private function maybe_get_join_for_customers(): string {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Improves a performance issue where order searches with full-text turned on could take 60+ seconds and cause gateway timeouts. See #59539 

<img width="1327" alt="Screenshot 2025-07-08 at 3 45 02 PM" src="https://github.com/user-attachments/assets/53b65a07-437f-4e7e-938a-cd6f93e8b455" />


The current implementation uses dependent subqueries, which were causing MySQL/MariaDB to execute the subqueries for each row in the orders table. This is not a problem with a low number of orders, but it scales up and gets worse the more orders you get. I started noticing >500ms queries locally somewhere in the 10k to 20k orders range, and we had a customer note a problem with timeouts occurring when having ~125k orders.

The solution is to replace the `WHERE id IN (SELECT...)` patterns with `LEFT JOIN` on derived tables, so the search is only run once per query, instead of once per row.



### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
|        |       |



### How to test the changes in this Pull Request:

0. Stay on trunk.
1. Go to WooCommerce > Settings > Advance > Features, and enable the `HPOS Full text search indexes` feature
<img width="1062" alt="Screenshot 2024-04-02 at 10 03 49 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/cf485a50-687a-4bcb-84a4-8a5a32fe4306">

2. Have 20k orders or more. I used wc-smooth-generator.
3. Go to admin view (`/wp-admin/admin.php?page=wc-orders`), and search for orders using different product names and customer names used in step 1. Check that the results are as expected.
4. Use query-manager or another similar plugin to look for queries and sort by times. Find the main "SELECT COUNT.. " query.
5. Apply this branch, then do the same thing (search, check results, see queries and note execution times).


On trunk, you should see slow query like this:
```sql
SELECT COUNT(*)
FROM wp_wc_orders
WHERE 1=1
AND (wp_wc_orders.status IN ('wc-pending','wc-processing','wc-on-hold','wc-completed','wc-cancelled','wc-refunded','wc-failed'))
AND (wp_wc_orders.type = 'shop_order')
AND ( ( `wp_wc_orders`.transaction_id LIKE '%joe%'
OR `wp_wc_orders`.billing_email LIKE 'joe%'
OR wp_wc_orders.id IN (
SELECT order_id
FROM wp_wc_order_addresses
WHERE MATCH( wp_wc_order_addresses.first_name, wp_wc_order_addresses.last_name, wp_wc_order_addresses.company, wp_wc_order_addresses.address_1, wp_wc_order_addresses.address_2, wp_wc_order_addresses.city, wp_wc_order_addresses.state, wp_wc_order_addresses.postcode, wp_wc_order_addresses.country, wp_wc_order_addresses.email, wp_wc_order_addresses.phone ) AGAINST ( 'joe*' IN BOOLEAN MODE ) )
OR wp_wc_orders.id in (
SELECT order_id
FROM wp_woocommerce_order_items search_query_items
WHERE MATCH ( search_query_items.order_item_name ) AGAINST ( 'joe*' IN BOOLEAN MODE ) ) ) )
```

On this branch, you should see this instead:
```sql
SELECT COUNT(DISTINCT wp_wc_orders.id)
FROM wp_wc_orders
LEFT JOIN (
SELECT DISTINCT order_id
FROM wp_wc_order_addresses
WHERE MATCH ( first_name, last_name, company, address_1, address_2, city, state, postcode, country, email , phone ) AGAINST ( 'joe*' IN BOOLEAN MODE ) ) AS fts_addresses
ON fts_addresses.order_id = wp_wc_orders.id
LEFT JOIN (
SELECT DISTINCT order_id
FROM wp_woocommerce_order_items
WHERE MATCH ( order_item_name ) AGAINST ( 'joe*' IN BOOLEAN MODE ) ) AS fts_items
ON fts_items.order_id = wp_wc_orders.id
WHERE 1=1
AND (wp_wc_orders.status IN ('wc-pending','wc-processing','wc-on-hold','wc-completed','wc-cancelled','wc-refunded','wc-failed'))
AND (wp_wc_orders.type = 'shop_order')
AND ( ( `wp_wc_orders`.transaction_id LIKE '%joe%'
OR `wp_wc_orders`.billing_email LIKE 'joe%'
OR fts_addresses.order_id IS NOT NULL
OR fts_items.order_id IS NOT NULL ) )
```

It should return the same results, and be much faster.


Explain before:
```
+------+--------------------+-----------------------+----------+---------------------------------------+---------------------+---------+------+-------+-------------+
| id   | select_type        | table                 | type     | possible_keys                         | key                 | key_len | ref  | rows  | Extra       |
+------+--------------------+-----------------------+----------+---------------------------------------+---------------------+---------+------+-------+-------------+
|    1 | PRIMARY            | wp_wc_orders          | ALL      | status,billing_email,type_status_date | NULL                | NULL    | NULL | 19163 | Using where |
|    3 | DEPENDENT SUBQUERY | search_query_items    | fulltext | order_id,order_item_fts               | order_item_fts      | 0       |      | 1     | Using where |
|    2 | DEPENDENT SUBQUERY | wp_wc_order_addresses | fulltext | order_id,order_addresses_fts          | order_addresses_fts | 0       |      | 1     | Using where |
+------+--------------------+-----------------------+----------+---------------------------------------+---------------------+---------+------+-------+-------------+

```

Explain after:
```
+------+-------------+----------------------------+----------+---------------------------------------+---------------------+---------+---------------------------+-------+------------------------------+
| id   | select_type | table                      | type     | possible_keys                         | key                 | key_len | ref                       | rows  | Extra                        |
+------+-------------+----------------------------+----------+---------------------------------------+---------------------+---------+---------------------------+-------+------------------------------+
|    1 | PRIMARY     | wp_wc_orders               | ALL      | status,billing_email,type_status_date | NULL                | NULL    | NULL                      | 19163 | Using where                  |
|    1 | PRIMARY     | <derived2>                 | ref      | key0                                  | key0                | 9       | wordpress.wp_wc_orders.id | 1     |                        |
|    1 | PRIMARY     | <derived3>                 | ref      | key0                                  | key0                | 9       | wordpress.wp_wc_orders.id | 1     | Using where                  |
|    3 | DERIVED     | wp_woocommerce_order_items | fulltext | order_item_fts                        | order_item_fts      | 0       |                           | 1     | Using where; Using temporary |
|    2 | DERIVED     | wp_wc_order_addresses      | fulltext | order_addresses_fts                   | order_addresses_fts | 0       |                           | 1     | Using where; Using temporary |
+------+-------------+----------------------------+----------+---------------------------------------+---------------------+---------+---------------------------+-------+------------------------------+

```

On my setup, the slower one takes **1087ms** and the faster one **19ms**. This is with 19,165 rows in wp_wc_orders, 29,792 in wp_wc_order_addresses, and 99,079 rows in wp_woocommerce_order_items.

It's not clear to me why mysql runs the original query as dependent subqueries to me. I think the ` OR ` statements are throwing off its optimizer.

### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>
