### PR TITLE
Product Filters: gracefully handle invalid items

### DIFF
--- a/plugins/woocommerce/changelog/fix-handle-empty-attribute-term-filter
+++ b/plugins/woocommerce/changelog/fix-handle-empty-attribute-term-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: gracefully handle invalid items

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -78,43 +78,44 @@ final class ProductFilterAttribute extends AbstractBlock {
 			array()
 		);
 
-		$active_product_attributes = array_reduce(
-			array_keys( $params ),
-			function ( $acc, $attribute ) {
-				if ( strpos( $attribute, 'filter_' ) === 0 ) {
-					$acc[] = str_replace( 'filter_', '', $attribute );
-				}
-				return $acc;
-			},
-			array()
+		$active_attributes = array();
+		$all_term_slugs    = array();
+		$query_types       = array();
+
+		foreach ( array_keys( $product_attributes_map ) as $attribute_name ) {
+			$param_key = "filter_{$attribute_name}";
+			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
+				$term_slugs                                  = explode( ',', $params[ $param_key ] );
+				$active_attributes[ "pa_{$attribute_name}" ] = $term_slugs;
+				$query_types[ $attribute_name ]              = $params[ 'query_type_' . $attribute_name ] ?? 'or';
+				$all_term_slugs                              = array_merge( $all_term_slugs, $term_slugs );
+			}
+		}
+
+		if ( empty( $active_attributes ) ) {
+			return $items;
+		}
+
+		$attribute_terms = get_terms(
+			array(
+				'taxonomy'   => array_keys( $active_attributes ),
+				'slug'       => $all_term_slugs,
+				'hide_empty' => false,
+			)
 		);
 
-		$active_product_attributes = array_filter(
-			$active_product_attributes,
-			function ( $item ) use ( $product_attributes_map ) {
-				return in_array( $item, array_keys( $product_attributes_map ), true );
-			}
-		);
+		if ( is_wp_error( $attribute_terms ) ) {
+			return $items;
+		}
 
-		foreach ( $active_product_attributes as $product_attribute ) {
-			if ( empty( $params[ "filter_{$product_attribute}" ] ) || ! is_string( $params[ "filter_{$product_attribute}" ] ) ) {
-				continue;
-			}
-
-			$terms                = explode( ',', $params[ "filter_{$product_attribute}" ] );
-			$attribute_label      = wc_attribute_label( "pa_{$product_attribute}" );
-			$attribute_query_type = $params[ "query_type_{$product_attribute}" ] ?? 'or';
-
-			// Get attribute term by slug.
-			foreach ( $terms as $term ) {
-				$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
-				$items[]     = array(
-					'type'               => 'attribute/' . $product_attribute,
-					'value'              => $term,
-					'activeLabel'        => "$attribute_label: $term_object->name",
-					'attributeQueryType' => $attribute_query_type,
-				);
-			}
+		foreach ( $attribute_terms as $term_object ) {
+			$attribute_name = str_replace( 'pa_', '', $term_object->taxonomy );
+			$items[]        = array(
+				'type'               => 'attribute/' . $attribute_name,
+				'value'              => $term_object->slug,
+				'activeLabel'        => sprintf( '%s: %s', $product_attributes_map[ $attribute_name ], $term_object->name ),
+				'attributeQueryType' => $query_types[ $attribute_name ] ?? 'or',
+			);
 		}
 
 		return $items;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -89,7 +89,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 				continue;
 			}
 
-			// Filter out empty slugs and trim whitespace
+			// Filter out empty slugs and trim whitespace.
 			$term_slugs = array_filter(
 				array_map( 'trim', explode( ',', $params[ $param_key ] ) ),
 			);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -84,12 +84,23 @@ final class ProductFilterAttribute extends AbstractBlock {
 
 		foreach ( array_keys( $product_attributes_map ) as $attribute_name ) {
 			$param_key = "filter_{$attribute_name}";
-			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
-				$term_slugs                                  = explode( ',', $params[ $param_key ] );
-				$active_attributes[ "pa_{$attribute_name}" ] = $term_slugs;
-				$query_types[ $attribute_name ]              = $params[ 'query_type_' . $attribute_name ] ?? 'or';
-				$all_term_slugs                              = array_merge( $all_term_slugs, $term_slugs );
+
+			if ( empty( $params[ $param_key ] ) || ! is_string( $params[ $param_key ] ) ) {
+				continue;
 			}
+
+			// Filter out empty slugs and trim whitespace
+			$term_slugs = array_filter(
+				array_map( 'trim', explode( ',', $params[ $param_key ] ) ),
+			);
+
+			if ( empty( $term_slugs ) ) {
+				continue;
+			}
+
+			$active_attributes[ "pa_{$attribute_name}" ] = $term_slugs;
+			$query_types[ $attribute_name ]              = $params[ 'query_type_' . $attribute_name ] ?? 'or';
+			$all_term_slugs                              = array_merge( $all_term_slugs, $term_slugs );
 		}
 
 		if ( empty( $active_attributes ) ) {
@@ -104,7 +115,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 			)
 		);
 
-		if ( is_wp_error( $attribute_terms ) ) {
+		if ( is_wp_error( $attribute_terms ) || empty( $attribute_terms ) ) {
 			return $items;
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -49,7 +49,7 @@ final class ProductFilterRating extends AbstractBlock {
 			return $items;
 		}
 
-		$valid_ratings = array( '1', '2', '3', '4', '5' );
+		$valid_ratings  = array( '1', '2', '3', '4', '5' );
 		$active_ratings = explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] );
 		$active_ratings = array_filter(
 			$active_ratings,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -49,12 +49,12 @@ final class ProductFilterRating extends AbstractBlock {
 			return $items;
 		}
 
+		$valid_ratings = array( '1', '2', '3', '4', '5' );
 		$active_ratings = explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] );
-		$active_ratings = array_map( 'intval', $active_ratings );
 		$active_ratings = array_filter(
 			$active_ratings,
-			function ( $rating ) {
-				return $rating >= 1 && $rating <= 5;
+			function ( $rating ) use ( $valid_ratings ) {
+				return in_array( $rating, $valid_ratings, true );
 			}
 		);
 		$active_ratings = array_unique( $active_ratings );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -49,12 +49,11 @@ final class ProductFilterRating extends AbstractBlock {
 			return $items;
 		}
 
-		$valid_ratings  = array( '1', '2', '3', '4', '5' );
-		$active_ratings = explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] );
+		$active_ratings = array_map( 'absint', explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] ) );
 		$active_ratings = array_filter(
 			$active_ratings,
-			function ( $rating ) use ( $valid_ratings ) {
-				return in_array( $rating, $valid_ratings, true );
+			function ( $rating ) {
+				return $rating > 0 && $rating < 6;
 			}
 		);
 		$active_ratings = array_unique( $active_ratings );
@@ -95,28 +94,26 @@ final class ProductFilterRating extends AbstractBlock {
 		$rating_counts_with_min = array_filter(
 			$rating_counts,
 			function ( $rating ) use ( $min_rating ) {
-				return $rating['rating'] >= $min_rating;
+				return $rating['rating'] >= $min_rating & $rating['rating'] < 6;
 			}
 		);
 		$filter_params          = $block->context['filterParams'] ?? array();
 		$rating_query           = $filter_params[ self::RATING_FILTER_QUERY_VAR ] ?? '';
-		$selected_rating        = array_filter( explode( ',', $rating_query ) );
+		$selected_rating        = array_filter( array_map( 'absint', explode( ',', $rating_query ) ) );
 
 		$filter_options = array_map(
 			function ( $rating ) use ( $selected_rating ) {
-				$value = (string) $rating['rating'];
-
 				$aria_label = sprintf(
 					/* translators: %1$d is referring to rating value. Example: Rated 4 out of 5. */
 					__( 'Rated %1$d out of 5', 'woocommerce' ),
-					$value,
+					$rating['rating'],
 				);
 
 				return array(
-					'label'     => $this->render_rating_label( (int) $value ),
+					'label'     => $this->render_rating_label( (int) $rating['rating'] ),
 					'ariaLabel' => $aria_label,
-					'value'     => $value,
-					'selected'  => in_array( $value, $selected_rating, true ),
+					'value'     => $rating['rating'],
+					'selected'  => in_array( $rating['rating'], $selected_rating, true ),
 					'count'     => $rating['count'],
 					'type'      => 'rating',
 				);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -49,9 +49,15 @@ final class ProductFilterRating extends AbstractBlock {
 			return $items;
 		}
 
+		$active_ratings = explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] );
+		$active_ratings = array_map( 'intval', $active_ratings );
 		$active_ratings = array_filter(
-			explode( ',', $params[ self::RATING_FILTER_QUERY_VAR ] )
+			$active_ratings,
+			function ( $rating ) {
+				return $rating >= 1 && $rating <= 5;
+			}
 		);
+		$active_ratings = array_unique( $active_ratings );
 
 		if ( empty( $active_ratings ) ) {
 			return $items;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -65,7 +65,7 @@ final class ProductFilterRating extends AbstractBlock {
 		foreach ( $active_ratings as $rating ) {
 			$items[] = array(
 				'type'        => 'rating',
-				'value'       => $rating,
+				'value'       => (string) $rating,
 				/* translators: %s is referring to rating value. Example: Rated 4 out of 5. */
 				'activeLabel' => sprintf( __( 'Rating: Rated %d out of 5', 'woocommerce' ), $rating ),
 			);
@@ -112,7 +112,7 @@ final class ProductFilterRating extends AbstractBlock {
 				return array(
 					'label'     => $this->render_rating_label( (int) $rating['rating'] ),
 					'ariaLabel' => $aria_label,
-					'value'     => $rating['rating'],
+					'value'     => (string) $rating['rating'],
 					'selected'  => in_array( $rating['rating'], $selected_rating, true ),
 					'count'     => $rating['count'],
 					'type'      => 'rating',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -53,14 +53,15 @@ final class ProductFilterStatus extends AbstractBlock {
 		}
 
 		$active_statuses = array_filter(
-			explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
+			array_map( 'trim', explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] ) ),
+			function ( $status ) use ( $status_options ) {
+				return array_key_exists( $status, $status_options );
+			}
 		);
 
 		if ( empty( $active_statuses ) ) {
 			return $items;
 		}
-
-		$action_namespace = $this->get_full_block_name();
 
 		foreach ( $active_statuses as $status ) {
 			$items[] = array(

--- a/plugins/woocommerce/src/Blocks/QueryFilters.php
+++ b/plugins/woocommerce/src/Blocks/QueryFilters.php
@@ -13,9 +13,7 @@ final class QueryFilters {
 	 *
 	 * @internal
 	 */
-	public function init() {
-		add_filter( 'posts_clauses', array( $this, 'main_query_filter' ), 10, 2 );
-	}
+	public function init() {}
 
 	/**
 	 * Filter the posts clauses of the main query to support global filters.

--- a/plugins/woocommerce/src/Blocks/QueryFilters.php
+++ b/plugins/woocommerce/src/Blocks/QueryFilters.php
@@ -1,4 +1,6 @@
 <?php
+declare( strict_types = 1 );
+
 namespace Automattic\WooCommerce\Blocks;
 
 use WC_Tax;
@@ -425,7 +427,12 @@ final class QueryFilters {
 		$attribute_ids_for_and_filtering = array();
 
 		foreach ( $chosen_attributes as $taxonomy => $data ) {
-			$all_terms                  = get_terms( $taxonomy, array( 'hide_empty' => false ) );
+			$all_terms                  = get_terms(
+				array(
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+				)
+			);
 			$term_ids_by_slug           = wp_list_pluck( $all_terms, 'term_id', 'slug' );
 			$term_ids_to_filter_by      = array_values( array_intersect_key( $term_ids_by_slug, array_flip( $data['terms'] ) ) );
 			$term_ids_to_filter_by      = array_map( 'absint', $term_ids_to_filter_by );

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -126,13 +126,19 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 			return $args;
 		}
 
-		$stock_statuses = array_intersect(
+		$filtered_stock_statuses = array_intersect(
 			array_map( 'esc_sql', $stock_statuses ),
 			array_keys( wc_get_product_stock_status_options() )
 		);
 
-		$args['join']   = $this->append_product_sorting_table_join( $args['join'] );
-		$args['where'] .= ' AND wc_product_meta_lookup.stock_status IN ("' . implode( '","', $stock_statuses ) . '")';
+		if ( ! empty( $filtered_stock_statuses ) ) {
+			$args['join']   = $this->append_product_sorting_table_join( $args['join'] );
+			$args['where'] .= ' AND wc_product_meta_lookup.stock_status IN ("' . implode( '","', $filtered_stock_statuses ) . '")';
+		}
+
+		if ( ! empty( $stock_statuses ) && empty( $filtered_stock_statuses ) ) {
+			$args['where'] .= ' AND 1=0';
+		}
 
 		return $args;
 	}

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -226,8 +226,9 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 
 		$all_terms = get_terms(
 			array(
-				'taxonomy' => array_keys( $chosen_attributes ),
-				'slug'     => $all_terms_slugs,
+				'taxonomy'   => array_keys( $chosen_attributes ),
+				'slug'       => $all_terms_slugs,
+				'hide_empty' => false,
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

We don't handle invalid term well which throws a warning when one is used. This PR fix that issue by only process valid term.  I also add `hide_empty` argument back to the query clause which was removed in https://github.com/woocommerce/woocommerce/pull/59508 to ensure the final query doesn't change.

Fixes [WOOPLUG-4978](https://linear.app/a8c/issue/WOOPLUG-4978/handle-invalid-product-filter-terms-gracefully)

<!-- Begin testing instructions -->

| Before | After |
|--------|--------|
| <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/6c727aef-340f-4ecc-85fb-25a6f7870f23" /> | <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/cb525814-d2e3-4aa7-90ed-47ae37108d32" /> |
| <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/63389899-c0c9-4bc0-bcf5-ccb22b1fd34e" /> | <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/6db4a000-3627-48eb-86ab-db73b26cbbd7" /> |
| <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/eef4d4fe-7040-4698-8d2a-b5493457d311" /> | <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/e77f1bd8-ed89-4993-8f72-12b7f79da353" /> |

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Given that the current store has a Color attribute.
2. Go to shop page on the front end, see manually add `filter_color=invalid-color` to the URL.
3. See no notice/warning and Active Filters doesn't contain invalid item.
4. Try invalid rating_filter value like the screenshot, see Active Filters doesn't contain invalid item.

Note that the result with invalid items of Price Filter and Rating Filter doesn't look right, as it should be empty result with invalid filter. But we're relying on legacy behavior that has been introduced since the age of classic themes and widgets. We will address them in the future.

<!-- End testing instructions -->
