### PR TITLE
Ensure validation error does not show when copy-pasting valid passwords into the create-password component

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4944-strong-password-validation-breaking-with-copypaste-passwords
+++ b/plugins/woocommerce/changelog/wooplug-4944-strong-password-validation-breaking-with-copypaste-passwords
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent password input field erroring if password is copy-pasted in

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
@@ -21,7 +21,10 @@ const CreatePassword = () => {
 		useDispatch( validationStore );
 
 	useEffect( () => {
-		if ( customerPassword && passwordStrength < 2 ) {
+		if ( ! customerPassword ) {
+			return;
+		}
+		if ( passwordStrength < 2 ) {
 			setValidationErrors( {
 				'account-password': {
 					message: __(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/create-password.tsx
@@ -5,7 +5,7 @@ import PasswordStrengthMeter from '@woocommerce/base-components/cart-checkout/pa
 import { checkoutStore, validationStore } from '@woocommerce/block-data';
 import { ValidatedTextInput } from '@woocommerce/blocks-components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const CreatePassword = () => {
@@ -19,6 +19,27 @@ const CreatePassword = () => {
 	const { __internalSetCustomerPassword } = useDispatch( checkoutStore );
 	const { setValidationErrors, clearValidationError } =
 		useDispatch( validationStore );
+
+	useEffect( () => {
+		if ( customerPassword && passwordStrength < 2 ) {
+			setValidationErrors( {
+				'account-password': {
+					message: __(
+						'Please create a stronger password',
+						'woocommerce'
+					),
+					hidden: true,
+				},
+			} );
+			return;
+		}
+		clearValidationError( 'account-password' );
+	}, [
+		clearValidationError,
+		customerPassword,
+		passwordStrength,
+		setValidationErrors,
+	] );
 
 	return (
 		<ValidatedTextInput
@@ -41,21 +62,7 @@ const CreatePassword = () => {
 							hidden: true,
 						},
 					} );
-					return;
 				}
-				if ( passwordStrength < 2 ) {
-					setValidationErrors( {
-						'account-password': {
-							message: __(
-								'Please create a stronger password',
-								'woocommerce'
-							),
-							hidden: true,
-						},
-					} );
-					return;
-				}
-				clearValidationError( 'account-password' );
 			} }
 			feedback={
 				<PasswordStrengthMeter

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/test/create-password.test.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/test/create-password.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import CreatePassword from '../create-password';
+
+describe( 'CreatePassword', () => {
+	let user: ReturnType< typeof userEvent.setup >;
+
+	beforeEach( () => {
+		user = userEvent.setup();
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the password input field', () => {
+		render( <CreatePassword /> );
+
+		expect(
+			screen.getByLabelText( 'Create a password' )
+		).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Create a password' ) ).toHaveAttribute(
+			'type',
+			'password'
+		);
+		expect( screen.getByLabelText( 'Create a password' ) ).toHaveAttribute(
+			'required'
+		);
+	} );
+
+	// Note, this test does not use zxcvbn - it is not mocked or bundled in the test environment.
+	it( 'shows the password strength meter when typing', async () => {
+		render( <CreatePassword /> );
+		const input = screen.getByLabelText( 'Create a password' );
+
+		// Initially, the meter should be hidden
+		const meter = screen.getByRole( 'meter', {
+			name: 'Password strength',
+		} );
+		expect(
+			meter.closest( '.wc-block-components-password-strength' )
+		).toHaveClass( 'hidden' );
+
+		// Type a password
+		await act( async () => {
+			await user.clear( input );
+			await user.type( input, 'g' );
+		} );
+
+		// The meter should now be visible
+		await waitFor( () => {
+			expect(
+				meter.closest( '.wc-block-components-password-strength' )
+			).not.toHaveClass( 'hidden' );
+		} );
+
+		// Check that the strength value is displayed
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Too weak/i )
+			).toBeInTheDocument();
+		} );
+
+		await act( async () => {
+			await user.clear( input );
+			await user.type( input, 'test12!' );
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Weak/i )
+			).toBeInTheDocument();
+		} );
+
+		await act( async () => {
+			await user.clear( input );
+			await user.type( input, 'med len 1' );
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Medium/i )
+			).toBeInTheDocument();
+		} );
+
+		await act( async () => {
+			await user.clear( input );
+			await user.type( input, '!StrongPass!2' );
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Strong/i )
+			).toBeInTheDocument();
+		} );
+
+		await act( async () => {
+			await user.clear( input );
+			await user.type( input, 'This$IsA%Super()Strong935:Pa5W0Rd' );
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Very strong/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'does not show a warning after a strong password is pasted in', async () => {
+		render( <CreatePassword /> );
+		const input = screen.getByLabelText( 'Create a password' );
+
+		// Initially, the meter should be hidden
+		const meter = screen.getByRole( 'meter', {
+			name: 'Password strength',
+		} );
+		expect(
+			meter.closest( '.wc-block-components-password-strength' )
+		).toHaveClass( 'hidden' );
+
+		// Type a password
+		await act( async () => {
+			await user.clear( input );
+			await user.click( input );
+			await user.paste( 'This$IsA%Super()Strong935:Pa5W0Rd' );
+		} );
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Very strong/i )
+			).toBeInTheDocument();
+		} );
+		act( () => input.blur() );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( /Password Strength: Very strong/i )
+			).toBeInTheDocument();
+		} );
+		await waitFor( () => {
+			expect(
+				screen.queryByText( /Please create a stronger password/i )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/test/create-password.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/test/create-password.tsx
@@ -3,6 +3,8 @@
  */
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { checkoutStore } from '@woocommerce/block-data';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,6 +17,7 @@ describe( 'CreatePassword', () => {
 	beforeEach( () => {
 		user = userEvent.setup();
 		jest.clearAllMocks();
+		dispatch( checkoutStore ).__internalSetCustomerPassword( '' );
 	} );
 
 	it( 'renders the password input field', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixed a race condition in the WooCommerce Checkout Block's password field validation that was causing incorrect  validation errors when users pasted passwords into the box. The issue occurred because the  password strength validation in the `onChange` handler was checking the `passwordStrength` state _before_ the `PasswordStrengthMeter` component had finished calculating it. This is resolved this by moving the code that sets the validation error to a separate `useEffect` which runs when `passwordStrength` or `customerPassword` changes. This will ensure the validation error is triggered only after password strength is calculated. We need to run it on `customerPassword` changes too because passwords of the same strength should still re-trigger the validation error.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4944

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/d0d2815eff874ebbbf1e555acdb1fc6e | https://www.loom.com/share/58a863aa318f48c6b889d59533a2414d |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a block theme.
2. Go to WooCommerce -> Settings -> Accounts & Privacy
3. Enable "Allow customers to create an account" -> "During checkout"
4. As a logged-out user, add an item to the cart and go to the Checkout block. 
5. Click "Create an account with {store name}" and paste this password into the box `Y*Zty3oTxcnaAR**qTgN`
6. Click out of the box and ensure the "Strong" meter remains.
7. Type various passwords into the box and ensure the meter works showing different strengths. Click off the box and ensure that no error shows, _unless_ your password is weak.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
