### PR TITLE
[Blueprints]: Skip steps that set the Site Visibility to Live

### DIFF
--- a/plugins/woocommerce/changelog/59579-blueprints-skip-live-site-visibility-option
+++ b/plugins/woocommerce/changelog/59579-blueprints-skip-live-site-visibility-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Skip steps that change the Site Visibility to Live when importing a Blueprint.

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -87,6 +87,13 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 		let sessionToken = '';
 		// Loop through each step and send it to the endpoint
 		for ( const step of steps ) {
+
+			// Skip steps that set the Site Visibility to Live.
+			// Admins should have a chance to review their store before it is set to Live.
+			if ( 'no' === step?.options?.woocommerce_coming_soon ) {
+				continue;
+			}
+
 			const stepJson = JSON.stringify( {
 				step_definition: step,
 			} );

--- a/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/BlueprintUploadDropzone.tsx
@@ -87,10 +87,9 @@ const importBlueprint = async ( steps: BlueprintStep[] ) => {
 		let sessionToken = '';
 		// Loop through each step and send it to the endpoint
 		for ( const step of steps ) {
-
 			// Skip steps that set the Site Visibility to Live.
 			// Admins should have a chance to review their store before it is set to Live.
-			if ( 'no' === step?.options?.woocommerce_coming_soon ) {
+			if ( step?.options?.woocommerce_coming_soon === 'no' ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
@@ -23,6 +23,7 @@ export type BlueprintImportResponse = {
 
 export type BlueprintStep = {
 	step: string;
+	options?: Record<string, string>;
 };
 
 export type BlueprintImportStepResponse = {

--- a/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
+++ b/plugins/woocommerce/client/admin/client/blueprint/components/types.ts
@@ -23,7 +23,7 @@ export type BlueprintImportResponse = {
 
 export type BlueprintStep = {
 	step: string;
-	options?: Record<string, string>;
+	options?: Record< string, string >;
 };
 
 export type BlueprintImportStepResponse = {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Taking inspiration from this issue: https://github.com/woocommerce/woocommerce/issues/59369, we revisited how we deal with import steps that set the Site Visibility to Live. 

Blueprint imports are only allowed on Coming Soon sites. However, if the Blueprint was exported from a Live site and then imported to a Coming Soon site, then the latter would automatically be transformed to Live after the import without giving the admin the chance to double-check their configuration. Moreover, since paid plugins/themes are cannot be imported via Blueprints yet, this would potentially lead to a half-finished site, that is not 1-1 the same as the original site and therefore is not ready to be published. 

This PR skips all import steps that set the site to Live. It also fixes the type definition of `BlueprintStep`, which was incomplete.

Closes #59369 
Closes https://linear.app/a8c/issue/WOOPLUG-4871

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with a brand new site.
2. Ensure that the site is in Coming Soon mode, under WooCommerce > Settings > Site Visibility.
3. Go to WooCommerce > Settings > Advanced > Blueprints. 
4. Click to import the following configuration file that changes the site's visibility option to Live:

[woo-blueprint-live.json](https://github.com/user-attachments/files/21141629/woo-blueprint-live.json)

5. Ensure that the import is completed without errors. 
6. Refresh the page and ensure that your site is still in Coming Soon.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Skip steps that change the Site Visibility to Live when importing a Blueprint.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
