### PR TITLE
Interactivity API powered MiniCart - Fix block styles

### DIFF
--- a/plugins/woocommerce/changelog/59561-wooplug-4935-interactivity-api-powered-mini-cart-block-styles-arent
+++ b/plugins/woocommerce/changelog/59561-wooplug-4935-interactivity-api-powered-mini-cart-block-styles-arent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apply block styles in iAPI powered MiniCart.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/button/style.scss
@@ -39,7 +39,8 @@
 		}
 	}
 
-	&.outlined {
+	&.outlined,
+	&.is-style-outline {
 		background: transparent;
 		color: currentColor;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/block.json
@@ -1,0 +1,43 @@
+{
+	"name": "woocommerce/mini-cart-contents",
+	"version": "1.0.0",
+	"title": "Mini-Cart Contents",
+	"description": "Display a Mini-Cart widget.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"lock": false,
+		"__experimentalBorder": {
+			"color": true,
+			"width": true
+		}
+	},
+	"attributes": {
+		"isPreview": {
+			"type": "boolean",
+			"default": false
+		},
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		},
+		"width": {
+			"type": "string",
+			"default": "480px"
+		}
+	},
+	"apiVersion": 3,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -12,8 +12,7 @@
 		"inserter": true,
 		"color": {
 			"text": true,
-			"background": true,
-			"__experimentalSkipSerialization": true
+			"background": true
 		}
 	},
 	"attributes": {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -39,16 +39,17 @@ class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_empty_mini_cart_contents( $attributes, $content, $block ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-wp-bind--aria-hidden' => '!state.cartIsEmpty',
+				'data-wp-bind--hidden' => '!state.cartIsEmpty',
+				'data-wp-interactive' => 'woocommerce/mini-cart',
+			)
+		);
 
 		ob_start();
 		?>
-		<div 
-			data-wp-bind--aria-hidden="!state.cartIsEmpty"
-			data-wp-bind--hidden="!state.cartIsEmpty" 
-			data-wp-interactive="woocommerce/mini-cart" 
-			<?php echo $wrapper_attributes; ?>		
-		>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-mini-cart__empty-cart-wrapper">
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -42,8 +42,8 @@ class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'data-wp-bind--aria-hidden' => '!state.cartIsEmpty',
-				'data-wp-bind--hidden' => '!state.cartIsEmpty',
-				'data-wp-interactive' => 'woocommerce/mini-cart',
+				'data-wp-bind--hidden'      => '!state.cartIsEmpty',
+				'data-wp-interactive'       => 'woocommerce/mini-cart',
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -39,13 +39,15 @@ class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_empty_mini_cart_contents( $attributes, $content, $block ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
 		ob_start();
 		?>
 		<div 
 			data-wp-bind--aria-hidden="!state.cartIsEmpty"
 			data-wp-bind--hidden="!state.cartIsEmpty" 
 			data-wp-interactive="woocommerce/mini-cart" 
-			class="wp-block-woocommerce-empty-mini-cart-contents-block"			
+			<?php echo $wrapper_attributes; ?>		
 		>
 			<div class="wc-block-mini-cart__empty-cart-wrapper">
 				<?php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
@@ -39,11 +39,16 @@ class FilledMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_filled_mini_cart_contents( $attributes, $content, $block ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-wp-bind--hidden' => 'state.cartIsEmpty',
+				'data-wp-interactive'  => 'woocommerce/mini-cart',
+			)
+		);
 
 		ob_start();
 		?>
-		<div data-wp-bind--hidden="state.cartIsEmpty" data-wp-interactive="woocommerce/mini-cart" <?php echo $wrapper_attributes; ?>>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
@@ -39,9 +39,11 @@ class FilledMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_filled_mini_cart_contents( $attributes, $content, $block ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
 		ob_start();
 		?>
-		<div data-wp-bind--hidden="state.cartIsEmpty" data-wp-interactive="woocommerce/mini-cart" class="wp-block-woocommerce-filled-mini-cart-contents-block">
+		<div data-wp-bind--hidden="state.cartIsEmpty" data-wp-interactive="woocommerce/mini-cart" <?php echo $wrapper_attributes; ?>>
 			<?php
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -23,21 +23,32 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
-		$default_view_cart_text    = __( 'View my cart', 'woocommerce' );
-		$view_cart_text            = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
-		$cart_page_id              = wc_get_page_id( 'cart' );
-		$cart_page_url             = get_permalink( $cart_page_id );
-		// Default style class is not added by default, so it needs to be added manually if it doesn't exist.
-		$block_style_default_class = '';
-		if ( ! isset( $attributes['className'] ) || strpos( $attributes['className'], 'is-style-' ) === false ) {
-			$block_style_default_class = 'is-style-outline';
-		}
-		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-cart ' . $block_style_default_class ) );
+		$default_view_cart_text = __( 'View my cart', 'woocommerce' );
+		$view_cart_text         = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
+		$cart_page_id           = wc_get_page_id( 'cart' );
+		$cart_page_url          = get_permalink( $cart_page_id );
+		$classes                = implode(
+			' ',
+			array_filter(
+				array(
+					'wc-block-components-button',
+					'wp-element-button wc-block-mini-cart__footer-cart',
+					// Default style class is not added by default, so it needs to be added manually if it doesn't exist.
+					( ! isset( $attributes['className'] ) || strpos( $attributes['className'], 'is-style-' ) === false ) ? 'is-style-outline' : '',
+				)
+			)
+		);
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'href'  => esc_url( $cart_page_url ),
+				'class' => $classes
+			)
+		);
 
 		ob_start();
 
 		?>
-		<a href="<?php echo esc_url( $cart_page_url ); ?>" <?php echo $wrapper_attributes; ?>>
+		<a <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-components-button__text">
 				<?php echo esc_html( $view_cart_text ); ?>
 			</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -29,7 +29,7 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 		$cart_page_url             = get_permalink( $cart_page_id );
 		// Default style class is not added by default, so it needs to be added manually if it doesn't exist.
 		$block_style_default_class = '';
-		if ( ! isset ( $attributes['classname]'] ) || ! strpos( $attributes['classname'], 'is-style-' ) ){
+		if ( ! isset( $attributes['className'] ) || strpos( $attributes['className'], 'is-style-' ) === false ) {
 			$block_style_default_class = 'is-style-outline';
 		}
 		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-cart ' . $block_style_default_class ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -38,10 +38,10 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 				)
 			)
 		);
-		$wrapper_attributes = get_block_wrapper_attributes(
+		$wrapper_attributes     = get_block_wrapper_attributes(
 			array(
 				'href'  => esc_url( $cart_page_url ),
-				'class' => $classes
+				'class' => $classes,
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -27,11 +27,12 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 		$view_cart_text         = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
 		$cart_page_id           = wc_get_page_id( 'cart' );
 		$cart_page_url          = get_permalink( $cart_page_id );
+		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-cart' ) );
 
 		ob_start();
 
 		?>
-		<a href="<?php echo esc_url( $cart_page_url ); ?>" class="wc-block-components-button wp-element-button wp-block-woocommerce-mini-cart-cart-button-block wc-block-mini-cart__footer-cart outlined">
+		<a href="<?php echo esc_url( $cart_page_url ); ?>" <?php echo $wrapper_attributes; ?>>
 			<div class="wc-block-components-button__text">
 				<?php echo esc_html( $view_cart_text ); ?>
 			</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -23,11 +23,16 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_markup( $attributes, $content, $block ) {
-		$default_view_cart_text = __( 'View my cart', 'woocommerce' );
-		$view_cart_text         = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
-		$cart_page_id           = wc_get_page_id( 'cart' );
-		$cart_page_url          = get_permalink( $cart_page_id );
-		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-cart' ) );
+		$default_view_cart_text    = __( 'View my cart', 'woocommerce' );
+		$view_cart_text            = $attributes['cartButtonLabel'] ? $attributes['cartButtonLabel'] : $default_view_cart_text;
+		$cart_page_id              = wc_get_page_id( 'cart' );
+		$cart_page_url             = get_permalink( $cart_page_id );
+		// Default style class is not added by default, so it needs to be added manually if it doesn't exist.
+		$block_style_default_class = '';
+		if ( ! isset ( $attributes['classname]'] ) || ! strpos( $attributes['classname'], 'is-style-' ) ){
+			$block_style_default_class = 'is-style-outline';
+		}
+		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-cart ' . $block_style_default_class ) );
 
 		ob_start();
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -30,7 +30,7 @@ class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
 		$wrapper_attributes          = get_block_wrapper_attributes(
 			array(
 				'href'  => esc_url( $checkout_page_url ),
-				'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-checkout'
+				'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-checkout',
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -27,10 +27,11 @@ class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
 		$go_to_checkout_text         = $attributes['checkoutButtonLabel'] ? $attributes['checkoutButtonLabel'] : $default_go_to_checkout_text;
 		$checkout_page_id            = wc_get_page_id( 'checkout' );
 		$checkout_page_url           = get_permalink( $checkout_page_id );
+		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-checkout' ) );
 
 		ob_start();
 		?>
-		<a href="<?php echo esc_url( $checkout_page_url ); ?>" class="wc-block-components-button wp-element-button wp-block-woocommerce-mini-cart-checkout-button-block wc-block-mini-cart__footer-checkout contained">
+		<a href="<?php echo esc_url( $checkout_page_url ); ?>" <?php echo $wrapper_attributes; ?>>
 			<div class="wc-block-components-button__text">
 				<?php echo esc_html( $go_to_checkout_text ); ?>
 			</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -27,11 +27,16 @@ class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
 		$go_to_checkout_text         = $attributes['checkoutButtonLabel'] ? $attributes['checkoutButtonLabel'] : $default_go_to_checkout_text;
 		$checkout_page_id            = wc_get_page_id( 'checkout' );
 		$checkout_page_url           = get_permalink( $checkout_page_id );
-		$wrapper_attributes     = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-checkout' ) );
+		$wrapper_attributes          = get_block_wrapper_attributes(
+			array(
+				'href'  => esc_url( $checkout_page_url ),
+				'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__footer-checkout'
+			)
+		);
 
 		ob_start();
 		?>
-		<a href="<?php echo esc_url( $checkout_page_url ); ?>" <?php echo $wrapper_attributes; ?>>
+		<a <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-components-button__text">
 				<?php echo esc_html( $go_to_checkout_text ); ?>
 			</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -64,11 +64,15 @@ class MiniCartContents extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_mini_cart_contents( $attributes, $content, $block ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-wp-interactive' => 'woocommerce/mini-cart-contents',
+			)
+		);
 
 		ob_start();
 		?>
-		<div data-wp-interactive="woocommerce/mini-cart-contents" <?php echo $wrapper_attributes; ?>>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-components-drawer__close-wrapper">
 				<button data-wp-on--click="woocommerce/mini-cart::callbacks.closeDrawer" class="wc-block-components-button wp-element-button wc-block-components-drawer__close contained" aria-label="Close" type="button">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -64,9 +64,11 @@ class MiniCartContents extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_mini_cart_contents( $attributes, $content, $block ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
 		ob_start();
 		?>
-		<div data-wp-interactive="woocommerce/mini-cart-contents" class="wp-block-woocommerce-mini-cart-contents">
+		<div data-wp-interactive="woocommerce/mini-cart-contents" <?php echo $wrapper_attributes; ?>>
 			<div class="wc-block-components-drawer__close-wrapper">
 				<button data-wp-on--click="woocommerce/mini-cart::callbacks.closeDrawer" class="wc-block-components-button wp-element-button wc-block-components-drawer__close contained" aria-label="Close" type="button">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -35,8 +35,8 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 		$wrapper_attributes               = get_block_wrapper_attributes(
 			array(
 				'data-wp-interactive' => 'woocommerce/mini-cart-footer-block',
-				'class'               => 'wc-block-mini-cart__footer'
-			) 
+				'class'               => 'wc-block-mini-cart__footer',
+			)
 		);
 
 		if ( $html->next_tag( 'bdi' ) ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -32,6 +32,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 		$subtotal                         = $display_cart_price_including_tax ? $cart->get_subtotal_tax() : $cart->get_subtotal();
 		$formatted_subtotal               = '';
 		$html                             = new \WP_HTML_Tag_Processor( wc_price( $subtotal ) );
+		$wrapper_attributes     		  = get_block_wrapper_attributes( array( 'class' => 'wc-block-mini-cart__footer' ) );
 
 		if ( $html->next_tag( 'bdi' ) ) {
 			while ( $html->next_token() ) {
@@ -50,7 +51,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 
 		?>
 		<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<div data-wp-interactive="woocommerce/mini-cart-footer-block" class="wp-block-woocommerce-mini-cart-footer-block wc-block-mini-cart__footer">
+		<div data-wp-interactive="woocommerce/mini-cart-footer-block" <?php echo $wrapper_attributes; ?>>
 			<div class="wc-block-components-totals-item wc-block-mini-cart__footer-subtotal">
 				<span class="wc-block-components-totals-item__label">
 					<?php echo esc_html( $subtotal_label ); ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -32,7 +32,12 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 		$subtotal                         = $display_cart_price_including_tax ? $cart->get_subtotal_tax() : $cart->get_subtotal();
 		$formatted_subtotal               = '';
 		$html                             = new \WP_HTML_Tag_Processor( wc_price( $subtotal ) );
-		$wrapper_attributes     		  = get_block_wrapper_attributes( array( 'class' => 'wc-block-mini-cart__footer' ) );
+		$wrapper_attributes               = get_block_wrapper_attributes(
+			array(
+				'data-wp-interactive' => 'woocommerce/mini-cart-footer-block',
+				'class'               => 'wc-block-mini-cart__footer'
+			) 
+		);
 
 		if ( $html->next_tag( 'bdi' ) ) {
 			while ( $html->next_token() ) {
@@ -50,8 +55,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 		);
 
 		?>
-		<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<div data-wp-interactive="woocommerce/mini-cart-footer-block" <?php echo $wrapper_attributes; ?>>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wc-block-components-totals-item wc-block-mini-cart__footer-subtotal">
 				<span class="wc-block-components-totals-item__label">
 					<?php echo esc_html( $subtotal_label ); ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -73,11 +73,17 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 			)
 		);
 
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wc-block-mini-cart__items' ) );
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-wp-interactive' => esc_attr( $this->get_full_block_name() ),
+				'class'               => 'wc-block-mini-cart__items',
+				'tabindex'            => '-1',
+			)
+		);
 
 		ob_start();
 		?>
-		<div data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>" <?php echo $wrapper_attributes; ?> tabindex="-1">
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<div class="wp-block-woocommerce-mini-cart-products-table-block wc-block-mini-cart__products-table">
 				<table class="wc-block-cart-items wc-block-mini-cart-items" tabindex="-1">
 					<caption class="screen-reader-text">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -73,9 +73,11 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 			)
 		);
 
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wc-block-mini-cart__items' ) );
+
 		ob_start();
 		?>
-		<div data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>" class="wp-block-woocommerce-mini-cart-items-block wc-block-mini-cart__items" tabindex="-1">
+		<div data-wp-interactive="<?php echo esc_attr( $this->get_full_block_name() ); ?>" <?php echo $wrapper_attributes; ?> tabindex="-1">
 			<div class="wp-block-woocommerce-mini-cart-products-table-block wc-block-mini-cart__products-table">
 				<table class="wc-block-cart-items wc-block-mini-cart-items" tabindex="-1">
 					<caption class="screen-reader-text">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -43,12 +43,13 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 		$shop_url                     = get_permalink( wc_get_page_id( 'shop' ) );
 		$default_start_shopping_label = __( 'Start shopping', 'woocommerce' );
 		$start_shopping_label         = $attributes['startShoppingButtonLabel'] ? $attributes['startShoppingButtonLabel'] : $default_start_shopping_label;
+		$wrapper_attributes           = get_block_wrapper_attributes( array( 'class' => 'wc-block-components-button wp-element-button wc-block-mini-cart__shopping-button' ) );
 		?>
 		<div class="wp-block-button has-text-align-center">
 			<a
 				data-wp-interactive="woocommerce/mini-cart-shopping-button-block"
 				href="<?php echo esc_attr( $shop_url ); ?>"
-				class="wc-block-components-button wp-element-button wp-block-woocommerce-mini-cart-shopping-button-block wc-block-mini-cart__shopping-button contained"
+				<?php echo $wrapper_attributes; ?>
 			>
 				<div class="wc-block-components-button__text">
 					<?php echo esc_html( $start_shopping_label ); ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -49,7 +49,7 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 			<a
 				data-wp-interactive="woocommerce/mini-cart-shopping-button-block"
 				href="<?php echo esc_attr( $shop_url ); ?>"
-				<?php echo $wrapper_attributes; ?>
+				<?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			>
 				<div class="wc-block-components-button__text">
 					<?php echo esc_html( $start_shopping_label ); ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
@@ -38,17 +38,19 @@ class MiniCartTitleBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_title_block( $attributes, $content, $block ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => 'wc-block-mini-cart__title',
+			)
+		);
 		ob_start();
 		?>
-		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-			<h2 class="wc-block-mini-cart__title">
+			<h2 <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo $content;
 				?>
 			</h2>
-		</div>
 		<?php
 		return ob_get_clean();
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
@@ -41,7 +41,7 @@ class MiniCartTitleBlock extends AbstractInnerBlock {
 		$wrapper_attributes = get_block_wrapper_attributes();
 		ob_start();
 		?>
-		<div <?php echo $wrapper_attributes ?>>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<h2 class="wc-block-mini-cart__title">
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
@@ -38,9 +38,10 @@ class MiniCartTitleBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render_experimental_iapi_title_block( $attributes, $content, $block ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
 		ob_start();
 		?>
-		<div class="wp-block-woocommerce-mini-cart-title-block">
+		<div <?php echo $wrapper_attributes ?>>
 			<h2 class="wc-block-mini-cart__title">
 				<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -60,9 +60,11 @@ class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
 			)
 		);
 
+		$wrapper_attributes = get_block_wrapper_attributes();
+
 		ob_start();
 		?>
-		<span data-wp-text="state.itemsInCartText" data-wp-interactive="woocommerce/mini-cart-title-items-counter-block" class="wp-block-woocommerce-mini-cart-title-items-counter-block">
+		<span data-wp-text="state.itemsInCartText" data-wp-interactive="woocommerce/mini-cart-title-items-counter-block" <?php echo $wrapper_attributes ?>>
 		</span>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -60,11 +60,16 @@ class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
 			)
 		);
 
-		$wrapper_attributes = get_block_wrapper_attributes();
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-wp-bind--text'        => 'state.itemsInCartText',
+				'data-wp-interactive'       => 'woocommerce/mini-cart-title-items-counter-block',
+			)
+		);
 
 		ob_start();
 		?>
-		<span data-wp-text="state.itemsInCartText" data-wp-interactive="woocommerce/mini-cart-title-items-counter-block" <?php echo $wrapper_attributes ?>>
+		<span <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		</span>
 		<?php
 		return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -62,8 +62,8 @@ class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'data-wp-bind--text'        => 'state.itemsInCartText',
-				'data-wp-interactive'       => 'woocommerce/mini-cart-title-items-counter-block',
+				'data-wp-bind--text'  => 'state.itemsInCartText',
+				'data-wp-interactive' => 'woocommerce/mini-cart-title-items-counter-block',
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -62,7 +62,7 @@ class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
-				'data-wp-bind--text'  => 'state.itemsInCartText',
+				'data-wp-text'        => 'state.itemsInCartText',
 				'data-wp-interactive' => 'woocommerce/mini-cart-title-items-counter-block',
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
@@ -40,10 +40,11 @@ class MiniCartTitleLabelBlock extends AbstractInnerBlock {
 	protected function render_experimental_iapi_title_label_block( $attributes, $content, $block ) {
 		$default_cart_label = __( 'Your cart', 'woocommerce' );
 		$cart_label         = $attributes['label'] ? $attributes['label'] : $default_cart_label;
+		$wrapper_attributes = get_block_wrapper_attributes();
 
 		ob_start();
 		?>
-		<span class="wp-block-woocommerce-mini-cart-title-label-block">
+		<span <?php echo $wrapper_attributes ?>>
 			<?php echo esc_html( $cart_label ); ?>
 		</span>
 		<?php

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
@@ -44,7 +44,7 @@ class MiniCartTitleLabelBlock extends AbstractInnerBlock {
 
 		ob_start();
 		?>
-		<span <?php echo $wrapper_attributes ?>>
+		<span <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php echo esc_html( $cart_label ); ?>
 		</span>
 		<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59507 .

Most of the block styles of the minicart blocks aren't being applied in the iAPI version. Most of them is because they aren't using `wrapper_attributes`, so this PR basically does that.

I've checked all the use cases I found and I'm listing them here.


All the scenarios are tested modifying the Mini-Cart pattern going to Site-Editor -> Patterns -> Mini-Cart

## MiniCart Contents styles should apply
Adding background or text colors in this block should apply.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="484" alt="Screenshot 2025-07-09 at 12 03 35" src="https://github.com/user-attachments/assets/a05eb981-c8ca-4198-ac0d-02997e6651a0" /> | <img width="477" alt="Screenshot 2025-07-09 at 16 31 31" src="https://github.com/user-attachments/assets/f3e0d17d-3376-4e95-b790-888dd2265225" /> | <img width="475" alt="Screenshot 2025-07-09 at 11 11 43" src="https://github.com/user-attachments/assets/339304eb-590b-4cc5-90a5-1793de32d772" /> |

**Testing instructions**

1. Select the Mini-Cart Contents block.
2. Apply a background color.
3. Check the applied styles in the frontend.

## Blocks should inherit the parent text color

When the `MiniCart Contents` has some text colors, it should apply to all inner blocks.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="478" alt="Screenshot 2025-07-09 at 12 07 43" src="https://github.com/user-attachments/assets/75dcd683-d7ee-400b-a0e2-efb105d76eca" /> | <img width="478" alt="Screenshot 2025-07-09 at 16 34 18" src="https://github.com/user-attachments/assets/6f4ccace-8926-4e89-84ee-699ad224a9c5" /> | <img width="475" alt="Screenshot 2025-07-09 at 12 12 53" src="https://github.com/user-attachments/assets/21158bc5-c4d2-4574-9323-9a323e30ea7b" /> |

**Testing instructions**

1. Select the Mini-Cart Contents block.
2. Apply a text color.
3. Check the applied styles in the frontend.

## Mini-Cart Title

It should be able to override the parent text styles.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="478" alt="Screenshot 2025-07-09 at 12 44 42" src="https://github.com/user-attachments/assets/ce6658b9-6076-47c3-82c4-3d7ce3cdf237" /> | <img width="474" alt="Screenshot 2025-07-09 at 16 35 17" src="https://github.com/user-attachments/assets/8890d638-ee27-4293-b1c3-eab5e2ebb825" /> | <img width="477" alt="Screenshot 2025-07-09 at 12 43 40" src="https://github.com/user-attachments/assets/7f2edbfa-27c8-4a6f-98d1-ff5a38c6d06d" /> |


**Testing instructions**

1. Select the Mini-Cart Title block.
2. Apply a text color.
3. Check the applied styles in the frontend.

##  Mini-Cart Title Label & Items Count

They should be able to override the parent text and background styles.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="478" alt="Screenshot 2025-07-09 at 12 44 42" src="https://github.com/user-attachments/assets/ce6658b9-6076-47c3-82c4-3d7ce3cdf237" /> | <img width="477" alt="Screenshot 2025-07-09 at 16 36 16" src="https://github.com/user-attachments/assets/4fef089c-ff19-48c7-adee-8f79aaf5260d" /> | <img width="477" alt="Screenshot 2025-07-09 at 12 43 18" src="https://github.com/user-attachments/assets/258f578e-7b9c-4324-96a1-419e247c36b0" /> |

**Testing instructions**

1. Select the Mini-Cart Title Label and the Items Counter blocks.
2. Apply a text and background color.
3. Check the applied styles in the frontend.

## Mini-Cart View Cart Button - Outline variant - No custom styles

It should use the background color of the `Mini-Cart Contents` block as background. It should use the text color of the `Mini-Cart Contents` block as border and text colors.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="478" alt="Screenshot 2025-07-09 at 12 49 22" src="https://github.com/user-attachments/assets/d6ca61c9-5f7d-4365-8b05-0d7691efe464" /> | <img width="477" alt="Screenshot 2025-07-09 at 16 37 26" src="https://github.com/user-attachments/assets/b6ebc81a-bb5f-4a96-b393-590aa6a69c86" /> | <img width="476" alt="Screenshot 2025-07-09 at 11 22 35" src="https://github.com/user-attachments/assets/cf7acc8f-ce36-4066-91c4-6c5553fa6342" /> |

On hover, It should use the background color of the `Mini-Cart Contents` block as boder and text colors. It should use the text color of the `Mini-Cart Contents` block as background color.

**Testing instructions**

1. Select the Mini-Cart View Cart button block.
2. Apply the Outline variation.
3. Check the applied styles in the frontend.

## Mini-Cart View Cart Button - Fill variant - No custom styles

It shouldn't apply the styles from the `Mini-Cart Contents` block, and it should be filled.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="478" alt="Screenshot 2025-07-09 at 12 49 22" src="https://github.com/user-attachments/assets/d6ca61c9-5f7d-4365-8b05-0d7691efe464" /> | <img width="475" alt="Screenshot 2025-07-09 at 16 48 14" src="https://github.com/user-attachments/assets/7db503b8-83da-401d-a201-b113f4234057" /> | <img width="479" alt="Screenshot 2025-07-09 at 12 54 10" src="https://github.com/user-attachments/assets/e7d5404f-318a-4f14-b651-61127cee99d6" /> |

On hover, it should use the `Mini-Cart Contents` text color as background and the background text color as text.

**Testing instructions**

1. Select the Mini-Cart View Cart button block.
2. Apply the Fill variation.
3. Check the applied styles in the frontend.

## Mini-Cart View Cart Button - Custom styles

Custom styles should prevail over the parent block, including on hover.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="477" alt="Screenshot 2025-07-09 at 12 58 53" src="https://github.com/user-attachments/assets/1d23e984-a1b9-4afe-bf7a-39e3d79fbb0c" /> | <img width="478" alt="Screenshot 2025-07-09 at 16 49 37" src="https://github.com/user-attachments/assets/c92dd959-022b-4119-9772-7bd3f5cffd8c" /> | <img width="478" alt="Screenshot 2025-07-09 at 12 56 02" src="https://github.com/user-attachments/assets/ea34b001-5dae-46ea-9a7d-db0318f13846" /> |

**Testing instructions**

1. Select the Mini-Cart View Cart button block.
2. Apply custom styles.
3. Check the applied styles in the frontend.

## Mini-Cart Checkout Button - Outline variant - No custom styles

It should use the background color of the `Mini-Cart Contents` block as background. It should use the text color of the `Mini-Cart Contents` block as border and text colors.

On hover, it should use its own styles.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="476" alt="Screenshot 2025-07-09 at 13 10 41" src="https://github.com/user-attachments/assets/3d073eaf-f148-42c4-a572-4a0f11009cf2" /> | <img width="478" alt="Screenshot 2025-07-09 at 16 50 42" src="https://github.com/user-attachments/assets/7853a417-4a8b-4cbb-b12f-ad72b273039c" /> | <img width="478" alt="Screenshot 2025-07-09 at 13 03 44" src="https://github.com/user-attachments/assets/aae2afdc-2def-44ad-95d4-e9a36c3ca468" /> |


**Testing instructions**

1. Select the Mini-Cart Checkout Cart button block.
2. Apply Outline variation.
3. Check the applied styles in the frontend.

## Mini-Cart Checkout Button - Fill variant - No custom styles

It should use the `Mini-Cart Contents` text color as background and the background text color as text.

On hover, it should not change.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="476" alt="Screenshot 2025-07-09 at 13 10 41" src="https://github.com/user-attachments/assets/3d073eaf-f148-42c4-a572-4a0f11009cf2" /> | <img width="478" alt="Screenshot 2025-07-09 at 16 51 17" src="https://github.com/user-attachments/assets/ed11950d-6c76-44e6-b772-082f854b375a" /> | <img width="481" alt="Screenshot 2025-07-09 at 13 05 09" src="https://github.com/user-attachments/assets/19cd53f3-0cfd-4929-8f0a-889150439345" /> |


**Testing instructions**

1. Select the Mini-Cart Checkout Cart button block.
2. Apply Outline variation.
3. Check the applied styles in the frontend.

## Mini-Cart Checkout Button - Custom styles

Custom styles should prevail over the parent block, including on hover.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="477" alt="Screenshot 2025-07-09 at 12 58 53" src="https://github.com/user-attachments/assets/1d23e984-a1b9-4afe-bf7a-39e3d79fbb0c" /> | <img width="480" alt="Screenshot 2025-07-09 at 16 52 19" src="https://github.com/user-attachments/assets/713f25f9-2f11-4a9f-80bc-d859f0703301" /> | <img width="476" alt="Screenshot 2025-07-09 at 13 01 35" src="https://github.com/user-attachments/assets/40ae87ee-c756-4576-9585-33439ed44f77" /> |


**Testing instructions**

1. Select the Mini-Cart Checkout Cart button block.
2. Apply custom styles.
3. Check the applied styles in the frontend.

## Empty Mini-Cart Shopping Button - Outline variant - No custom styles

It should use the background color of the `Mini-Cart Contents` block as background. It should use the text color of the `Mini-Cart Contents` block as border and text colors.

On hover, it should use its own styles.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="471" alt="Screenshot 2025-07-09 at 13 09 30" src="https://github.com/user-attachments/assets/52b50a2b-7c78-44cb-81b2-00b3548c55ca" /> | <img width="457" alt="Screenshot 2025-07-09 at 16 53 47" src="https://github.com/user-attachments/assets/919e2b6a-fa5d-47ee-835d-b4a8837a72e6" /> | <img width="473" alt="Screenshot 2025-07-09 at 13 06 53" src="https://github.com/user-attachments/assets/801430f2-0d34-429c-8fb2-08a8fe3ad691" /> |


**Testing instructions**

1. Select the Mini-Cart Shopping button block.
2. Apply Outline variation.
3. Check the applied styles in the frontend.

## Empty Mini-Cart Shopping Button - Fill variant - No custom styles

It should use its own styles.

On hover, it should not change.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="471" alt="Screenshot 2025-07-09 at 13 09 30" src="https://github.com/user-attachments/assets/52b50a2b-7c78-44cb-81b2-00b3548c55ca" /> | <img width="448" alt="Screenshot 2025-07-09 at 16 54 16" src="https://github.com/user-attachments/assets/d70adc2b-fade-4461-a0c5-f41857b37e5b" /> | <img width="477" alt="Screenshot 2025-07-09 at 13 07 33" src="https://github.com/user-attachments/assets/182e8a4c-7fd1-48c9-8507-bca620a5722e" /> |

**Testing instructions**

1. Select the Mini-Cart Shopping button block.
2. Apply Fill variation.
3. Check the applied styles in the frontend.

## Empty Mini-Cart Shopping Button - Custom styles

Custom styles should prevail over the parent block.

| Before this PR | After this PR | React MiniCart   |
|--|--|--|
| <img width="480" alt="Screenshot 2025-07-09 at 13 00 08" src="https://github.com/user-attachments/assets/af24672f-23af-4a1c-8c9d-0083e0024490" /> | <img width="466" alt="Screenshot 2025-07-09 at 16 54 51" src="https://github.com/user-attachments/assets/4c5a64c1-5fe0-49e2-b5af-6a5bfc63d4df" /> | <img width="469" alt="Screenshot 2025-07-09 at 13 01 21" src="https://github.com/user-attachments/assets/01070958-8ac5-461a-bcf1-2360ec87d734" /> |


**Testing instructions**

1. Select the Mini-Cart Shopping button block.
2. Apply custom styles.
3. Check the applied styles in the frontend.

----


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Apply block styles in iAPI powered MiniCart.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
