### PR TITLE
Add refunds handling to fulfillments

### DIFF
--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/fulfillment-editor.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/fulfillment-editor.tsx
@@ -8,7 +8,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Fulfillment, Order } from '../../data/types';
+import { Fulfillment } from '../../data/types';
 import {
 	combineItems,
 	getItemsFromFulfillment,
@@ -38,8 +38,6 @@ interface FulfillmentEditorProps {
 	onExpand: () => void;
 	onCollapse: () => void;
 	fulfillment: Fulfillment;
-	fulfillments: Fulfillment[];
-	order: Order;
 	disabled?: boolean;
 }
 export default function FulfillmentEditor( {
@@ -48,17 +46,17 @@ export default function FulfillmentEditor( {
 	onExpand,
 	onCollapse,
 	fulfillment,
-	fulfillments,
-	order,
 	disabled = false,
 }: FulfillmentEditorProps ) {
+	const { order, fulfillments, refunds } = useFulfillmentDrawerContext();
 	const { isEditing, setIsEditing } = useFulfillmentDrawerContext();
 	const [ error, setError ] = useState< string | null >( null );
-	const itemsInFulfillment = getItemsFromFulfillment( order, fulfillment );
-	const itemsNotInAnyFulfillment = getItemsNotInAnyFulfillment(
-		fulfillments,
-		order
-	);
+	const itemsInFulfillment = order
+		? getItemsFromFulfillment( order, fulfillment )
+		: [];
+	const itemsNotInAnyFulfillment = order
+		? getItemsNotInAnyFulfillment( fulfillments, order, refunds )
+		: [];
 	const selectableItems = combineItems(
 		[ ...itemsInFulfillment ],
 		[ ...itemsNotInAnyFulfillment ]
@@ -69,7 +67,7 @@ export default function FulfillmentEditor( {
 	// Reset error when order changes
 	useEffect( () => {
 		setError( null );
-	}, [ order.id ] );
+	}, [ order?.id ] );
 
 	const handleChevronClick = () => {
 		if ( isEditing ) return;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/fulfillments-list.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/fulfillments-list.tsx
@@ -5,11 +5,10 @@ import FulfillmentEditor from './fulfillment-editor';
 import { useFulfillmentDrawerContext } from '../../context/drawer-context';
 
 export default function FulfillmentsList() {
-	const { order, fulfillments, openSection, setOpenSection, isEditing } =
+	const { fulfillments, openSection, setOpenSection, isEditing } =
 		useFulfillmentDrawerContext();
 
 	return (
-		order &&
 		fulfillments.length > 0 && (
 			<div className="woocommerce-fulfillment-stored-fulfillments-list">
 				{ fulfillments.map( ( fulfillment, index ) => (
@@ -27,9 +26,7 @@ export default function FulfillmentsList() {
 						}
 						onCollapse={ () => setOpenSection( '' ) }
 						key={ fulfillment.id }
-						order={ order }
 						fulfillment={ fulfillment }
-						fulfillments={ fulfillments }
 					/>
 				) ) }
 			</div>

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/new-fulfillment-form.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/components/fulfillments/new-fulfillment-form.tsx
@@ -21,8 +21,14 @@ import ShipmentForm from '../shipment-form';
 import CustomerNotificationBox from '../customer-notification-form';
 
 const NewFulfillmentForm: React.FC = () => {
-	const { order, fulfillments, openSection, setOpenSection, isEditing } =
-		useFulfillmentDrawerContext();
+	const {
+		order,
+		fulfillments,
+		refunds,
+		openSection,
+		setOpenSection,
+		isEditing,
+	} = useFulfillmentDrawerContext();
 	const [ error, setError ] = useState< string | null >( null );
 
 	// Reset error when order changes
@@ -34,7 +40,8 @@ const NewFulfillmentForm: React.FC = () => {
 		() =>
 			getItemsNotInAnyFulfillment(
 				fulfillments,
-				order ?? ( { line_items: [] as LineItem[] } as Order )
+				order ?? ( { line_items: [] as LineItem[] } as Order ),
+				refunds ?? []
 			).map( ( item ) => ( {
 				...item,
 				selection: item.selection.map( ( selection ) => ( {
@@ -42,7 +49,7 @@ const NewFulfillmentForm: React.FC = () => {
 					checked: true,
 				} ) ),
 			} ) ),
-		[ fulfillments, order ]
+		[ fulfillments, order, refunds ]
 	);
 
 	if ( ! order ) {

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/drawer-context.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/drawer-context.tsx
@@ -8,7 +8,7 @@ import { isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Fulfillment, Order } from '../data/types';
+import { Fulfillment, Order, Refund } from '../data/types';
 import { store as FulfillmentsStore } from '../data/store';
 import { getItemsNotInAnyFulfillment } from '../utils/order-utils';
 
@@ -17,6 +17,8 @@ interface FulfillmentDrawerContextProps {
 	setFulfillments: ( fulfillments: Fulfillment[] ) => void;
 	order: Order | null;
 	setOrder: ( order: Order | null ) => void;
+	refunds: Refund[];
+	setRefunds: ( refunds: Refund[] ) => void;
 	openSection: string;
 	setOpenSection: ( section: string ) => void;
 	isEditing: boolean;
@@ -28,6 +30,8 @@ const defaultContextProps: FulfillmentDrawerContextProps = {
 	setFulfillments: () => {},
 	order: null,
 	setOrder: () => {},
+	refunds: [],
+	setRefunds: () => {},
 	openSection: '',
 	setOpenSection: () => {},
 	isEditing: false,
@@ -57,6 +61,7 @@ export const FulfillmentDrawerProvider = ( {
 	const [ openSection, setOpenSection ] = useState( 'order' );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ fulfillments, setFulfillments ] = useState< Fulfillment[] >();
+	const [ refunds, setRefunds ] = useState< Refund[] >();
 	const [ order, setOrder ] = useState< Order | null >();
 
 	useSelect(
@@ -67,8 +72,13 @@ export const FulfillmentDrawerProvider = ( {
 			const store = select( FulfillmentsStore );
 			const orderData = store.getOrder( orderId );
 			const fulfillmentsData = store.readFulfillments( orderId );
+			const refundsData = store.getRefunds( orderId );
 			if ( ! isEqual( orderData, order ) ) {
 				setOrder( orderData );
+				setIsEditing( false );
+			}
+			if ( ! isEqual( refundsData, refunds ) ) {
+				setRefunds( refundsData ?? [] );
 				setIsEditing( false );
 			}
 			if ( ! isEqual( fulfillmentsData, fulfillments ) ) {
@@ -76,14 +86,15 @@ export const FulfillmentDrawerProvider = ( {
 				setIsEditing( false );
 			}
 		},
-		[ orderId, fulfillments, order ]
+		[ orderId, fulfillments, order, refunds ]
 	);
 
 	useLayoutEffect( () => {
 		const hasPendingItemsInOrder =
 			order &&
 			fulfillments &&
-			getItemsNotInAnyFulfillment( fulfillments, order ).length > 0;
+			getItemsNotInAnyFulfillment( fulfillments, order, refunds ).length >
+				0;
 
 		if ( hasPendingItemsInOrder ) {
 			// If there are pending items in the order and multiple fulfillments,
@@ -98,7 +109,7 @@ export const FulfillmentDrawerProvider = ( {
 			// collapse all.
 			setOpenSection( '' );
 		}
-	}, [ orderId, fulfillments, order ] );
+	}, [ orderId, fulfillments, order, refunds ] );
 
 	if ( orderId === null ) {
 		return null;
@@ -111,6 +122,8 @@ export const FulfillmentDrawerProvider = ( {
 				setFulfillments,
 				order: order ?? null,
 				setOrder,
+				refunds: refunds ?? [],
+				setRefunds,
 				openSection,
 				setOpenSection,
 				isEditing,

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/fulfillment-context.tsx
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/context/fulfillment-context.tsx
@@ -21,7 +21,7 @@ import {
 } from '../data/constants';
 
 interface FulfillmentContextProps {
-	order?: Order;
+	order: Order | null;
 	fulfillment: Fulfillment | null;
 	setFulfillment: ( fulfillment: Fulfillment | null ) => void;
 	selectedItems: ItemSelection[];
@@ -31,7 +31,7 @@ interface FulfillmentContextProps {
 }
 
 const defaultContextProps: FulfillmentContextProps = {
-	order: undefined,
+	order: null,
 	fulfillment: null,
 	setFulfillment: () => {},
 	selectedItems: [],
@@ -59,7 +59,7 @@ export const FulfillmentProvider = ( {
 	items,
 	children,
 }: {
-	order: Order;
+	order: Order | null;
 	fulfillment?: Fulfillment | null;
 	items?: ItemSelection[];
 	children: React.ReactNode;

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/store.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/store.ts
@@ -7,7 +7,7 @@ import { createReduxStore, register } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Order, Fulfillment } from './types';
+import { Order, Fulfillment, Refund } from './types';
 
 export const STORE_NAME = 'order/fulfillments';
 
@@ -31,6 +31,7 @@ const getFulfillmentErrorMessage = (
 
 const actionTypes = {
 	SET_ORDER: 'SET_ORDER',
+	SET_REFUNDS: 'SET_REFUNDS',
 	SET_LOADING: 'SET_LOADING',
 	SET_ERROR: 'SET_ERROR',
 	SET_FULFILLMENTS: 'SET_FULFILLMENTS',
@@ -47,6 +48,7 @@ interface ResponseWithFulfillments {
 
 interface OrderState {
 	order: Order | null;
+	refunds: Refund[];
 	fulfillments: Fulfillment[];
 	loading: boolean;
 	error: string | null;
@@ -58,6 +60,7 @@ const DEFAULT_STATE: { orderMap: Record< string, OrderState > } = {
 
 const getInitialOrderState = (): OrderState => ( {
 	order: null,
+	refunds: [],
 	fulfillments: [],
 	loading: false,
 	error: null,
@@ -67,6 +70,9 @@ const getInitialOrderState = (): OrderState => ( {
 const internalActions = {
 	setOrder( orderId: number, order: Order ) {
 		return { type: actionTypes.SET_ORDER, orderId, order };
+	},
+	setRefunds( orderId: number, refunds: Refund[] ) {
+		return { type: actionTypes.SET_REFUNDS, orderId, refunds };
 	},
 	setLoading( orderId: number, isLoading: boolean ) {
 		return { type: actionTypes.SET_LOADING, orderId, isLoading };
@@ -209,6 +215,17 @@ function reducer( state = DEFAULT_STATE, action: Action ) {
 					[ action.orderId ]: { ...prev, order: action.order },
 				},
 			};
+		case actionTypes.SET_REFUNDS:
+			return {
+				...state,
+				orderMap: {
+					...state.orderMap,
+					[ action.orderId ]: {
+						...prev,
+						refunds: action.refunds,
+					},
+				},
+			};
 		case actionTypes.SET_LOADING:
 			return {
 				...state,
@@ -278,6 +295,9 @@ const selectors = {
 	getOrder( state: typeof DEFAULT_STATE, orderId: number ) {
 		return state.orderMap[ orderId ]?.order;
 	},
+	getRefunds( state: typeof DEFAULT_STATE, orderId: number ) {
+		return state.orderMap[ orderId ]?.refunds || [];
+	},
 	isLoading( state: typeof DEFAULT_STATE, orderId: number ) {
 		return !! state.orderMap[ orderId ]?.loading;
 	},
@@ -313,6 +333,13 @@ const resolvers = {
 					method: 'GET',
 				} );
 				dispatch.setOrder( orderId, order );
+				if ( order.refunds.length > 0 ) {
+					const refunds: Refund[] = await apiFetch( {
+						path: `/wc/v3/orders/${ orderId }/refunds`,
+						method: 'GET',
+					} );
+					dispatch.setRefunds( orderId, refunds );
+				}
 			} catch ( error: unknown ) {
 				dispatch.setError(
 					orderId,

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/types.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/data/types.ts
@@ -32,6 +32,7 @@ export interface Order {
 	meta_data: OrderMetaDatum[];
 	line_items: LineItem[];
 	shipping_lines: ShippingLine[];
+	refunds: OrderRefund[];
 	payment_url: string;
 	is_editable: boolean;
 	needs_payment: boolean;
@@ -41,6 +42,29 @@ export interface Order {
 	date_completed_gmt: null;
 	date_paid_gmt: Date;
 	currency_symbol: string;
+	_links: Links;
+}
+
+export interface OrderRefund {
+	id: number;
+	reason: string;
+	total: string;
+}
+
+export interface Refund {
+	id: number;
+	parent_id: number;
+	date_created: Date;
+	date_created_gmt: Date;
+	amount: string;
+	reason: string;
+	refunded_by: number;
+	refunded_payment: boolean;
+	meta_data: OrderMetaDatum[];
+	line_items: LineItem[];
+	shipping_lines: ShippingLine[];
+	tax_lines: OrderMetaDatum[];
+	fee_lines: OrderMetaDatum[];
 	_links: Links;
 }
 

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/utils/order-utils.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/utils/order-utils.ts
@@ -6,7 +6,7 @@ import { range } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Fulfillment, LineItem, Order } from '../data/types';
+import { Fulfillment, LineItem, Order, Refund } from '../data/types';
 import { getFulfillmentItems } from './fulfillment-utils';
 
 /**
@@ -154,26 +154,46 @@ const reduceItems = (
  */
 export const getItemsNotInAnyFulfillment = (
 	fulfillments: Fulfillment[],
-	order: Order
+	order: Order,
+	refunds: Refund[] = []
 ): ItemSelection[] => {
-	// If there are no fulfillments, return all items from the order.
-	if ( fulfillments.length === 0 ) {
-		return getItemsFromOrder( order );
+	let itemsFromOrder = getItemsFromOrder( order );
+
+	if ( refunds.length > 0 ) {
+		const itemsRefunded = refunds.reduce( ( acc, refund ) => {
+			const refundedItems = refund.line_items.map(
+				( item: LineItem ) => ( {
+					// Refunded items have a different item_id, find the original item in the order.
+					item_id:
+						itemsFromOrder.find(
+							( orderItem ) =>
+								orderItem.item.product_id === item.product_id
+						)?.item_id || item.id,
+					item,
+					selection: range( -item.quantity ).map( ( index ) => ( {
+						index,
+						checked: true,
+					} ) ),
+				} )
+			);
+			return combineItems( acc, refundedItems );
+		}, [] as ItemSelection[] );
+
+		// Reduce the refunded items from the order items.
+		itemsFromOrder = reduceItems( itemsFromOrder, itemsRefunded );
 	}
 
-	// If there are fulfillments, combine the items from all fulfillments and reduce them from the order items.
-	const itemsFromFulfillments = fulfillments.reduce( ( acc, fulfillment ) => {
-		const items = getItemsFromFulfillment( order, fulfillment );
-		return combineItems( acc, items );
-	}, [] as ItemSelection[] );
-	const itemsFromOrder = getItemsFromOrder( order );
+	if ( fulfillments.length > 0 ) {
+		// If there are fulfillments, combine the items from all fulfillments and reduce them from the order items.
+		const itemsInAnyFulfillment = fulfillments.reduce(
+			( acc, fulfillment ) => {
+				const items = getItemsFromFulfillment( order, fulfillment );
+				return combineItems( acc, items );
+			},
+			[] as ItemSelection[]
+		);
+		itemsFromOrder = reduceItems( itemsFromOrder, itemsInAnyFulfillment );
+	}
 
-	const itemsNotInAnyFulfillment = reduceItems(
-		itemsFromOrder,
-		itemsFromFulfillments
-	);
-
-	return itemsNotInAnyFulfillment.filter(
-		( item ) => item.selection.length > 0
-	);
+	return itemsFromOrder.filter( ( item ) => item.selection.length > 0 );
 };

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
@@ -25,10 +25,11 @@ class FulfillmentUtils {
 		$items_in_fulfillments = self::get_all_items_of_fulfillments( $fulfillments );
 		$order_items           = array_map(
 			function ( $item ) use ( $order ) {
+				// Refunded item quantities are saved as negative values in the order.
 				return array(
 					'item_id' => $item->get_id(),
 					'item'    => $item,
-					'qty'     => $item->get_quantity() - $order->get_qty_refunded_for_item( $item ),
+					'qty'     => $item->get_quantity() + $order->get_qty_refunded_for_item( $item->get_id() ),
 				);
 			},
 			$order->get_items() ?? array()
@@ -116,7 +117,8 @@ class FulfillmentUtils {
 	public static function calculate_order_fulfillment_status( WC_Order $order, $fulfillments = array() ): string {
 		$has_fulfillments = ! empty( $fulfillments );
 		if ( $has_fulfillments ) {
-			$pending_items  = self::get_pending_items( $order, $fulfillments );
+			$pending_items = self::get_pending_items( $order, $fulfillments );
+
 			$all_fulfilled  = true;
 			$some_fulfilled = false;
 

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
@@ -17,19 +17,19 @@ class FulfillmentUtils {
 	 *
 	 * @param WC_Order $order The order object.
 	 * @param array    $fulfillments An array of fulfillments to check.
+	 * @param bool     $without_refunds Whether to exclude refunded items from the pending items.
 	 *
 	 * @return array An array of pending items.
 	 */
-	public static function get_pending_items( WC_Order $order, $fulfillments ): array {
-
+	public static function get_pending_items( WC_Order $order, $fulfillments, $without_refunds = true ): array {
 		$items_in_fulfillments = self::get_all_items_of_fulfillments( $fulfillments );
 		$order_items           = array_map(
-			function ( $item ) use ( $order ) {
+			function ( $item ) use ( $order, $without_refunds ) {
 				// Refunded item quantities are saved as negative values in the order.
 				return array(
 					'item_id' => $item->get_id(),
 					'item'    => $item,
-					'qty'     => $item->get_quantity() + $order->get_qty_refunded_for_item( $item->get_id() ),
+					'qty'     => $item->get_quantity() + ( $without_refunds ? $order->get_qty_refunded_for_item( $item->get_id() ) : 0 ),
 				);
 			},
 			$order->get_items() ?? array()
@@ -48,6 +48,26 @@ class FulfillmentUtils {
 			$order_items,
 			function ( $item ) {
 				return $item['qty'] > 0; // Only return items with a positive quantity.
+			}
+		);
+	}
+
+	/**
+	 * Get refunded items for an order.
+	 *
+	 * @param WC_Order $order The order object.
+	 *
+	 * @return array An array of refunded items with their IDs and quantities.
+	 */
+	public static function get_refunded_items( WC_Order $order ): array {
+		$items_refunded = array();
+		foreach ( $order->get_items() as $item ) {
+			$items_refunded[ $item->get_id() ] = -1 * $order->get_qty_refunded_for_item( $item->get_id() );
+		}
+		return array_filter(
+			$items_refunded,
+			function ( $qty ) {
+				return $qty > 0; // Only include items that have been refunded.
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Internal\Fulfillments;
 
 use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
 use Automattic\WooCommerce\Internal\Fulfillments\Providers\AbstractShippingProvider;
+use WC_Order;
+use WC_Order_Refund;
 
 /**
  * FulfillmentsManager class.
@@ -26,8 +28,8 @@ class FulfillmentsManager {
 		add_filter( 'wc_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'wc_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'wc_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
-		add_filter( 'woocommerce_order_refunded', array( $this, 'update_fulfillments_after_refund' ), 10, 2 );
-		add_filter( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
+		add_action( 'woocommerce_refund_created', array( $this, 'update_fulfillments_after_refund' ), 10, 1 );
+		add_action( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
 
 		$this->init_fulfillment_status_hooks();
 	}
@@ -157,34 +159,32 @@ class FulfillmentsManager {
 
 
 	/**
-	 * Update fulfillments after an order is refunded.
+	 * Update fulfillments after a refund is created.
 	 *
-	 * This method updates the fulfillments after an order is refunded to ensure that the fulfillment status
-	 * and items are correctly adjusted based on the refund.
-	 *
-	 * @param int $order_id The ID of the order being refunded.
-	 * @param int $refund_id The ID of the refund being processed.
+	 * @param int $refund_id The ID of the refund created.
 	 *
 	 * @return void
 	 */
-	public function update_fulfillments_after_refund( int $order_id, int $refund_id ): void {
-		// We just need to process the new refund being added, as other refunds may have already been processed.
-		// If we re-process all refunds of the order, we may remove more items from fulfillments than necessary,
-		// which could lead to incorrect fulfillment statuses.
-		if ( ! $order_id || ! $refund_id ) {
-			return; // If the order ID or refund ID is not valid, do nothing.
-		}
-
-		// Get the refund object.
-		$refund = wc_get_order( $refund_id );
-		if ( ! $refund instanceof \WC_Order && $refund->get_parent_id() !== $order_id ) {
-			return; // If the refund is not a valid order, or the parent is wrong, do nothing.
-		}
-
+	public function update_fulfillments_after_refund( int $refund_id ): void {
 		// Get the order object.
+		$refund = $refund_id ? wc_get_order( $refund_id ) : null;
+		if ( ! $refund instanceof WC_Order_Refund ) {
+			return; // If the order is not valid, do nothing.
+		}
+
+		$order_id = $refund->get_parent_id();
+		if ( ! $order_id ) {
+			return; // If the refund does not have a parent order, do nothing.
+		}
 		$order = wc_get_order( $order_id );
 		if ( ! $order instanceof \WC_Order ) {
 			return; // If the order is not valid, do nothing.
+		}
+
+		// If there are no refunded items, we can skip the fulfillment update.
+		$items_refunded = FulfillmentUtils::get_refunded_items( $order );
+		if ( empty( $items_refunded ) ) {
+			return; // No items were refunded, so no need to update fulfillments.
 		}
 
 		// Get the fulfillments data store and read all fulfillments for the order.
@@ -194,20 +194,52 @@ class FulfillmentsManager {
 			return; // No fulfillments found for the order.
 		}
 
-		// Preparation: We need to reduce the quantities of items in fulfillments based on the refunded quantities.
-		// Not remove the same refunded quantities from all fulfillments, but from all fulfillments combined.
-
-		$items_refunded = array_map(
+		// Get all refunded items from the order.
+		$pending_items_without_refunds = FulfillmentUtils::get_pending_items( $order, $fulfillments, false );
+		$pending_items_without_refunds = array_map(
 			function ( $item ) {
 				return array(
-					'item_id' => $item->get_id(),
-					'qty'     => $item->get_quantity(),
+					'item_id' => $item['item_id'],
+					'qty'     => $item['qty'],
 				);
 			},
-			$refund->get_items()
+			$pending_items_without_refunds
 		);
-		$items_refunded = array_column( $items_refunded, 'qty', 'item_id' );
 
+		// Check if the refunded items can be removed from pending items.
+		foreach ( $items_refunded as $item_id => &$refunded_qty ) {
+			$pending_item_record = array_filter(
+				$pending_items_without_refunds,
+				function ( $item ) use ( $item_id ) {
+					return isset( $item['item_id'] ) && $item['item_id'] === $item_id;
+				}
+			);
+			if ( ! empty( $pending_item_record ) ) {
+				$pending_item_record = reset( $pending_item_record );
+				if ( isset( $pending_item_record['qty'] ) && $pending_item_record['qty'] > 0 ) {
+					// If the pending item quantity is greater than the refunded quantity, reduce it.
+					$refunded_qty -= $pending_item_record['qty'];
+				}
+			}
+		}
+
+		// If all refunded items can be removed from pending items, we can skip the fulfillment update.
+		$items_need_removal_from_fulfillments = array_filter(
+			$items_refunded,
+			function ( $actual_qty ) {
+				return $actual_qty > 0;
+			}
+		);
+
+		if ( empty( $items_need_removal_from_fulfillments ) ) {
+			return;
+		}
+
+		// Now we need to adjust the fulfillments based on the refunded items.
+		// Loop through each fulfillment and adjust the items based on the refunded quantities.
+		// We will remove items from fulfillments if they are fully refunded, or reduce their quantity if partially refunded.
+		// If a fulfillment has no items left after adjustment, we will delete it.
+		// If a fulfillment has items left, we will update the fulfillment with the new items.
 		foreach ( $fulfillments as $fulfillment ) {
 			if ( ! $fulfillment instanceof Fulfillment ) {
 				continue; // Skip if the fulfillment is not an instance of Fulfillment.
@@ -226,17 +258,19 @@ class FulfillmentsManager {
 			// Adjust the items based on the refund.
 			$new_items = array();
 			foreach ( $items as $item ) {
-				if ( isset( $item['qty'] ) && isset( $item['item_id'] ) && isset( $items_refunded[ $item['item_id'] ] ) ) {
-					if ( $items_refunded[ $item['item_id'] ] <= $item['qty'] ) {
+				if ( isset( $item['qty'] ) && isset( $item['item_id'] ) && isset( $items_need_removal_from_fulfillments[ $item['item_id'] ] ) ) {
+					if ( $items_need_removal_from_fulfillments[ $item['item_id'] ] <= $item['qty'] ) {
 						// If the refunded quantity is less than or equal to the item quantity, reduce the item quantity.
-						$item['qty']                       += $items_refunded[ $item['item_id'] ];
-						$items_refunded[ $item['item_id'] ] = 0; // Set refunded quantity to zero after adjustment.
+						$item['qty'] -= $items_need_removal_from_fulfillments[ $item['item_id'] ];
+						$items_need_removal_from_fulfillments[ $item['item_id'] ] = 0; // Set refunded quantity to zero after adjustment.
 					} else {
 						// If the refunded quantity is greater than the item quantity, set the item quantity to zero.
-						$item['qty']                         = 0;
-						$items_refunded[ $item['item_id'] ] += $item['qty']; // Reduce the refunded quantity.
+						$item['qty'] = 0;
+						$items_need_removal_from_fulfillments[ $item['item_id'] ] -= $item['qty']; // Reduce the refunded quantity.
 					}
 					$new_items[] = $item; // Add the adjusted item to the new items array.
+				} else {
+					$new_items[] = $item; // If the item is not in the refunded items, keep it as is.
 				}
 			}
 

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -26,7 +26,7 @@ class FulfillmentsManager {
 		add_filter( 'wc_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'wc_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'wc_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
-		add_filter( 'woocommerce_order_refunded', array( $this, 'update_fulfillments_after_refund' ), 10, 1 );
+		add_filter( 'woocommerce_order_refunded', array( $this, 'update_fulfillments_after_refund' ), 10, 2 );
 		add_filter( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
 
 		$this->init_fulfillment_status_hooks();
@@ -163,20 +163,50 @@ class FulfillmentsManager {
 	 * and items are correctly adjusted based on the refund.
 	 *
 	 * @param int $order_id The ID of the order being refunded.
+	 * @param int $refund_id The ID of the refund being processed.
 	 *
 	 * @return void
 	 */
-	public function update_fulfillments_after_refund( int $order_id ): void {
-		$order = wc_get_order( $order_id );
-		if ( ! $order instanceof \WC_Order ) {
-			return;
+	public function update_fulfillments_after_refund( int $order_id, int $refund_id ): void {
+		// We just need to process the new refund being added, as other refunds may have already been processed.
+		// If we re-process all refunds of the order, we may remove more items from fulfillments than necessary,
+		// which could lead to incorrect fulfillment statuses.
+		if ( ! $order_id || ! $refund_id ) {
+			return; // If the order ID or refund ID is not valid, do nothing.
 		}
 
+		// Get the refund object.
+		$refund = wc_get_order( $refund_id );
+		if ( ! $refund instanceof \WC_Order && $refund->get_parent_id() !== $order_id ) {
+			return; // If the refund is not a valid order, or the parent is wrong, do nothing.
+		}
+
+		// Get the order object.
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return; // If the order is not valid, do nothing.
+		}
+
+		// Get the fulfillments data store and read all fulfillments for the order.
 		$fulfillments_data_store = wc_get_container()->get( FulfillmentsDataStore::class );
 		$fulfillments            = $fulfillments_data_store->read_fulfillments( \WC_Order::class, (string) $order_id );
 		if ( empty( $fulfillments ) ) {
 			return; // No fulfillments found for the order.
 		}
+
+		// Preparation: We need to reduce the quantities of items in fulfillments based on the refunded quantities.
+		// Not remove the same refunded quantities from all fulfillments, but from all fulfillments combined.
+
+		$items_refunded = array_map(
+			function ( $item ) {
+				return array(
+					'item_id' => $item->get_id(),
+					'qty'     => $item->get_quantity(),
+				);
+			},
+			$refund->get_items()
+		);
+		$items_refunded = array_column( $items_refunded, 'qty', 'item_id' );
 
 		foreach ( $fulfillments as $fulfillment ) {
 			if ( ! $fulfillment instanceof Fulfillment ) {
@@ -184,7 +214,7 @@ class FulfillmentsManager {
 			}
 
 			if ( $fulfillment->get_is_fulfilled() ) {
-				continue; // Skip if the fulfillment is already fulfilled.
+				continue; // Skip if the fulfillment is already fulfilled. We don't remove items from fulfilled fulfillments.
 			}
 
 			// Get the items from the fulfillment.
@@ -196,10 +226,15 @@ class FulfillmentsManager {
 			// Adjust the items based on the refund.
 			$new_items = array();
 			foreach ( $items as $item ) {
-				if ( isset( $item['qty'] ) && isset( $item['item_id'] ) ) {
-					$item['qty'] += $order->get_qty_refunded_for_item( $item['item_id'] );
-					if ( $item['qty'] < 0 ) {
-						$item['qty'] = 0; // Ensure quantity does not go negative.
+				if ( isset( $item['qty'] ) && isset( $item['item_id'] ) && isset( $items_refunded[ $item['item_id'] ] ) ) {
+					if ( $items_refunded[ $item['item_id'] ] <= $item['qty'] ) {
+						// If the refunded quantity is less than or equal to the item quantity, reduce the item quantity.
+						$item['qty']                       += $items_refunded[ $item['item_id'] ];
+						$items_refunded[ $item['item_id'] ] = 0; // Set refunded quantity to zero after adjustment.
+					} else {
+						// If the refunded quantity is greater than the item quantity, set the item quantity to zero.
+						$item['qty']                         = 0;
+						$items_refunded[ $item['item_id'] ] += $item['qty']; // Reduce the refunded quantity.
 					}
 					$new_items[] = $item; // Add the adjusted item to the new items array.
 				}

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -26,6 +26,8 @@ class FulfillmentsManager {
 		add_filter( 'wc_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'wc_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'wc_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
+		add_filter( 'woocommerce_order_refunded', array( $this, 'update_fulfillments_after_refund' ), 10, 1 );
+		add_filter( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
 
 		$this->init_fulfillment_status_hooks();
 	}
@@ -118,7 +120,120 @@ class FulfillmentsManager {
 		// Read all fulfillments for the order.
 		$fulfillments = $fulfillments_data_store->read_fulfillments( \WC_Order::class, (string) $order->get_id() );
 
-		// Update the fulfillment status of the order.
+		$this->update_fulfillment_status( $order, $fulfillments );
+	}
+
+	/**
+	 * Update fulfillment status after a refund is deleted.
+	 *
+	 * This method updates the fulfillment status after a refund is deleted to ensure that the fulfillment status
+	 * and items are correctly adjusted based on the refund deletion.
+	 *
+	 * @param int $refund_id The ID of the refund being deleted.
+	 *
+	 * @return void
+	 */
+	public function update_fulfillment_status_after_refund_deleted( int $refund_id ): void {
+		$refund = wc_get_order( $refund_id );
+		if ( ! $refund instanceof \WC_Order ) {
+			return; // If the refund is not a valid order, do nothing.
+		}
+
+		$order_id = $refund->get_parent_id();
+		if ( ! $order_id ) {
+			return; // If the refund does not have a parent order, do nothing.
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return; // If the order is not valid, do nothing.
+		}
+
+		$fulfillments_data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+		$fulfillments            = $fulfillments_data_store->read_fulfillments( \WC_Order::class, (string) $order_id );
+
+		$this->update_fulfillment_status( $order, $fulfillments );
+	}
+
+
+	/**
+	 * Update fulfillments after an order is refunded.
+	 *
+	 * This method updates the fulfillments after an order is refunded to ensure that the fulfillment status
+	 * and items are correctly adjusted based on the refund.
+	 *
+	 * @param int $order_id The ID of the order being refunded.
+	 *
+	 * @return void
+	 */
+	public function update_fulfillments_after_refund( int $order_id ): void {
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return;
+		}
+
+		$fulfillments_data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+		$fulfillments            = $fulfillments_data_store->read_fulfillments( \WC_Order::class, (string) $order_id );
+		if ( empty( $fulfillments ) ) {
+			return; // No fulfillments found for the order.
+		}
+
+		foreach ( $fulfillments as $fulfillment ) {
+			if ( ! $fulfillment instanceof Fulfillment ) {
+				continue; // Skip if the fulfillment is not an instance of Fulfillment.
+			}
+
+			if ( $fulfillment->get_is_fulfilled() ) {
+				continue; // Skip if the fulfillment is already fulfilled.
+			}
+
+			// Get the items from the fulfillment.
+			$items = $fulfillment->get_items();
+			if ( empty( $items ) ) {
+				continue; // Skip if there are no items in the fulfillment.
+			}
+
+			// Adjust the items based on the refund.
+			$new_items = array();
+			foreach ( $items as $item ) {
+				if ( isset( $item['qty'] ) && isset( $item['item_id'] ) ) {
+					$item['qty'] += $order->get_qty_refunded_for_item( $item['item_id'] );
+					if ( $item['qty'] < 0 ) {
+						$item['qty'] = 0; // Ensure quantity does not go negative.
+					}
+					$new_items[] = $item; // Add the adjusted item to the new items array.
+				}
+			}
+
+			$new_items = array_filter(
+				$new_items,
+				function ( $item ) {
+					return isset( $item['qty'] ) && $item['qty'] > 0; // Only keep items with a positive quantity.
+				}
+			);
+
+			if ( empty( $new_items ) ) {
+				// If no items remain after adjustment, delete the fulfillment.
+				$fulfillment->delete();
+			} else {
+				// Update the fulfillment items with the new items.
+				$fulfillment->set_items( $new_items );
+				$fulfillment->save();
+			}
+		}
+
+		$this->update_fulfillment_status( $order, $fulfillments );
+	}
+
+	/**
+	 * Update the fulfillment status for the order.
+	 *
+	 * @param \WC_Order $order The order object.
+	 * @param array     $fulfillments The fulfillments data store.
+	 *
+	 * This method updates the fulfillment status for the order based on the fulfillments data store.
+	 */
+	private function update_fulfillment_status( $order, $fulfillments = array() ) {
 		$last_status = FulfillmentUtils::calculate_order_fulfillment_status( $order, $fulfillments );
 		if ( 'no_fulfillments' === $last_status ) {
 			$order->delete_meta_data( '_fulfillment_status' );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -28,10 +28,9 @@ class FulfillmentsManager {
 		add_filter( 'wc_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'wc_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'wc_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
-		add_action( 'woocommerce_refund_created', array( $this, 'update_fulfillments_after_refund' ), 10, 1 );
-		add_action( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
 
 		$this->init_fulfillment_status_hooks();
+		$this->init_refund_hooks();
 	}
 
 	/**
@@ -45,6 +44,16 @@ class FulfillmentsManager {
 		add_action( 'wc_fulfillment_after_create', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
 		add_action( 'wc_fulfillment_after_update', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
 		add_action( 'wc_fulfillment_after_delete', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
+	}
+
+	/**
+	 * Initialize refund-related hooks.
+	 *
+	 * This method initializes the hooks related to refunds, such as updating fulfillments after a refund is created
+	 */
+	private function init_refund_hooks() {
+		add_action( 'woocommerce_refund_created', array( $this, 'update_fulfillments_after_refund' ), 10, 1 );
+		add_action( 'woocommerce_delete_order_refund', array( $this, 'update_fulfillment_status_after_refund_deleted' ), 10, 1 );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
@@ -7,7 +7,24 @@ use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 /**
  * FulfillmentUtilsTest class.
  */
-class FulfillmentUtilsTest extends \WP_UnitTestCase {
+class FulfillmentUtilsTest extends \WC_Unit_Test_Case {
+	/**
+	 * Set up the test environment.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public static function tearDownAfterClass(): void {
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
+		parent::tearDownAfterClass();
+	}
+
 	/**
 	 * Test that plugins can extend the order fulfillment statuses.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
@@ -15,6 +15,11 @@ use WC_Order;
 class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 
 	/**
+	 * @var FulfillmentsManager
+	 */
+	private FulfillmentsManager $manager;
+
+	/**
 	 * Set up the test environment.
 	 */
 	public static function setUpBeforeClass(): void {
@@ -32,25 +37,30 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->manager = new FulfillmentsManager();
+	}
+
+	/**
 	 * Test hooks.
 	 */
 	public function test_hooks() {
-		$manager = new FulfillmentsManager();
-		$this->assertNotFalse( has_filter( 'wc_fulfillment_translate_meta_key', array( $manager, 'translate_fulfillment_meta_key' ) ) );
+		$this->assertNotFalse( has_filter( 'wc_fulfillment_translate_meta_key', array( $this->manager, 'translate_fulfillment_meta_key' ) ) );
 	}
 
 	/**
 	 * Test the translate_fulfillment_meta_key method.
 	 */
 	public function test_translate_fulfillment_meta_key() {
-		$manager = new FulfillmentsManager();
-
 		// Test with a known meta key.
-		$translated_key = $manager->translate_fulfillment_meta_key( 'fulfillment_status' );
+		$translated_key = $this->manager->translate_fulfillment_meta_key( 'fulfillment_status' );
 		$this->assertEquals( __( 'Fulfillment Status', 'woocommerce' ), $translated_key );
 
 		// Test with an unknown meta key.
-		$translated_key = $manager->translate_fulfillment_meta_key( 'unknown_meta_key' );
+		$translated_key = $this->manager->translate_fulfillment_meta_key( 'unknown_meta_key' );
 		$this->assertEquals( 'unknown_meta_key', $translated_key );
 	}
 
@@ -58,8 +68,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test extending the translation of a fulfillment meta key.
 	 */
 	public function test_extend_translate_fulfillment_meta_key() {
-		$manager = new FulfillmentsManager();
-
 		// Extend the translations.
 		add_filter(
 			'wc_fulfillment_meta_key_translations',
@@ -70,7 +78,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		);
 
 		// Test the extended translation.
-		$translated_key = $manager->translate_fulfillment_meta_key( 'custom_meta_key' );
+		$translated_key = $this->manager->translate_fulfillment_meta_key( 'custom_meta_key' );
 		$this->assertEquals( __( 'Custom Meta Key', 'woocommerce' ), $translated_key );
 	}
 
@@ -78,7 +86,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test that the filter for translating fulfillment meta keys works correctly.
 	 */
 	public function test_translate_fulfillment_meta_key_with_filter() {
-		new FulfillmentsManager();
 
 		// Add a filter to modify the translations.
 		add_filter(
@@ -102,9 +109,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test that the initial shipping providers are loaded correctly.
 	 */
 	public function test_get_initial_shipping_providers() {
-		// Ensure the FulfillmentsManager is instantiated to load shipping providers filter.
-		new FulfillmentsManager();
-
 		/**
 		 * Filter to get initial shipping providers
 		 *
@@ -151,17 +155,15 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test that the fulfillment status hooks are initialized correctly.
 	 */
 	public function test_init_fulfillment_status_hooks() {
-		$manager = new FulfillmentsManager();
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_create', array( $manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_update', array( $manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_delete', array( $manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'wc_fulfillment_after_create', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'wc_fulfillment_after_update', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'wc_fulfillment_after_delete', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
 	}
 
 	/**
 	 * Test that the fulfillment status is updated on fulfillment creation.
 	 */
 	public function test_update_order_fulfillment_status_on_fulfillment_updates() {
-		$manager      = new FulfillmentsManager();
 		$fulfillments = array();
 		$product      = \WC_Helper_Product::create_simple_product();
 		$order        = OrderHelper::create_order( get_current_user_id(), $product );
@@ -204,7 +206,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test that the tracking number can be parsed correctly.
 	 */
 	public function test_try_parse_tracking_number_nominal() {
-		$manager         = new FulfillmentsManager();
 		$tracking_number = '1234567890';
 
 		/**
@@ -234,7 +235,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 			);
 
 		// Test with a valid tracking number.
-		$parsed_number = $manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
+		$parsed_number = $this->manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
 		$this->assertEquals( $tracking_number, $parsed_number['tracking_number'] );
 		$this->assertEquals( 'mock_shipping_provider', $parsed_number['shipping_provider'] );
 		$this->assertEquals( 'https://example.com/track?number=' . $tracking_number, $parsed_number['tracking_url'] );
@@ -244,7 +245,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test tracking number parsing without any matches.
 	 */
 	public function test_try_parse_tracking_number_no_match() {
-		$manager         = new FulfillmentsManager();
 		$tracking_number = '1234567890';
 
 		/**
@@ -270,7 +270,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 			->willReturn( null );
 
 		// Test with a valid tracking number.
-		$parsed_number = $manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
+		$parsed_number = $this->manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
 		$this->assertEquals( array(), $parsed_number );
 	}
 
@@ -278,7 +278,6 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test tracking number parsing without any shipping providers.
 	 */
 	public function test_try_parse_tracking_number_no_providers() {
-		$manager         = new FulfillmentsManager();
 		$tracking_number = '1234567890';
 
 		add_filter(
@@ -290,7 +289,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		);
 
 		// Test with a valid tracking number.
-		$parsed_number = $manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
+		$parsed_number = $this->manager->try_parse_tracking_number( $tracking_number, 'US', 'CA' );
 		$this->assertEquals( array(), $parsed_number );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
@@ -1,0 +1,694 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
+
+use Automattic\WooCommerce\Internal\Fulfillments\Fulfillment;
+use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\Tests\Internal\Fulfillments\Helpers\FulfillmentsHelper;
+use WC_Order;
+
+/**
+ * Tests for Fulfillment refund handling.
+ */
+class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * FulfillmentsDataStore instance.
+	 *
+	 * @var FulfillmentsDataStore
+	 */
+	private $data_store;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public static function tearDownAfterClass(): void {
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+	}
+
+	/**
+	 * Helper method to create an order with products.
+	 *
+	 * @param int $product_count Number of products to add.
+	 * @param int $quantity      Quantity per product.
+	 * @return WC_Order
+	 */
+	private function create_test_order( int $product_count = 2, int $quantity = 5 ): WC_Order {
+		$order = OrderHelper::create_order();
+
+		// Remove existing items to start fresh.
+		foreach ( $order->get_items() as $item ) {
+			$order->remove_item( $item->get_id() );
+		}
+
+		// Add specific test products.
+		for ( $i = 0; $i < $product_count; $i++ ) {
+			$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+			$product->set_regular_price( 10 );
+			$product->save();
+
+			$item = new \WC_Order_Item_Product();
+			$item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => $quantity,
+					'subtotal' => $quantity * 10,
+					'total'    => $quantity * 10,
+				)
+			);
+			$order->add_item( $item );
+		}
+
+		$order->calculate_totals();
+		$order->save();
+
+		return $order;
+	}
+
+	/**
+	 * Helper method to create a fulfillment with specific items.
+	 *
+	 * @param WC_Order $order Order to create fulfillment for.
+	 * @param array    $items Items to include in fulfillment.
+	 * @param bool     $is_fulfilled Whether the fulfillment is completed.
+	 * @return Fulfillment
+	 */
+	private function create_test_fulfillment( WC_Order $order, array $items, bool $is_fulfilled = false ): Fulfillment {
+		$fulfillment = FulfillmentsHelper::create_fulfillment(
+			array(
+				'entity_type'  => WC_Order::class,
+				'entity_id'    => $order->get_id(),
+				'status'       => $is_fulfilled ? 'fulfilled' : 'unfulfilled',
+				'is_fulfilled' => $is_fulfilled,
+			)
+		);
+
+		$fulfillment->set_items( $items );
+		$fulfillment->save();
+
+		return $fulfillment;
+	}
+
+	/**
+	 * Helper method to create a refund.
+	 *
+	 * @param WC_Order $order Order to refund.
+	 * @param array    $refund_items Items to refund with quantities.
+	 * @param float    $amount Refund amount.
+	 * @param string   $reason Refund reason.
+	 * @return \WC_Order_Refund
+	 */
+	private function create_test_refund( WC_Order $order, array $refund_items, float $amount = 10.0, string $reason = 'Test refund' ): \WC_Order_Refund {
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'amount'     => $amount,
+				'reason'     => $reason,
+				'line_items' => $refund_items,
+			)
+		);
+
+		if ( is_wp_error( $refund ) ) {
+			return $refund;
+		}
+
+		$refund->save();
+		return $refund;
+	}
+
+	/**
+	 * Test that fulfilled fulfillments are not affected by refunds.
+	 */
+	public function test_fulfilled_fulfillments_not_affected_by_refunds() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create fulfilled fulfillment with 3 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 3,
+				),
+			),
+			true
+		);
+
+		// Refund 5 items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 5,
+				'refund_total' => 50,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 50.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should still have 1 fulfillment with 3 items (unchanged).
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 3, $remaining_items[0]['qty'] );
+		$this->assertTrue( $remaining_fulfillment->get_is_fulfilled() );
+	}
+
+	/**
+	 * Test basic unfulfilled fulfillment reduction.
+	 */
+	public function test_unfulfilled_fulfillments_partial_refund_reduces_items_correctly() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		$hook_called = 0;
+		add_action(
+			'woocommerce_refund_created',
+			function () use ( &$hook_called ) {
+				$hook_called++;
+			},
+			10,
+			0
+		);
+
+		// Create unfulfilled fulfillment with 7 items (3 pending remain).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 7,
+				),
+			),
+			false
+		);
+
+		// Refund 5 items - should reduce unfulfilled to 5 items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 5,
+				'refund_total' => 50,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 50.0 );
+
+		$this->assertEquals( 1, $hook_called, 'Refund hook should be called once.' );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have 1 fulfillment with 5 items.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 5, $remaining_items[0]['qty'] );
+	}
+
+	/**
+	 * Test refunds with only pending items (no fulfillments).
+	 */
+	public function test_refund_with_only_pending_items() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// No fulfillments created - all items are pending.
+
+		// Refund 3 items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 3,
+				'refund_total' => 30,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 30.0 );
+
+		// Check that no fulfillments exist (all were pending).
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		$this->assertCount( 0, $all_fulfillments );
+
+		// Verify the order item quantity is correctly updated after refund.
+		$order->get_data_store()->read( $order );
+		$updated_items = $order->get_items();
+		$updated_item  = $updated_items[ $item_id ];
+		$this->assertEquals( 10, $updated_item->get_quantity() ); // Original quantity unchanged.
+	}
+
+	/**
+	 * Test refunds with only fulfilled fulfillments.
+	 */
+	public function test_refund_with_only_fulfilled_fulfillments() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create fulfilled fulfillment with all 10 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 10,
+				),
+			),
+			true
+		);
+
+		// Refund 3 items - should not affect fulfilled fulfillment.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 3,
+				'refund_total' => 30,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 30.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should still have 1 fulfillment with 10 items (unchanged).
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 10, $remaining_items[0]['qty'] );
+		$this->assertTrue( $remaining_fulfillment->get_is_fulfilled() );
+	}
+
+	/**
+	 * Test refunds with only unfulfilled fulfillments.
+	 */
+	public function test_refund_with_only_unfulfilled_fulfillments() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create unfulfilled fulfillment with all 10 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 10,
+				),
+			),
+			false
+		);
+
+		// Refund 3 items - should reduce unfulfilled fulfillment to 7 items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 3,
+				'refund_total' => 30,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 30.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have 1 fulfillment with 7 items.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 7, $remaining_items[0]['qty'] );
+		$this->assertFalse( $remaining_fulfillment->get_is_fulfilled() );
+	}
+
+	/**
+	 * Test refund that completely removes an unfulfilled fulfillment.
+	 */
+	public function test_refund_completely_removes_unfulfilled_fulfillment() {
+		// Create order with 1 product, 10 quantity.
+		$order   = $this->create_test_order( 1, 10 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create unfulfilled fulfillment with 5 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 5,
+				),
+			),
+			false
+		);
+
+		// Create another unfulfilled fulfillment with 3 items (2 pending remain).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 3,
+				),
+			),
+			true
+		);
+
+		// Refund 8 items - should remove the entire unfulfilled fulfillment and the pending items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 8,
+				'refund_total' => 80,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 80.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have no fulfillments left.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 3, $remaining_items[0]['qty'] ); // Only the fulfilled fulfillment remains with 3 items.
+	}
+
+	/**
+	 * Test mixed fulfillments - fulfilled and unfulfilled.
+	 */
+	public function test_mixed_fulfillments_refund_priority() {
+		// Create order with 1 product, 20 quantity.
+		$order   = $this->create_test_order( 1, 20 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create fulfilled fulfillment with 8 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 8,
+				),
+			),
+			true
+		);
+
+		// Create unfulfilled fulfillment with 7 items (5 pending remain).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 7,
+				),
+			),
+			false
+		);
+
+		// Refund 10 items - should protect fulfilled (8), reduce unfulfilled to 2.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 10,
+				'refund_total' => 100,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 100.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have 2 fulfillments: 1 fulfilled (8 items), 1 unfulfilled (2 items).
+		$this->assertCount( 2, $all_fulfillments );
+
+		foreach ( $all_fulfillments as $fulfillment ) {
+			$items = $fulfillment->get_items();
+			if ( $fulfillment->get_is_fulfilled() ) {
+				$this->assertEquals( 8, $items[0]['qty'] ); // Fulfilled unchanged.
+			} else {
+				$this->assertEquals( 2, $items[0]['qty'] ); // Unfulfilled reduced from 7 to 2.
+			}
+		}
+	}
+
+	/**
+	 * Test multiple unfulfilled fulfillments with refund.
+	 */
+	public function test_multiple_unfulfilled_fulfillments_refund() {
+		// Create order with 1 product, 20 quantity.
+		$order   = $this->create_test_order( 1, 20 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create first unfulfilled fulfillment with 8 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 8,
+				),
+			),
+			false
+		);
+
+		// Create second unfulfilled fulfillment with 7 items (5 pending remain).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 7,
+				),
+			),
+			false
+		);
+
+		// Refund 10 items - should reduce unfulfilled fulfillments proportionally.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 10,
+				'refund_total' => 100,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 100.0 ); // 10 items refunded from 5 pending and 5 first fulfillment.
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have 2 fulfillments left: 1 with 3 items, 1 with 7 items.
+		$this->assertCount( 2, $all_fulfillments );
+		$this->assertEquals( 3, $all_fulfillments[0]->get_items()[0]['qty'], 'First fulfillment should have 3 items after refund.' );
+		$this->assertEquals( 7, $all_fulfillments[1]->get_items()[0]['qty'], 'Second fulfillment should have 7 items after refund.' );
+	}
+
+	/**
+	 * Test multiple unfulfilled fulfillments with refund.
+	 */
+	public function test_multiple_unfulfilled_fulfillments_refund_removes_one() {
+		// Create order with 1 product, 20 quantity.
+		$order   = $this->create_test_order( 1, 20 );
+		$items   = $order->get_items();
+		$item_id = array_key_first( $items );
+
+		// Create first unfulfilled fulfillment with 8 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 8,
+				),
+			),
+			false
+		);
+
+		// Create second unfulfilled fulfillment with 7 items (5 pending remain).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 7,
+				),
+			),
+			false
+		);
+
+		// Refund 13 items - should reduce unfulfilled fulfillments proportionally.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 13,
+				'refund_total' => 130,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 130.0 );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		$this->assertEquals( 1, count( $all_fulfillments ), 'Should have 1 fulfillment left after refund.' );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 7, $remaining_items[0]['qty'], 'Remaining fulfillment should have 7 items after refund.' );
+	}
+
+	/**
+	 * Test refund with multiple products.
+	 */
+	public function test_refund_with_multiple_products() {
+		// Create order with 2 products, 10 quantity each.
+		$order = $this->create_test_order( 2, 10 );
+		$items = $order->get_items();
+
+		$item_ids  = array_keys( $items );
+		$item_id_1 = $item_ids[0];
+		$item_id_2 = $item_ids[1];
+
+		$hook_called = 0;
+		add_action(
+			'woocommerce_refund_created',
+			function () use ( &$hook_called ) {
+				$hook_called++;
+			},
+			10,
+			0
+		);
+
+		// Create unfulfilled fulfillment with both products. (Pending 1:4, Pending 2:2).
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id_1,
+					'qty'     => 6,
+				),
+				array(
+					'item_id' => $item_id_2,
+					'qty'     => 8,
+				),
+			),
+			false
+		);
+
+		// Refund 3 of product 1 and 5 of product 2.
+		$refund_items = array(
+			$item_id_1 => array(
+				'qty'          => 3,
+				'refund_total' => 30,
+			),
+			$item_id_2 => array(
+				'qty'          => 5,
+				'refund_total' => 50,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 80.0 );
+
+		$this->assertEquals( 1, $hook_called, 'Refund hook should be called once.' );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+
+		// Should have 1 fulfillment with reduced quantities.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+
+		// Check that both products have correct remaining quantities.
+		$quantities_by_item = array();
+		foreach ( $remaining_items as $item ) {
+			$quantities_by_item[ $item['item_id'] ] = $item['qty'];
+		}
+
+		$this->assertEquals( 6, $quantities_by_item[ $item_id_1 ] ); // 10 - 6 = 4 pending, 3 reduced from pending, fulfillment stays the same.
+		$this->assertEquals( 5, $quantities_by_item[ $item_id_2 ] ); // 10 - 8 = 2 pending, 2 reduced from pending, 3 reduced from fulfillment, 5.
+	}
+
+
+	/**
+	 * Test fulfillment modifications with multiple refunds.
+	 */
+	public function test_fulfillment_modifications_with_multiple_refunds() {
+		// Create order with 1 product, 20 quantity.
+		$order       = $this->create_test_order( 1, 20 );
+		$items       = $order->get_items();
+		$item_id     = array_key_first( $items );
+		$hook_called = 0;
+		add_action(
+			'woocommerce_refund_created',
+			function () use ( &$hook_called ) {
+				$hook_called++;
+			},
+			10,
+			0
+		);
+		// Create unfulfilled fulfillment with 15 items.
+		$this->create_test_fulfillment(
+			$order,
+			array(
+				array(
+					'item_id' => $item_id,
+					'qty'     => 15,
+				),
+			),
+			false
+		);
+		// Refund 7 items - should reduce unfulfilled fulfillment to 13 items (5 was removed from pending items).
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 7,
+				'refund_total' => 70,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 70.0 );
+
+		$this->assertEquals( 1, $hook_called, 'Refund hook should be called once.' );
+
+		// Check fulfillments after refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		// Should have 1 fulfillment with 13 items.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 13, $remaining_items[0]['qty'] );
+		$this->assertFalse( $remaining_fulfillment->get_is_fulfilled() );
+
+		// Now refund 3 more items - should reduce unfulfilled fulfillment to 10 items.
+		$refund_items = array(
+			$item_id => array(
+				'qty'          => 3,
+				'refund_total' => 30,
+			),
+		);
+		$this->create_test_refund( $order, $refund_items, 30.0 );
+		$this->assertEquals( 2, $hook_called, 'Refund hook should be called again.' );
+		// Check fulfillments after second refund.
+		$all_fulfillments = $this->data_store->read_fulfillments( WC_Order::class, (string) $order->get_id() );
+		// Should have 1 fulfillment with 10 items.
+		$this->assertCount( 1, $all_fulfillments );
+		$remaining_fulfillment = $all_fulfillments[0];
+		$remaining_items       = $remaining_fulfillment->get_items();
+		$this->assertEquals( 10, $remaining_items[0]['qty'] );
+		$this->assertFalse( $remaining_fulfillment->get_is_fulfilled() );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
 
 use Automattic\WooCommerce\Internal\Fulfillments\Fulfillment;
 use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsManager;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\Tests\Internal\Fulfillments\Helpers\FulfillmentsHelper;
 use WC_Order;
@@ -22,12 +23,21 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	private $data_store;
 
 	/**
+	 * FulfillmentsManager instance.
+	 *
+	 * @var FulfillmentsManager
+	 */
+	private FulfillmentsManager $manager;
+
+	/**
 	 * Set up the test environment.
 	 */
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$container               = wc_get_container();
+		$fulfillments_controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$fulfillments_controller->register();
 	}
 
 	/**
@@ -44,6 +54,7 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+		$this->manager    = new FulfillmentsManager();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR enhances the order fulfillment system with explicit actions running when an item of an order gets refunded/returned. The old and new approach is as follows: 

#### Old approach
- Fulfillments showed all the order items all the time, even if the item(s) are removed from the order after a refund. 

#### New approach
- We hide refunded items from the pending items list.
- When a refund happens, we check all the fulfillments of the order, if an unfulfilled fulfillment has that item, we remove the refunded quantity from the fulfillment. 
- We keep the refunded item in fulfilled fulfillments, as it means the item is still shipped to the customer, and we track shipments in fulfillments. 
- When a refund gets cancelled (yep, that's possible), we put the item back into the pending items list, so the user can select it in a new fulfillment.

**The order of item removal from fulfillments**
1. If pending items can cover the refunds, we remove the refunded items from pending items list.
2. If the item doesn't exist on the pending items list, we look for unfulfilled fulfillments that contains the item, and we remove it from the fulfillment.
3. We don't touch fulfilled fulfillments. And fulfilled fulfillments can't switch to unfulfilled via the UI.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58714 WOOPLUG-4574

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Preparation

1. Create an order with 10 of item A, and 10 of item B of your choice. 
2. Navigate to the order details. 
3. Open the fulfillment drawer using the pen icon besides the fulfillment status badge on top right corner of the order details box.
4. Check that you can see 10x of Item A and 10x of Item B on the order items list.

#### Testing refunds with no fulfillments

1. Refund 2x of Item A. 
2. Open the fulfillment drawer, see that the order items list shows 8x Item A on the list.

#### Testing refunds with unfulfilled fulfillments (no overlap)

1. Create a fulfillment containing 5x Item A.
2. Refund 2x of Item A.
3. Open the fulfillment drawer, see that the pending items list show 1x of Item A, and the fulfillment contains 5x Item A.

#### Testing refunds with unfulfilled fulfillments (with overlap)

1. Refund 2x more of Item A.
2. Open the fulfillment drawer, see that the pending items list doesn't contain Item A anymore, and the Item A count in the unfulfilled fulfillment dropped to 4.

#### Testing refunds delete unfulfilled fulfillments

1. Refund 4x of Item A.
2. Open the fulfillments drawer, see that you don't see the unfulfilled fulfillment anymore, and no more Item A is on the list.

#### Resetting before the latter tests

1. Delete the refunds you've created from the UI. 
2. Refresh the page
3. Open the fulfillments 

#### Testing mixed fulfillments don't get deleted. 

1. Create an unfulfilled fulfillment with 2x Item A and 2x Item B (fulfillment 1)
2. Create another unfulfilled fulfillment with the same items (fulfillment 2)
3. Create a fulfilled fulfillment with the same items (fulfillment 3)
4. Refund 5x Item A
5. See that there's no pending item A, and one Item A is left in fulfillment 1, fulfillment 2 and fulfillment 3 are untouched.
6. Refund 2x Item A
7. See that there's no Item A left in fulfillment 1, and one item A in fulfillment 2 is left.
8. Refund 2x Item A again
9. See that there's no Item A left in fulfillment 2, and 2 item A remains in fulfillment 3, because fulfilled fulfillments are untouched.
10. See that fulfillment 1 and 2 only contains Item B, and aren't deleted.

#### Testing full refund
1. Refund all the remaining items on the order
2. See that the unfulfilled fulfillments are deleted
3. See that the order fulfillment status is fulfilled (may need refresh)
4. See that there's only fulfillment 3 with 2x Item A and 2x Item B.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a sub-issue of a feature branch, which will be added as a single changelog item.
</details>
