### PR TITLE
Add to Cart + Options: Show user-friendly error when individually sold product already in cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-59269
+++ b/plugins/woocommerce/changelog/fix-issue-59269
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Add to Cart + Options block to show user-friendly error when individually sold product is already in cart

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -329,7 +329,7 @@ const { state, actions } = store< Store >(
 					// Dispatches the event to sync the @wordpress/data store.
 					emitSyncEvent( { quantityChanges } );
 
-					const errors = [];
+					// Show all errors from the batch responses.
 					for ( const response of json.responses ) {
 						const body = response?.body;
 						if (
@@ -338,13 +338,8 @@ const { state, actions } = store< Store >(
 							'code' in body &&
 							'message' in body
 						) {
-							errors.push( body );
+							actions.showNoticeError( body as ApiErrorResponse );
 						}
-					}
-					if ( errors.length ) {
-						errors.forEach( ( error ) =>
-							actions.showNoticeError( error as ApiErrorResponse )
-						);
 					}
 				} catch ( error ) {
 					// Reverts the optimistic update.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -87,13 +87,16 @@ function emitSyncEvent( {
 function getUserFriendlyErrorMessage(
 	error: Error | ApiErrorResponse
 ): string {
-	if (
-		( error as ApiErrorResponse ).code ===
-		'woocommerce_rest_missing_attributes'
-	) {
-		return 'Please select product attributes before adding to cart.';
+	const code = ( error as ApiErrorResponse )?.code;
+
+	switch ( code ) {
+		case 'woocommerce_rest_missing_attributes':
+			return 'Please select product attributes before adding to cart.';
+		case 'no_successful_cart_response':
+			return 'This product can only be purchased once. You cannot add it to your cart again.';
+		default:
+			return error.message;
 	}
-	return error.message;
 }
 
 // Todo: export this store once the store is public.
@@ -294,9 +297,10 @@ const { state, actions } = store< Store >(
 
 					// Checks if the last successful cart response is valid.
 					if ( ! lastSuccessfulCartResponse ) {
-						throw new Error(
-							'No successful cart response received.'
-						);
+						throw generateError( {
+							code: 'no_successful_cart_response',
+							message: 'No successful cart response received.',
+						} );
 					}
 
 					// Checks if the last successful response contains any errors.
@@ -324,6 +328,24 @@ const { state, actions } = store< Store >(
 
 					// Dispatches the event to sync the @wordpress/data store.
 					emitSyncEvent( { quantityChanges } );
+
+					const errors = [];
+					for ( const response of json.responses ) {
+						const body = response?.body;
+						if (
+							body &&
+							typeof body === 'object' &&
+							'code' in body &&
+							'message' in body
+						) {
+							errors.push( body );
+						}
+					}
+					if ( errors.length ) {
+						errors.forEach( ( error ) =>
+							actions.showNoticeError( error as ApiErrorResponse )
+						);
+					}
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -292,7 +292,7 @@ const { state, actions } = store< Store >(
 					const errorResponses = Array.isArray( json.responses )
 						? json.responses.filter(
 								( response ) =>
-									response.status < 200 &&
+									response.status < 200 ||
 									response.status >= 300
 						  )
 						: [];

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -92,8 +92,6 @@ function getUserFriendlyErrorMessage(
 	switch ( code ) {
 		case 'woocommerce_rest_missing_attributes':
 			return 'Please select product attributes before adding to cart.';
-		case 'no_successful_cart_response':
-			return 'This product can only be purchased once. You cannot add it to your cart again.';
 		default:
 			return error.message;
 	}
@@ -283,7 +281,6 @@ const { state, actions } = store< Store >(
 							throw generateError( response );
 					} );
 
-					// Gets the last successful cart response.
 					const successfulResponses = Array.isArray( json.responses )
 						? json.responses.filter(
 								( response ) =>
@@ -291,17 +288,23 @@ const { state, actions } = store< Store >(
 									response.status < 300
 						  )
 						: [];
-					const lastSuccessfulCartResponse = successfulResponses[
-						successfulResponses.length - 1
-					]?.body as Cart;
+
+					const errorResponses = Array.isArray( json.responses )
+						? json.responses.filter(
+								( response ) =>
+									response.status < 200 &&
+									response.status >= 300
+						  )
+						: [];
 
 					// Only update the cart and trigger events if there is at least one successful response.
 					if ( successfulResponses.length > 0 ) {
-						// Use the last successful response to update the local cart.
-						const cartResponse = lastSuccessfulCartResponse;
+						const lastSuccessfulCartResponse = successfulResponses[
+							successfulResponses.length - 1
+						]?.body as Cart;
 
-						// Updates the local cart.
-						state.cart = cartResponse;
+						// Use the last successful response to update the local cart.
+						state.cart = lastSuccessfulCartResponse;
 
 						// Dispatches a legacy event.
 						triggerAddedToCartEvent( {
@@ -312,18 +315,17 @@ const { state, actions } = store< Store >(
 						emitSyncEvent( { quantityChanges } );
 					}
 
-					// Show all errors from the batch responses.
-					for ( const response of json.responses ) {
-						const body = response?.body;
+					// Show error notices for all failed responses.
+					errorResponses.forEach( ( response ) => {
 						if (
-							body &&
-							typeof body === 'object' &&
-							'code' in body &&
-							'message' in body
+							response.body &&
+							typeof response.body === 'object'
 						) {
-							actions.showNoticeError( body as ApiErrorResponse );
+							actions.showNoticeError(
+								response.body as ApiErrorResponse
+							);
 						}
-					}
+					} );
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -295,39 +295,22 @@ const { state, actions } = store< Store >(
 						successfulResponses.length - 1
 					]?.body as Cart;
 
-					// Checks if the last successful cart response is valid.
-					if ( ! lastSuccessfulCartResponse ) {
-						throw generateError( {
-							code: 'no_successful_cart_response',
-							message: 'No successful cart response received.',
+					// Only update the cart and trigger events if there is at least one successful response.
+					if ( successfulResponses.length > 0 ) {
+						// Use the last successful response to update the local cart.
+						const cartResponse = lastSuccessfulCartResponse;
+
+						// Updates the local cart.
+						state.cart = cartResponse;
+
+						// Dispatches a legacy event.
+						triggerAddedToCartEvent( {
+							preserveCartData: true,
 						} );
+
+						// Dispatches the event to sync the @wordpress/data store.
+						emitSyncEvent( { quantityChanges } );
 					}
-
-					// Checks if the last successful response contains any errors.
-					if (
-						lastSuccessfulCartResponse?.errors &&
-						Array.isArray( lastSuccessfulCartResponse.errors )
-					) {
-						lastSuccessfulCartResponse.errors.forEach(
-							( error ) => {
-								actions.showNoticeError( error );
-							}
-						);
-					}
-
-					// Use the last successful response to update the local cart.
-					const cartResponse = lastSuccessfulCartResponse;
-
-					// Updates the local cart.
-					state.cart = cartResponse;
-
-					// Dispatches a legacy event.
-					triggerAddedToCartEvent( {
-						preserveCartData: true,
-					} );
-
-					// Dispatches the event to sync the @wordpress/data store.
-					emitSyncEvent( { quantityChanges } );
 
 					// Show all errors from the batch responses.
 					for ( const response of json.responses ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the error handling for the `Add to Cart + Options` block when attempting to add an individually sold product that is already in the cart.
#### Current behavior:

- When trying to add an individually sold product twice, sometimes shows a generic `No successful cart response received` error
- Sometimes shows no error at all when other products are successfully added to cart

#### New behavior:

- Always shows a user-friendly error message when attempting to add an individually sold product that's already in the cart
- Allows other products to be added successfully while still displaying relevant error messages
- Provides consistent error feedback regardless of other cart operations

Closes #59269 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/5ae7a016-6c43-434a-8cf3-19115c80fb17

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to _Appearance > Editor > Templates > Single Product_.
2. Click on the `Add to Cart with Options` block and update to the blockified version.
3. Create a grouped product with
- One child product sold individually
- One child product that can be sold multiple times
4. In the frontend, navigate to the grouped product page with an empty cart
5. Add the individually-sold child product to the cart (should work fine)
6. Try to add the same individually-sold product again
7. A user-friendly error message should appear explaining the product cannot be added twice
8. Add one of the non-individually sold children and a individually-sold to verify it works correctly i.e. it adds the product and also shows a notice.
9. Set the non-individually sold product quantity back to 0
10. Try adding the individually-sold product again
11. The same user-friendly error should appear.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
