### PR TITLE
[dev] CI: update PHPUnit tests execution timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
           pattern: 'last-run__${{ strategy.job-index }}'
 
       - name: 'Run tests (${{ matrix.testType }})'
-        timeout-minutes: ${{ ( github.event_name == 'pull_request' && matrix.testType == 'e2e' && 20 ) || 360 }}
+        timeout-minutes: ${{ ( github.event_name == 'pull_request' && ( ( matrix.testType == 'e2e' && 20 ) || ( matrix.testType == 'unit:php' && 10 ) ) ) || 360 }}
         env:
           E2E_ENV_KEY: ${{ secrets.E2E_ENV_KEY }}
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_CORE_E2E_TOKEN }}

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader class.
+ * Autoloader clazz.
  *
  * @since 3.7.0
  */

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Autoloader clazz.
+ * Autoloader class.
  *
  * @since 3.7.0
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1751979980718979-slack-C03CPM3UXDJ

Cap the PHPUnit tests execution time to 10 minutes max.

### How to test the changes in this Pull Request:

- CI-checks shall pass: [example run](https://github.com/woocommerce/woocommerce/actions/runs/16163036379) with some test changes.