### PR TITLE
Fix: Enable strict_types for session classes

### DIFF
--- a/plugins/woocommerce/changelog/fix-session-strict-types
+++ b/plugins/woocommerce/changelog/fix-session-strict-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Adds strict_types to session class and fixes type definitions and usage to reduce chances of type errors
+
+

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
@@ -132,11 +132,11 @@ abstract class WC_Session {
 	}
 
 	/**
-	 * Get customer ID.
+	 * Get customer ID. If the session is not initialized, returns an empty string.
 	 *
-	 * @return ?string
+	 * @return string
 	 */
 	public function get_customer_id() {
-		return $this->_customer_id;
+		return $this->_customer_id ?? '';
 	}
 }

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
@@ -7,6 +7,8 @@
  * @package     WooCommerce\Abstracts
  */
 
+declare(strict_types=1);
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -19,23 +21,23 @@ abstract class WC_Session {
 	/**
 	 * Customer ID.
 	 *
-	 * @var string $_customer_id Customer ID.
+	 * @var ?string $_customer_id Customer ID.
 	 */
-	protected $_customer_id;
+	protected $_customer_id; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Session Data.
 	 *
 	 * @var array $_data Data array.
 	 */
-	protected $_data = array();
+	protected $_data = array(); // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Dirty when the session needs saving.
 	 *
 	 * @var bool $_dirty When something changes
 	 */
-	protected $_dirty = false;
+	protected $_dirty = false; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Init hooks and session data. Extended by child classes.
@@ -52,7 +54,7 @@ abstract class WC_Session {
 	/**
 	 * Magic get method.
 	 *
-	 * @param mixed $key Key to get.
+	 * @param string $key Key to get.
 	 * @return mixed
 	 */
 	public function __get( $key ) {
@@ -62,8 +64,8 @@ abstract class WC_Session {
 	/**
 	 * Magic set method.
 	 *
-	 * @param mixed $key Key to set.
-	 * @param mixed $value Value to set.
+	 * @param string $key Key to set.
+	 * @param mixed  $value Value to set.
 	 */
 	public function __set( $key, $value ) {
 		$this->set( $key, $value );
@@ -72,17 +74,17 @@ abstract class WC_Session {
 	/**
 	 * Magic isset method.
 	 *
-	 * @param mixed $key Key to check.
+	 * @param string $key Key to check.
 	 * @return bool
 	 */
 	public function __isset( $key ) {
-		return isset( $this->_data[ sanitize_title( $key ) ] );
+		return isset( $this->_data[ sanitize_key( $key ) ] );
 	}
 
 	/**
 	 * Magic unset method.
 	 *
-	 * @param mixed $key Key to unset.
+	 * @param string $key Key to unset.
 	 */
 	public function __unset( $key ) {
 		$key = sanitize_key( $key );
@@ -96,12 +98,12 @@ abstract class WC_Session {
 	 * Get a session variable.
 	 *
 	 * @param string $key Key to get.
-	 * @param mixed  $default used if the session variable isn't set.
-	 * @return array|string value of session variable
+	 * @param mixed  $default_value used if the session variable isn't set.
+	 * @return mixed value of session variable
 	 */
-	public function get( $key, $default = null ) {
+	public function get( $key, $default_value = null ) {
 		$key = sanitize_key( $key );
-		return isset( $this->_data[ $key ] ) ? maybe_unserialize( $this->_data[ $key ] ) : $default;
+		return isset( $this->_data[ $key ] ) ? maybe_unserialize( $this->_data[ $key ] ) : $default_value;
 	}
 
 	/**
@@ -132,7 +134,7 @@ abstract class WC_Session {
 	/**
 	 * Get customer ID.
 	 *
-	 * @return string
+	 * @return ?string
 	 */
 	public function get_customer_id() {
 		return $this->_customer_id;

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -728,7 +728,7 @@ class WC_Session_Handler extends WC_Session {
 		global $wpdb;
 
 		if ( Constants::is_defined( 'WP_SETUP_CONFIG' ) ) {
-			return false;
+			return $default_value;
 		}
 
 		// Try to get it from the cache, it will return false if not present or if object cache not in use.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore Generic.PHP.RequireStrictTypes.MissingDeclaration
+<?php
 /**
  * Handle data for the current customers session.
  * Implements the WC_Session abstract class.
@@ -7,8 +7,9 @@
  *
  * @class    WC_Session_Handler
  * @package  WooCommerce\Classes
- * @internal "Missing required strict_types declaration" rule has been ignored to prevent errors with `StringUtil::starts_with` when used on a nonce action which could be -1 rather than a string.
  */
+
+declare(strict_types=1);
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Utilities\StringUtil;
@@ -26,21 +27,21 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @var string cookie name
 	 */
-	protected $_cookie; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
+	protected $_cookie = ''; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Stores session expiry.
 	 *
-	 * @var string session due to expire timestamp
+	 * @var int session due to expire timestamp
 	 */
-	protected $_session_expiring; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
+	protected $_session_expiring = 0; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Stores session due to expire timestamp.
 	 *
-	 * @var string session expiration timestamp
+	 * @var int session expiration timestamp
 	 */
-	protected $_session_expiration; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
+	protected $_session_expiration = 0; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * True when the cookie exists.
@@ -54,7 +55,7 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @var string Custom session table name
 	 */
-	protected $_table; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
+	protected $_table = ''; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
 	/**
 	 * Constructor for the session class.
@@ -67,7 +68,7 @@ class WC_Session_Handler extends WC_Session {
 		 *
 		 * @param string $cookie Cookie name.
 		 */
-		$this->_cookie = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
+		$this->_cookie = (string) apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
 		$this->_table  = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
 		$this->set_session_expiration();
 	}
@@ -170,8 +171,8 @@ class WC_Session_Handler extends WC_Session {
 
 		// Customer ID will be an MD5 hash id this is a guest session.
 		$this->_customer_id        = $cookie[0];
-		$this->_session_expiration = $cookie[1];
-		$this->_session_expiring   = $cookie[2];
+		$this->_session_expiration = (int) $cookie[1];
+		$this->_session_expiring   = (int) $cookie[2];
 		$this->_has_cookie         = true;
 
 		$this->restore_session_data();
@@ -190,14 +191,14 @@ class WC_Session_Handler extends WC_Session {
 		}
 
 		// If the user logs in, update session.
-		if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
-			$this->migrate_guest_session_to_user_session( get_current_user_id() );
+		if ( is_user_logged_in() && (string) get_current_user_id() !== $this->get_customer_id() ) {
+			$this->migrate_guest_session_to_user_session();
 		}
 
 		// Update session if its close to expiring.
 		if ( $this->is_session_expiring() ) {
 			$this->set_session_expiration();
-			$this->update_session_timestamp( $this->_customer_id, $this->_session_expiration );
+			$this->update_session_timestamp( $this->get_customer_id(), $this->_session_expiration );
 		}
 	}
 
@@ -216,13 +217,11 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Migrates a guest session to a user session.
-	 *
-	 * @param int $user_id The user ID to migrate to.
+	 * Migrates a guest session to the current user session.
 	 */
-	private function migrate_guest_session_to_user_session( int $user_id ) {
-		$guest_session_id   = $this->_customer_id;
-		$user_session_id    = strval( $user_id );
+	private function migrate_guest_session_to_user_session() {
+		$guest_session_id   = $this->get_customer_id();
+		$user_session_id    = (string) get_current_user_id();
 		$guest_session_data = (array) $this->_data;
 		$user_session_data  = (array) $this->get_session( $user_session_id, array() );
 
@@ -287,7 +286,7 @@ class WC_Session_Handler extends WC_Session {
 		 * @param array $session_data The session data loaded from storage.
 		 * @return array Modified session data to be used for initialization.
 		 */
-		$this->_data = apply_filters( 'woocommerce_restored_session_data', $session_data );
+		$this->_data = (array) apply_filters( 'woocommerce_restored_session_data', $session_data );
 	}
 
 	/**
@@ -337,12 +336,12 @@ class WC_Session_Handler extends WC_Session {
 		}
 
 		// If user has logged out, session cookie is invalid.
-		if ( ! is_user_logged_in() && ! $this->is_customer_guest( $this->_customer_id ) ) {
+		if ( ! is_user_logged_in() && ! $this->is_customer_guest( $this->get_customer_id() ) ) {
 			return false;
 		}
 
 		// Session from a different user is not valid. (Although from a guest user will be valid).
-		if ( is_user_logged_in() && ! $this->is_customer_guest( $this->_customer_id ) && strval( get_current_user_id() ) !== $this->_customer_id ) {
+		if ( is_user_logged_in() && ! $this->is_customer_guest( $this->get_customer_id() ) && (string) get_current_user_id() !== $this->get_customer_id() ) {
 			return false;
 		}
 
@@ -369,7 +368,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @param string $message Value to hash.
 	 * @return string Hashed value.
 	 */
-	private function hash( $message ) {
+	private function hash( string $message ) {
 		if ( function_exists( 'wp_fast_hash' ) ) {
 			return wp_fast_hash( $message );
 		}
@@ -385,7 +384,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @param string $hash Hash to verify.
 	 * @return bool Whether the hash is valid.
 	 */
-	private function verify_hash( $message, $hash ) {
+	private function verify_hash( string $message, string $hash ) {
 		if ( function_exists( 'wp_verify_fast_hash' ) ) {
 			return wp_verify_fast_hash( $message, $hash );
 		}
@@ -403,8 +402,8 @@ class WC_Session_Handler extends WC_Session {
 	 */
 	public function set_customer_session_cookie( $set ) {
 		if ( $set ) {
-			$cookie_hash  = $this->hash( $this->_customer_id . '|' . $this->_session_expiration );
-			$cookie_value = $this->_customer_id . '|' . $this->_session_expiration . '|' . $this->_session_expiring . '|' . $cookie_hash;
+			$cookie_hash  = $this->hash( $this->get_customer_id() . '|' . (string) $this->_session_expiration );
+			$cookie_value = $this->get_customer_id() . '|' . (string) $this->_session_expiration . '|' . (string) $this->_session_expiring . '|' . $cookie_hash;
 
 			if ( $this->get_cookie_value() !== $cookie_value ) {
 				$this->set_cookie_value( $cookie_value );
@@ -459,7 +458,7 @@ class WC_Session_Handler extends WC_Session {
 		 *
 		 * @param bool $use_secure_cookie Whether to use a secure cookie.
 		 */
-		return apply_filters( 'wc_session_use_secure_cookie', wc_site_is_https() && is_ssl() );
+		return (bool) apply_filters( 'wc_session_use_secure_cookie', wc_site_is_https() && is_ssl() );
 	}
 
 	/**
@@ -532,8 +531,7 @@ class WC_Session_Handler extends WC_Session {
 			$expiring_seconds = $expiration_seconds * 0.9;
 		}
 
-		$this->_session_expiring = time() + $expiring_seconds;
-
+		$this->_session_expiring   = time() + $expiring_seconds;
 		$this->_session_expiration = time() + $expiration_seconds;
 	}
 
@@ -543,7 +541,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return string
 	 */
 	public function generate_customer_id() {
-		return is_user_logged_in() ? strval( get_current_user_id() ) : wc_rand_hash( 't_', 30 );
+		return is_user_logged_in() ? (string) get_current_user_id() : wc_rand_hash( 't_', 30 );
 	}
 
 	/**
@@ -566,8 +564,8 @@ class WC_Session_Handler extends WC_Session {
 	public function get_customer_unique_id() {
 		$customer_id = '';
 
-		if ( $this->has_session() && $this->_customer_id ) {
-			$customer_id = $this->_customer_id;
+		if ( $this->has_session() && $this->get_customer_id() ) {
+			$customer_id = $this->get_customer_id();
 		} elseif ( is_user_logged_in() ) {
 			$customer_id = (string) get_current_user_id();
 		}
@@ -616,7 +614,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return array
 	 */
 	public function get_session_data() {
-		return $this->has_session() ? (array) $this->get_session( $this->_customer_id, array() ) : array();
+		return $this->has_session() ? (array) $this->get_session( $this->get_customer_id(), array() ) : array();
 	}
 
 	/**
@@ -645,12 +643,12 @@ class WC_Session_Handler extends WC_Session {
 					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
  					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
 					$this->_table,
-					$this->_customer_id,
+					$this->get_customer_id(),
 					maybe_serialize( $this->_data ),
 					$this->_session_expiration
 				)
 			);
-			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
+			wp_cache_set( $this->get_cache_prefix() . $this->get_customer_id(), $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
 
 			/**
@@ -658,7 +656,7 @@ class WC_Session_Handler extends WC_Session {
 			 * self::init_session_cookie() upon user login detection initially occurs. However, since some third-party
 			 * extensions override this method, relocating this logic could break backward compatibility.
 			 */
-			if ( ! empty( $old_session_key ) && $this->_customer_id !== $old_session_key && ! is_object( get_user_by( 'id', $old_session_key ) ) ) {
+			if ( ! empty( $old_session_key ) && $this->get_customer_id() !== $old_session_key && ! is_object( get_user_by( 'id', $old_session_key ) ) ) {
 				$this->delete_session( $old_session_key );
 			}
 		}
@@ -668,7 +666,7 @@ class WC_Session_Handler extends WC_Session {
 	 * Destroy all session data.
 	 */
 	public function destroy_session() {
-		$this->delete_session( $this->_customer_id );
+		$this->delete_session( $this->get_customer_id() );
 		$this->forget_session();
 		$this->set_session_expiration();
 	}
@@ -695,13 +693,13 @@ class WC_Session_Handler extends WC_Session {
 	 * This filter runs everything `wp_verify_nonce()` and `wp_create_nonce()` gets called.
 	 *
 	 * @since 5.3.0
-	 * @param int    $uid    User ID.
-	 * @param string $action The nonce action.
+	 * @param int        $uid    User ID.
+	 * @param int|string $action The nonce action.
 	 * @return int|string
 	 */
 	public function maybe_update_nonce_user_logged_out( $uid, $action ) {
-		if ( StringUtil::starts_with( $action, 'woocommerce' ) ) {
-			return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
+		if ( $action && StringUtil::starts_with( (string) $action, 'woocommerce' ) ) {
+			return $this->has_session() && $this->get_customer_id() ? $this->get_customer_id() : $uid;
 		}
 		return $uid;
 	}
@@ -724,13 +722,13 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @param string $customer_id Customer ID.
 	 * @param mixed  $default_value Default session value.
-	 * @return string|array
+	 * @return array
 	 */
 	public function get_session( $customer_id, $default_value = false ) {
 		global $wpdb;
 
 		if ( Constants::is_defined( 'WP_SETUP_CONFIG' ) ) {
-			return false;
+			return array();
 		}
 
 		// Try to get it from the cache, it will return false if not present or if object cache not in use.
@@ -749,15 +747,18 @@ class WC_Session_Handler extends WC_Session {
 			}
 		}
 
-		return maybe_unserialize( $value );
+		return (array) maybe_unserialize( $value );
 	}
 
 	/**
 	 * Delete the session from the cache and database.
 	 *
-	 * @param int $customer_id Customer ID.
+	 * @param string $customer_id Customer session ID.
 	 */
 	public function delete_session( $customer_id ) {
+		if ( ! $customer_id ) {
+			return;
+		}
 		$GLOBALS['wpdb']->delete( $this->_table, array( 'session_key' => $customer_id ) );
 		wp_cache_delete( $this->get_cache_prefix() . $customer_id, WC_SESSION_CACHE_GROUP );
 	}
@@ -769,6 +770,9 @@ class WC_Session_Handler extends WC_Session {
 	 * @param int    $timestamp Timestamp to expire the cookie.
 	 */
 	public function update_session_timestamp( $customer_id, $timestamp ) {
+		if ( ! $customer_id ) {
+			return;
+		}
 		$GLOBALS['wpdb']->update( $this->_table, array( 'session_expiry' => $timestamp ), array( 'session_key' => $customer_id ), array( '%d' ) );
 	}
 
@@ -779,6 +783,6 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	private function session_exists( $customer_id ) {
-		return null !== $GLOBALS['wpdb']->get_var( $GLOBALS['wpdb']->prepare( 'SELECT session_key FROM %i WHERE session_key = %s', $this->_table, $customer_id ) );
+		return $customer_id && null !== $GLOBALS['wpdb']->get_var( $GLOBALS['wpdb']->prepare( 'SELECT session_key FROM %i WHERE session_key = %s', $this->_table, $customer_id ) );
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -698,7 +698,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return int|string
 	 */
 	public function maybe_update_nonce_user_logged_out( $uid, $action ) {
-		if ( $action && StringUtil::starts_with( (string) $action, 'woocommerce' ) ) {
+		if ( is_string( $action ) && StringUtil::starts_with( $action, 'woocommerce' ) ) {
 			return $this->has_session() && $this->get_customer_id() ? $this->get_customer_id() : $uid;
 		}
 		return $uid;

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -138,7 +138,7 @@ class WC_Session_Handler extends WC_Session {
 				return false;
 			}
 
-			$cookie_session_data = $this->get_session( $cookie[0] );
+			$cookie_session_data = (array) $this->get_session( $cookie[0], array() );
 
 			// Cookie session was originally created via this token. Return and use cookie session to prevent creating a new clone.
 			if ( isset( $cookie_session_data['previous_customer_id'] ) && $cookie_session_data['previous_customer_id'] === $payload['user_id'] ) {
@@ -208,7 +208,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @param string $clone_from_customer_id The customer ID to clone from.
 	 */
 	private function clone_session_data( string $clone_from_customer_id ) {
-		$session_data                         = $this->get_session( $clone_from_customer_id, array() );
+		$session_data                         = (array) $this->get_session( $clone_from_customer_id, array() );
 		$session_data['previous_customer_id'] = $clone_from_customer_id;
 		$session_data                         = array_diff_key( $session_data, array( 'customer' => true ) );
 		$this->_data                          = $session_data;
@@ -722,13 +722,13 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @param string $customer_id Customer ID.
 	 * @param mixed  $default_value Default session value.
-	 * @return array
+	 * @return mixed Returns either the session data or the default value. Returns false if WP setup is in progress.
 	 */
 	public function get_session( $customer_id, $default_value = false ) {
 		global $wpdb;
 
 		if ( Constants::is_defined( 'WP_SETUP_CONFIG' ) ) {
-			return array();
+			return false;
 		}
 
 		// Try to get it from the cache, it will return false if not present or if object cache not in use.
@@ -747,7 +747,7 @@ class WC_Session_Handler extends WC_Session {
 			}
 		}
 
-		return (array) maybe_unserialize( $value );
+		return maybe_unserialize( $value );
 	}
 
 	/**

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -18,27 +18,27 @@ final class SessionHandler extends WC_Session {
 	 *
 	 * @var string
 	 */
-	protected $token;
+	protected $token = '';
 
 	/**
 	 * Table name for session data.
 	 *
 	 * @var string Custom session table name
 	 */
-	protected $table;
+	protected $table = '';
 
 	/**
 	 * Expiration timestamp.
 	 *
 	 * @var int
 	 */
-	protected $session_expiration;
+	protected $session_expiration = 0;
 
 	/**
 	 * Constructor for the session class.
 	 */
 	public function __construct() {
-		$this->token = wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
+		$this->token = (string) wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
 		$this->table = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -38,7 +38,7 @@ final class SessionHandler extends WC_Session {
 	 * Constructor for the session class.
 	 */
 	public function __construct() {
-		$this->token = (string) wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
+		$this->token = wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? '' ) );
 		$this->table = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
 	}
 

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -66,8 +66,8 @@ final class SessionHandler extends WC_Session {
 	 *
 	 * @param string $customer_id Customer ID.
 	 * @param mixed  $default_value Default session value.
-	 *
-	 * @return string|array|bool
+
+	 * @return mixed Returns either the session data or the default value. Returns false if WP setup is in progress.
 	 */
 	public function get_session( $customer_id, $default_value = false ) {
 		global $wpdb;

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -74,7 +74,7 @@ final class SessionHandler extends WC_Session {
 
 		// This mimics behaviour from default WC_Session_Handler class. There will be no sessions retrieved while WP setup is due.
 		if ( Constants::is_defined( 'WP_SETUP_CONFIG' ) ) {
-			return false;
+			return $default_value;
 		}
 
 		$value = $wpdb->get_var(

--- a/plugins/woocommerce/src/StoreApi/SessionHandler.php
+++ b/plugins/woocommerce/src/StoreApi/SessionHandler.php
@@ -58,7 +58,7 @@ final class SessionHandler extends WC_Session {
 
 		$this->_customer_id       = $payload['user_id'];
 		$this->session_expiration = $payload['exp'];
-		$this->_data              = (array) $this->get_session( $this->_customer_id, array() );
+		$this->_data              = (array) $this->get_session( $this->get_customer_id(), array() );
 	}
 
 	/**
@@ -104,7 +104,7 @@ final class SessionHandler extends WC_Session {
 				$wpdb->prepare(
 					'INSERT INTO %i (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d) ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)',
 					$this->table,
-					$this->_customer_id,
+					$this->get_customer_id(),
 					maybe_serialize( $this->_data ),
 					$this->session_expiration
 				)

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php
@@ -51,9 +51,9 @@ class CartTokenUtils {
 		$parts = JsonWebToken::get_parts( $cart_token )->payload;
 
 		return array(
-			'user_id' => strval( $parts->user_id ?? '' ),
-			'exp'     => intval( $parts->exp ?? 0 ),
-			'iss'     => strval( $parts->iss ?? '' ),
+			'user_id' => $parts->user_id ?? '',
+			'exp'     => $parts->exp ?? 0,
+			'iss'     => $parts->iss ?? '',
 		);
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/CartTokenUtils.php
@@ -51,9 +51,9 @@ class CartTokenUtils {
 		$parts = JsonWebToken::get_parts( $cart_token )->payload;
 
 		return array(
-			'user_id' => $parts->user_id ?? '',
-			'exp'     => $parts->exp ?? 0,
-			'iss'     => $parts->iss ?? '',
+			'user_id' => strval( $parts->user_id ?? '' ),
+			'exp'     => intval( $parts->exp ?? 0 ),
+			'iss'     => strval( $parts->iss ?? '' ),
 		);
 	}
 


### PR DESCRIPTION
Fixes WOOPRD-643

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/59479 we reverted the strict_types definition because of a potential fatal error. This PR adds it back and updates docblocks, return types, and casting to ensure types are correct across the session classes.

The main issues I found were:

- We always assume `_customer_id` is string, when it starts off `null`.
- We failed to check the type of the data returned from filter hooks. This PR casts the return value to the expected type.
- Several docblocks were inaccurate which could lead to mistakes.

I've avoided adding type hints to public methods since we should maintain backwards compatibility.

Since this touches the same file [as this patch](https://github.com/woocommerce/woocommerce/pull/59530/files) I've incorporated that fix as well, but will rebase once the other PR is merged and CFE raised.

### How to test the changes in this Pull Request:

1. Smoke test logged in and guest cart sessions by adding items to the cart and ensuring there are no errors or warnings in error_logs
2. Run through the shortcode flow
3. Run though the blocks flow
4. Go through a flow with WooCommerce Payments to ensure no conflicts with the session handler
5. Ensure all CI passes

<!-- End testing instructions -->

### Testing that has already taken place:

Only light smoke testing so far.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
