### PR TITLE
Remove changelog entries from intermediate branches

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -109,6 +109,8 @@ jobs:
           fi
 
           # Normalize the version by removing .0 patch if present, as the changelog command does not support it
-          VERSION=${VERSION%.0}
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            VERSION=${VERSION%.0}
+          fi
 
           pnpm utils code-freeze changelog -o ${{ github.repository_owner }} -v $VERSION $BRANCH_ARG $APPEND_CHANGELOG $OVERRIDE_DATE

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
@@ -8,14 +8,10 @@ import { execSync } from 'child_process';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import {
-	checkoutRemoteBranch,
-	cloneAuthenticatedRepo,
-} from '../../../core/git';
+import { cloneAuthenticatedRepo } from '../../../core/git';
 import {
 	updateTrunkChangelog,
 	updateReleaseBranchChangelogs,
-	updateBranchChangelog,
 	updateIntermediateBranches,
 } from './lib';
 import { Options } from './types';

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
@@ -8,8 +8,16 @@ import { execSync } from 'child_process';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import { cloneAuthenticatedRepo } from '../../../core/git';
-import { updateTrunkChangelog, updateReleaseBranchChangelogs } from './lib';
+import {
+	checkoutRemoteBranch,
+	cloneAuthenticatedRepo,
+} from '../../../core/git';
+import {
+	updateTrunkChangelog,
+	updateReleaseBranchChangelogs,
+	updateBranchChangelog,
+	updateIntermediateBranches,
+} from './lib';
 import { Options } from './types';
 
 export const changelogCommand = new Command( 'changelog' )
@@ -91,7 +99,12 @@ export const changelogCommand = new Command( 'changelog' )
 		await updateTrunkChangelog(
 			options,
 			tmpRepoPath,
-			releaseBranch,
+			releaseBranchChanges
+		);
+
+		await updateIntermediateBranches(
+			options,
+			tmpRepoPath,
 			releaseBranchChanges
 		);
 	} );

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -320,31 +320,59 @@ async function getTrunkWooCommerceVersion(
 	return version;
 }
 
+function getNextVersion( currentVersion: string ) {
+	const parts = currentVersion.split( '.' ).map( Number );
+	let major = parts[ 0 ];
+	let minor = parts[ 1 ];
+
+	minor++;
+
+	// If minor exceeds 9, reset to 0 and increment major
+	if ( minor > 9 ) {
+		major++;
+		minor = 0;
+	}
+
+	return `${ major }.${ minor }`;
+}
+
 /**
  * Generates a list of release branch names between the target version and the trunk version.
  * Each branch name follows the format `release/{major}.{minor}`.
  *
- * @param trunkVersion  the current trunk version in the "major.minor" format (e.g., "8.7").
  * @param targetVersion the target version in the "major.minor" format (e.g., "9.5").
+ * @param trunkVersion  the current trunk version in the "major.minor" format (e.g., "8.7").
  * @return An array of branch names representing all release branches between the target and trunk versions.
  */
 function getTargetBranches(
-	trunkVersion: string,
-	targetVersion: string
+	targetVersion: string,
+	trunkVersion: string
 ): string[] {
+	const [ currentMajor, currentMinor ] = trunkVersion
+		.split( '.' )
+		.map( Number );
 	const [ targetMajor, targetMinor ] = targetVersion
 		.split( '.' )
 		.map( Number );
-	const [ trunkMajor, trunkMinor ] = trunkVersion.split( '.' ).map( Number );
 
-	const branches: string[] = [];
-
-	for (
-		let v = Number( `${ targetMajor }.${ targetMinor }` ) + 0.1;
-		v < Number( `${ trunkMajor }.${ trunkMinor }` );
-		v += 0.1
+	// Check if the target is greater than the trunk version
+	if (
+		targetMajor < currentMajor ||
+		( targetMajor === currentMajor && targetMinor <= currentMinor )
 	) {
-		branches.push( `release/${ v.toFixed( 1 ) }` );
+		Logger.notice(
+			`Target version ${ targetVersion } is not greater than trunk version ${ trunkVersion }. Skipping intermediate branches generation.`
+		);
+		return [];
+	}
+
+	const branches = [];
+	let version = getNextVersion( trunkVersion );
+
+	while ( version !== targetVersion ) {
+		Logger.notice( `Adding intermediate branch for version ${ version }` );
+		branches.push( `release/${ version }` );
+		version = getNextVersion( version );
 	}
 
 	return branches;
@@ -375,21 +403,18 @@ export const updateIntermediateBranches = async (
 	}
 
 	const targetBranches = getTargetBranches( trunkVersion, options.version );
+	Logger.notice(
+		`Target branches to update: ${ targetBranches.join( ', ' ) }`
+	);
 
 	for ( const targetBranch of targetBranches ) {
 		try {
-			Logger.notice(
-				`Updating changelogs for target branch: ${ targetBranch }`
-			);
-
 			await updateBranchChangelog(
 				options,
 				tmpRepoPath,
 				targetBranch,
 				releaseBranchChanges
 			);
-
-			Logger.notice( `Successfully updated ${ targetBranch }` );
 		} catch ( error ) {
 			Logger.error(
 				`Failed to update ${ targetBranch }: ${ error.message }`

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -19,9 +19,9 @@ import { getToday } from '../../get-version/lib';
 /**
  * Perform changelog adjustments after Jetpack Changelogger has run.
  *
- * @param {string} 	override    Time override.
+ * @param {string}  override        Time override.
  * @param {boolean} appendChangelog Whether to append the changelog or replace it.
- * @param {string} 	tmpRepoPath Path where the temporary repo is cloned.
+ * @param {string}  tmpRepoPath     Path where the temporary repo is cloned.
  */
 const updateReleaseChangelogs = async (
 	override: string,
@@ -339,13 +339,12 @@ function getTargetBranches(
 
 	const branches: string[] = [];
 
-	for ( let major = targetMajor; major <= trunkMajor; major++ ) {
-		const startMinor = major === targetMajor ? targetMinor + 1 : 0;
-		const endMinor = major === trunkMajor ? trunkMinor : 9;
-
-		for ( let minor = startMinor; minor <= endMinor; minor++ ) {
-			branches.push( `release/${ major }.${ minor }` );
-		}
+	for (
+		let v = Number( `${ targetMajor }.${ targetMinor }` ) + 0.1;
+		v < Number( `${ trunkMajor }.${ trunkMinor }` );
+		v += 0.1
+	) {
+		branches.push( `release/${ v.toFixed( 1 ) }` );
 	}
 
 	return branches;

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -5,6 +5,7 @@ import simpleGit from 'simple-git';
 import { execSync } from 'child_process';
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
+import { readFileSync } from 'fs';
 
 /**
  * Internal dependencies
@@ -188,7 +189,7 @@ export const updateReleaseBranchChangelogs = async (
 };
 
 /**
- * Perform changelog operations on trunk by submitting a pull request.
+ * Perform changelog operations on a given branch by submitting a pull request.
  *
  * @param {Object} options                                 CLI options
  * @param {string} tmpRepoPath                             temp repo path
@@ -197,7 +198,7 @@ export const updateReleaseBranchChangelogs = async (
  * @param {Object} releaseBranchChanges.deletionCommitHash commit from the changelog deletions in updateReleaseBranchChangelogs
  * @param {Object} releaseBranchChanges.prNumber           pr number created in updateReleaseBranchChangelogs
  */
-export const updateTrunkChangelog = async (
+export const updateBranchChangelog = async (
 	options: Options,
 	tmpRepoPath: string,
 	releaseBranch: string,
@@ -212,8 +213,8 @@ export const updateTrunkChangelog = async (
 	} );
 
 	try {
-		await git.checkout( 'trunk' );
-		const branch = `delete/${ version }-changelog`;
+		await git.checkout( releaseBranch );
+		const branch = `delete/${ releaseBranch }-changelog-from-${ version }`;
 		Logger.notice(
 			`Committing deletions in ${ branch } on ${ tmpRepoPath }`
 		);
@@ -242,21 +243,158 @@ export const updateTrunkChangelog = async (
 		const pullRequest = await createPullRequest( {
 			owner,
 			name,
-			title: `Release: Remove ${ version } change files`,
+			title: `Release: Remove ${ version } change files from ${ releaseBranch }`,
 			body: `This pull request was automatically generated to remove the changefiles from ${ version } that are compiled into the \`${ releaseBranch }\` ${
 				prNumber > 0 ? `branch via #${ prNumber }` : ''
 			}`,
 			head: branch,
-			base: 'trunk',
+			base: releaseBranch,
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 	} catch ( e ) {
-		if ( e.message.includes( 'No commits between trunk' ) ) {
+		if ( e.message.includes( `No commits between ${ releaseBranch }` ) ) {
 			Logger.notice(
-				'No commits between trunk and the branch, skipping the PR.'
+				`No commits between ${ releaseBranch } and the branch, skipping the PR.`
+			);
+		} else if (
+			e.message.includes( 'did not match any file(s) known to git' )
+		) {
+			Logger.notice(
+				`Branch ${ releaseBranch } does not exist, skipping the PR.`
 			);
 		} else {
 			Logger.error( e );
+		}
+	}
+};
+
+/**
+ * Perform changelog operations on trunk by submitting a pull request.
+ *
+ * @param {Object} options                                 CLI options
+ * @param {string} tmpRepoPath                             temp repo path
+ * @param {Object} releaseBranchChanges                    update data from updateReleaseBranchChangelogs
+ * @param {Object} releaseBranchChanges.deletionCommitHash commit from the changelog deletions in updateReleaseBranchChangelogs
+ * @param {Object} releaseBranchChanges.prNumber           pr number created in updateReleaseBranchChangelogs
+ */
+export const updateTrunkChangelog = async (
+	options: Options,
+	tmpRepoPath: string,
+	releaseBranchChanges: { deletionCommitHash: string; prNumber: number }
+): Promise< void > => {
+	return await updateBranchChangelog(
+		options,
+		tmpRepoPath,
+		'trunk',
+		releaseBranchChanges
+	);
+};
+
+/**
+ * Retrieves the WooCommerce version from the trunk branch
+ *
+ * @param tmpRepoPath cloned repo path
+ * @return the WooCommerce version string if found, or `null` if not found.
+ */
+async function getTrunkWooCommerceVersion(
+	tmpRepoPath: string
+): Promise< string | null > {
+	const git = simpleGit( {
+		baseDir: tmpRepoPath,
+		config: [ 'core.hooksPath=/dev/null' ],
+	} );
+
+	await git.checkout( 'trunk' );
+
+	const wooCommercePhpPath = path.join(
+		tmpRepoPath,
+		'plugins/woocommerce/woocommerce.php'
+	);
+	const fileContent = readFileSync( wooCommercePhpPath, 'utf8' );
+
+	const versionMatch = fileContent.match( /\*\s+Version:\s+(\d+\.\d+)/ );
+	const version = versionMatch ? versionMatch[ 1 ] : null;
+
+	Logger.notice( `WooCommerce trunk version is ${ version }` );
+
+	return version;
+}
+
+/**
+ * Generates a list of release branch names between the target version and the trunk version.
+ * Each branch name follows the format `release/{major}.{minor}`.
+ *
+ * @param trunkVersion  the current trunk version in the "major.minor" format (e.g., "8.7").
+ * @param targetVersion the target version in the "major.minor" format (e.g., "9.5").
+ * @return An array of branch names representing all release branches between the target and trunk versions.
+ */
+function getTargetBranches(
+	trunkVersion: string,
+	targetVersion: string
+): string[] {
+	const [ targetMajor, targetMinor ] = targetVersion
+		.split( '.' )
+		.map( Number );
+	const [ trunkMajor, trunkMinor ] = trunkVersion.split( '.' ).map( Number );
+
+	const branches: string[] = [];
+
+	for ( let major = targetMajor; major <= trunkMajor; major++ ) {
+		const startMinor = major === targetMajor ? targetMinor + 1 : 0;
+		const endMinor = major === trunkMajor ? trunkMinor : 9;
+
+		for ( let minor = startMinor; minor <= endMinor; minor++ ) {
+			branches.push( `release/${ major }.${ minor }` );
+		}
+	}
+
+	return branches;
+}
+
+/**
+ * Updates the changelogs for all intermediate branches between the trunk and the target release version.
+ *
+ * @param          options                                 a list of options
+ * @param          tmpRepoPath                             cloned repo path
+ * @param {Object} releaseBranchChanges                    update data from updateReleaseBranchChangelogs
+ * @param {Object} releaseBranchChanges.deletionCommitHash commit from the changelog deletions in updateReleaseBranchChangelogs
+ * @param {Object} releaseBranchChanges.prNumber           pr number created in updateReleaseBranchChangelogs
+ */
+export const updateIntermediateBranches = async (
+	options: Options,
+	tmpRepoPath: string,
+	releaseBranchChanges: { deletionCommitHash: string; prNumber: number }
+): Promise< void > => {
+	Logger.notice(
+		`Starting intermediate branches update for version ${ options.version }`
+	);
+
+	const trunkVersion = await getTrunkWooCommerceVersion( tmpRepoPath );
+	if ( ! trunkVersion ) {
+		Logger.error( 'Could not determine WooCommerce trunk version.' );
+		return;
+	}
+
+	const targetBranches = getTargetBranches( trunkVersion, options.version );
+
+	for ( const targetBranch of targetBranches ) {
+		try {
+			Logger.notice(
+				`Updating changelogs for target branch: ${ targetBranch }`
+			);
+
+			await updateBranchChangelog(
+				options,
+				tmpRepoPath,
+				targetBranch,
+				releaseBranchChanges
+			);
+
+			Logger.notice( `Successfully updated ${ targetBranch }` );
+		} catch ( error ) {
+			Logger.error(
+				`Failed to update ${ targetBranch }: ${ error.message }`
+			);
 		}
 	}
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the `pnpm utils code-freeze changelog` command to remove the changelog entries from intermediate branches, if they exists. 
Until now, when generating the changelog inside a release branch, the entries are removed from both the branch and trunk but not for intermediate release branches. For example, if a fix is cherry picked to 9.9.5, we don't want to include it in the changelog for 10.0.0 even though it should exist in that branch.

Closes #59475 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


⚠️ If you want to test on your own Slack workspace, follow the instructions from the Steps to set up a Slack app from https://github.com/woocommerce/woocommerce/pull/58417, otherwise follow these 👇

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In the forked repo, create a PR with the branch `59475/update-changelog-branches` and merge it (to get this new workflow into `trunk`).
3. In your forked repo create the `release/10.1` branches and update the version in `plugins/woocommerce/woocommerce.php` to `10.2.0-dev`.
4. Now go to `Actions`, click on the `Release: Compile changelog` and run it with version `9.9`.
5. Wait for the flow to finish successfully and make sure a PR has been create for all branches from `9.9` until `10.1` removing the changelog files. Also, make sure a PR has been created against `trunk` removing the changelog files and updating the `readme.txt`.

<img width="496" alt="Screenshot 2025-07-09 at 14 32 11" src="https://github.com/user-attachments/assets/3d0519cc-d69b-4415-a561-3fb50931dd50" />


### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
