### PR TITLE
[Blueprints] Fixed validation error when importing a live site config

### DIFF
--- a/plugins/woocommerce/changelog/59564-fix-issue-59369
+++ b/plugins/woocommerce/changelog/59564-fix-issue-59369
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixed an issue that prevented importing a Blueprint configuration from a Live site.
+

--- a/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
+++ b/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php
@@ -272,6 +272,10 @@ class RestApi {
 			$session_token = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : uniqid( 'bp_', true );
 		}
 
+		if ( false === get_transient( 'blueprint_import_session_' . $session_token ) ) {
+			set_transient( 'blueprint_import_session_' . $session_token, true, 10 * MINUTE_IN_SECONDS );
+		}
+
 		if ( ! $this->can_import_blueprint( $session_token ) ) {
 			return array(
 				'success'  => false,
@@ -282,10 +286,6 @@ class RestApi {
 					),
 				),
 			);
-		}
-
-		if ( false === get_transient( 'blueprint_import_session_' . $session_token ) ) {
-			set_transient( 'blueprint_import_session_' . $session_token, true, 10 * MINUTE_IN_SECONDS );
 		}
 
 		// Get the raw body size.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The fix that was done as part of on [[Blueprint] Prevent import interruption when site state changes from Coming Soon to Live](https://github.com/woocommerce/woocommerce/pull/57797) was to create a session ID and store it in a transient. If that transient exists at the point when the Site Visibility option changes, then the code doesn't do the standard validation to check if the site is in Coming Soon mode, that happens on every single step that is imported. 

The problem though is that:

- First [the session ID is created](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php#L268-L273).

- Then, can_import_blueprint [checks if the transient exists](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php#L332-L334). 

- And after that [is the transient created](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/Blueprint/RestApi.php#L287-L289). 

So, `can_import_blueprint` checks for a transient that hasn't been created yet. Creating the transient before `can_import_blueprint` solves the issue. 

Closes #59369 

(For Bug Fixes) Bug introduced in PR #57797 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with a brand new site.
2. Ensure that the site is in Coming Soon mode, under WooCommerce > Settings > Site Visibility.
3. Go to WooCommerce > Settings > Advanced > Blueprints. 
4. Click to import the following configuration file that changes the site's visibility option to Live:

[woo-blueprint-live.json](https://github.com/user-attachments/files/21141629/woo-blueprint-live.json)

5. Ensure that the import is completed without errors. 
6. Refresh the page and ensure that your site is now Live.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fixed an issue that prevented importing a Blueprint configuration from a Live site.
</details>
