### PR TITLE
[Experimental] Render ProductFilterTaxonomy block on the frontend

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -77,6 +77,7 @@ const productFiltersStore = {
 			}
 
 			activeFilters.forEach( ( filter ) => {
+				// todo: refactor this to use params data from Automattic\WooCommerce\Internal\ProductFilters\Params.
 				const { type, value } = filter;
 
 				if ( ! value ) return;
@@ -100,6 +101,11 @@ const productFiltersStore = {
 					addParam( `filter_${ slug }`, value );
 					params[ `query_type_${ slug }` ] =
 						filter.attributeQueryType || 'or';
+				}
+
+				if ( type.includes( 'taxonomy' ) ) {
+					const [ , taxonomy ] = type.split( '/' );
+					addParam( `filter_${ taxonomy }`, value );
 				}
 			} );
 			return params;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -105,7 +105,11 @@ const productFiltersStore = {
 
 				if ( type.includes( 'taxonomy' ) ) {
 					const [ , taxonomy ] = type.split( '/' );
-					addParam( `filter_${ taxonomy }`, value );
+					const config = getConfig( BLOCK_NAME );
+					const taxonomyParamsMap = config?.taxonomyParamsMap || {};
+					const paramKey =
+						taxonomyParamsMap[ taxonomy ] || `filter_${ taxonomy }`;
+					addParam( paramKey, value );
 				}
 			} );
 			return params;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -76,6 +76,9 @@ const productFiltersStore = {
 				params[ key ] = value;
 			}
 
+			const config = getConfig( BLOCK_NAME );
+			const taxonomyParamsMap = config?.taxonomyParamsMap || {};
+
 			activeFilters.forEach( ( filter ) => {
 				// todo: refactor this to use params data from Automattic\WooCommerce\Internal\ProductFilters\Params.
 				const { type, value } = filter;
@@ -105,10 +108,7 @@ const productFiltersStore = {
 
 				if ( type.includes( 'taxonomy' ) ) {
 					const [ , taxonomy ] = type.split( '/' );
-					const config = getConfig( BLOCK_NAME );
-					const taxonomyParamsMap = config?.taxonomyParamsMap || {};
-					const paramKey =
-						taxonomyParamsMap[ taxonomy ] || `filter_${ taxonomy }`;
+					const paramKey = taxonomyParamsMap[ taxonomy ];
 					addParam( paramKey, value );
 				}
 			} );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -3,6 +3,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection\Utils as ProductCollectionUtils;
+use Automattic\WooCommerce\Internal\ProductFilters\FilterDataProvider;
+use Automattic\WooCommerce\Internal\ProductFilters\QueryClauses;
+
 /**
  * Product Filter: Taxonomy Block.
  */
@@ -98,6 +102,73 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $block_attributes Block attributes.
+	 * @param string   $content          Block content.
+	 * @param WP_Block $block            Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $block_attributes, $content, $block ) {
+		// Skip rendering in admin or during AJAX requests.
+		if ( is_admin() || wp_doing_ajax() ) {
+			return '';
+		}
+
+		// TODO: Implement full frontend rendering logic similar to ProductFilterAttribute.
+		// This will include taxonomy term counts, interactive filtering, and proper HTML output.
+		return '';
+	}
+
+	/**
+	 * Retrieve the taxonomy term counts for current block.
+	 *
+	 * @param WP_Block $block    Block instance.
+	 * @param string   $taxonomy Taxonomy slug.
+	 * @return array Term counts with term_id as key and count as value.
+	 */
+	private function get_taxonomy_term_counts( $block, $taxonomy ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
+		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
+
+		// Remove current taxonomy from query vars to avoid circular counting.
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		if ( isset( $taxonomy_params[ $taxonomy ] ) ) {
+			$param_key = $taxonomy_params[ $taxonomy ];
+			unset( $query_vars[ $param_key ] );
+		}
+
+		/**
+		 * Prevent circular counting when calculating filter counts with active attribute filters.
+		 * Removes product attribute taxonomy filters to ensure accurate cross-filter counting.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/52759
+		 */
+		if ( isset( $query_vars['taxonomy'] ) && false !== strpos( $query_vars['taxonomy'], 'pa_' ) ) {
+			unset(
+				$query_vars['taxonomy'],
+				$query_vars['term']
+			);
+		}
+
+		// Remove from tax_query if present.
+		if ( ! empty( $query_vars['tax_query'] ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			$query_vars['tax_query'] = ProductCollectionUtils::remove_query_array( $query_vars['tax_query'], 'taxonomy', $taxonomy );
+		}
+
+		$counts = $container->get( FilterDataProvider::class )->with( $container->get( QueryClauses::class ) )->get_taxonomy_counts( $query_vars, $taxonomy );
+
+		return $counts;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -134,6 +134,14 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			return '';
 		}
 
+		// Pass taxonomy parameter mapping to frontend via interactivity config.
+		wp_interactivity_config(
+			'woocommerce/product-filters',
+			array(
+				'taxonomyParamsMap' => $taxonomy_params,
+			)
+		);
+
 		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
 		$hide_empty      = $block_attributes['hideEmpty'] ?? true;
 		$orderby         = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -67,7 +67,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 
 		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
 			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
-				$term_slugs                          = explode( ',', $params[ $param_key ] );
+				$term_slugs                          = array_map( 'sanitize_title', explode( ',', $params[ $param_key ] ) );
 				$active_taxonomies[ $taxonomy_slug ] = $term_slugs;
 				$all_term_slugs                      = array_merge( $all_term_slugs, $term_slugs );
 			}
@@ -171,7 +171,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		$param_key      = $taxonomy_params[ $taxonomy ];
 
 		if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
-			$selected_terms = array_filter( explode( ',', $filter_params[ $param_key ] ) );
+			$selected_terms = array_filter( array_map( 'sanitize_title', explode( ',', $filter_params[ $param_key ] ) ) );
 		}
 
 		$filter_context = array(
@@ -182,7 +182,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 
 		if ( ! empty( $taxonomy_counts ) ) {
 			$taxonomy_options = array_map(
-				function ( $term ) use ( $block_attributes, $taxonomy_counts, $selected_terms, $taxonomy ) {
+				function ( $term ) use ( $taxonomy_counts, $selected_terms, $taxonomy ) {
 					$term          = (array) $term;
 					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -52,20 +52,20 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array Active filters items.
 	 */
 	public function prepare_selected_filters( $items, $params ) {
-		$container = wc_get_container();
+		$container      = wc_get_container();
 		$params_handler = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
 
-		// Use centralized parameter mapping to avoid hardcoding URL parameter formats
+		// Use centralized parameter mapping to avoid hardcoding URL parameter formats.
 		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
 
 		$active_taxonomies = array();
-		$all_term_slugs = array();
+		$all_term_slugs    = array();
 
 		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
 			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
-				$term_slugs = explode( ',', $params[ $param_key ] );
+				$term_slugs                          = explode( ',', $params[ $param_key ] );
 				$active_taxonomies[ $taxonomy_slug ] = $term_slugs;
-				$all_term_slugs = array_merge( $all_term_slugs, $term_slugs );
+				$all_term_slugs                      = array_merge( $all_term_slugs, $term_slugs );
 			}
 		}
 
@@ -73,12 +73,14 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			return $items;
 		}
 
-		// Single query for all taxonomies and terms to avoid N+1 query problem
-		$terms = get_terms( array(
-			'taxonomy'   => array_keys( $active_taxonomies ),
-			'slug'       => array_unique( $all_term_slugs ),
-			'hide_empty' => false,
-		) );
+		// Single query for all taxonomies and terms to avoid N+1 query problem.
+		$terms = get_terms(
+			array(
+				'taxonomy'   => array_keys( $active_taxonomies ),
+				'slug'       => array_unique( $all_term_slugs ),
+				'hide_empty' => false,
+			)
+		);
 
 		if ( is_wp_error( $terms ) || empty( $terms ) ) {
 			return $items;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -290,7 +290,7 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
 		$taxonomy_data   = array();
 
-		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
+		foreach ( array_keys( $taxonomy_params ) as $taxonomy_slug ) {
 			$taxonomy = get_taxonomy( $taxonomy_slug );
 
 			if ( ! $taxonomy ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -285,16 +285,18 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array
 	 */
 	private function get_taxonomies() {
-		$taxonomies    = get_taxonomies(
-			array(
-				'public'      => true,
-				'object_type' => array( 'product' ),
-			),
-			'objects'
-		);
-		$taxonomy_data = array();
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+		$taxonomy_data   = array();
 
-		foreach ( $taxonomies as $taxonomy ) {
+		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
+			$taxonomy = get_taxonomy( $taxonomy_slug );
+
+			if ( ! $taxonomy ) {
+				continue;
+			}
+
 			$taxonomy_data[] = array(
 				'label'  => $taxonomy->label,
 				'name'   => $taxonomy->name,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -114,13 +114,109 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 */
 	protected function render( $block_attributes, $content, $block ) {
 		// Skip rendering in admin or during AJAX requests.
-		if ( is_admin() || wp_doing_ajax() ) {
+		if ( is_admin() || wp_doing_ajax() || empty( $block_attributes['taxonomy'] ) ) {
 			return '';
 		}
 
-		// TODO: Implement full frontend rendering logic similar to ProductFilterAttribute.
-		// This will include taxonomy term counts, interactive filtering, and proper HTML output.
-		return '';
+		$taxonomy        = $block_attributes['taxonomy'];
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
+		if ( ! $taxonomy_object || ! taxonomy_exists( $taxonomy ) ) {
+			return '';
+		}
+
+		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
+		$hide_empty      = $block_attributes['hideEmpty'] ?? true;
+		$orderby         = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
+		$order           = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
+
+		$args = array(
+			'taxonomy' => $taxonomy,
+			'orderby'  => $orderby,
+			'order'    => $order,
+		);
+
+		if ( $hide_empty ) {
+			$args['include'] = array_keys( $taxonomy_counts );
+		} else {
+			$args['hide_empty'] = false;
+		}
+
+		$taxonomy_terms = get_terms( $args );
+
+		if ( is_wp_error( $taxonomy_terms ) ) {
+			return '';
+		}
+
+		// Get selected terms from filter params.
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+		$filter_params   = $block->context['filterParams'] ?? array();
+		$selected_terms  = array();
+
+		if ( isset( $taxonomy_params[ $taxonomy ] ) ) {
+			$param_key = $taxonomy_params[ $taxonomy ];
+			if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
+				$selected_terms = array_filter( explode( ',', $filter_params[ $param_key ] ) );
+			}
+		}
+
+		$filter_context = array(
+			'showCounts' => $block_attributes['showCounts'] ?? false,
+			'items'      => array(),
+			'groupLabel' => $taxonomy_object->labels->singular_name,
+		);
+
+		if ( ! empty( $taxonomy_counts ) ) {
+			$taxonomy_options = array_map(
+				function ( $term ) use ( $block_attributes, $taxonomy_counts, $selected_terms, $taxonomy ) {
+					$term          = (array) $term;
+					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
+
+					return array(
+						'label'    => $term['name'],
+						'value'    => $term['slug'],
+						'selected' => in_array( $term['slug'], $selected_terms, true ),
+						'count'    => $term['count'],
+						'type'     => 'taxonomy/' . $taxonomy,
+					);
+				},
+				$taxonomy_terms
+			);
+
+			$filter_context['items'] = $taxonomy_options;
+		}
+
+		$wrapper_attributes = array(
+			'data-wp-interactive' => 'woocommerce/product-filters',
+			'data-wp-key'         => wp_unique_prefixed_id( $this->get_block_type() ),
+			'data-wp-context'     => wp_json_encode(
+				array(
+					'activeLabelTemplate' => $taxonomy_object->labels->singular_name . ': {{label}}',
+					'filterType'          => 'taxonomy/' . $taxonomy,
+				),
+				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			),
+		);
+
+		if ( empty( $filter_context['items'] ) ) {
+			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
+		}
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			array_reduce(
+				$block->parsed_block['innerBlocks'],
+				function ( $carry, $parsed_block ) use ( $filter_context ) {
+					$carry .= ( new \WP_Block( $parsed_block, array( 'filterData' => $filter_context ) ) )->render();
+					return $carry;
+				},
+				''
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -125,6 +125,15 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			return '';
 		}
 
+		// Validate that this taxonomy is configured in the parameter map.
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		if ( ! isset( $taxonomy_params[ $taxonomy ] ) ) {
+			return '';
+		}
+
 		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
 		$hide_empty      = $block_attributes['hideEmpty'] ?? true;
 		$orderby         = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
@@ -149,17 +158,12 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		}
 
 		// Get selected terms from filter params.
-		$container       = wc_get_container();
-		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
-		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
-		$filter_params   = $block->context['filterParams'] ?? array();
-		$selected_terms  = array();
+		$filter_params  = $block->context['filterParams'] ?? array();
+		$selected_terms = array();
+		$param_key      = $taxonomy_params[ $taxonomy ];
 
-		if ( isset( $taxonomy_params[ $taxonomy ] ) ) {
-			$param_key = $taxonomy_params[ $taxonomy ];
-			if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
-				$selected_terms = array_filter( explode( ',', $filter_params[ $param_key ] ) );
-			}
+		if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
+			$selected_terms = array_filter( explode( ',', $filter_params[ $param_key ] ) );
 		}
 
 		$filter_context = array(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -16,6 +16,18 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	protected $block_name = 'product-filter-taxonomy';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+	}
+
+	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.
@@ -28,6 +40,62 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		if ( is_admin() ) {
 			$this->asset_data_registry->add( 'filterableProductTaxonomies', $this->get_taxonomies() );
 		}
+	}
+
+	/**
+	 * Prepare the active filter items.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
+	 * @param array $items  The active filter items.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters items.
+	 */
+	public function prepare_selected_filters( $items, $params ) {
+		$container = wc_get_container();
+		$params_handler = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+
+		// Use centralized parameter mapping to avoid hardcoding URL parameter formats
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		$active_taxonomies = array();
+		$all_term_slugs = array();
+
+		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
+			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
+				$term_slugs = explode( ',', $params[ $param_key ] );
+				$active_taxonomies[ $taxonomy_slug ] = $term_slugs;
+				$all_term_slugs = array_merge( $all_term_slugs, $term_slugs );
+			}
+		}
+
+		if ( empty( $active_taxonomies ) ) {
+			return $items;
+		}
+
+		// Single query for all taxonomies and terms to avoid N+1 query problem
+		$terms = get_terms( array(
+			'taxonomy'   => array_keys( $active_taxonomies ),
+			'slug'       => array_unique( $all_term_slugs ),
+			'hide_empty' => false,
+		) );
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return $items;
+		}
+
+		foreach ( $terms as $term ) {
+			$taxonomy_object = get_taxonomy( $term->taxonomy );
+			if ( $taxonomy_object ) {
+				$items[] = array(
+					'type'        => 'taxonomy/' . $term->taxonomy,
+					'value'       => $term->slug,
+					'activeLabel' => $taxonomy_object->labels->singular_name . ': ' . $term->name,
+				);
+			}
+		}
+
+		return $items;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:


This PR implements the frontend rendering functionality for the ProductFilterTaxonomy block including displaying the options and interacting with options.

Closes WOOPLUG-4767
Closes #59131

### Screenshots or screen recordings:

| No filter | Has filters |
| ------ | ----- |
|   <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/dc25f143-7f9b-436a-82a0-59a783802e29" />    |   <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/855c8d0e-b6a8-4ccd-bb0f-ff6dfd1efbb9" />    |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template
2. Add Taxonomy Filter block inside Product Filters block
3. Configure the block to filter by a specific taxonomy (e.g., product categories, tags, or custom taxonomies)
4. Enable Product Counts for all filter blocks that have the settings.
5. Save the template and view it on the frontend
6. Verify that the taxonomy filter renders correctly with available terms
7. Test clicking on different taxonomy terms to filter the products
8. Verify that the URL parameters are updated correctly when filters are applied
9. Test that the product collection updates to show only products matching the selected taxonomy terms
10. Verify that term counts are displayed correctly and update when other filters are applied
11. Test edge cases like empty taxonomies or invalid configurations to ensure proper error handling 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Experimental - Render ProductFilterTaxonomy block on the frontend frontend

</details>
