### PR TITLE
Fix `manage_stock` type to allow boolean and string values

### DIFF
--- a/plugins/woocommerce/changelog/59581-59319-fix-manage-stock-type
+++ b/plugins/woocommerce/changelog/59581-59319-fix-manage-stock-type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Fix `manage_stock` type to allow boolean and string values for product variations.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -2409,7 +2409,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 							),
 							'manage_stock' => array(
 								'description' => __( 'Stock management at variation level.', 'woocommerce' ),
-								'type'        => 'boolean',
+								'type'        => array( 'boolean', 'string' ),
 								'default'     => false,
 								'context'     => array( 'view', 'edit' ),
 							),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -691,7 +691,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				),
 				'manage_stock'          => array(
 					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
-					'type'        => 'boolean',
+					'type'        => array( 'boolean', 'string' ),
 					'default'     => false,
 					'context'     => array( 'view', 'edit' ),
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds string to `manage_stock` property in product variations, it already can return a boolean or a string (`parent`).
This goes with an update to docs: https://github.com/woocommerce/woocommerce-rest-api-docs/pull/272

Closes https://github.com/woocommerce/woocommerce/issues/59319

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a variable product with at least one variation.
2. Make requests to:
- `OPTIONS /wp-json/wc/v3/products/[PRODUCT_ID]/variations`
- `OPTIONS /wp-json/wc/v3/products/[PRODUCT_ID]/variations/[PRODUCT_VARIATION_ID]`
3. Search in the responses for `manage_stock` and check type is always `"type": ["boolean", "string"]`
```php
"manage_stock": {
    "default": false,
    "description": "Stock management at variation level.",
    "type": [
        "boolean",
        "string"
    ],
    "required": false
}
```
4. Make a request to `OPTIONS /wp-json/wc/v1/products/[PRODUCT_ID]`.
5. Search in the responses for `manage_stock` and check type is always `"type": ["boolean", "string"]` when the property is for a variation (description is `Stock management at variation level.`, product level should be just `boolean` type):
```php
"manage_stock": {
    "default": false,
    "description": "Stock management at variation level.",
    "type": [
        "boolean",
        "string"
    ],
    ...
}
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix `manage_stock` type to allow boolean and string values for product variations.
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
