### PR TITLE
Update woocommerce_address_providers to accept objects alongside class names

### DIFF
--- a/plugins/woocommerce/changelog/59617-update-change-woocommerce_address_providers-to-accept-objects
+++ b/plugins/woocommerce/changelog/59617-update-change-woocommerce_address_providers-to-accept-objects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Support passing objects for woocommerce_address_providers filter.

--- a/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AbstractAutomatticAddressProvider.php
@@ -56,13 +56,13 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 	public function load_jwt() {
 
 		// If we already have a loaded, valid token, we return early.
-		if ( $this->jwt && JsonWebToken::shallow_validate( $this->jwt ) ) {
+		if ( $this->jwt && is_string( $this->jwt ) && JsonWebToken::shallow_validate( $this->jwt ) ) {
 			return;
 		}
 
 		$cached_jwt = $this->get_cached_option( 'address_autocomplete_jwt' );
 		// If we have a cached, valid token, we load it to class and return early.
-		if ( $cached_jwt && JsonWebToken::shallow_validate( $cached_jwt ) ) {
+		if ( $cached_jwt && is_string( $cached_jwt ) && JsonWebToken::shallow_validate( $cached_jwt ) ) {
 			$this->jwt = $cached_jwt;
 			return;
 		}
@@ -75,7 +75,7 @@ abstract class AbstractAutomatticAddressProvider extends WC_Address_Provider {
 
 		try {
 			$fresh_jwt = $this->get_address_service_jwt();
-			if ( $fresh_jwt && JsonWebToken::shallow_validate( $fresh_jwt ) ) {
+			if ( $fresh_jwt && is_string( $fresh_jwt ) && JsonWebToken::shallow_validate( $fresh_jwt ) ) {
 				$this->set_jwt( $fresh_jwt );
 				// Clear retry data on success.
 				$this->delete_cached_option( 'jwt_retry_data' );

--- a/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
@@ -51,7 +51,9 @@ class AddressProviderController {
 		 * Filter the registered address providers.
 		 *
 		 * @since 9.9.0
-		 * @param WC_Address_Provider[] $providers Array of fully qualified class names or instances that extend WC_Address_Provider.
+		 * @param array $providers Array of fully qualified class names (strings) or WC_Address_Provider instances.
+		 *                         Class names will be instantiated automatically.
+		 *                         Example: array( 'My_Provider_Class', new My_Other_Provider() )
 		 */
 		$provider_items = apply_filters( 'woocommerce_address_providers', array() );
 

--- a/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
+++ b/plugins/woocommerce/src/Internal/AddressProvider/AddressProviderController.php
@@ -51,20 +51,20 @@ class AddressProviderController {
 		 * Filter the registered address providers.
 		 *
 		 * @since 9.9.0
-		 * @param WC_Address_Provider[] $providers Array of fully qualified class names that extend WC_Address_Provider.
+		 * @param WC_Address_Provider[] $providers Array of fully qualified class names or instances that extend WC_Address_Provider.
 		 */
-		$provider_class_names = apply_filters( 'woocommerce_address_providers', array() );
+		$provider_items = apply_filters( 'woocommerce_address_providers', array() );
 
 		// The filter returned nothing but an empty array, so we can skip the rest of the function.
-		if ( empty( $provider_class_names ) && is_array( $provider_class_names ) ) {
+		if ( empty( $provider_items ) && is_array( $provider_items ) ) {
 			return array();
 		}
 
 		$logger = wc_get_logger();
 
-		if ( ! is_array( $provider_class_names ) ) {
+		if ( ! is_array( $provider_items ) ) {
 			$logger->error(
-				'Invalid return value for woocommerce_address_providers, expected an array of class names.',
+				'Invalid return value for woocommerce_address_providers, expected an array of class names or instances.',
 				array(
 					'context' => 'address_provider_service',
 				)
@@ -75,36 +75,29 @@ class AddressProviderController {
 		$providers = array();
 		$seen_ids  = array();
 
-		foreach ( $provider_class_names as $provider_class_name ) {
+		foreach ( $provider_items as $provider_item ) {
+			if ( is_string( $provider_item ) && class_exists( $provider_item ) ) {
+				$provider_item = new $provider_item();
+			}
 
-			// Validate the class name is a string.
-			if ( ! is_string( $provider_class_name ) ) {
+			// Providers need to be valid and extend WC_Address_Provider.
+			if ( ! is_a( $provider_item, WC_Address_Provider::class ) ) {
 				$logger->error(
-					'Invalid class name for address provider, expected a string.',
+					sprintf(
+						'Invalid address provider item "%s", expected a string class name or WC_Address_Provider instance.',
+						is_object( $provider_item ) ? get_class( $provider_item ) : gettype( $provider_item )
+					),
 					array(
 						'context' => 'address_provider_service',
 					)
 				);
 				continue;
 			}
-
-			// Ensure the class exists and is a valid WC_Address_Provider subclass.
-			if ( ! class_exists( $provider_class_name ) || ! is_subclass_of( $provider_class_name, WC_Address_Provider::class ) ) {
-				$logger->error(
-					'Invalid address provider class, class does not exist or is not a subclass of WC_Address_Provider: ' . $provider_class_name,
-					array(
-						'context' => 'address_provider_service',
-					)
-				);
-				continue;
-			}
-
-			$provider_instance = new $provider_class_name();
 
 			// Validate the instance has the necessary properties.
-			if ( empty( $provider_instance->id ) || empty( $provider_instance->name ) ) {
+			if ( empty( $provider_item->id ) || empty( $provider_item->name ) ) {
 				$logger->error(
-					'Invalid address provider instance, id or name property is missing or empty: ' . $provider_class_name,
+					'Invalid address provider instance, id or name property is missing or empty: ' . get_class( $provider_item ),
 					array(
 						'context' => 'address_provider_service',
 					)
@@ -113,13 +106,13 @@ class AddressProviderController {
 			}
 
 			// Check for duplicate IDs.
-			if ( isset( $seen_ids[ $provider_instance->id ] ) ) {
+			if ( isset( $seen_ids[ $provider_item->id ] ) ) {
 				$logger->error(
 					sprintf(
 						'Duplicate provider ID found. ID "%s" is used by both %s and %s.',
-						$provider_instance->id,
-						$seen_ids[ $provider_instance->id ],
-						$provider_class_name
+						$provider_item->id,
+						$seen_ids[ $provider_item->id ],
+						get_class( $provider_item )
 					),
 					array(
 						'context' => 'address_provider_service',
@@ -129,10 +122,10 @@ class AddressProviderController {
 			}
 
 			// Track the ID and its provider class for error reporting.
-			$seen_ids[ $provider_instance->id ] = $provider_class_name;
+			$seen_ids[ $provider_item->id ] = get_class( $provider_item );
 
 			// Add the provider instance to the array after all checks are completed.
-			$providers[] = $provider_instance;
+			$providers[] = $provider_item;
 		}
 
 		if ( ! empty( $this->preferred_provider_option ) && ! empty( $providers ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/AddressProvider/AddressProviderControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/AddressProvider/AddressProviderControllerTest.php
@@ -669,7 +669,7 @@ class AddressProviderControllerTest extends MockeryTestCase {
 			->expects( $this->once() )
 			->method( 'error' )
 			->with(
-				'Invalid return value for woocommerce_address_providers, expected an array of class names.',
+				'Invalid return value for woocommerce_address_providers, expected an array of class names or instances.',
 				array( 'context' => 'address_provider_service' )
 			);
 
@@ -695,7 +695,7 @@ class AddressProviderControllerTest extends MockeryTestCase {
 			->expects( $this->once() )
 			->method( 'error' )
 			->with(
-				'Invalid class name for address provider, expected a string.',
+				'Invalid address provider item "integer", expected a string class name or WC_Address_Provider instance.',
 				array( 'context' => 'address_provider_service' )
 			);
 
@@ -721,7 +721,7 @@ class AddressProviderControllerTest extends MockeryTestCase {
 			->expects( $this->once() )
 			->method( 'error' )
 			->with(
-				'Invalid address provider class, class does not exist or is not a subclass of WC_Address_Provider: NonExistentClass',
+				'Invalid address provider item "string", expected a string class name or WC_Address_Provider instance.',
 				array( 'context' => 'address_provider_service' )
 			);
 
@@ -786,11 +786,11 @@ class AddressProviderControllerTest extends MockeryTestCase {
 			->method( 'error' )
 			->withConsecutive(
 				array(
-					'Invalid class name for address provider, expected a string.',
+					'Invalid address provider item "integer", expected a string class name or WC_Address_Provider instance.',
 					array( 'context' => 'address_provider_service' ),
 				),
 				array(
-					'Invalid address provider class, class does not exist or is not a subclass of WC_Address_Provider: NonExistentClass',
+					'Invalid address provider item "string", expected a string class name or WC_Address_Provider instance.',
 					array( 'context' => 'address_provider_service' ),
 				),
 				array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:
While working on the address provider implementation in WooCommerce Payment, I noticed our filter `woocommerce_address_providers` has an explicit requirement to only accept class names, not objects, I don't see a good reason to enforce this, but it's limiting because plugins might want to initiate an object first with their dependencies before passing it to us, like WooCommerce Payment needing to pass its services and container, while still keeping the class testable  by just injecting services in construct.

Another important part is that we're trying to match `woocommerce_payment_gateways`, which also accepts objects, so this matches that one up.

### How to test the changes in this Pull Request:
Install the following plugin
[generic-address-provider.zip](https://github.com/user-attachments/files/21182332/generic-address-provider.zip)

1. Enable address autocomplete and make sure it's the only one, or if you have other ones, make sure Generic provider is selected.
2. In shortcode checkout, make sure you can make requests for autocomplete.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Support passing objects for woocommerce_address_providers filter.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
