### PR TITLE
FeaturesUtil: Skip feature compatibility declarations on front-end requests to avoid unnecessary get_plugins() calls

### DIFF
--- a/plugins/woocommerce/changelog/featureutil-skip-disk-lookups-on-frontend
+++ b/plugins/woocommerce/changelog/featureutil-skip-disk-lookups-on-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+FeaturesUtil: Skip feature compability declarations on front-end requests to avoid unnecessary get_plugins() calls

--- a/plugins/woocommerce/changelog/featureutil-skip-disk-lookups-on-frontend
+++ b/plugins/woocommerce/changelog/featureutil-skip-disk-lookups-on-frontend
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-FeaturesUtil: Skip feature compability declarations on front-end requests to avoid unnecessary get_plugins() calls
+FeaturesUtil: Skip feature compatibility declarations on front-end requests to avoid unnecessary get_plugins() calls

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -55,6 +55,9 @@ class FeaturesUtil {
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
 	 */
 	public static function declare_compatibility( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
+		if ( ! is_admin() && ! wp_doing_ajax() && ! wp_doing_cron() && ! wp_is_json_request() && ! defined( 'WP_CLI' ) ) {
+			return true; // Pretend success; compatibility isn't used on frontend anyway. This avoids disk access.
+		}
 		$plugin_id = wc_get_container()->get( PluginUtil::class )->get_wp_plugin_id( $plugin_file );
 
 		if ( ! $plugin_id ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Problem

WooCommerce add-ons declare compatibility with features like `cart_checkout_blocks` by hooking into `before_woocommerce_init` which fires on every request, including frontend pages. Each declaration calls `PluginUtil::get_wp_plugin_id()`, which invokes `get_plugins()` to normalize plugin paths (handling edge cases like symlinks or full `__FILE__` paths).

This leads to performance issues on the frontend:

* `get_plugins()` scans the disk ([1](https://github.com/WordPress/wordpress-develop/blob/b38123cf04859dd67930d961d1406d8fb023ec07/src/wp-admin/includes/plugin.php#L301), [2](https://github.com/WordPress/wordpress-develop/blob/b38123cf04859dd67930d961d1406d8fb023ec07/src/wp-admin/includes/plugin.php#L94)) for all plugin headers on each request, as it's in a non-persistent cache group (`wp_cache_add_non_persistent_groups(['plugins'])` [in WP core](https://github.com/WordPress/wordpress-develop/blob/b38123cf04859dd67930d961d1406d8fb023ec07/src/wp-includes/load.php#L927)).
* As far as I can tell, compatibility info isn't used on the frontend. It's for wp-admin warnings and feature toggles. For a customer browsing the shop, this is wasted I/O.

This aligns with long-standing WP concerns about `get_plugins()` misuse (See [Trac 42217](https://core.trac.wordpress.org/ticket/42217)).

Stack trace example from a frontend request (e.g., product category page):
```
get_plugins
Stack trace:
#0 : - get_plugins()
#1 LegacyProxy.php:83 - call_user_func_array("get_plugins", [])
#2 PluginUtil.php:170 - call_function("get_plugins")
#3 FeaturesUtil.php:58 - get_wp_plugin_id("/path/to/plugin.php")
#4 woocommerce-min-max-quantities.php:355 - declare_compatibility("cart_checkout_blocks", "/path/to/plugin.php")
#5 class-wp-hook.php:324 - declare_feature_compatibilities("")
#6 ... (continues through WooCommerce init and WP settings)
```

Here is a picture of the stack from one of my runs on local:
<img width="2000" height="574" alt="stack-trace" src="https://github.com/user-attachments/assets/82907e72-5743-4a85-a529-eb7fd68e60d2" />

This is "only" 3ms on my local M4 mac with no load, but this is close to an ideal setup. I suspect on real production sites, it could be worse, especially with load, a large number of plugins to scan (50+), or networked drives. Additionally, this part of start up proportionally takes longer than other actions, and looks to be unused work on the front-end.

### Changes proposed in this Pull Request:

Add a conditional check in `FeaturesUtil::declare_compatibility()` to skip the method on pure frontend requests (non-admin, non-AJAX, non-cron, non-JSON/REST). It returns true to mimic success, avoiding errors in calling code.

* Skips on: Standard frontend pages (e.g., shop, product views).
* Still runs on: Admin dashboard, AJAX, cron, JSON/REST API (e.g., cart endpoints), preserving behavior where compatibility might be queried.

Benefit: We avoid disk scans from `get_plugins()` on customer front-end traffic.


### How to test the changes in this Pull Request:

* Have WooCommerce with at least one add-on that calls `FeaturesUtil::declare_compatibility()`. For example, you may use wc-smooth-generator, or woocommerce-min-max-quantities (but I think mostly every addon does).
* **Goal 1**: Confirm that  `get_plugins()` is called on front-end requests on trunk, but not on this branch.
  * Can be done with an `error_log()` in `wp-admin/includes/plugin.php`  ([here](https://github.com/WordPress/wordpress-develop/blob/b38123cf04859dd67930d961d1406d8fb023ec07/src/wp-admin/includes/plugin.php#L279)) 
  * (Optional) Use timing measurements to see that on trunk, the first call to [get_plugins](https://github.com/woocommerce/woocommerce/blob/24e4e7139cbf4a23f0f370ceee8b24e5fb8bdb92/plugins/woocommerce/src/Utilities/PluginUtil.php#L170) per request takes >= 2ms.
* **Goal 2**: Confirm that Feature Compatibility information is not used on the front-end.
  * The strategy I used was to examine `FeaturesController.php` for any functions that accessed `private $compatibility_info_by_plugin` or `private $compatibility_info_by_feature`.  
    * Functions creating the info: `declare_compatibility()`, `init_compatibility_info_by_feature()`
    * Functions using the info: `get_compatible_features_for_plugin()`, `get_compatible_plugins_for_feature()`, `get_incompatible_plugins()`, `maybe_display_feature_incompatibility_warning()`. 
    * I added `error_log()` to the top of these functions that also included `$actual_link = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";`.
    * Verified that these functions were not being used on the front-end as I did normal operations like browsing the store and making a purchase.
  * Another strategy could be to research the Features system or to have knowledge of its use and purpose. 
  * Or whatever you deem appropriate.
* **Goal 3**: Confirm that Feature registration and compatibility is still working on admin side.
  * Can add logging statements to confirm that the early return in this PR is not executed on wp-admin pages.


### Testing that has already taken place:

Verified with local logging: Declarations are skipped on the frontend but still fire in admin+API. Confirmed get_plugins() no longer called on product pages.

### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>
