### PR TITLE
Add to Cart + Options: make sure individually sold products quantities are reset when they are children of a grouped product

### DIFF
--- a/plugins/woocommerce/changelog/fix-59596-individually-sold-grouped-product
+++ b/plugins/woocommerce/changelog/fix-59596-individually-sold-grouped-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options block: make sure individually sold products quantities are reset when they are children of a grouped product

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -346,14 +346,14 @@ const addToCartWithOptionsStore = store(
 					const addedItems: GroupedCartItem[] = [];
 
 					for ( const childProductId of groupedProductIds ) {
+						if ( quantity[ childProductId ] === 0 ) {
+							continue;
+						}
+
 						const newQuantity = getNewQuantity(
 							childProductId,
 							quantity[ childProductId ]
 						);
-
-						if ( newQuantity === 0 ) {
-							continue;
-						}
 
 						addedItems.push( {
 							id: childProductId,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59596.

### How to test the changes in this Pull Request:

1. Create a grouped product with at least two individually-sold products as children.
2. Add both of them to your cart.
3. Reload the page.
4. Try adding them again to your cart. Verify the errors appear correctly.
5. Now, uncheck one of the checkboxes and click in *Add to cart* again.
6. Verify only one error is shown.

https://github.com/user-attachments/assets/5e936d23-300b-4e81-96d7-caf370c71a54
