### PR TITLE
Product tracking - handle non-existing fields more gracefully

### DIFF
--- a/plugins/woocommerce/changelog/59567-wccom-1588-add-defensive-checks-to-wp-admin-tracking-code
+++ b/plugins/woocommerce/changelog/59567-wccom-1588-add-defensive-checks-to-wp-admin-tracking-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Extra defensive coding in JS when editing products with some of the "standard" product fields removed from the UI

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -599,11 +599,19 @@ const attachProductVariationsTracks = () => {
 				const selectElement = document.querySelector(
 					'#field_to_edit'
 				) as HTMLSelectElement | null;
+				if ( ! selectElement ) {
+					return;
+				}
 				// Get the index of the selected option
-				const selectedIndex = selectElement?.selectedIndex ?? -1;
+				const selectedIndex = selectElement.selectedIndex;
+				const selectedOption = selectElement.options[ selectedIndex ];
+				if ( ! selectedOption ) {
+					return;
+				}
+
 				recordEvent( 'product_variations_buttons', {
 					action: 'bulk_actions',
-					selected: selectElement?.options[ selectedIndex ]?.value,
+					selected: selectedOption?.value,
 				} );
 			},
 		},

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -65,11 +65,11 @@ export const getProductData = () => {
 	let tagsText = '';
 
 	if ( ! isBlockEditor ) {
-		tagsText = (
-			document.querySelector(
-				'[name="tax_input[product_tag]"]'
-			) as HTMLInputElement
-		 ).value;
+		const tagsElement = document.querySelector(
+			'[name="tax_input[product_tag]"]'
+		) as HTMLInputElement | null;
+		tagsText = tagsElement?.value || '';
+
 		const content = document.querySelector(
 			'#content'
 		) as HTMLInputElement;
@@ -79,11 +79,10 @@ export const getProductData = () => {
 			description_value = tinymce.get( 'content' ).getContent();
 		}
 	} else {
-		description_value = (
-			document.querySelector(
-				'.block-editor-rich-text__editable'
-			) as HTMLInputElement
-		 )?.value;
+		const blockEditorElement = document.querySelector(
+			'.block-editor-rich-text__editable'
+		) as HTMLInputElement | null;
+		description_value = blockEditorElement?.value || '';
 	}
 
 	const productTypeOptions = getProductTypeOptions();
@@ -141,8 +140,8 @@ export const getProductData = () => {
 				(
 					document.querySelector(
 						'#_thumbnail_id'
-					) as HTMLInputElement
-				 )?.value,
+					) as HTMLInputElement | null
+				 )?.value || '0',
 				10
 			) > 0
 				? 'Yes'
@@ -181,21 +180,36 @@ export const getProductData = () => {
  * @return string
  */
 const getPublishDate = ( prefix = '' ) => {
-	const month = (
-		document.querySelector( `#${ prefix }mm` ) as HTMLInputElement
-	 )?.value;
-	const day = (
-		document.querySelector( `#${ prefix }jj` ) as HTMLInputElement
-	 )?.value;
-	const year = (
-		document.querySelector( `#${ prefix }aa` ) as HTMLInputElement
-	 )?.value;
-	const hours = (
-		document.querySelector( `#${ prefix }hh` ) as HTMLInputElement
-	 )?.value;
-	const seconds = (
-		document.querySelector( `#${ prefix }mn` ) as HTMLInputElement
-	 )?.value;
+	const month =
+		(
+			document.querySelector(
+				`#${ prefix }mm`
+			) as HTMLInputElement | null
+		 )?.value || '';
+	const day =
+		(
+			document.querySelector(
+				`#${ prefix }jj`
+			) as HTMLInputElement | null
+		 )?.value || '';
+	const year =
+		(
+			document.querySelector(
+				`#${ prefix }aa`
+			) as HTMLInputElement | null
+		 )?.value || '';
+	const hours =
+		(
+			document.querySelector(
+				`#${ prefix }hh`
+			) as HTMLInputElement | null
+		 )?.value || '';
+	const seconds =
+		(
+			document.querySelector(
+				`#${ prefix }mn`
+			) as HTMLInputElement | null
+		 )?.value || '';
 
 	return `${ month }-${ day }-${ year } ${ hours }:${ seconds }`;
 };
@@ -584,12 +598,12 @@ const attachProductVariationsTracks = () => {
 			callback: () => {
 				const selectElement = document.querySelector(
 					'#field_to_edit'
-				) as HTMLSelectElement;
+				) as HTMLSelectElement | null;
 				// Get the index of the selected option
-				const selectedIndex = selectElement.selectedIndex;
+				const selectedIndex = selectElement?.selectedIndex ?? -1;
 				recordEvent( 'product_variations_buttons', {
 					action: 'bulk_actions',
-					selected: selectElement.options[ selectedIndex ]?.value,
+					selected: selectElement?.options[ selectedIndex ]?.value,
 				} );
 			},
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Add a couple of defensive checks before attempting to read values from fields on product edit screen. In case some custom code removed them from local WooCommerce instances, we don't want scripts to throw errors.

This is what happens now on `trunk` when removing some fields from the editor:
![Screenshot 2025-07-09 at 14 44 49](https://github.com/user-attachments/assets/4ee46266-0001-4bca-ae71-13f2a2fa8224)


We noticed the error happening when we tried to limit visible fields on WooCommerce.com.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WCCOM-1588.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go through usual setup
   - checkout branch
   - `pnpm install -frozen-lockfile`
   - `cd plugins/woocommerce`
   - start docker `pnpm -- wp-env start`
   - start build `pnpm --filter='@woocommerce/plugin-woocommerce' watch:bui
2. Create a new product and save it.
3. Add these changes to `plugins/woocommerce/woocommerce.php` to remove some of fields that JS script previously expected to be there:
```php
add_filter( 'woocommerce_product_data_tabs', function( $tabs ) {
    unset( $tabs['inventory'] );
    unset( $tabs['shipping'] );
    unset( $tabs['linked_product'] );
    unset( $tabs['attribute'] );
    unset( $tabs['variations'] );
    unset( $tabs['advanced'] );
    return $tabs;
});

add_action( 'woocommerce_product_options_general_product_data', function() {
    // Override default fields by not rendering them
}, 5 );

add_action( 'admin_menu', function() {
    remove_meta_box( 'submitdiv', 'product', 'side' );
});

add_action( 'admin_menu', function() {
    remove_meta_box( 'tagsdiv-product_tag', 'product', 'side' );
});

```
5. Go to product edit screen and confirm you don't see the following error in the console 
![Screenshot 2025-07-09 at 14 44 49](https://github.com/user-attachments/assets/d3b010ae-fef3-48a3-8f0d-ef695e7a68a7)

6. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Extra defensive coding in JS when editing products with some of the "standard" product fields removed from the UI

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
