### PR TITLE
MIC: Ensure that managed variations appear in the List Table when filtered by a product variable ID

### DIFF
--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/ListTable.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/ListTable.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Admin\NotificationsPage;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\EligibilityService;
 
 /**
  * Notifications list table for Customer Stock Notifications.
@@ -65,7 +66,27 @@ class ListTable extends \WP_List_Table {
 	public $data_store;
 
 	/**
+	 * Eligibility service.
+	 *
+	 * @var EligibilityService
+	 */
+	public $eligibility_service;
+
+	/**
+	 * Init.
+	 *
+	 * @internal
+	 *
+	 * @param EligibilityService $eligibility_service Eligibility service.
+	 */
+	final public function init( EligibilityService $eligibility_service ) {
+		$this->eligibility_service = $eligibility_service;
+	}
+
+	/**
 	 * Constructor.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -352,8 +373,14 @@ class ListTable extends \WP_List_Table {
 		}
 
 		if ( ! empty( $_GET['customer_stock_notifications_product_filter'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$filter                   = absint( wp_unslash( $_GET['customer_stock_notifications_product_filter'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$query_args['product_id'] = array( $filter );
+			$filter  = absint( wp_unslash( $_GET['customer_stock_notifications_product_filter'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$product = wc_get_product( $filter );
+			if ( $product instanceof \WC_Product ) {
+				$target_ids               = $this->eligibility_service->get_target_product_ids( $product );
+				$query_args['product_id'] = $target_ids;
+			} else {
+				NotificationsPage::add_notice( __( 'Invalid product selected.', 'woocommerce' ), 'error' );
+			}
 		}
 
 		if ( ! empty( $_GET['customer_stock_notifications_customer_filter'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -661,46 +688,6 @@ class ListTable extends \WP_List_Table {
 	}
 
 	/**
-	 * Calculate total items.
-	 *
-	 * @return void
-	 */
-	private function calculate_total_items(): void {
-
-		// Count active notifications.
-		$this->total_active_items = $this->data_store->query(
-			array(
-				'return' => 'count',
-				'status' => NotificationStatus::ACTIVE,
-			)
-		);
-
-		// Count pending notifications.
-		$this->total_pending_items = $this->data_store->query(
-			array(
-				'return' => 'count',
-				'status' => NotificationStatus::PENDING,
-			)
-		);
-
-		// Count cancelled notifications.
-		$this->total_cancelled_items = $this->data_store->query(
-			array(
-				'return' => 'count',
-				'status' => NotificationStatus::CANCELLED,
-			)
-		);
-
-		// Count sent notifications.
-		$this->total_sent_items = $this->data_store->query(
-			array(
-				'return' => 'count',
-				'status' => NotificationStatus::SENT,
-			)
-		);
-	}
-
-	/**
 	 * Process actions.
 	 */
 	public function process_actions(): void {
@@ -770,7 +757,7 @@ class ListTable extends \WP_List_Table {
 		if ( 'enable' === $this->current_action() ) {
 			foreach ( $notifications as $id ) {
 
-				$notification = new Notification( $id );
+				$notification = Factory::get_notification( $id );
 				$notification->set_status( NotificationStatus::ACTIVE );
 				$this->data_store->update( $notification );
 
@@ -791,7 +778,7 @@ class ListTable extends \WP_List_Table {
 
 		} elseif ( 'cancel' === $this->current_action() ) {
 			foreach ( $notifications as $id ) {
-				$notification = new Notification( $id );
+				$notification = Factory::get_notification( $id );
 				$notification->set_status( NotificationStatus::CANCELLED );
 				$this->data_store->update( $notification );
 			}
@@ -812,7 +799,7 @@ class ListTable extends \WP_List_Table {
 
 		} elseif ( 'delete' === $this->current_action() ) {
 			foreach ( $notifications as $id ) {
-				$notification = new Notification( $id );
+				$notification = Factory::get_notification( $id );
 				$this->data_store->delete( $notification );
 			}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationsPage.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Admin/NotificationsPage.php
@@ -29,7 +29,7 @@ class NotificationsPage {
 	 * Render page.
 	 */
 	public function output() {
-		$table = new ListTable();
+		$table = wc_get_container()->get( ListTable::class );
 		$table->process_actions();
 		$this->output_admin_notice();
 		$table->prepare_items();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes [WOOPRD-611: MIC: Ensure that managed variations appear in the List Table when filtered by a product variable ID](https://linear.app/a8c/issue/WOOPRD-611/mic-ensure-that-managed-variations-appear-in-the-list-table-when)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a variable product with 2 variations.
2. Set stock management on the parent and set stock to 0.
3. Edit the variations, and set one of the two to manage its own stock.
4. Create three notifications by clicking **WooCommerce > Notifications > Add New**—one for the parent and one for each variation.
5. Visit the list table at **WooCommerce > Notifications**.
6. Filter by the variable product.
7. Check that you only see the notification for the variable product.
8. Apply this fix.
9. Refresh and ensure the list shows the variable parent's notification and the managed variation.
10. Now filter by the variation that manages its own stock.
11. Ensure only the notification for that specific variation appears.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
