### PR TITLE
Add filters for custom columns and row data in Analytics > Taxes serv…

### DIFF
--- a/plugins/woocommerce/changelog/59598-hook-add-analytics-taxes-export-filters
+++ b/plugins/woocommerce/changelog/59598-hook-add-analytics-taxes-export-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add: Filter hooks to extend columns and row data in the Analytics > Taxes export, matching the extensibility found in Orders, Products, Categories, Coupons, Downloads, and Variations exports.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -226,7 +226,7 @@ class Controller extends GenericController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Label.
 	 */
 	public function get_export_columns() {
-		return array(
+		$export_columns = array(
 			'tax_code'     => __( 'Tax code', 'woocommerce' ),
 			'rate'         => __( 'Rate', 'woocommerce' ),
 			'total_tax'    => __( 'Total tax', 'woocommerce' ),
@@ -234,7 +234,25 @@ class Controller extends GenericController implements ExportableInterface {
 			'shipping_tax' => __( 'Shipping tax', 'woocommerce' ),
 			'orders_count' => __( 'Orders', 'woocommerce' ),
 		);
+
+		/**
+		 * Filter to allow developers to add or modify column headers for the
+		 * Analytics > Taxes export.
+		 *
+		 * Developers can use this filter to add custom columns to the exported CSV
+		 * and data grid for taxes report.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $export_columns Export columns as an associative array (column_id => label).
+		 * @return array Modified export columns.
+		 */
+		return apply_filters(
+			'woocommerce_report_taxes_export_columns',
+			$export_columns
+		);
 	}
+
 
 	/**
 	 * Get the column values for export.
@@ -243,7 +261,7 @@ class Controller extends GenericController implements ExportableInterface {
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		return array(
+		$export_item = array(
 			'tax_code'     => \WC_Tax::get_rate_code(
 				(object) array(
 					'tax_rate_id'       => $item['tax_rate_id'],
@@ -258,6 +276,25 @@ class Controller extends GenericController implements ExportableInterface {
 			'order_tax'    => self::csv_number_format( $item['order_tax'] ),
 			'shipping_tax' => self::csv_number_format( $item['shipping_tax'] ),
 			'orders_count' => $item['orders_count'],
+		);
+
+		/**
+		 * Filter to allow developers to add or modify row data for the
+		 * Analytics > Taxes export.
+		 *
+		 * Developers can use this filter to add data for custom columns to the exported CSV
+		 * and data grid for taxes report.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array $export_item Export item data as an associative array (column_id => value).
+		 * @param array $item        Raw item data from report query.
+		 * @return array Modified export item data.
+		 */
+		return apply_filters(
+			'woocommerce_report_taxes_prepare_export_item',
+			$export_item,
+			$item
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This Pull Request introduces new filter hooks to the Analytics > Taxes export REST API:

- `woocommerce_report_taxes_export_columns` — Allows developers to add or modify column headers in the Taxes export.
- `woocommerce_report_taxes_prepare_export_item` — Allows developers to add or modify row data in the Taxes export.

These changes provide extensibility for the Taxes export, similar to what already exists for the Orders, Products, Categories, Coupons, Downloads, and Variations analytics exports. With these filters, third-party plugins and custom code can inject new columns and data into the Taxes CSV export—whether downloaded directly or sent via email.

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), follow these steps:

1. Check out this branch: `hook/add-analytics-taxes-export-filters`
2. Add the following code in a plugin or your (child) theme’s `functions.php`:
    ```php
    add_filter( 'woocommerce_report_taxes_export_columns', function( $columns ) {
        $columns['custom_tax_column'] = __( 'Custom Tax Column', 'your-text-domain' );
        return $columns;
    } );
    add_filter( 'woocommerce_report_taxes_prepare_export_item', function( $export_item, $item ) {
        $export_item['custom_tax_column'] = 'Custom Value'; // Replace with dynamic data as needed.
        return $export_item;
    }, 10, 2 );
    ```
3. Go to **Analytics → Taxes → Download** and export the report.
4. If the export is sent to your email (for large files), open the CSV and verify the new column and data appear.

---

### Testing that has already taken place

- Verified that adding the filters as described above results in additional columns and data in the exported file.
- Confirmed consistent behavior with similar analytics export hooks for Orders, Products, Categories, Coupons, Downloads, and Variations.
- Tested in a local development environment running WordPress 6.x and WooCommerce trunk.

---

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance

- [ ] Patch
- [x] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [x] Add - Adds functionality
- [ ] Update - Update existing functionality
- [ ] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Add: Filter hooks to extend columns and row data in the Analytics > Taxes export, matching the extensibility found in Orders, Products, Categories, Coupons, Downloads, and Variations exports.

</details>

<details>
<summary>Changelog Entry Comment</summary>

<!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
