### PR TITLE
Ensure other additional fields are filled so errors doesn't steal focus during e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4649-flaky-test-fields-with-json-schema-validation-show
+++ b/plugins/woocommerce/changelog/wooplug-4649-flaky-test-fields-with-json-schema-validation-show
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This PR only updates tests.
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -314,6 +314,11 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 			await checkoutPageObject.fillInCheckoutWithTestData(
 				{},
 				{
+					contact: {
+						'Alternative Email': 'alt@email.com',
+						'Is this a personal purchase or a business purchase?':
+							'Personal',
+					},
 					address: {
 						shipping: {
 							'Government ID': '12345',

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/additional-fields.guest-shopper.block_theme.spec.ts
@@ -394,6 +394,11 @@ test.describe( 'Shopper → Additional Checkout Fields', () => {
 			await checkoutPageObject.fillInCheckoutWithTestData(
 				{},
 				{
+					contact: {
+						'Alternative Email': 'alt@email.com',
+						'Is this a personal purchase or a business purchase?':
+							'Personal',
+					},
 					address: {
 						shipping: {
 							'Government ID': '12345',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The test was marked as flaky because there were additional fields without values which caused server-side errors. (Alternative email).

There was a race condition where the server-side error would appear and steal focus away from the currently selected element.

The flow went like this:

Enters invalid VAT value -> Checks to see invalid error message appears -> Focuses the VAT number input -> error returns from the server causing focus to be taken away from the VAT input -> playwright continues typing into the newly focused input (it just sends keyboard events).

Now I have made sure the alternative email and personal/business purchase fields have values.

<details>
 <summary>Click for more info on how playwright's `fill` worsk</summary>
  1. Client-side (packages/playwright-core/src/client/elementHandle.ts:139): Simple wrapper that calls the channel method
  2. Server-side (/packages/playwright-core/src/server/dom.ts:576): Handles retries and progress tracking
  3. Injected script (/packages/injected/src/injectedScript.ts:804): The actual DOM manipulation logic that:
    - Handles different input types (text, number, date, etc.)
    - For date/time inputs: Sets value directly and fires input/change events
    - For text inputs: Selects all text and returns 'needsinput' to trigger keyboard input
    - For textareas and contenteditable: Also selects text and returns 'needsinput'
    - Validates that the element is fillable (input, textarea, or contenteditable)

This race condition is possible because of:
  1. The fill function in `injectedScript.ts:804-836` calls `selectText()` to select all text in the target element
  2. It then returns `'needsinput'` to signal that keyboard input is needed
  3. In `dom.ts:596-600`, when it gets `'needsinput',` it calls `page.keyboard.type(value)`

It is between step 2 and there that the issue happens.
</details>

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4649

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Inspect changes and ensure CI passes, the test should not be reported as flaky. It may be a while before we actually know if this work

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
