### PR TITLE
 Add taxonomy support to Product Collection Data API endpoint

### DIFF
--- a/docs/apis/store-api/resources-endpoints/product-collection-data.md
+++ b/docs/apis/store-api/resources-endpoints/product-collection-data.md
@@ -7,7 +7,7 @@ GET /products/collection-data
 GET /products/collection-data?calculate_price_range=true
 GET /products/collection-data?calculate_attribute_counts[0][query_type]=or&calculate_attribute_counts[0][taxonomy]=pa_color
 GET /products/collection-data?calculate_rating_counts=true
-GET /products/collection-data?calculate_taxonomy_counts[0][taxonomy]=product_cat
+GET /products/collection-data?calculate_taxonomy_counts[0]=product_cat
 ```
 
 | Attribute                       | Type   | Required | Description                                                                                                                                                                                                |
@@ -16,13 +16,13 @@ GET /products/collection-data?calculate_taxonomy_counts[0][taxonomy]=product_cat
 | `calculate_attribute_counts`    | object |    No    | Returns attribute counts for a list of attribute taxonomies you pass in via this parameter. Each should be provided as an object with keys "taxonomy" and "query_type". If empty, `null` will be returned. |
 | `calculate_rating_counts`       | bool   |    No    | Returns the counts of products with a certain average rating, 1-5. If false, only `null` will be returned.                                                                                                 |
 | `calculate_stock_status_counts` | bool   |    No    | Returns counts of products with each stock status (in stock, out of stock, on backorder). If false, only `null` will be returned.                                                                         |
-| `calculate_taxonomy_counts`     | object |    No    | Returns taxonomy counts for a list of taxonomies you pass in via this parameter. Each should be provided as an object with key "taxonomy". If empty, `null` will be returned.                           |
+| `calculate_taxonomy_counts`     | array  |    No    | Returns taxonomy counts for a list of taxonomies you pass in via this parameter. Each should be provided as a taxonomy name string. If empty, `null` will be returned.                                 |
 
 
 **In addition to the above attributes**, all product list attributes are supported. This allows you to get data for a certain subset of products. See [the products API list products section](/docs/apis/store-api/resources-endpoints/products#list-products) for the full list.
 
 ```sh
-curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true&calculate_taxonomy_counts[0][taxonomy]=product_cat"
+curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true&calculate_taxonomy_counts[0]=product_cat"
 ```
 
 **Example response:**

--- a/docs/apis/store-api/resources-endpoints/product-collection-data.md
+++ b/docs/apis/store-api/resources-endpoints/product-collection-data.md
@@ -7,20 +7,22 @@ GET /products/collection-data
 GET /products/collection-data?calculate_price_range=true
 GET /products/collection-data?calculate_attribute_counts[0][query_type]=or&calculate_attribute_counts[0][taxonomy]=pa_color
 GET /products/collection-data?calculate_rating_counts=true
+GET /products/collection-data?calculate_taxonomy_counts[0][taxonomy]=product_cat
 ```
 
-| Attribute                    | Type   | Required | Description                                                                                                                                                                                                |
-| :--------------------------- | :----- | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `calculate_price_range`      | bool   |    No    | Returns the min and max price for the product collection. If false, only `null` will be returned.                                                                                                          |
-| `calculate_attribute_counts` | object |    No    | Returns attribute counts for a list of attribute taxonomies you pass in via this parameter. Each should be provided as an object with keys "taxonomy" and "query_type". If empty, `null` will be returned. |
-| `calculate_rating_counts`    | bool   |    No    | Returns the counts of products with a certain average rating, 1-5. If false, only `null` will be returned.                                                                                                 |
-| `calculate_stock_status_counts` | bool   |    No    | Returns counts of products with each stock status (in stock, out of stock, on backorder). If false, only `null` will be returned.                                                                       |
+| Attribute                       | Type   | Required | Description                                                                                                                                                                                                |
+| :------------------------------ | :----- | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `calculate_price_range`         | bool   |    No    | Returns the min and max price for the product collection. If false, only `null` will be returned.                                                                                                          |
+| `calculate_attribute_counts`    | object |    No    | Returns attribute counts for a list of attribute taxonomies you pass in via this parameter. Each should be provided as an object with keys "taxonomy" and "query_type". If empty, `null` will be returned. |
+| `calculate_rating_counts`       | bool   |    No    | Returns the counts of products with a certain average rating, 1-5. If false, only `null` will be returned.                                                                                                 |
+| `calculate_stock_status_counts` | bool   |    No    | Returns counts of products with each stock status (in stock, out of stock, on backorder). If false, only `null` will be returned.                                                                         |
+| `calculate_taxonomy_counts`     | object |    No    | Returns taxonomy counts for a list of taxonomies you pass in via this parameter. Each should be provided as an object with key "taxonomy". If empty, `null` will be returned.                           |
 
 
 **In addition to the above attributes**, all product list attributes are supported. This allows you to get data for a certain subset of products. See [the products API list products section](/docs/apis/store-api/resources-endpoints/products#list-products) for the full list.
 
 ```sh
-curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true"
+curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true&calculate_taxonomy_counts[0][taxonomy]=product_cat"
 ```
 
 **Example response:**
@@ -61,6 +63,20 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?cal
 		{
 			"rating": 4,
 			"count": 1
+		}
+	],
+	"taxonomy_counts": [
+		{
+			"term": 25,
+			"count": 8
+		},
+		{
+			"term": 26,
+			"count": 6
+		},
+		{
+			"term": 27,
+			"count": 2
 		}
 	]
 }

--- a/docs/apis/store-api/resources-endpoints/product-collection-data.md
+++ b/docs/apis/store-api/resources-endpoints/product-collection-data.md
@@ -7,7 +7,7 @@ GET /products/collection-data
 GET /products/collection-data?calculate_price_range=true
 GET /products/collection-data?calculate_attribute_counts[0][query_type]=or&calculate_attribute_counts[0][taxonomy]=pa_color
 GET /products/collection-data?calculate_rating_counts=true
-GET /products/collection-data?calculate_taxonomy_counts[0]=product_cat
+GET /products/collection-data?calculate_taxonomy_counts=product_cat
 ```
 
 | Attribute                       | Type   | Required | Description                                                                                                                                                                                                |
@@ -22,7 +22,7 @@ GET /products/collection-data?calculate_taxonomy_counts[0]=product_cat
 **In addition to the above attributes**, all product list attributes are supported. This allows you to get data for a certain subset of products. See [the products API list products section](/docs/apis/store-api/resources-endpoints/products#list-products) for the full list.
 
 ```sh
-curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true&calculate_taxonomy_counts[0]=product_cat"
+curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true&calculate_taxonomy_counts=product_cat,product_tag"
 ```
 
 **Example response:**

--- a/plugins/woocommerce/changelog/59608-wooplug-4766-product-collection-data-api-add-support-for-taxonomy
+++ b/plugins/woocommerce/changelog/59608-wooplug-4766-product-collection-data-api-add-support-for-taxonomy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add taxonomy support to Product Collection Data API endpoint with calculate_taxonomy_counts parameter

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -168,6 +168,29 @@ class ProductCollectionData extends AbstractRoute {
 			}
 		}
 
+		if ( ! empty( $request['calculate_taxonomy_counts'] ) ) {
+			$taxonomies = [];
+
+			foreach ( $request['calculate_taxonomy_counts'] as $taxonomy_to_count ) {
+				if ( ! empty( $taxonomy_to_count['taxonomy'] ) ) {
+					$taxonomies[] = $taxonomy_to_count['taxonomy'];
+				}
+			}
+
+			$data['taxonomy_counts'] = [];
+
+			if ( $taxonomies ) {
+				$counts = $filters->get_taxonomy_counts( $request, $taxonomies );
+
+				foreach ( $counts as $key => $value ) {
+					$data['taxonomy_counts'][] = (object) [
+						'term'  => $key,
+						'count' => $value,
+					];
+				}
+			}
+		}
+
 		return rest_ensure_response( $this->schema->get_item_response( $data ) );
 	}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -73,6 +73,7 @@ class ProductCollectionData extends AbstractRoute {
 			'attribute_counts'    => null,
 			'stock_status_counts' => null,
 			'rating_counts'       => null,
+			'taxonomy_counts'     => null,
 		];
 		$filters = new ProductQueryFilters();
 
@@ -218,6 +219,23 @@ class ProductCollectionData extends AbstractRoute {
 			'description' => __( 'If true, calculates rating counts for products in the collection.', 'woocommerce' ),
 			'type'        => 'boolean',
 			'default'     => false,
+		];
+
+		$params['calculate_taxonomy_counts'] = [
+			'description' => __( 'If requested, calculates taxonomy term counts for products in the collection.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => [
+				'type'       => 'object',
+				'properties' => [
+					'taxonomy'   => [
+						'description' => __( 'Taxonomy name.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+				],
+			],
+			'default'     => [],
 		];
 
 		return $params;

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -169,7 +169,7 @@ class ProductCollectionData extends AbstractRoute {
 		}
 
 		if ( ! empty( $request['calculate_taxonomy_counts'] ) ) {
-			$taxonomies = $request['calculate_taxonomy_counts'];
+			$taxonomies              = $request['calculate_taxonomy_counts'];
 			$data['taxonomy_counts'] = [];
 
 			if ( $taxonomies ) {

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -169,14 +169,7 @@ class ProductCollectionData extends AbstractRoute {
 		}
 
 		if ( ! empty( $request['calculate_taxonomy_counts'] ) ) {
-			$taxonomies = [];
-
-			foreach ( $request['calculate_taxonomy_counts'] as $taxonomy_to_count ) {
-				if ( ! empty( $taxonomy_to_count['taxonomy'] ) ) {
-					$taxonomies[] = $taxonomy_to_count['taxonomy'];
-				}
-			}
-
+			$taxonomies = $request['calculate_taxonomy_counts'];
 			$data['taxonomy_counts'] = [];
 
 			if ( $taxonomies ) {
@@ -248,15 +241,8 @@ class ProductCollectionData extends AbstractRoute {
 			'description' => __( 'If requested, calculates taxonomy term counts for products in the collection.', 'woocommerce' ),
 			'type'        => 'array',
 			'items'       => [
-				'type'       => 'object',
-				'properties' => [
-					'taxonomy'   => [
-						'description' => __( 'Taxonomy name.', 'woocommerce' ),
-						'type'        => 'string',
-						'context'     => [ 'view', 'edit' ],
-						'readonly'    => true,
-					],
-				],
+				'type'        => 'string',
+				'description' => __( 'Taxonomy name.', 'woocommerce' ),
 			],
 			'default'     => [],
 		];

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductCollectionDataSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ProductCollectionDataSchema.php
@@ -118,6 +118,29 @@ class ProductCollectionDataSchema extends AbstractSchema {
 					],
 				],
 			],
+			'taxonomy_counts'     => [
+				'description' => __( 'Returns number of products within taxonomy terms.', 'woocommerce' ),
+				'type'        => [ 'array', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'term'  => [
+							'description' => __( 'Term ID', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'count' => [
+							'description' => __( 'Number of products.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
+			],
 		];
 	}
 
@@ -138,6 +161,7 @@ class ProductCollectionDataSchema extends AbstractSchema {
 			'attribute_counts'    => $data['attribute_counts'],
 			'rating_counts'       => $data['rating_counts'],
 			'stock_status_counts' => $data['stock_status_counts'],
+			'taxonomy_counts'     => $data['taxonomy_counts'],
 		];
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductType;
 use Automattic\WooCommerce\Enums\CatalogVisibility;
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
 use WC_Tax;
 
 /**
@@ -13,7 +14,7 @@ use WC_Tax;
  *
  * Helper class to handle product queries for the API.
  */
-class ProductQuery {
+class ProductQuery implements QueryClausesGenerator {
 	/**
 	 * Prepare query args to pass to WP_Query for a REST API request.
 	 *
@@ -346,10 +347,10 @@ class ProductQuery {
 	 * Add in conditional search filters for products.
 	 *
 	 * @param array     $args Query args.
-	 * @param \WC_Query $wp_query WC_Query object.
+	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( $args, $wp_query ) {
+	public function add_query_clauses( array $args, \WP_Query $wp_query ) {
 		global $wpdb;
 
 		if ( $wp_query->get( 'search' ) ) {

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -243,7 +243,7 @@ class ProductQueryFilters {
 		// Get counts for each taxonomy individually.
 		foreach ( $taxonomies as $taxonomy ) {
 			$counts     = $filter_data->get_taxonomy_counts( $query_vars, $taxonomy );
-			$all_counts = array_merge( $all_counts, $counts );
+			$all_counts = $all_counts + $counts; // Use + operator to preserve keys
 		}
 
 		return $all_counts;

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -243,7 +243,7 @@ class ProductQueryFilters {
 		// Get counts for each taxonomy individually.
 		foreach ( $taxonomies as $taxonomy ) {
 			$counts     = $filter_data->get_taxonomy_counts( $query_vars, $taxonomy );
-			$all_counts = $all_counts + $counts; // Use + operator to preserve keys
+			$all_counts = $all_counts + $counts; // Use + operator to preserve keys.
 		}
 
 		return $all_counts;

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -213,4 +213,39 @@ class ProductQueryFilters {
 
 		return array_map( 'absint', wp_list_pluck( $results, 'product_count', 'rounded_average_rating' ) );
 	}
+
+	/**
+	 * Get taxonomy counts for the current products.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @param array            $taxonomies Taxonomies to count.
+	 * @return array termId=>count pairs.
+	 */
+	public function get_taxonomy_counts( $request, $taxonomies = [] ) {
+		// Remove paging and sorting params from the request.
+		$request->set_param( 'page', null );
+		$request->set_param( 'per_page', null );
+		$request->set_param( 'order', null );
+		$request->set_param( 'orderby', null );
+
+		// Convert request to query_vars for FilterData.
+		$product_query = new ProductQuery();
+		$query_vars    = $product_query->prepare_objects_query( $request );
+
+		// Use FilterData with ProductQuery as QueryClausesGenerator.
+		$container = wc_get_container();
+
+		$filter_data_provider = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\FilterDataProvider::class );
+		$filter_data          = $filter_data_provider->with( $product_query );
+
+		$all_counts = array();
+
+		// Get counts for each taxonomy individually.
+		foreach ( $taxonomies as $taxonomy ) {
+			$counts     = $filter_data->get_taxonomy_counts( $query_vars, $taxonomy );
+			$all_counts = array_merge( $all_counts, $counts );
+		}
+
+		return $all_counts;
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
@@ -194,11 +194,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
 		$request->set_param(
 			'calculate_taxonomy_counts',
-			array(
-				array(
-					'taxonomy' => 'product_cat',
-				),
-			)
+			array( 'product_cat' )
 		);
 
 		$response = rest_get_server()->dispatch( $request );
@@ -237,14 +233,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
 		$request->set_param(
 			'calculate_taxonomy_counts',
-			array(
-				array(
-					'taxonomy' => 'product_cat',
-				),
-				array(
-					'taxonomy' => 'product_tag',
-				),
-			)
+			array( 'product_cat', 'product_tag' )
 		);
 
 		$response = rest_get_server()->dispatch( $request );
@@ -303,11 +292,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$request->set_param( 'calculate_rating_counts', true );
 		$request->set_param(
 			'calculate_taxonomy_counts',
-			array(
-				array(
-					'taxonomy' => 'product_cat',
-				),
-			)
+			array( 'product_cat' )
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$validate = new ValidateSchema( $schema );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
@@ -52,6 +52,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( null, $data['price_range'] );
 		$this->assertEquals( null, $data['attribute_counts'] );
 		$this->assertEquals( null, $data['rating_counts'] );
+		$this->assertEquals( null, $data['taxonomy_counts'] );
 	}
 
 	/**
@@ -69,6 +70,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( '10000', $data['price_range']->max_price );
 		$this->assertEquals( null, $data['attribute_counts'] );
 		$this->assertEquals( null, $data['rating_counts'] );
+		$this->assertEquals( null, $data['taxonomy_counts'] );
 	}
 
 	/**
@@ -102,6 +104,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( null, $data['price_range'] );
 		$this->assertEquals( null, $data['rating_counts'] );
+		$this->assertEquals( null, $data['taxonomy_counts'] );
 
 		$this->assertIsArray( $data );
 
@@ -137,6 +140,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( null, $data['price_range'] );
 		$this->assertEquals( null, $data['rating_counts'] );
+		$this->assertEquals( null, $data['taxonomy_counts'] );
 
 		$this->assertIsArray( $data );
 
@@ -156,6 +160,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( null, $data['price_range'] );
 		$this->assertEquals( null, $data['attribute_counts'] );
+		$this->assertEquals( null, $data['taxonomy_counts'] );
 		$this->assertEquals(
 			array(
 				(object) array(
@@ -172,6 +177,85 @@ class ProductCollectionData extends ControllerTestCase {
 	}
 
 	/**
+	 * Test taxonomy calculation method.
+	 */
+	public function test_calculate_taxonomy_counts() {
+		$fixtures = new FixtureData();
+
+		// Create test categories.
+		$category1 = wp_insert_term( 'Test Category 1', 'product_cat' );
+		$category2 = wp_insert_term( 'Test Category 2', 'product_cat' );
+
+		// Assign products to categories.
+		wp_set_post_terms( $this->products[0]->get_id(), array( $category1['term_id'] ), 'product_cat' );
+		wp_set_post_terms( $this->products[1]->get_id(), array( $category1['term_id'], $category2['term_id'] ), 'product_cat' );
+
+		// Test product_cat taxonomy.
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
+		$request->set_param(
+			'calculate_taxonomy_counts',
+			array(
+				array(
+					'taxonomy' => 'product_cat',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( null, $data['price_range'] );
+		$this->assertEquals( null, $data['attribute_counts'] );
+		$this->assertEquals( null, $data['rating_counts'] );
+
+		$this->assertIsArray( $data['taxonomy_counts'] );
+		$this->assertNotEmpty( $data['taxonomy_counts'] );
+
+		// Verify structure of taxonomy counts.
+		foreach ( $data['taxonomy_counts'] as $taxonomy_count ) {
+			$this->assertTrue( property_exists( $taxonomy_count, 'term' ) );
+			$this->assertTrue( property_exists( $taxonomy_count, 'count' ) );
+			$this->assertIsInt( $taxonomy_count->term );
+			$this->assertIsInt( $taxonomy_count->count );
+		}
+
+		// Find our test categories in the results.
+		$found_categories = array_filter(
+			$data['taxonomy_counts'],
+			function ( $item ) use ( $category1, $category2 ) {
+				return in_array( $item->term, array( $category1['term_id'], $category2['term_id'] ), true );
+			}
+		);
+
+		$this->assertNotEmpty( $found_categories, 'Test categories should be found in taxonomy counts' );
+
+		// Test multiple taxonomies.
+		$tag1 = wp_insert_term( 'Test Tag 1', 'product_tag' );
+		wp_set_post_terms( $this->products[0]->get_id(), array( $tag1['term_id'] ), 'product_tag' );
+
+		$request = new \WP_REST_Request( 'GET', '/wc/store/v1/products/collection-data' );
+		$request->set_param(
+			'calculate_taxonomy_counts',
+			array(
+				array(
+					'taxonomy' => 'product_cat',
+				),
+				array(
+					'taxonomy' => 'product_tag',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data['taxonomy_counts'] );
+		$this->assertNotEmpty( $data['taxonomy_counts'] );
+	}
+
+	/**
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
@@ -182,6 +266,7 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertArrayHasKey( 'calculate_price_range', $params );
 		$this->assertArrayHasKey( 'calculate_attribute_counts', $params );
 		$this->assertArrayHasKey( 'calculate_rating_counts', $params );
+		$this->assertArrayHasKey( 'calculate_taxonomy_counts', $params );
 	}
 
 	/**
@@ -195,6 +280,10 @@ class ProductCollectionData extends ControllerTestCase {
 				$fixtures->get_product_attribute( 'size', array( 'small', 'medium', 'large' ) ),
 			)
 		);
+
+		// Create test category for taxonomy counts.
+		$category = wp_insert_term( 'Schema Test Category', 'product_cat' );
+		wp_set_post_terms( $product->get_id(), array( $category['term_id'] ), 'product_cat' );
 
 		$routes     = new \Automattic\WooCommerce\StoreApi\RoutesController( new \Automattic\WooCommerce\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-collection-data' );
@@ -212,6 +301,14 @@ class ProductCollectionData extends ControllerTestCase {
 			)
 		);
 		$request->set_param( 'calculate_rating_counts', true );
+		$request->set_param(
+			'calculate_taxonomy_counts',
+			array(
+				array(
+					'taxonomy' => 'product_cat',
+				),
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 		$validate = new ValidateSchema( $schema );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
@@ -242,6 +242,39 @@ class ProductCollectionData extends ControllerTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data['taxonomy_counts'] );
 		$this->assertNotEmpty( $data['taxonomy_counts'] );
+
+		// Find our test categories and tag in the results.
+		$found_categories = array_filter(
+			$data['taxonomy_counts'],
+			function ( $item ) use ( $category1, $category2 ) {
+				return in_array( $item->term, array( $category1['term_id'], $category2['term_id'] ), true );
+			}
+		);
+
+		$found_tags = array_filter(
+			$data['taxonomy_counts'],
+			function ( $item ) use ( $tag1 ) {
+				return $item->term === $tag1['term_id'];
+			}
+		);
+
+		$this->assertNotEmpty( $found_categories, 'Test categories should be found in taxonomy counts' );
+		$this->assertNotEmpty( $found_tags, 'Test tag should be found in taxonomy counts' );
+
+		// Verify the counts are correct.
+		foreach ( $found_categories as $category ) {
+			if ( $category->term === $category1['term_id'] ) {
+				$this->assertEquals( 2, $category->count, 'Category 1 should have 2 products' );
+			} elseif ( $category->term === $category2['term_id'] ) {
+				$this->assertEquals( 1, $category->count, 'Category 2 should have 1 product' );
+			}
+		}
+
+		foreach ( $found_tags as $tag ) {
+			if ( $tag->term === $tag1['term_id'] ) {
+				$this->assertEquals( 1, $tag->count, 'Tag 1 should have 1 product' );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
@@ -180,8 +180,6 @@ class ProductCollectionData extends ControllerTestCase {
 	 * Test taxonomy calculation method.
 	 */
 	public function test_calculate_taxonomy_counts() {
-		$fixtures = new FixtureData();
-
 		// Create test categories.
 		$category1 = wp_insert_term( 'Test Category 1', 'product_cat' );
 		$category2 = wp_insert_term( 'Test Category 2', 'product_cat' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds taxonomy support to the Product Collection Data API endpoint, enabling clients to retrieve taxonomy counts (such as categories and tags) for products in a collection.

**Key changes:**
- Added `calculate_taxonomy_counts` parameter to the product collection data endpoint
- Implemented taxonomy count calculation logic that returns term IDs and their corresponding product counts
- Enhanced test coverage to verify taxonomy counts for both categories and tags

Closes WOOPLUG-4766
Closes https://github.com/woocommerce/woocommerce/issues/59130

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a test environment with WooCommerce installed
2. Create test products and assign them to various categories and tags
3. Make a REST API request to `/wc/store/v1/products/collection-data` with the `calculate_taxonomy_counts` parameter:
   ```
   GET /wc/store/v1/products/collection-data?calculate_taxonomy_counts[]=product_cat&calculate_taxonomy_counts[]=product_tag
   ```
4. Verify the response includes a `taxonomy_counts` array with term IDs and their corresponding product counts
5. Test with different taxonomy combinations to ensure accurate count calculations
6. Run the PHPUnit tests to verify all functionality works correctly:
   ```
   pnpm run test:php:env tests/php/src/Blocks/StoreApi/Routes/ProductCollectionData.php
   ```

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add taxonomy support to Product Collection Data API endpoint with calculate_taxonomy_counts parameter

</details> 
