### PR TITLE
Fix applying coupon codes that differ only in space (e.g., "cou pon" and "coupon")

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4927-coupon-code-invalid-when-similar-code-is-used-prior
+++ b/plugins/woocommerce/changelog/wooplug-4927-coupon-code-invalid-when-similar-code-is-used-prior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix applying coupon codes that differ only in space (e.g., "cou pon" and "coupon")

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -212,7 +212,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 
 		// The `coupon_id_from_code` entry in the object cache must not exist when the coupon is not published, otherwise the coupon will remain available for use.
 		if ( 'publish' !== $coupon->get_status() ) {
-			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
+			$hashed_code = md5( $coupon->get_code() );
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code, 'coupons' );
 		}
 
 		do_action( 'woocommerce_update_coupon', $coupon->get_id(), $coupon );
@@ -243,7 +244,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $id );
 
-			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
+			$hashed_code = md5( $coupon->get_code() );
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code, 'coupons' );
 
 			$coupon->set_id( 0 );
 			do_action( 'woocommerce_delete_coupon', $id );

--- a/plugins/woocommerce/includes/wc-coupon-functions.php
+++ b/plugins/woocommerce/includes/wc-coupon-functions.php
@@ -112,12 +112,16 @@ function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {
 	}
 
 	$data_store = WC_Data_Store::load( 'coupon' );
-	$ids        = wp_cache_get( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, 'coupons' );
+	// Coupon code allows spaces, which doesn't work well with some cache engines (e.g. memcached).
+	$hashed_code = md5( $code );
+	$cache_key   = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $hashed_code;
+
+	$ids = wp_cache_get( $cache_key, 'coupons' );
 
 	if ( false === $ids ) {
 		$ids = $data_store->get_ids_by_code( $code );
 		if ( $ids ) {
-			wp_cache_set( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, $ids, 'coupons' );
+			wp_cache_set( $cache_key, $ids, 'coupons' );
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

`memcached` caching engine (possibly others) doesn't work well when the key uses space.  This is cause an issue when applying or editing coupons that differ only in space (e.g. `cou pon` and `coupon`), because both of them are saved with the same key. Whichever is saved to cache the first, will be returned also for the other one. 

This PR adds md5 (it's fast, and we don't care about security in this case) hashes the code to make it unique and acceptable for `memcached`. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59487, closes WOOPLUG-4927.

(For Bug Fixes) Bug introduced in PR #56319 (likely).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="562" height="260" alt="Screenshot 2025-07-10 at 22 12 09" src="https://github.com/user-attachments/assets/4cdb41d3-326f-40db-9360-a32408ab2024" />     |   <img width="628" height="208" alt="Screenshot 2025-07-10 at 22 12 16" src="https://github.com/user-attachments/assets/3bbb513e-4e51-43b8-83bd-f351f855c101" />    |
|   <img width="440" height="297" alt="Screenshot 2025-07-10 at 22 14 15" src="https://github.com/user-attachments/assets/b64336d5-7b68-47d8-affd-d0cb00f93f8e" />     |   <img width="443" height="217" alt="Screenshot 2025-07-10 at 22 13 32" src="https://github.com/user-attachments/assets/cd6ebced-23d4-4e5c-94fe-ce0932393662" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure you have caching with memcached enabled (this is default on jurassic.ninja). 
2. Create a coupon code named `te st`. 
3. Create another one named `test`. 
4. Verify there isn't `Coupon code already exists - customers will use the latest coupon with this code.` error when saving the coupon. 
5. Apply the first coupon. 
6. Apply the second coupon.
7. Verify there isn't `"{$code}" is an invalid coupon code.` error and both coupons can be applied.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
