### PR TITLE
Prevent order discount above coupon amount when editing order in admin

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4794-fixed-cart-discount-giving-discount-above-coupon-amount
+++ b/plugins/woocommerce/changelog/wooplug-4794-fixed-cart-discount-giving-discount-above-coupon-amount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent order discount above coupon amount when editing order in admin

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -452,6 +452,7 @@ function wc_save_order_items( $order_id, $items ) {
 	}
 
 	$order->update_taxes();
+	$order->recalculate_coupons();
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
@@ -414,7 +414,7 @@ test.describe(
 				)
 			).toBeVisible();
 			await expect(
-				page.locator( 'table' ).filter( { hasText: 'Paid: $200.00' } )
+				page.locator( 'table' ).filter( { hasText: 'Paid: $220.00' } )
 			).toBeVisible();
 		} );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/discounts/discounts.php
@@ -1688,4 +1688,63 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$coupon_discounts = array_sum( $discounts->get_discounts_by_coupon() );
 		$this->assertEquals( 5.0, $coupon_discounts ); // $5 discount for 1 product.
 	}
+
+	/**
+	 * Test that fixed cart discount coupons maintain their total amount when quantities change in admin orders.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/XXXXX
+	 */
+	public function test_fixed_cart_discount_quantity_change_admin_order() {
+		$price = 20;
+		// Create a product with a price of $20.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( $price );
+		$product->save();
+
+		// Create a fixed cart discount coupon of $10.
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Create an order with our specific product and 1 item quantity.
+		$order = new WC_Order();
+		$order->set_status( 'processing' );
+		$order->save();
+		$order_item_id = $order->add_product( $product, 1 );
+
+		// Apply the coupon to the order.
+		$order->apply_coupon( $coupon->get_code() );
+		$order->calculate_totals();
+
+		// Verify initial discount amount is $10.
+		$coupons     = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupons );
+		$this->assertEquals( 10.0, $coupon_item->get_discount(), 'Initial discount should be $10' );
+
+		// Verify order total is $10 (original $20 - $10 discount).
+		$this->assertEquals( 10.0, $order->get_total(), 'Order total should be $10 after $10 discount' );
+
+		// Now change the quantity to 2 and save the order items.
+		$items = array(
+			'order_item_id'  => array( $order_item_id ),
+			'order_item_qty' => array( $order_item_id => 2 ),
+			'line_total'     => array( $order_item_id => 2 * $price ),
+			'line_subtotal'  => array( $order_item_id => 2 * $price ),
+		);
+
+		// Save the order items - this should trigger the coupon recalculation.
+		wc_save_order_items( $order->get_id(), $items );
+
+		// Reload the order to get updated data.
+		$order = wc_get_order( $order->get_id() );
+
+		// Verify the discount is still $10 (fixed cart discount should not increase with quantity).
+		$coupons     = $order->get_items( 'coupon' );
+		$coupon_item = reset( $coupons );
+		$this->assertEquals( 10.0, $coupon_item->get_discount(), 'Discount should remain $10 after quantity change' );
+
+		// Verify order total is $30 (original $40 - $10 discount).
+		$this->assertEquals( 30.0, $order->get_total(), 'Order total should be $30 after quantity change' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a bug where fixed cart discount coupons were not being properly redistributed when product quantities were changed in admin orders. When increasing product quantity in admin orders, the discount amount was incorrectly increasing beyond the coupon's fixed amount instead of maintaining the same total discount and redistributing it proportionally.

The fix adds a call to `$order->recalculate_coupons()` in the `wc_save_order_items()` function to ensure that fixed cart discounts are properly recalculated when order items are saved after quantity changes.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59190, closes WOOPLUG-4794.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Used $10 off coupon, added 2 products and then manually change the quantity to both to 2.

| Before | After |
| ------ | ----- |
|   <img width="696" height="546" alt="Screenshot 2025-07-10 at 23 50 18" src="https://github.com/user-attachments/assets/8496a696-ffd6-41af-ac0b-07363fb04722" />     |    <img width="699" height="551" alt="Screenshot 2025-07-10 at 23 49 34" src="https://github.com/user-attachments/assets/e314f9e6-4adb-4e1d-8d9c-e08550e74dee" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fixed cart discount coupon with amount $10.
2. Create a new order from admin with any product (price $20), apply the coupon, and save the order.
3. Change the product quantity from 1 to 2 and save the order.
4. Verify that the discount amount remains $10 (not $20) and the order total is $30 (not $20).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
