### PR TITLE
[dev] Release: canonical extensions testing workflow tweaks

### DIFF
--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -77,16 +77,16 @@ for repository in ${filtered[@]}; do
 	echo -n " previous run #${previous_run} "
 
 	# Start a new run and report back.
-	( echo "{\"wc-version\":\"$version\", \"wp-version\":\"$wordpress\", \"php-version\":\"$php\", \"qit-tests\":\"WooCommerce Pre-Release Tests (includes Activation, WooCommerce E2E and API tests)\"}" | gh workflow run ${workflow_id} --json --repo $repository >/dev/null 2>&1) || echo -n '[insufficient permissions] '
-	for i in {1..10}; do
-	    echo -n '.' && sleep 1s
-	    last_run=$( gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${repository##https://github.com/}/actions/workflows/${workflow_id}/runs?per_page=1 --jq '.workflow_runs.[].id' )
-	    if [[ $last_run != $previous_run ]]; then
-            running+=( "$repository;${last_run}" )
-            echo -n " new run #${last_run}"
-            break
-	    fi
-	done
+#	( echo "{\"wc-version\":\"$version\", \"wp-version\":\"$wordpress\", \"php-version\":\"$php\", \"qit-tests\":\"WooCommerce Pre-Release Tests (includes Activation, WooCommerce E2E and API tests)\"}" | gh workflow run ${workflow_id} --json --repo $repository >/dev/null 2>&1) || echo -n '[insufficient permissions] '
+#	for i in {1..10}; do
+#	    echo -n '.' && sleep 1s
+#	    last_run=$( gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${repository##https://github.com/}/actions/workflows/${workflow_id}/runs?per_page=1 --jq '.workflow_runs.[].id' )
+#	    if [[ $last_run != $previous_run ]]; then
+#            running+=( "$repository;${last_run}" )
+#            echo -n " new run #${last_run}"
+#            break
+#	    fi
+#	done
 
 	echo ''
 done

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -42,7 +42,7 @@ skipped=()
 echo -n "Looking up repositories (${#repositories[@]}): "
 for repository in ${repositories[@]}; do
 	repository=${repository%/}
-	match=$( ( gh workflow list --json path --jq '.[].path' --repo $repository | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml)' | wc -l | tr -d '[:space:]' ) || echo '0' )
+	match=$( ( gh workflow list --json path --jq '.[].path' --repo $repository | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' | wc -l | tr -d '[:space:]' ) || echo '0' )
 	if [[ $match == '1' ]]; then
 		filtered+=( $repository )
 	else
@@ -67,7 +67,7 @@ for repository in ${filtered[@]}; do
 	echo -n "    -- ${repository##*/} :"
 
 	# Report identified workflow details.
-	workflow=$( gh workflow list --json path,id --repo $repository | jq --compact-output '.[]' | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml)' )
+	workflow=$( gh workflow list --json path,id --repo https://github.com/woocommerce/woocommerce-gateway-stripe | jq --compact-output '.[]' | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' )
 	workflow_path=$( echo $workflow | jq --raw-output '( .path )' )
 	workflow_id=$( echo $workflow | jq --raw-output '( .id )' )
 	echo -n " workflow ${workflow_path} (#${workflow_id})"

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -77,16 +77,16 @@ for repository in ${filtered[@]}; do
 	echo -n " previous run #${previous_run} "
 
 	# Start a new run and report back.
-#	( echo "{\"wc-version\":\"$version\", \"wp-version\":\"$wordpress\", \"php-version\":\"$php\", \"qit-tests\":\"WooCommerce Pre-Release Tests (includes Activation, WooCommerce E2E and API tests)\"}" | gh workflow run ${workflow_id} --json --repo $repository >/dev/null 2>&1) || echo -n '[insufficient permissions] '
-#	for i in {1..10}; do
-#	    echo -n '.' && sleep 1s
-#	    last_run=$( gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${repository##https://github.com/}/actions/workflows/${workflow_id}/runs?per_page=1 --jq '.workflow_runs.[].id' )
-#	    if [[ $last_run != $previous_run ]]; then
-#            running+=( "$repository;${last_run}" )
-#            echo -n " new run #${last_run}"
-#            break
-#	    fi
-#	done
+	( echo "{\"wc-version\":\"$version\", \"wp-version\":\"$wordpress\", \"php-version\":\"$php\", \"qit-tests\":\"WooCommerce Pre-Release Tests (includes Activation, WooCommerce E2E and API tests)\"}" | gh workflow run ${workflow_id} --json --repo $repository >/dev/null 2>&1) || echo -n '[insufficient permissions] '
+	for i in {1..10}; do
+	    echo -n '.' && sleep 1s
+	    last_run=$( gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${repository##https://github.com/}/actions/workflows/${workflow_id}/runs?per_page=1 --jq '.workflow_runs.[].id' )
+	    if [[ $last_run != $previous_run ]]; then
+            running+=( "$repository;${last_run}" )
+            echo -n " new run #${last_run}"
+            break
+	    fi
+	done
 
 	echo ''
 done

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -67,7 +67,7 @@ for repository in ${filtered[@]}; do
 	echo -n "    -- ${repository##*/} :"
 
 	# Report identified workflow details.
-	workflow=$( gh workflow list --json path,id --repo https://github.com/woocommerce/woocommerce-gateway-stripe | jq --compact-output '.[]' | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' )
+	workflow=$( gh workflow list --json path,id --repo $repository | jq --compact-output '.[]' | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' )
 	workflow_path=$( echo $workflow | jq --raw-output '( .path )' )
 	workflow_id=$( echo $workflow | jq --raw-output '( .id )' )
 	echo -n " workflow ${workflow_path} (#${workflow_id})"

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -42,7 +42,7 @@ skipped=()
 echo -n "Looking up repositories (${#repositories[@]}): "
 for repository in ${repositories[@]}; do
 	repository=${repository%/}
-	match=$( ( gh workflow list --json path --jq '.[].path' --repo $repository | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' | wc -l | tr -d '[:space:]' ) || echo '0' )
+	match=$( ( gh workflow list --json path --jq '.[].path' --repo $repository 2>/dev/null | grep -E '.github/workflows/(manual-ci.yml|ci-manual.yml|manual_qit.yml)' | wc -l | tr -d '[:space:]' ) || echo '0' )
 	if [[ $match == '1' ]]; then
 		filtered+=( $repository )
 	else

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -55,7 +55,7 @@ skipped=( $( printf '%s\n' "${skipped[@]}" | sort ) )
 echo ''
 
 # Report the skipped repositories.
-echo "Skipping due to missing target workflows or access permissions (${#skipped[@]} repo(s))"
+echo "Skipping due to missing target workflows or not access to repository (${#skipped[@]} repo(s))"
 for repository in ${skipped[@]}; do
 	echo "    -- ${repository##*/}"
 done

--- a/bin/run-canonical-extensions-tests.sh
+++ b/bin/run-canonical-extensions-tests.sh
@@ -55,7 +55,7 @@ skipped=( $( printf '%s\n' "${skipped[@]}" | sort ) )
 echo ''
 
 # Report the skipped repositories.
-echo "Skipping due to missing target workflows or not access to repository (${#skipped[@]} repo(s))"
+echo "Skipping due to missing target workflows or no access to repository (${#skipped[@]} repo(s))"
 for repository in ${skipped[@]}; do
 	echo "    -- ${repository##*/}"
 done


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #59102, WOOPLUG-4748.

Follow up on #59502: extend the list of target workflows after updating the extensions list.

### How to test the changes in this Pull Request:

- Preferably: investigate [example run](https://github.com/woocommerce/woocommerce/actions/runs/16220264724/job/45798834363)

Alternative (for hands-on experience):
- Run [the workflow](https://github.com/woocommerce/woocommerce/actions/workflows/tests-canonical-extensions.yml) from this branch (provide `rc` as WooCommerce version and leave other inputs empty).
- 36 repos will be skipped (due to missing workflows and repos not visible to the bot), 1 repo will run the checks and 2 repos will report insufficient privileges (bot needs write permissions)
- Please cancel the corresponding run in `woocommerce-gift-cards` repo to speed up testing and keep associated costs low
- Bots' permissions consolidation in the repositories will be performed in a separate initiative

