### PR TITLE
Experimental - Use real store data for previewing taxonomy filter block

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/collections/use-collection-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/collections/use-collection-data.ts
@@ -37,6 +37,11 @@ const buildCollectionDataQuery = (
 		).asc( [ 'taxonomy', 'query_type' ] );
 	}
 
+	if ( Array.isArray( collectionDataQueryState.calculate_taxonomy_counts ) ) {
+		query.calculate_taxonomy_counts =
+			collectionDataQueryState.calculate_taxonomy_counts;
+	}
+
 	return query;
 };
 
@@ -45,6 +50,7 @@ interface UseCollectionDataProps {
 		taxonomy: string;
 		queryType: string;
 	};
+	queryTaxonomy?: string;
 	queryPrices?: boolean;
 	queryStock?: boolean;
 	queryRating?: boolean;
@@ -54,6 +60,7 @@ interface UseCollectionDataProps {
 
 export const useCollectionData = ( {
 	queryAttribute,
+	queryTaxonomy,
 	queryPrices,
 	queryStock,
 	queryRating,
@@ -66,6 +73,10 @@ export const useCollectionData = ( {
 	const [ collectionDataQueryState ] = useQueryStateByContext( context );
 	const [ calculateAttributesQueryState, setCalculateAttributesQueryState ] =
 		useQueryStateByKey( 'calculate_attribute_counts', [], context );
+	const [
+		calculateTaxonomyCountsQueryState,
+		setCalculateTaxonomyCountsQueryState,
+	] = useQueryStateByKey( 'calculate_taxonomy_counts', [], context );
 	const [ calculatePriceRangeQueryState, setCalculatePriceRangeQueryState ] =
 		useQueryStateByKey( 'calculate_price_range', null, context );
 	const [
@@ -76,6 +87,7 @@ export const useCollectionData = ( {
 		useQueryStateByKey( 'calculate_rating_counts', null, context );
 
 	const currentQueryAttribute = useShallowEqual( queryAttribute || {} );
+	const currentQueryTaxonomy = useShallowEqual( queryTaxonomy );
 	const currentQueryPrices = useShallowEqual( queryPrices );
 	const currentQueryStock = useShallowEqual( queryStock );
 	const currentQueryRating = useShallowEqual( queryRating );
@@ -105,6 +117,22 @@ export const useCollectionData = ( {
 		currentQueryAttribute,
 		calculateAttributesQueryState,
 		setCalculateAttributesQueryState,
+	] );
+
+	useEffect( () => {
+		if (
+			currentQueryTaxonomy &&
+			! calculateTaxonomyCountsQueryState.includes( currentQueryTaxonomy )
+		) {
+			setCalculateTaxonomyCountsQueryState( [
+				...calculateTaxonomyCountsQueryState,
+				currentQueryTaxonomy,
+			] );
+		}
+	}, [
+		currentQueryTaxonomy,
+		calculateTaxonomyCountsQueryState,
+		setCalculateTaxonomyCountsQueryState,
 	] );
 
 	useEffect( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/collections/use-collection-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/collections/use-collection-data.ts
@@ -46,14 +46,16 @@ const buildCollectionDataQuery = (
 };
 
 interface UseCollectionDataProps {
-	queryAttribute?: {
-		taxonomy: string;
-		queryType: string;
-	};
-	queryTaxonomy?: string;
-	queryPrices?: boolean;
-	queryStock?: boolean;
-	queryRating?: boolean;
+	queryAttribute?:
+		| {
+				taxonomy: string;
+				queryType: string;
+		  }
+		| undefined;
+	queryTaxonomy?: string | undefined;
+	queryPrices?: boolean | undefined;
+	queryStock?: boolean | undefined;
+	queryRating?: boolean | undefined;
 	queryState: Record< string, unknown >;
 	isEditor?: boolean;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/constants.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/constants.ts
@@ -5,20 +5,20 @@ import { FilterOptionItem } from '../../types';
 
 export const termOptionsPreview: FilterOptionItem[] = [
 	{
-		label: 'Sample Category 1',
-		value: 'sample-category-1',
+		label: 'Sample Item 1',
+		value: 'sample-item-1',
 		selected: false,
 		count: 10,
 	},
 	{
-		label: 'Sample Category 2',
-		value: 'sample-category-2',
+		label: 'Sample Item 2',
+		value: 'sample-item-2',
 		selected: true,
 		count: 12,
 	},
 	{
-		label: 'Sample Category 3',
-		value: 'sample-category-3',
+		label: 'Sample Item 3',
+		value: 'sample-item-3',
 		selected: false,
 		count: 5,
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -9,6 +9,10 @@ import {
 import { withSpokenMessages } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useCollectionData } from '@woocommerce/base-context/hooks';
+import { objectHasProp } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -22,37 +26,130 @@ import type { FilterOptionItem } from '../../types';
 import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
 import { getTaxonomyLabel } from './utils';
+import { sortFilterOptions } from '../../utils/sort-filter-options';
 
 const Edit = ( props: EditProps ) => {
 	const { attributes: blockAttributes } = props;
 
-	const { taxonomy, isPreview, displayStyle, showCounts, sortOrder } =
-		blockAttributes;
+	const {
+		taxonomy,
+		isPreview,
+		displayStyle,
+		showCounts,
+		sortOrder,
+		hideEmpty,
+	} = blockAttributes;
 
-	// For now, use fake data - will be replaced with real taxonomy data later
 	const [ termOptions, setTermOptions ] = useState< FilterOptionItem[] >(
 		[]
 	);
 	const [ isOptionsLoading, setIsOptionsLoading ] =
 		useState< boolean >( true );
 
+	// Fetch taxonomy terms using WordPress core data
+	const { taxonomyTerms, isTermsLoading } = useSelect(
+		( select ) => {
+			if ( ! taxonomy || isPreview ) {
+				return { taxonomyTerms: [], isTermsLoading: false };
+			}
+
+			const { getEntityRecords, hasFinishedResolution } =
+				select( coreStore );
+			const selectorArgs = [
+				'taxonomy',
+				taxonomy,
+				{
+					per_page: -1,
+					hide_empty: hideEmpty,
+					orderby: 'name',
+					order: 'asc',
+				},
+			];
+
+			return {
+				taxonomyTerms: getEntityRecords( ...selectorArgs ) || [],
+				isTermsLoading: ! hasFinishedResolution(
+					'getEntityRecords',
+					selectorArgs
+				),
+			};
+		},
+		[ taxonomy, hideEmpty, isPreview ]
+	);
+
+	// Fetch taxonomy counts using the updated useCollectionData hook
+	const { data: filteredCounts, isLoading: isFilterCountsLoading } =
+		useCollectionData( {
+			queryTaxonomy: taxonomy,
+			queryState: {},
+			isEditor: true,
+		} );
+
 	useEffect( () => {
-		setTermOptions( [
-			...termOptionsPreview.sort( ( a, b ) => {
-				switch ( sortOrder ) {
-					case 'name-asc':
-						return a.value > b.value ? 1 : -1;
-					case 'name-desc':
-						return a.value < b.value ? 1 : -1;
-					case 'count-asc':
-						return a.count > b.count ? 1 : -1;
-					default:
-						return a.count < b.count ? 1 : -1;
+		if ( isPreview ) {
+			// Use preview data for preview mode
+			setTermOptions(
+				sortFilterOptions( [ ...termOptionsPreview ], sortOrder )
+			);
+			setIsOptionsLoading( false );
+			return;
+		}
+
+		if ( isTermsLoading || isFilterCountsLoading ) {
+			setIsOptionsLoading( true );
+			return;
+		}
+
+		if ( ! taxonomy || ! taxonomyTerms.length ) {
+			setTermOptions( [] );
+			setIsOptionsLoading( false );
+			return;
+		}
+
+		// Get taxonomy counts from the API response
+		const taxonomyCounts =
+			objectHasProp( filteredCounts, 'taxonomy_counts' ) &&
+			Array.isArray( filteredCounts.taxonomy_counts )
+				? filteredCounts.taxonomy_counts
+				: [];
+
+		// Create a map for quick lookup of counts by term ID
+		const countsMap = new Map(
+			taxonomyCounts.map( ( item ) => [ item.term, item.count ] )
+		);
+
+		// Process the terms
+		const processedTerms = taxonomyTerms
+			.map( ( term ): FilterOptionItem | null => {
+				const count = countsMap.get( term.id ) || 0;
+
+				// If hideEmpty is true and count is 0, exclude this term
+				if ( hideEmpty && count === 0 ) {
+					return null;
 				}
-			} ),
-		] );
+
+				return {
+					label: term.name,
+					value: term.slug,
+					selected: false,
+					count,
+				};
+			} )
+			.filter( ( term ): term is FilterOptionItem => term !== null );
+
+		// Sort the processed terms
+		setTermOptions( sortFilterOptions( processedTerms, sortOrder ) );
 		setIsOptionsLoading( false );
-	}, [ sortOrder ] );
+	}, [
+		taxonomy,
+		taxonomyTerms,
+		filteredCounts,
+		sortOrder,
+		hideEmpty,
+		isPreview,
+		isTermsLoading,
+		isFilterCountsLoading,
+	] );
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(
 		useBlockProps(),
@@ -79,6 +176,9 @@ const Edit = ( props: EditProps ) => {
 		}
 	);
 
+	const isLoading =
+		isTermsLoading || isFilterCountsLoading || isOptionsLoading;
+
 	if ( ! taxonomy )
 		return (
 			<div { ...innerBlocksProps }>
@@ -87,6 +187,21 @@ const Edit = ( props: EditProps ) => {
 					<p>
 						{ __(
 							'Please select a taxonomy to use this filter!',
+							'woocommerce'
+						) }
+					</p>
+				</Notice>
+			</div>
+		);
+
+	if ( ! isLoading && ! isPreview && taxonomyTerms.length === 0 )
+		return (
+			<div { ...innerBlocksProps }>
+				<TaxonomyFilterInspectorControls { ...props } />
+				<Notice>
+					<p>
+						{ __(
+							'There are no products with the selected taxonomy.',
 							'woocommerce'
 						) }
 					</p>
@@ -105,7 +220,7 @@ const Edit = ( props: EditProps ) => {
 								termOptions.length === 0 && isPreview
 									? termOptionsPreview
 									: termOptions,
-							isLoading: isOptionsLoading,
+							isLoading,
 							showCounts,
 						},
 					} }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/block-editor';
 import { withSpokenMessages } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useCollectionData } from '@woocommerce/base-context/hooks';
@@ -41,15 +41,18 @@ const Edit = ( props: EditProps ) => {
 	} = blockAttributes;
 
 	const [ termOptions, setTermOptions ] = useState< FilterOptionItem[] >(
-		[]
+		isPreview
+			? sortFilterOptions( [ ...termOptionsPreview ], sortOrder )
+			: []
 	);
-	const [ isOptionsLoading, setIsOptionsLoading ] =
-		useState< boolean >( true );
+	const [ isOptionsLoading, setIsOptionsLoading ] = useState< boolean >(
+		! isPreview
+	);
 
 	// Fetch taxonomy terms using WordPress core data
 	const { taxonomyTerms, isTermsLoading } = useSelect(
 		( select ) => {
-			if ( ! taxonomy || isPreview ) {
+			if ( isPreview || ! taxonomy ) {
 				return { taxonomyTerms: [], isTermsLoading: false };
 			}
 
@@ -59,7 +62,7 @@ const Edit = ( props: EditProps ) => {
 				'taxonomy',
 				taxonomy,
 				{
-					per_page: -1,
+					per_page: 15,
 					hide_empty: hideEmpty,
 					orderby: 'name',
 					order: 'asc',
@@ -80,18 +83,17 @@ const Edit = ( props: EditProps ) => {
 	// Fetch taxonomy counts using the updated useCollectionData hook
 	const { data: filteredCounts, isLoading: isFilterCountsLoading } =
 		useCollectionData( {
-			queryTaxonomy: taxonomy,
+			queryTaxonomy: isPreview ? undefined : taxonomy,
 			queryState: {},
 			isEditor: true,
 		} );
 
 	useEffect( () => {
 		if ( isPreview ) {
-			// Use preview data for preview mode
+			// In preview mode, use the preview data directly
 			setTermOptions(
 				sortFilterOptions( [ ...termOptionsPreview ], sortOrder )
 			);
-			setIsOptionsLoading( false );
 			return;
 		}
 
@@ -100,7 +102,7 @@ const Edit = ( props: EditProps ) => {
 			return;
 		}
 
-		if ( ! taxonomy || ! taxonomyTerms.length ) {
+		if ( ! taxonomyTerms.length ) {
 			setTermOptions( [] );
 			setIsOptionsLoading( false );
 			return;
@@ -113,29 +115,29 @@ const Edit = ( props: EditProps ) => {
 				? filteredCounts.taxonomy_counts
 				: [];
 
-		// Create a map for quick lookup of counts by term ID
-		const countsMap = new Map(
-			taxonomyCounts.map( ( item ) => [ item.term, item.count ] )
-		);
-
 		// Process the terms
-		const processedTerms = taxonomyTerms
-			.map( ( term ): FilterOptionItem | null => {
-				const count = countsMap.get( term.id ) || 0;
+		const processedTerms = taxonomyTerms.reduce(
+			( acc: FilterOptionItem[], term ) => {
+				const count =
+					taxonomyCounts.find( ( item ) => item.term === term.id )
+						?.count || 0;
 
 				// If hideEmpty is true and count is 0, exclude this term
 				if ( hideEmpty && count === 0 ) {
-					return null;
+					return acc;
 				}
 
-				return {
+				acc.push( {
 					label: term.name,
 					value: term.slug,
 					selected: false,
 					count,
-				};
-			} )
-			.filter( ( term ): term is FilterOptionItem => term !== null );
+				} );
+
+				return acc;
+			},
+			[]
+		);
 
 		// Sort the processed terms
 		setTermOptions( sortFilterOptions( processedTerms, sortOrder ) );
@@ -200,9 +202,13 @@ const Edit = ( props: EditProps ) => {
 				<TaxonomyFilterInspectorControls { ...props } />
 				<Notice>
 					<p>
-						{ __(
-							'There are no products with the selected taxonomy.',
-							'woocommerce'
+						{ sprintf(
+							// translators: %s: Taxonomy name.
+							__(
+								'There are no products associated with %s.',
+								'woocommerce'
+							),
+							taxonomy
 						) }
 					</p>
 				</Notice>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -203,12 +203,12 @@ const Edit = ( props: EditProps ) => {
 				<Notice>
 					<p>
 						{ sprintf(
-							// translators: %s: Taxonomy name.
+							// translators: %s: Taxonomy label.
 							__(
 								'There are no products associated with %s.',
 								'woocommerce'
 							),
-							taxonomy
+							getTaxonomyLabel( taxonomy )
 						) }
 					</p>
 				</Notice>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
@@ -53,7 +53,26 @@ async function setup( attributes: BlockAttributes ) {
 	const testBlock = [
 		{
 			name: 'woocommerce/product-filter-taxonomy',
-			attributes,
+			attributes: {
+				...attributes,
+				// Enable preview mode for UI tests
+				isPreview: true,
+			},
+		},
+	];
+	return initializeEditor( testBlock );
+}
+
+// Helper function for tests that need to test real data behavior
+async function setupRealData( attributes: BlockAttributes ) {
+	const testBlock = [
+		{
+			name: 'woocommerce/product-filter-taxonomy',
+			attributes: {
+				...attributes,
+				// Disable preview mode for real data tests
+				isPreview: false,
+			},
 		},
 	];
 	return initializeEditor( testBlock );
@@ -147,6 +166,15 @@ describe( 'Taxonomy Filter block', () => {
 		} );
 
 		test( 'should allow toggling product counts', async () => {
+			await selectBlock( /Block: Product Categories Filter/i );
+
+			const block = within(
+				screen.getByLabelText( /Block: Product Categories Filter/i )
+			);
+
+			// expect the list doesn't have count indicators initially
+			expect( block.queryAllByText( /\(\d+\)/ ) ).toHaveLength( 0 );
+
 			const productCountsToggle = screen.getByRole( 'checkbox', {
 				name: /Product counts/i,
 			} );
@@ -156,6 +184,11 @@ describe( 'Taxonomy Filter block', () => {
 			} );
 
 			expect( productCountsToggle ).toBeChecked();
+
+			// expect the list has count indicators after toggling
+			expect( block.queryAllByText( /\(\d+\)/ ).length ).toBeGreaterThan(
+				0
+			);
 		} );
 	} );
 
@@ -176,6 +209,20 @@ describe( 'Taxonomy Filter block', () => {
 			expect( sortOrderSelect ).toHaveValue( 'count-desc' );
 		} );
 
+		test( 'should allow changing sort order when enabled', () => {
+			enableControl( 'Sort Order' );
+
+			const sortOrderSelect = screen.getByRole( 'combobox', {
+				name: /Sort Order/i,
+			} );
+
+			fireEvent.change( sortOrderSelect, {
+				target: { value: 'name-asc' },
+			} );
+
+			expect( sortOrderSelect ).toHaveValue( 'name-asc' );
+		} );
+
 		test( 'should show hide empty items toggle when enabled', () => {
 			enableControl( 'Hide items with no products' );
 
@@ -185,6 +232,78 @@ describe( 'Taxonomy Filter block', () => {
 
 			expect( hideEmptyToggle ).toBeInTheDocument();
 			expect( hideEmptyToggle ).toBeChecked(); // Default is true
+		} );
+
+		test( 'should allow toggling hide empty items when enabled', () => {
+			enableControl( 'Hide items with no products' );
+
+			const hideEmptyToggle = screen.getByRole( 'checkbox', {
+				name: /Hide items with no products/i,
+			} );
+
+			fireEvent.click( hideEmptyToggle );
+
+			expect( hideEmptyToggle ).not.toBeChecked();
+		} );
+	} );
+
+	describe( 'Attribute combinations', () => {
+		test( 'should handle all attributes set correctly', async () => {
+			await setup( {
+				taxonomy: 'product_cat',
+				showCounts: true,
+				displayStyle: 'dropdown',
+				sortOrder: 'name-asc',
+				hideEmpty: false,
+			} );
+			await selectBlock( /Block: Product Categories Filter/i );
+
+			const block = within(
+				screen.getByLabelText( /Block: Product Categories Filter/i )
+			);
+
+			// Should display the heading
+			expect(
+				block.getByText( /Product Categories/i )
+			).toBeInTheDocument();
+
+			// Check that all controls reflect the set attributes
+			expect(
+				screen.getByRole( 'combobox', { name: /Taxonomy/i } )
+			).toHaveValue( 'product_cat' );
+			expect(
+				screen.getByRole( 'checkbox', { name: /Product counts/i } )
+			).toBeChecked();
+
+			// Since we set attributes, these controls should already be visible
+			expect(
+				screen.getByRole( 'combobox', { name: /Sort Order/i } )
+			).toHaveValue( 'name-asc' );
+			expect(
+				screen.getByRole( 'checkbox', {
+					name: /Hide items with no products/i,
+				} )
+			).not.toBeChecked();
+		} );
+
+		test( 'should handle product tags taxonomy', async () => {
+			await setup( {
+				taxonomy: 'product_tag',
+				showCounts: true,
+			} );
+			await selectBlock( /Block: Product Tags Filter/i );
+
+			const block = within(
+				screen.getByLabelText( /Block: Product Tags Filter/i )
+			);
+
+			// Should display the taxonomy label as heading
+			expect( block.getByText( /Product Tags/i ) ).toBeInTheDocument();
+
+			// Should show count indicators since showCounts is true
+			expect( block.queryAllByText( /\(\d+\)/ ).length ).toBeGreaterThan(
+				0
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
@@ -55,23 +55,7 @@ async function setup( attributes: BlockAttributes ) {
 			name: 'woocommerce/product-filter-taxonomy',
 			attributes: {
 				...attributes,
-				// Enable preview mode for UI tests
 				isPreview: true,
-			},
-		},
-	];
-	return initializeEditor( testBlock );
-}
-
-// Helper function for tests that need to test real data behavior
-async function setupRealData( attributes: BlockAttributes ) {
-	const testBlock = [
-		{
-			name: 'woocommerce/product-filter-taxonomy',
-			attributes: {
-				...attributes,
-				// Disable preview mode for real data tests
-				isPreview: false,
 			},
 		},
 	];

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
@@ -15,25 +15,38 @@ import {
 import '../';
 import '../../checkbox-list';
 
-// Mock the getSetting function to return mock taxonomy data
-jest.mock( '@woocommerce/settings', () => ( {
-	getSetting: jest.fn( ( key: string, defaultValue: unknown ) => {
-		if ( key === 'filterableProductTaxonomies' ) {
-			return [
-				{
-					name: 'product_cat',
-					label: 'Product Categories',
-					labels: { singular_name: 'Category' },
-				},
-				{
-					name: 'product_tag',
-					label: 'Product Tags',
-					labels: { singular_name: 'Tag' },
-				},
-			];
-		}
-		return defaultValue;
-	} ),
+// Mock getSetting to return the taxonomy data we need
+jest.mock( '@woocommerce/settings', () => {
+	const originalModule = jest.requireActual( '@woocommerce/settings' );
+	return {
+		...originalModule,
+		getSetting: jest.fn( ( key, defaultValue ) => {
+			if ( key === 'filterableProductTaxonomies' ) {
+				return [
+					{
+						name: 'product_cat',
+						label: 'Product Categories',
+						labels: { singular_name: 'Category' },
+					},
+					{
+						name: 'product_tag',
+						label: 'Product Tags',
+						labels: { singular_name: 'Tag' },
+					},
+				];
+			}
+			// Use the original getSetting for other keys
+			return originalModule.getSetting( key, defaultValue );
+		} ),
+	};
+} );
+
+// Mock WooCommerce schema selectors to prevent namespace errors
+jest.mock( '../../../../../data/schema/selectors', () => ( {
+	getRoute: jest.fn( () => null ),
+	getRoutes: jest.fn( () => ( {
+		'/wc/store/v1': {},
+	} ) ),
 } ) );
 
 async function setup( attributes: BlockAttributes ) {
@@ -80,7 +93,7 @@ describe( 'Taxonomy Filter block', () => {
 			).toBeInTheDocument();
 		} );
 
-		test( 'should display taxonomy filter with preview data when taxonomy is selected', async () => {
+		test( 'should display taxonomy filter when taxonomy is selected', async () => {
 			await setup( { taxonomy: 'product_cat' } );
 			await selectBlock( /Block: Product Categories Filter/i );
 
@@ -124,31 +137,6 @@ describe( 'Taxonomy Filter block', () => {
 			expect( taxonomySelect ).toHaveValue( 'product_tag' );
 		} );
 
-		test( 'should show sort order control with default value when enabled', () => {
-			enableControl( 'Sort Order' );
-
-			const sortOrderSelect = screen.getByRole( 'combobox', {
-				name: /Sort Order/i,
-			} );
-
-			expect( sortOrderSelect ).toBeInTheDocument();
-			expect( sortOrderSelect ).toHaveValue( 'count-desc' );
-		} );
-
-		test( 'should allow changing sort order when enabled', () => {
-			enableControl( 'Sort Order' );
-
-			const sortOrderSelect = screen.getByRole( 'combobox', {
-				name: /Sort Order/i,
-			} );
-
-			fireEvent.change( sortOrderSelect, {
-				target: { value: 'name-asc' },
-			} );
-
-			expect( sortOrderSelect ).toHaveValue( 'name-asc' );
-		} );
-
 		test( 'should show product counts toggle', () => {
 			const productCountsToggle = screen.getByRole( 'checkbox', {
 				name: /Product counts/i,
@@ -159,15 +147,6 @@ describe( 'Taxonomy Filter block', () => {
 		} );
 
 		test( 'should allow toggling product counts', async () => {
-			await selectBlock( /Block: Product Categories Filter/i );
-
-			const block = within(
-				screen.getByLabelText( /Block: Product Categories Filter/i )
-			);
-
-			// expect the list doesn't have count indicators
-			expect( block.queryAllByText( /\(\d+\)/ ) ).toHaveLength( 0 );
-
 			const productCountsToggle = screen.getByRole( 'checkbox', {
 				name: /Product counts/i,
 			} );
@@ -177,11 +156,24 @@ describe( 'Taxonomy Filter block', () => {
 			} );
 
 			expect( productCountsToggle ).toBeChecked();
+		} );
+	} );
 
-			// expect the list has count indicators
-			expect( block.queryAllByText( /\(\d+\)/ ).length ).toBeGreaterThan(
-				0
-			);
+	describe( 'Advanced controls', () => {
+		beforeEach( async () => {
+			await setup( { taxonomy: 'product_cat' } );
+			await selectBlock( /Block: Product Categories Filter/i );
+		} );
+
+		test( 'should show sort order control when enabled', () => {
+			enableControl( 'Sort Order' );
+
+			const sortOrderSelect = screen.getByRole( 'combobox', {
+				name: /Sort Order/i,
+			} );
+
+			expect( sortOrderSelect ).toBeInTheDocument();
+			expect( sortOrderSelect ).toHaveValue( 'count-desc' );
 		} );
 
 		test( 'should show hide empty items toggle when enabled', () => {
@@ -193,59 +185,6 @@ describe( 'Taxonomy Filter block', () => {
 
 			expect( hideEmptyToggle ).toBeInTheDocument();
 			expect( hideEmptyToggle ).toBeChecked(); // Default is true
-		} );
-
-		test( 'should allow toggling hide empty items when enabled', () => {
-			enableControl( 'Hide items with no products' );
-
-			const hideEmptyToggle = screen.getByRole( 'checkbox', {
-				name: /Hide items with no products/i,
-			} );
-
-			fireEvent.click( hideEmptyToggle );
-
-			expect( hideEmptyToggle ).not.toBeChecked();
-		} );
-	} );
-
-	describe( 'Different attribute combinations', () => {
-		test( 'should handle all attributes set', async () => {
-			await setup( {
-				taxonomy: 'product_cat',
-				showCounts: true,
-				displayStyle: 'dropdown',
-				sortOrder: 'name-asc',
-				hideEmpty: false,
-				isPreview: false,
-			} );
-			await selectBlock( /Block: Product Categories Filter/i );
-
-			const block = within(
-				screen.getByLabelText( /Block: Product Categories Filter/i )
-			);
-
-			// Should display the heading
-			expect(
-				block.getByText( /Product Categories/i )
-			).toBeInTheDocument();
-
-			// Check that all controls reflect the set attributes
-			expect(
-				screen.getByRole( 'combobox', { name: /Taxonomy/i } )
-			).toHaveValue( 'product_cat' );
-			expect(
-				screen.getByRole( 'checkbox', { name: /Product counts/i } )
-			).toBeChecked();
-
-			// Since we set attributes, these controls should already be visible
-			expect(
-				screen.getByRole( 'combobox', { name: /Sort Order/i } )
-			).toHaveValue( 'name-asc' );
-			expect(
-				screen.getByRole( 'checkbox', {
-					name: /Hide items with no products/i,
-				} )
-			).not.toBeChecked();
 		} );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
@@ -6,7 +6,7 @@ import type { FilterOptionItem } from '../types';
 /**
  * Sorts filter options based on the specified sort order
  *
- * @param options - Array of filter option items to sort
+ * @param options   - Array of filter option items to sort
  * @param sortOrder - Sort order (name-asc, name-desc, count-asc, count-desc)
  * @return Sorted array of filter option items
  */

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import type { FilterOptionItem } from '../types';
+
+/**
+ * Sorts filter options based on the specified sort order
+ *
+ * @param options - Array of filter option items to sort
+ * @param sortOrder - Sort order (name-asc, name-desc, count-asc, count-desc)
+ * @return Sorted array of filter option items
+ */
+export function sortFilterOptions(
+	options: FilterOptionItem[],
+	sortOrder: string
+): FilterOptionItem[] {
+	return options.sort( ( a, b ) => {
+		switch ( sortOrder ) {
+			case 'name-asc':
+				return a.label.localeCompare( b.label );
+			case 'name-desc':
+				return b.label.localeCompare( a.label );
+			case 'count-asc':
+				return a.count - b.count;
+			default: // count-desc
+				return b.count - a.count;
+		}
+	} );
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR update the Taxonomy Filters block to use real taxonomy data in the editor.

Closes WOOPLUG-4768.
Closes https://github.com/woocommerce/woocommerce/issues/59132.

| Before | After |
|--------|--------|
| <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/db555093-7059-4872-a881-b86a89b0ad59" /> | <img width="1025" height="769" alt="image" src="https://github.com/user-attachments/assets/66f79de8-86b1-417d-a922-26f058af114a" /> | 

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to the block editor and add a Product Filters block
2. Add a Product categories Filter inner block
3. Verify that the preview data shows actual product categories.
4. Test with different taxonomy types (categories, tags, custom taxonomies) to ensure the preview data is appropriate for all taxonomy types

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Experimental - Use real store data for previewing taxonomy filter block
</details>
