### PR TITLE
Add min and max price methods for grouped products

### DIFF
--- a/plugins/woocommerce/changelog/59586-wooplug-4867-the-endpoint-wp-jsonwcv3productsorderbyprice-returns
+++ b/plugins/woocommerce/changelog/59586-wooplug-4867-the-endpoint-wp-jsonwcv3productsorderbyprice-returns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add experimental REST API support for grouped product min/max prices

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -41,6 +41,7 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": true
+		"add-to-cart-with-options-stepper-layout": true,
+		"experimental-wc-rest-api": false
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -41,6 +41,7 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": true
+		"add-to-cart-with-options-stepper-layout": true,
+		"experimental-wc-rest-api": true
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -148,6 +148,7 @@ class WC_Product_Grouped extends WC_Product {
 		return $this->get_prop( 'children', $context );
 	}
 
+
 	/**
 	 * Return the product's children - visible only.
 	 *
@@ -157,6 +158,40 @@ class WC_Product_Grouped extends WC_Product {
 	public function get_visible_children() {
 		$grouped_products = array_map( 'wc_get_product', $this->get_children() );
 		return array_filter( $grouped_products, 'wc_products_array_filter_visible_grouped' );
+	}
+
+	/**
+	 * Get the minimum price from visible child products.
+	 *
+	 * @since 10.1.0
+	 * @return string|float Minimum price or empty string if no children
+	 */
+	public function get_min_price() {
+		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$min_price = array_map( 'wc_get_price_to_display', $children );
+
+		if ( empty( $min_price ) ) {
+			return '';
+		}
+
+		return (string) min( $min_price );
+	}
+
+	/**
+	 * Get the maximum price from visible child products.
+	 *
+	 * @since 10.1.0
+	 * @return string|float Maximum price or empty string if no children
+	 */
+	public function get_max_price() {
+		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$max_price = array_map( 'wc_get_price_to_display', $children );
+
+		if ( empty( $max_price ) ) {
+			return '';
+		}
+
+		return (string) max( $max_price );
 	}
 
 	/*

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -164,7 +164,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * Get the minimum price from visible child products.
 	 *
 	 * @since 10.1.0
-	 * @return string|float Minimum price or empty string if no children
+	 * @return string Minimum price or empty string if no children
 	 */
 	public function get_min_price() {
 		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
@@ -181,7 +181,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * Get the maximum price from visible child products.
 	 *
 	 * @since 10.1.0
-	 * @return string|float Maximum price or empty string if no children
+	 * @return string Maximum price or empty string if no children
 	 */
 	public function get_max_price() {
 		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -148,7 +148,6 @@ class WC_Product_Grouped extends WC_Product {
 		return $this->get_prop( 'children', $context );
 	}
 
-
 	/**
 	 * Return the product's children - visible only.
 	 *
@@ -174,7 +173,7 @@ class WC_Product_Grouped extends WC_Product {
 			return '';
 		}
 
-		return (string) min( $min_price );
+		return wc_format_decimal( min( $min_price ) );
 	}
 
 	/**
@@ -191,7 +190,7 @@ class WC_Product_Grouped extends WC_Product {
 			return '';
 		}
 
-		return (string) max( $max_price );
+		return wc_format_decimal( max( $max_price ) );
 	}
 
 	/*

--- a/plugins/woocommerce/includes/class-wc-product-grouped.php
+++ b/plugins/woocommerce/includes/class-wc-product-grouped.php
@@ -166,14 +166,14 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return string Minimum price or empty string if no children
 	 */
 	public function get_min_price() {
-		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
-		$min_price = array_map( 'wc_get_price_to_display', $children );
+		$children = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$prices   = array_map( 'wc_get_price_to_display', $children );
 
-		if ( empty( $min_price ) ) {
+		if ( empty( $prices ) ) {
 			return '';
 		}
 
-		return wc_format_decimal( min( $min_price ) );
+		return wc_format_decimal( min( $prices ) );
 	}
 
 	/**
@@ -183,14 +183,14 @@ class WC_Product_Grouped extends WC_Product {
 	 * @return string Maximum price or empty string if no children
 	 */
 	public function get_max_price() {
-		$children  = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
-		$max_price = array_map( 'wc_get_price_to_display', $children );
+		$children = array_filter( array_map( 'wc_get_product', $this->get_children() ), 'wc_products_array_filter_visible_grouped' );
+		$prices   = array_map( 'wc_get_price_to_display', $children );
 
-		if ( empty( $max_price ) ) {
+		if ( empty( $prices ) ) {
 			return '';
 		}
 
-		return wc_format_decimal( max( $max_price ) );
+		return wc_format_decimal( max( $prices ) );
 	}
 
 	/*

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -8,6 +8,7 @@
  * @since   2.6.0
  */
 
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Enums\ProductTaxStatus;
@@ -1764,6 +1765,20 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$schema = $this->add_cogs_related_product_schema( $schema, false );
 		}
 
+		if ( Features::is_enabled( 'experimental-wc-rest-api' ) ) {
+			$schema['properties']['__experimental_min_price'] = array(
+				'description' => __( 'Product minimum price.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			);
+
+			$schema['properties']['__experimental_max_price'] = array(
+				'description' => __( 'Product maximum price.', 'woocommerce' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			);
+		}
+
 		return $this->add_additional_fields_schema( $schema );
 	}
 
@@ -1956,6 +1971,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 			if ( in_array( 'global_unique_id', $fields, true ) ) {
 				$data['global_unique_id'] = $product->get_global_unique_id( $context );
+			}
+
+			if ( in_array( '__experimental_min_price', $fields, true ) ) {
+				$data['__experimental_min_price'] = $product->get_type() === ProductType::GROUPED ? $product->get_min_price() : '';
+			}
+
+			if ( in_array( '__experimental_max_price', $fields, true ) ) {
+				$data['__experimental_max_price'] = $product->get_type() === ProductType::GROUPED ? $product->get_max_price() : '';
 			}
 
 			$post_type_obj = get_post_type_object( $this->post_type );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1974,11 +1974,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			}
 
 			if ( in_array( '__experimental_min_price', $fields, true ) ) {
-				$data['__experimental_min_price'] = $product->get_type() === ProductType::GROUPED ? $product->get_min_price() : '';
+				$data['__experimental_min_price'] = method_exists( $product, 'get_min_price' ) ? $product->get_min_price() : '';
 			}
 
 			if ( in_array( '__experimental_max_price', $fields, true ) ) {
-				$data['__experimental_max_price'] = $product->get_type() === ProductType::GROUPED ? $product->get_max_price() : '';
+				$data['__experimental_max_price'] = method_exists( $product, 'get_max_price' ) ? $product->get_max_price() : '';
 			}
 
 			$post_type_obj = get_post_type_object( $this->post_type );

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -135,18 +135,23 @@ class WC_Helper_Product {
 	 * @return WC_Product_Grouped
 	 */
 	public static function create_grouped_product() {
-		$simple_product_1 = self::create_simple_product();
-		$simple_product_2 = self::create_simple_product();
-		$product          = new WC_Product_Grouped();
-		$product->set_props(
+		$simple_product_1 = self::create_simple_product(
+			true,
 			array(
-				'name' => 'Dummy Grouped Product',
-				'sku'  => 'DUMMY GROUPED SKU',
+				'price'         => 1,
+				'regular_price' => 1,
 			)
 		);
+		$simple_product_2 = self::create_simple_product();
+			$product      = new WC_Product_Grouped();
+			$product->set_props(
+				array(
+					'name' => 'Dummy Grouped Product',
+					'sku'  => 'DUMMY GROUPED SKU',
+				)
+			);
 		$product->set_children( array( $simple_product_1->get_id(), $simple_product_2->get_id() ) );
 		$product->save();
-
 		return wc_get_product( $product->get_id() );
 	}
 
@@ -245,7 +250,7 @@ class WC_Helper_Product {
 		}
 
 		$variation_ids = array_map(
-			function( $variation ) {
+			function ( $variation ) {
 				return $variation->get_id();
 			},
 			$variations

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -651,7 +651,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 72, count( $properties ) );
+		$this->assertEquals( 74, count( $properties ) );
 	}
 
 	/**
@@ -696,7 +696,6 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 1, $response_product['categories'], print_r( $response_product, true ) );
 		$this->assertEquals( 'uncategorized', $response_product['categories'][0]['slug'] );
-
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -92,7 +92,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 			self::$products[] = wc_get_product( $child_product_id );
 		}
 		self::$products[] = $grouped_product;
-		$grouped_product  = wc_get_product( $grouped_product->get_id() );
 
 		foreach ( self::$products as $product ) {
 			$product->add_meta_data( 'test1', 'test1', true );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -12,6 +12,32 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	use CogsAwareUnitTestSuiteTrait;
 
 	/**
+	 * Enable the experimental REST API feature.
+	 */
+	private function enable_experimental_rest_api_feature() {
+		add_filter(
+			'woocommerce_admin_features',
+			function ( $features ) {
+				$features[] = 'experimental-wc-rest-api';
+				return $features;
+			}
+		);
+	}
+
+	/**
+	 * Disable the experimental REST API feature.
+	 */
+	private function disable_experimental_rest_api_feature() {
+		add_filter(
+			'woocommerce_admin_features',
+			function ( $features ) {
+				$features = array_diff( $features, array( 'experimental-wc-rest-api' ) );
+				return $features;
+			}
+		);
+	}
+
+	/**
 	 * Runs after each test.
 	 */
 	public function tearDown(): void {
@@ -59,6 +85,15 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 			)
 		);
 
+		$grouped_product       = WC_Helper_Product::create_grouped_product();
+		$children_products_ids = $grouped_product->get_children();
+
+		foreach ( $children_products_ids as $child_product_id ) {
+			self::$products[] = wc_get_product( $child_product_id );
+		}
+		self::$products[] = $grouped_product;
+		$grouped_product  = wc_get_product( $grouped_product->get_id() );
+
 		foreach ( self::$products as $product ) {
 			$product->add_meta_data( 'test1', 'test1', true );
 			$product->add_meta_data( 'test2', 'test2', true );
@@ -95,8 +130,9 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Get all expected fields.
 	 *
 	 * @param bool $with_cogs_enabled Ture to get the fields expected when the Cost of Goods Sold feature is enabled.
+	 * @param bool $with_experimental_rest_api True to get the fields expected when the experimental REST API feature is enabled.
 	 */
-	public function get_expected_response_fields( bool $with_cogs_enabled ) {
+	public function get_expected_response_fields( bool $with_cogs_enabled, bool $with_experimental_rest_api ) {
 		$fields = array(
 			'id',
 			'name',
@@ -174,6 +210,11 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 			$fields[] = 'cost_of_goods_sold';
 		}
 
+		if ( $with_experimental_rest_api ) {
+			$fields[] = '__experimental_min_price';
+			$fields[] = '__experimental_max_price';
+		}
+
 		return $fields;
 	}
 
@@ -181,17 +222,24 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Test that all expected response fields are present.
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 *
-	 * @testWith [true]
-	 *           [false]
+	 * @testWith [true, true]
+	 *           [false, false]
 	 *
 	 * @param bool $with_cogs_enabled Ture test with the Cost of Goods Sold feature enabled.
+	 * @param bool $with_experimental_rest_api True to test with the experimental REST API feature enabled.
 	 */
-	public function test_product_api_get_all_fields( bool $with_cogs_enabled ) {
+	public function test_product_api_get_all_fields( bool $with_cogs_enabled, bool $with_experimental_rest_api ) {
 		if ( $with_cogs_enabled ) {
 			$this->enable_cogs_feature();
 		}
 
-		$expected_response_fields = $this->get_expected_response_fields( $with_cogs_enabled );
+		if ( $with_experimental_rest_api ) {
+			$this->enable_experimental_rest_api_feature();
+		} else {
+			$this->disable_experimental_rest_api_feature();
+		}
+
+		$expected_response_fields = $this->get_expected_response_fields( $with_cogs_enabled, $with_experimental_rest_api );
 
 		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
@@ -225,17 +273,22 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	/**
 	 * Test that all fields are returned when requested one by one.
 	 *
-	 * @testWith [true]
-	 *           [false]
+	 * @testWith [true, true]
+	 *           [false, false]
 	 *
 	 * @param bool $with_cogs_enabled Ture test with the Cost of Goods Sold feature enabled.
+	 * @param bool $with_experimental_rest_api True to test with the experimental REST API feature enabled.
 	 */
-	public function test_products_get_each_field_one_by_one( bool $with_cogs_enabled ) {
+	public function test_products_get_each_field_one_by_one( bool $with_cogs_enabled, bool $with_experimental_rest_api ) {
 		if ( $with_cogs_enabled ) {
 			$this->enable_cogs_feature();
 		}
 
-		$expected_response_fields = $this->get_expected_response_fields( $with_cogs_enabled );
+		if ( $with_experimental_rest_api ) {
+			$this->enable_experimental_rest_api_feature();
+		}
+
+		$expected_response_fields = $this->get_expected_response_fields( $with_cogs_enabled, $with_experimental_rest_api );
 		$product                  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 
 		foreach ( $expected_response_fields as $field ) {
@@ -417,7 +470,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertCount( 4, $response_data );
+		$this->assertCount( 7, $response_data );
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
@@ -442,7 +495,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertCount( 4, $response_data );
+		$this->assertCount( 7, $response_data );
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
@@ -467,7 +520,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertCount( 4, $response_data );
+		$this->assertCount( 7, $response_data );
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
@@ -493,7 +546,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_data = $response->get_data();
-		$this->assertCount( 4, $response_data );
+		$this->assertCount( 7, $response_data );
 
 		foreach ( $response_data as $order ) {
 			$this->assertArrayHasKey( 'meta_data', $order );
@@ -970,7 +1023,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$response_products = $response->get_data();
 
-		$this->assertCount( 1, $response_products );
+		$this->assertCount( 2, $response_products );
 		$this->assertEquals( ProductType::GROUPED, $response_products[0]['type'] );
 	}
 
@@ -994,10 +1047,10 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_products = $response->get_data();
-		$this->assertCount( 2, $response_products );
+		$this->assertCount( 3, $response_products );
 
 		$product_types = wp_list_pluck( $response_products, 'type' );
-		$this->assertEqualsCanonicalizing( array( ProductType::EXTERNAL, ProductType::GROUPED ), $product_types );
+		$this->assertEqualsCanonicalizing( array( ProductType::EXTERNAL, ProductType::GROUPED, ProductType::GROUPED ), $product_types );
 	}
 
 	/**
@@ -1594,5 +1647,37 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that grouped products return correct min_price and max_price values.
+	 *
+	 * @return void
+	 */
+	public function test_grouped_product_min_max_price() {
+		$grouped_product = array_filter(
+			self::$products,
+			function ( $product ) {
+				return $product->get_type() === ProductType::GROUPED;
+			}
+		);
+		$grouped_product = reset( $grouped_product );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $grouped_product->get_id() ) );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( '__experimental_min_price', $data );
+		$this->assertArrayHasKey( '__experimental_max_price', $data );
+		$this->assertEquals( '1', $data['__experimental_min_price'] );
+		$this->assertEquals( '10', $data['__experimental_max_price'] );
+
+		$this->disable_experimental_rest_api_feature();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $grouped_product->get_id() ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayNotHasKey( '__experimental_min_price', $data );
+		$this->assertArrayNotHasKey( '__experimental_max_price', $data );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/59354 (WOOPLUG-4867)

This PR introduces experimental REST API functionality for grouped products to expose minimum and maximum price information. The changes include:

- Added new feature flag `experimental-wc-rest-api` (disabled in core, enabled in development)
- Extended `WC_Product_Grouped` class with `get_min_price()` and `get_max_price()` methods
- Enhanced REST API Products Controller to include experimental min/max price fields when the feature is enabled
- Updated test infrastructure to support the new experimental feature




### Screenshots or screen recordings:

<!-- This section can be removed if not applicable. -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Enable the experimental feature:**
   1. Ensure that you have installed WC Beta Tester.
   2. Navigate to `/wp-admin/tools.php?page=woocommerce-admin-test-helper&tab=features`.
   3. Enable the `experimental-wc-rest-api` feature flag.
   4. Save changes.

2. **Test grouped product creation:**
   1. Create a grouped product with multiple child products.
   2. Ensure child products have different prices (e.g., $1, $5, $10).
   3. Set some child products as visible, others as hidden.

3. **Test REST API response:**
   1. Make a GET request to `/wp-json/wc/v3/products/{grouped_product_id}`
   2. Verify that `__experimental_min_price` and `__experimental_max_price` fields are present
   3. Confirm values match the min/max prices of visible child products
   5. Test with feature flag disabled to ensure fields are not present
   6. Make a GET request to `/wp-json/wc/v3/products/`
   7.  Verify that `__experimental_min_price` and `__experimental_max_price` fields are present
   8. Confirm that  `__experimental_min_price` and `__experimental_max_price` fields aren't empty only for grouped products.
  

4. **Test edge cases:**
   1. Grouped product with single child (min and max should be equal)
   2. Non-grouped products (should have empty fields) 


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add experimental REST API support for grouped product min/max prices

</details>

<detail