### PR TITLE
Add workflow to bump WC core version

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -1,0 +1,145 @@
+name: 'Release: Bump version number'
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Type of version bump to perform'
+        required: true
+        type: choice
+        options:
+          - stable
+          - dev
+          - rc
+      branch:
+        description: 'Source branch to use.'
+        type: string
+        required: true
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-version:
+    name: Bump WooCommerce Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Get current version
+        id: get-current-version
+        run: |
+          version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
+          echo "Current version: $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Compute new version
+        id: compute-new-version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.inputs.branch;
+            const bumpType = context.payload.inputs.bump_type;
+            const currentVersion = '${{ steps.get-current-version.outputs.version }}';
+
+            const m = currentVersion.match( /(?<base>\d+\.\d+)\.(?<patch>\d+)(-rc\.(?<rc>\d+))?/ );
+            if ( ! m ) {
+              core.setFailed( `Current version (${ currentVersion }) does not have the expected format.` );
+              return;
+            }
+
+            const baseVersion = m.groups['base'];
+            const patch       = parseInt( m.groups['patch'] );
+            const rc          = m.groups['rc'] ? parseInt( m.groups['rc'] ) : null;
+
+            // Validate current version against bumpType and/or branch.
+            if ( 0 !== patch && ( 'dev' === bumpType || 'rc' === bumpType || ( 'stable' === bumpType && rc ) ) ) {
+              core.setFailed( `Bump type (${ bumpType }) does not apply to current version (${ currentVersion }).` );
+              return;
+            }
+
+            if ( ( 'trunk' === branch && ( rc || 'dev' !== bumpType ) ) || ( 'trunk' !== branch && 'dev' === bumpType ) ) {
+              core.setFailed( `Bump type (${ bumpType }) does not apply to source branch (${ branch }).` );
+              return;
+            }
+
+            // Compute new version.
+            let newVersion;
+
+            switch ( bumpType ) {
+              case 'dev':
+                newVersion = `${ ( Number( baseVersion ) + 0.1 ).toFixed( 1 ) }.0-dev`;
+                break;
+
+              case 'rc':
+                newVersion = `${ baseVersion }.${ patch }-rc.${ rc + 1 }`;
+                break;
+
+              case 'stable':
+                newVersion = rc ? `${ baseVersion }.0` : `${ baseVersion }.${ patch + 1 }`;
+                break;
+
+              default:
+                core.setFailed(`Invalid bump type.`);
+                return;
+            }
+
+            core.setOutput( 'nextVersion', newVersion );
+            core.setOutput( 'nextStable', newVersion.replace( /-(dev|rc\.\d+)/, '' ) );
+
+      - name: Bump version in files
+        env:
+          NEXT_VERSION: ${{ steps.compute-new-version.outputs.nextVersion }}
+          NEXT_STABLE: ${{ steps.compute-new-version.outputs.nextStable }}
+        run: |
+          cd plugins/woocommerce
+
+          # Update version header in woocommerce.php.
+          sed -i -E "s/Version: [0-9]+\.[0-9]+\.[0-9]+.*$/Version: $NEXT_VERSION/" woocommerce.php
+
+          # Update changelog in readme.txt.
+          sed -i -E "s/^= [0-9]+\.[0-9]+\.[0-9]+ [0-9]{4}-XX-XX =/= $NEXT_STABLE $(date +%Y)-XX-XX =/" readme.txt
+
+          # Update composer.json and package.json.
+          for filename in {composer,package}.json; do
+            jq --tab ".version = \"$NEXT_STABLE\"" ${filename} > tmp.json
+            mv tmp.json ${filename}
+          done
+
+          # Update $version property in class-woocommerce.php.
+          sed -i -E "s/public \\\$version = '[0-9]+\.[0-9]+\.[0-9]+';/public \\\$version = '$NEXT_STABLE'\;/" includes/class-woocommerce.php
+
+          if git diff --quiet; then
+            echo "::error::No changes to commit."
+            exit 1
+          fi
+
+      - name: Open PR with changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch_name="bump-wc-version-to-${{ steps.compute-new-version.outputs.nextVersion }}/${{ github.run_id }}"
+
+          # Configure Git.
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Push changes.
+          git checkout -b ${branch_name}
+          git commit \
+            --all \
+            --message 'Bump version to ${{ steps.compute-new-version.outputs.nextVersion }}.'
+          git push origin ${branch_name}
+
+          # Open PR.
+          gh pr create \
+            --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
+            --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
+            --base ${{ inputs.branch }} \
+            --head ${branch_name} \
+            --reviewer "${{ github.actor }}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR introduces workflow `Release: Bump version number` which can be used to bump WooCommerce versions both during development and in release branches for RCs and stable releases.

<img width="359" height="268" alt="Screenshot 2025-07-11 at 19 46 43" src="https://github.com/user-attachments/assets/4943b0e6-e22d-497e-b91d-4e1759b9e1f9" />

The workflow admits 3 types of version bump:

- `dev` which is meant to be used to transition `dev` versions only on `trunk` e.g.: `10.1.0-dev` → `10.2.0-dev`.
- `rc` which is meant to be used in release branches to bump RC versions e.g.: `10.1.0-rc.2` → `10.1.0-rc.3`.
- `stable` which is meant to be used in release branches to transition from RC to first stable or between stables e.g.: `10.1.0-rc.3` → `10.1.0` or `10.1.0` → `10.1.1`.

There's no need to manually specify the new version number, which is computed from the existing one and the bump type. This can help reduce errors when running the existing manual commands.


Related to #57936.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repo (`woocommerce/woocommerce`) and include at least `trunk`, `release/10.0` and create also a `release/10.1` using `trunk` as source.
1. Make sure this branch (`57936/version-bump`) is merged into `trunk` in your fork.
1. Go to **Actions > __Release: Bump version number__** in your fork:
   1. Run the workflow from `trunk`, using `release/10.1` as "Source branch" and bump type `rc`.
   1. Confirm that a PR bumping the version number to `10.1.0-rc.1` is created.
   1. Merge this PR into `release/10.1`.
   1. Run the workflow again with `release/10.1` as source and `rc` as bump type.
   1. Confirm that a PR bumping the version number to `10.1.0-rc.2` is created.
   1. Merge or close this last PR.
   1. Run the workflow again with source `release/10.1` and `stable` as bump type.
   1. Confirm that a PR bumping the version number to `10.1.0` is created.
1. For each of the following source branches and bump types, run the workflow (always from `trunk`) and confirm that the result is as indicated. Also confirm that the PR is created (and looks correct) in the cases required.

   |Source branch|Bump type|Result|
   |-------------|--------|------|
   |`release/10.0`|dev|**Failure.** `dev` only applies to `trunk`.|
   |`release/10.0`|rc|**Failure.** `release/9.9` is past RC time.|
   |`release/10.0`|stable|**Success.** A PR bumping versions to `10.0.2` is created.|
   |`trunk`|dev|**Success.** A PR bumping versions to `10.2.0-dev` is created.|
   |`trunk`|rc|**Failure.** `trunk` can only be bumped to the next `-dev` release.|
   |`trunk`|stable|**Failure.** `trunk` can only be bumped to the next `-dev` release.|

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
