### PR TITLE
Accessibility: add global event handler for anchors with button role triggering the click on spacebar keydown

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4953-accessibility-javascript-needed-for-adding-spacebar-support
+++ b/plugins/woocommerce/changelog/wooplug-4953-accessibility-javascript-needed-for-adding-spacebar-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Accessibility: add global event handler for anchors with button role triggering the click on spacebar keydown

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -17,7 +17,6 @@ jQuery( function( $ ) {
 		$( document.body )
 			.on( 'click', '.add_to_cart_button:not(.wc-interactive)', { addToCartHandler: this }, this.onAddToCart )
 			.on( 'click', '.remove_from_cart_button', { addToCartHandler: this }, this.onRemoveFromCart )
-			.on( 'keydown', '.remove_from_cart_button', this.onKeydownRemoveFromCart )
 			.on( 'added_to_cart', { addToCartHandler: this }, this.onAddedToCart )
 			.on( 'removed_from_cart', { addToCartHandler: this }, this.onRemovedFromCart )
 			.on( 'ajax_request_not_sent.adding_to_cart', this.updateButton );
@@ -168,18 +167,6 @@ jQuery( function( $ ) {
 			},
 			dataType: 'json'
 		});
-	};
-
-	/**
-	 * Handle when pressing the Space key on the remove item link.
-	 * This is necessary because the link got the role="button" attribute
-	 * and needs to act like a button.
-	 */
-	AddToCartHandler.prototype.onKeydownRemoveFromCart = function( event ) {
-		if ( event.key === ' ' ) {
-			event.preventDefault();
-			$( this ).trigger( 'click' );
-		}
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -31,31 +31,22 @@ jQuery( function ( $ ) {
 		$( '.woocommerce-store-notice' ).hide();
 	} else {
 		$( '.woocommerce-store-notice' ).show();
-		/**
-		 * After adding the role="button" attribute to the 
-		 * .woocommerce-store-notice__dismiss-link element, 
-		 * we need to add the keydown event listener to it.
-		 */
-		function store_notice_keydown_handler( event ) {
-			if ( ['Enter', ' '].includes( event.key ) ) {
-				event.preventDefault();
-				$( '.woocommerce-store-notice__dismiss-link' ).click();
-			}
-		}
 
 		// Set a cookie and hide the store notice when the dismiss button is clicked
 		function store_notice_click_handler( event ) {
 			Cookies.set( cookieName, 'hidden', { path: '/' } );
 			$( '.woocommerce-store-notice' ).hide();
 			event.preventDefault();
-			$( '.woocommerce-store-notice__dismiss-link' )
-				.off( 'click', store_notice_click_handler )
-				.off( 'keydown', store_notice_keydown_handler );
+			$( '.woocommerce-store-notice__dismiss-link' ).off(
+				'click',
+				store_notice_click_handler
+			);
 		}
-		
-		$( '.woocommerce-store-notice__dismiss-link' )
-			.on( 'click', store_notice_click_handler )
-			.on( 'keydown', store_notice_keydown_handler );
+
+		$( '.woocommerce-store-notice__dismiss-link' ).on(
+			'click',
+			store_notice_click_handler
+		);
 	}
 
 	// Make form field descriptions toggle on focus.
@@ -191,26 +182,14 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	// If the "Enable AJAX add to cart buttons on archives" setting is disabled
-	// the add-to-cart.js file won't be loaded, so we need to add the event listener here.
-	if ( typeof wc_add_to_cart_params === 'undefined') {
-		$( document.body ).on( 'keydown', '.remove_from_cart_button', on_keydown_remove_from_cart );
-	}
+	// Note: Spacebar support for .remove_from_cart_button (which has role="button")
+	// is now handled by the global a[role="button"] keydown handler above
 
-	$( document.body ).on( 'item_removed_from_classic_cart updated_wc_div', focus_populate_live_region );
+	$( document.body ).on(
+		'item_removed_from_classic_cart updated_wc_div',
+		focus_populate_live_region
+	);
 } );
-
-/**
- * Handle when pressing the Space key on the remove item link.
- * This is necessary because the link has the role="button" attribute
- * and needs to act like a button.
- */
-function on_keydown_remove_from_cart( event ) {
-	if ( event.key === ' ' ) {
-		event.preventDefault();
-		event.currentTarget.click();
-	}
-}
 
 /**
  * Focus on the first notice element on the page.
@@ -257,10 +236,10 @@ function refresh_sorted_by_live_region() {
 
 	if ( sorted_by_live_region ) {
 		var text = sorted_by_live_region.innerHTML;
-		sorted_by_live_region.setAttribute('aria-hidden', 'true');
-		
+		sorted_by_live_region.setAttribute( 'aria-hidden', 'true' );
+
 		var sorted_by_live_region_id = setTimeout( function () {
-			sorted_by_live_region.setAttribute('aria-hidden', 'false');
+			sorted_by_live_region.setAttribute( 'aria-hidden', 'false' );
 			sorted_by_live_region.innerHTML = '';
 			sorted_by_live_region.innerHTML = text;
 			clearTimeout( sorted_by_live_region_id );

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -14,6 +14,15 @@ jQuery( function ( $ ) {
 		}
 	} );
 
+	// Global accessibility handler for all links with role="button"
+	// This ensures both spacebar and enter keypresses trigger click events, as per ARIA specification
+	$( document.body ).on( 'keydown', 'a[role="button"]', function ( event ) {
+		if ( event.key === ' ' || event.key === 'Enter' ) {
+			event.preventDefault();
+			$( this ).trigger( 'click' );
+		}
+	} );
+
 	var noticeID = $( '.woocommerce-store-notice' ).data( 'noticeId' ) || '',
 		cookieName = 'store_notice' + noticeID;
 

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -16,10 +16,14 @@ jQuery( function ( $ ) {
 
 	// Global accessibility handler for all links with role="button"
 	// This ensures both spacebar and enter keypresses trigger click events, as per ARIA specification
-	$( document.body ).on( 'keydown', 'a[role="button"]', function ( event ) {
+	document.body.addEventListener( 'keydown', function ( event ) {
+		if ( ! event.target.matches( 'a[role="button"]' ) ) {
+			return;
+		}
+
 		if ( event.key === ' ' || event.key === 'Enter' ) {
 			event.preventDefault();
-			$( this ).trigger( 'click' );
+			event.target.click();
 		}
 	} );
 
@@ -182,7 +186,10 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	$( document.body ).on( 'item_removed_from_classic_cart updated_wc_div', focus_populate_live_region );
+	$( document.body ).on(
+		'item_removed_from_classic_cart updated_wc_div',
+		focus_populate_live_region
+	);
 } );
 
 /**

--- a/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/woocommerce.js
@@ -182,13 +182,7 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	// Note: Spacebar support for .remove_from_cart_button (which has role="button")
-	// is now handled by the global a[role="button"] keydown handler above
-
-	$( document.body ).on(
-		'item_removed_from_classic_cart updated_wc_div',
-		focus_populate_live_region
-	);
+	$( document.body ).on( 'item_removed_from_classic_cart updated_wc_div', focus_populate_live_region );
 } );
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

When links are remediated to announce as buttons, they should also function as a button and be able to be triggered with the spacebar. It's not necessarily a case and this came up in the composite products extensions audit, however, similar case(s) were found in WooCommerce core.

In this PR, I'm adding a global event handler for all `a[role="button"]`, that triggers click on those elements as a response to spacebar keydown.

In addition, I found few instances where it was explicitly attached to some anchors with button role. I removed those as it's handled globally now. This should also handle extensions and elements added after page load thanks to single event listener at the top.

Closes https://github.com/woocommerce/woocommerce/issues/59542

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     https://github.com/user-attachments/assets/c1fc336e-1e98-48f8-99fc-f777b56ef298   |      https://github.com/user-attachments/assets/33b3c0c3-3722-42dd-8beb-18f649c16ba5 |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Product Image Gallery - magnifying glass (bugfix testing)

1. Go to Editor > Single Product
2. Make sure you use Product Image Gallery block
3. Go to frontend
4. Use tab to focus on magnifying glass icon on gallery
5. Press spacebar
6. **Expected:** lightbox gallery opens
7. Close with escape and press enter
8. **Expected:** lightbox gallery opens

<img width="744" alt="image" src="https://github.com/user-attachments/assets/b81f651f-f258-4a1c-bf15-6f1e624c2b83" />

#### Classic Cart - remove product (regression testing)

1. Go to Editor > Page: Cart
2. Remove content and add Classic Cart
4. Go to frontend
5. Add some products to cart and go to cart
6. Use tab to focus on "X" button next to product
7. Press spacebar
8. **Expected:** product gets removed from cart
10. Focus on another one and press enter
11. **Expected:** product gets removed from cart

<img width="614" alt="image" src="https://github.com/user-attachments/assets/3169aa41-721f-4799-a2e3-e4da1f0d8f96" />

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
