### PR TITLE
Fix Product Attributes Taxonomies When Importing XML/WXR Using WP CLI

### DIFF
--- a/plugins/woocommerce/changelog/fix-wp-cli-xml-import
+++ b/plugins/woocommerce/changelog/fix-wp-cli-xml-import
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed product attributes taxonomies during XML/WXR import via WP CLI.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -173,7 +173,7 @@ class WC_Admin_Importers {
 	 * This code grabs the file before it is imported and ensures the taxonomies are created.
 	 */
 	public function post_importer_compatibility() {
-		wc_deprecated_function( 'post_importer_compatibility', '10.1.0', 'Compatibility with the WP WXR importer is filtering the posts instead of initializing at the start and having to re-parse the file.' );
+		wc_deprecated_function( 'post_importer_compatibility', '10.1.0', 'A new integration with the WP WXR importer now filters the posts during import and registers the taxonomies, instead of initializing them at the start of the import and having to re-parse the file.' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( empty( $_POST['import_id'] ) || ! class_exists( 'WXR_Parser' ) ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Integrations\WPPostsImporter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,6 +37,12 @@ class WC_Admin_Importers {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 		add_action( 'wp_ajax_woocommerce_do_ajax_product_import', array( $this, 'do_ajax_product_import' ) );
 		add_action( 'in_admin_footer', array( $this, 'track_importer_exporter_view' ) );
+
+		/**
+		 * Register the WP Posts importer.
+		 */
+		$wp_posts_importer = wc_get_container()->get( WPPostsImporter::class );
+		$wp_posts_importer->register();
 
 		// Register WooCommerce importers.
 		$this->importers['product_importer'] = array(
@@ -132,7 +139,6 @@ class WC_Admin_Importers {
 	 */
 	public function register_importers() {
 		if ( Constants::is_defined( 'WP_LOAD_IMPORTERS' ) ) {
-			add_action( 'import_start', array( $this, 'post_importer_compatibility' ) );
 			register_importer( 'woocommerce_product_csv', __( 'WooCommerce products (CSV)', 'woocommerce' ), __( 'Import <strong>products</strong> to your store via a csv file.', 'woocommerce' ), array( $this, 'product_importer' ) );
 			register_importer( 'woocommerce_tax_rate_csv', __( 'WooCommerce tax rates (CSV)', 'woocommerce' ), __( 'Import <strong>tax rates</strong> to your store via a csv file.', 'woocommerce' ), array( $this, 'tax_rates_importer' ) );
 		}
@@ -167,7 +173,7 @@ class WC_Admin_Importers {
 	 * This code grabs the file before it is imported and ensures the taxonomies are created.
 	 */
 	public function post_importer_compatibility() {
-		global $wpdb;
+		wc_deprecated_function( 'post_importer_compatibility', '10.1.0', 'Compatibility with the WP WXR importer is filtering the posts instead of initializing at the start and having to re-parse the file.' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( empty( $_POST['import_id'] ) || ! class_exists( 'WXR_Parser' ) ) {

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\CLIRunner as CustomOrdersTableCLIRunner;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\CLIRunner as ProductAttributesLookupCLIRunner;
+use Automattic\WooCommerce\Internal\Integrations\WPPostsImporter;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +34,12 @@ class WC_CLI {
 		 * @see https://github.com/woocommerce/woocommerce/issues/56305
 		 */
 		add_action( 'init', array( $this, 'add_blueprint_cli_hook' ) );
+
+		/**
+		 * Register the WP Posts importer.
+		 */
+		$wp_posts_importer = wc_get_container()->get( WPPostsImporter::class );
+		$wp_posts_importer->register();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Integrations/WPPostsImporter.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPPostsImporter.php
@@ -28,7 +28,7 @@ class WPPostsImporter {
 	 * @param array $posts The posts to process.
 	 * @return array
 	 */
-	public function register_product_attribute_taxonomies( $posts ): array {
+	public function register_product_attribute_taxonomies( $posts ) {
 		if ( ! is_array( $posts ) || empty( $posts ) ) {
 			return $posts;
 		}

--- a/plugins/woocommerce/src/Internal/Integrations/WPPostsImporter.php
+++ b/plugins/woocommerce/src/Internal/Integrations/WPPostsImporter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Integrations;
+
+/**
+ * Class WPPostsImporter
+ *
+ * @since 10.1.0
+ */
+class WPPostsImporter {
+
+	/**
+	 * Register the WP Posts importer.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'wp_import_posts', array( $this, 'register_product_attribute_taxonomies' ), 100, 1 );
+	}
+
+	/**
+	 * Register product attribute taxonomies when importing posts via the WXR importer.
+	 *
+	 * @since 10.1.0
+	 *
+	 * @param array $posts The posts to process.
+	 * @return array
+	 */
+	public function register_product_attribute_taxonomies( $posts ): array {
+		if ( ! is_array( $posts ) || empty( $posts ) ) {
+			return $posts;
+		}
+
+		foreach ( $posts as $post ) {
+
+			if ( 'product' !== $post['post_type'] || empty( $post['terms'] ) ) {
+				continue;
+			}
+
+			foreach ( $post['terms'] as $term ) {
+				if ( ! strstr( $term['domain'], 'pa_' ) ) {
+					continue;
+				}
+
+				if ( taxonomy_exists( $term['domain'] ) ) {
+					continue;
+				}
+
+				$attribute_name = wc_attribute_taxonomy_slug( $term['domain'] );
+
+				// Create the taxonomy.
+				if ( ! in_array( $attribute_name, wc_get_attribute_taxonomies(), true ) ) {
+					wc_create_attribute(
+						array(
+							'name'         => $attribute_name,
+							'slug'         => $attribute_name,
+							'type'         => 'select',
+							'order_by'     => 'menu_order',
+							'has_archives' => false,
+						)
+					);
+				}
+
+				// Register the taxonomy so that the import works.
+				register_taxonomy(
+					$term['domain'],
+					// phpcs:ignore
+					apply_filters( 'woocommerce_taxonomy_objects_' . $term['domain'], array( 'product' ) ),
+					// phpcs:ignore
+					apply_filters(
+						'woocommerce_taxonomy_args_' . $term['domain'],
+						array(
+							'hierarchical' => true,
+							'show_ui'      => false,
+							'query_var'    => true,
+							'rewrite'      => false,
+						)
+					)
+				);
+			}
+		}
+
+		return $posts;
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPLUG-2680: \[WP CLI\] sample-data/sample_products.xml Failed to import taxonomy](https://linear.app/a8c/issue/WOOPLUG-2680/wp-cli-sample-datasample-productsxml-failed-to-import-taxonomy)

This PR aims to resolve an issue with product attribute taxonomies not being recognized during a WP CLI import via the WordPress Posts Importer.

(For Bug Fixes) Bug introduced in PR `N/A`
I couldn't identify a specific PR that caused this, but code-wise it seems it never actually worked as intended in the WP CLI context.

### Specification

We already support this in the WC_Admin_Importers class, but it is limited to the wp-admin context. This PR aims to reorganize the fix into a dedicated internal service and make the service work in both contexts. 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites

1. Navigate to Tools > Import and click on "Install Now" under the "WordPress" importer.

#### Testing WP-CLI

1. Start with a store that has no products or product attributes.
3. `cd mysite/wp-content/plugins`
4. Run `wp import woocommerce/sample-data/sample_products.xml --authors=create`
5. Notice the initial errors stating "Failed to import..." related to product attributes.
6. Follow this process.
7. Delete the products added in the previous step and re-run the same WP CLI command.
8. Verify that all product attributes are saved correctly.

#### Testing the wp-admin Importer UI

1. Delete the product attributes, then delete the previously added products (in that order; this is important).
2. Go to Tools > Import and select the "WordPress" importer. 
3. Choose the sample_data/sample_products.xml file from the file picker and click "Upload file and import".
4. Check the box for "Download and import file attachments".
5. Click Submit.
6. Confirm that products and attributes are imported correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
