### PR TITLE
MIC: Process unsubscribe and verification email links

### DIFF
--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
@@ -177,7 +177,7 @@ class CustomerStockNotificationEmail extends WC_Email {
 			$product
 		);
 
-		$unsubscribe_key = $notification->get_unsubscribe_key( true );
+		$unsubscribe_key  = $notification->get_unsubscribe_key( true );
 		$user             = get_user_by( 'email', $notification->get_user_email() );
 		$is_guest         = ! is_a( $user, 'WP_User' );
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
@@ -177,14 +177,20 @@ class CustomerStockNotificationEmail extends WC_Email {
 			$product
 		);
 
-		$unsubscribe_link = '';
+		$unsubscribe_key = $notification->get_unsubscribe_key( true );
 		$user             = get_user_by( 'email', $notification->get_user_email() );
 		$is_guest         = ! is_a( $user, 'WP_User' );
 
 		return array(
 			'button_text'      => $button_text,
 			'button_link'      => $button_link,
-			'unsubscribe_link' => $unsubscribe_link,
+			'unsubscribe_link' => add_query_arg(
+                array(
+                    'email_link_action_key' => $unsubscribe_key,
+                    'notification_id'       => $notification->get_id(),
+                ),
+                get_option( 'siteurl' )
+            ),
 			'is_guest'         => $is_guest,
 		);
 	}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationEmail.php
@@ -177,20 +177,20 @@ class CustomerStockNotificationEmail extends WC_Email {
 			$product
 		);
 
-		$unsubscribe_key  = $notification->get_unsubscribe_key( true );
-		$user             = get_user_by( 'email', $notification->get_user_email() );
-		$is_guest         = ! is_a( $user, 'WP_User' );
+		$unsubscribe_key = $notification->get_unsubscribe_key( true );
+		$user            = get_user_by( 'email', $notification->get_user_email() );
+		$is_guest        = ! is_a( $user, 'WP_User' );
 
 		return array(
 			'button_text'      => $button_text,
 			'button_link'      => $button_link,
 			'unsubscribe_link' => add_query_arg(
-                array(
-                    'email_link_action_key' => $unsubscribe_key,
-                    'notification_id'       => $notification->get_id(),
-                ),
-                get_option( 'siteurl' )
-            ),
+				array(
+					'email_link_action_key' => $unsubscribe_key,
+					'notification_id'       => $notification->get_id(),
+				),
+				get_option( 'siteurl' )
+			),
 			'is_guest'         => $is_guest,
 		);
 	}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
@@ -142,12 +142,18 @@ class CustomerStockNotificationVerifiedEmail extends WC_Email {
 	private function get_additional_template_args(): array {
 		$notification = $this->object;
 
-		$unsubscribe_link = '';
+		$unsubscribe_key  = $notification->get_unsubscribe_key( true );
 		$user             = get_user_by( 'email', $notification->get_user_email() );
 		$is_guest         = ! is_a( $user, 'WP_User' );
 
 		return array(
-			'unsubscribe_link' => $unsubscribe_link,
+			'unsubscribe_link' => add_query_arg(
+                array(
+                    'email_link_action_key' => $unsubscribe_key,
+                    'notification_id'       => $notification->get_id(),
+                ),
+                get_option( 'siteurl' )
+            ),
 			'is_guest'         => $is_guest,
 		);
 	}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
@@ -147,14 +147,14 @@ class CustomerStockNotificationVerifiedEmail extends WC_Email {
 		$is_guest         = ! is_a( $user, 'WP_User' );
 
 		return array(
-			'unsubscribe_link' => add_query_arg(
+			'is_guest'         => $is_guest,
+            'unsubscribe_link' => add_query_arg(
                 array(
                     'email_link_action_key' => $unsubscribe_key,
                     'notification_id'       => $notification->get_id(),
                 ),
                 get_option( 'siteurl' )
             ),
-			'is_guest'         => $is_guest,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifiedEmail.php
@@ -140,21 +140,20 @@ class CustomerStockNotificationVerifiedEmail extends WC_Email {
 	 * @return array
 	 */
 	private function get_additional_template_args(): array {
-		$notification = $this->object;
-
-		$unsubscribe_key  = $notification->get_unsubscribe_key( true );
-		$user             = get_user_by( 'email', $notification->get_user_email() );
-		$is_guest         = ! is_a( $user, 'WP_User' );
+		$notification    = $this->object;
+		$unsubscribe_key = $notification->get_unsubscribe_key( true );
+		$user            = get_user_by( 'email', $notification->get_user_email() );
+		$is_guest        = ! is_a( $user, 'WP_User' );
 
 		return array(
 			'is_guest'         => $is_guest,
-            'unsubscribe_link' => add_query_arg(
-                array(
-                    'email_link_action_key' => $unsubscribe_key,
-                    'notification_id'       => $notification->get_id(),
-                ),
-                get_option( 'siteurl' )
-            ),
+			'unsubscribe_link' => add_query_arg(
+				array(
+					'email_link_action_key' => $unsubscribe_key,
+					'notification_id'       => $notification->get_id(),
+				),
+				get_option( 'siteurl' )
+			),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
 
+use Automattic\WooCommerce\Internal\StockNotifications\Config;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use WC_Email;
@@ -160,17 +161,24 @@ class CustomerStockNotificationVerifyEmail extends WC_Email {
 			$product
 		);
 
-		$verification_key = $notification->get_verification_key( true );
+		$verification_key     = $notification->get_verification_key( true );
+        $expiration_threshold = Config::get_verification_expiration_time_threshold();
+        $expiration_threshold_text = sprintf(
+            /* translators: %s is the time duration in minutes */
+            _n( '%s minute', '%s minutes', $expiration_threshold / 60, 'woocommerce' ),
+            floor( $expiration_threshold / 60 )
+        );
 
 		return array(
-			'verification_link'                 => add_query_arg(
+			'verification_button_text'          => $verification_button_text,
+            'verification_expiration_threshold' => $expiration_threshold_text,
+            'verification_link'                 => add_query_arg(
                 array(
                     'email_link_action_key' => $verification_key,
                     'notification_id'       => $notification->get_id(),
                 ),
                 get_option( 'siteurl' )
             ),
-			'verification_button_text'          => $verification_button_text,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
@@ -154,31 +154,30 @@ class CustomerStockNotificationVerifyEmail extends WC_Email {
 		 * @param Notification $notification The notification object.
 		 * @param WC_Product $product The product object.
 		 */
-		$verification_button_text = apply_filters(
+		$verification_button_text  = apply_filters(
 			'woocommerce_email_stock_notification_verify_button_text',
 			_x( 'Confirm', 'Stock Notification confirm notification', 'woocommerce' ),
 			$notification,
 			$product
 		);
-
-		$verification_key     = $notification->get_verification_key( true );
-        $expiration_threshold = Config::get_verification_expiration_time_threshold();
-        $expiration_threshold_text = sprintf(
-            /* translators: %s is the time duration in minutes */
-            _n( '%s minute', '%s minutes', $expiration_threshold / 60, 'woocommerce' ),
-            floor( $expiration_threshold / 60 )
-        );
+		$verification_key          = $notification->get_verification_key( true );
+		$expiration_threshold      = Config::get_verification_expiration_time_threshold();
+		$expiration_threshold_text = sprintf(
+			/* translators: %s is the time duration in minutes */
+			_n( '%s minute', '%s minutes', $expiration_threshold / 60, 'woocommerce' ),
+			floor( $expiration_threshold / 60 )
+		);
 
 		return array(
 			'verification_button_text'          => $verification_button_text,
-            'verification_expiration_threshold' => $expiration_threshold_text,
-            'verification_link'                 => add_query_arg(
-                array(
-                    'email_link_action_key' => $verification_key,
-                    'notification_id'       => $notification->get_id(),
-                ),
-                get_option( 'siteurl' )
-            ),
+			'verification_expiration_threshold' => $expiration_threshold_text,
+			'verification_link'                 => add_query_arg(
+				array(
+					'email_link_action_key' => $verification_key,
+					'notification_id'       => $notification->get_id(),
+				),
+				get_option( 'siteurl' )
+			),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/CustomerStockNotificationVerifyEmail.php
@@ -160,13 +160,17 @@ class CustomerStockNotificationVerifyEmail extends WC_Email {
 			$product
 		);
 
-		$verification_link    = '';
-		$expiration_threshold = '30m';
+		$verification_key = $notification->get_verification_key( true );
 
 		return array(
-			'verification_link'                 => $verification_link,
+			'verification_link'                 => add_query_arg(
+                array(
+                    'email_link_action_key' => $verification_key,
+                    'notification_id'       => $notification->get_id(),
+                ),
+                get_option( 'siteurl' )
+            ),
 			'verification_button_text'          => $verification_button_text,
-			'verification_expiration_threshold' => $expiration_threshold,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -35,7 +35,11 @@ class EmailActionController {
 			return;
 		}
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$this->validate_and_maybe_process_request( absint( $_GET['notification_id'] ), sanitize_text_field( $_GET['email_link_action_key'] ) );
+        $notification_id = absint( wp_unslash( $_GET['notification_id'] ) );
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $action_key      = sanitize_text_field( wp_unslash( $_GET['email_link_action_key'] ) );
+
+		$this->validate_and_maybe_process_request( $notification_id, $action_key );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -17,151 +17,149 @@ use Automattic\WooCommerce\Internal\StockNotifications\Notification;
  * @package Automattic\WooCommerce\Internal\StockNotifications\Emails
  */
 class EmailActionController {
-    /**
-     * EmailActionController constructor.
-     *
-     * Initializes the controller by adding actions to process verification and unsubscribe actions from requests.
-     */
-    public function __construct() {
-        add_action( 'template_redirect', array( $this, 'maybe_process_verification_action_from_request' ) );
-        add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe_action_from_request' ) );
-    }
+	/**
+	 * EmailActionController constructor.
+	 *
+	 * Initializes the controller by adding actions to process verification and unsubscribe actions from requests.
+	 */
+	public function __construct() {
+		add_action( 'template_redirect', array( $this, 'maybe_process_verification_action_from_request' ) );
+		add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe_action_from_request' ) );
+	}
 
-    /**
-     * This method checks if the request contains a verification action and processes it.
-     */
-    public function maybe_process_verification_action_from_request(): void {
-        $this->maybe_process_verification_action(
-            $_GET['notification_id'] ?? null,
-            $_GET['email_link_action_key'] ?? null
-        );
-    }
+	/**
+	 * This method checks if the request contains a verification action and processes it.
+	 */
+	public function maybe_process_verification_action_from_request(): void {
+		$this->maybe_process_verification_action(
+			$_GET['notification_id'] ? wp_unslash( $_GET['notification_id'] ) : null,
+			$_GET['email_link_action_key'] ? wp_unslash( $_GET['email_link_action_key'] ) : null
+		);
+	}
 
-    /**
-     * This method checks if the request contains an unsubscribe action and processes it.
-     */
-    public function maybe_process_unsubscribe_action_from_request(): void {
-        $this->maybe_process_unsubscribe_action(
-            $_GET['notification_id'] ?? null,
-            $_GET['email_link_action_key'] ?? null
-        );
-    }
+	/**
+	 * This method checks if the request contains an unsubscribe action and processes it.
+	 */
+	public function maybe_process_unsubscribe_action_from_request(): void {
+		$this->maybe_process_unsubscribe_action(
+			$_GET['notification_id'] ? wp_unslash( $_GET['notification_id'] ) : null,
+			$_GET['email_link_action_key'] ? wp_unslash( $_GET['email_link_action_key'] ) : null
+		);
+	}
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
 	 * TODO: redirect the request, notify the user of successful verification.
-     *
-     * @param string|null $notification_id The ID of the notification to process.
-     * @param string|null $action_key The action key to verify.
-     * @return void
+	 *
+	 * @param string $notification_id The ID of the notification to process.
+	 * @param string $action_key The action key to verify.
+	 * @return void
 	 */
-    public function maybe_process_verification_action( string|null $notification_id, string|null $action_key ): void  {
-        if ( ! $action_key ) {
-            return;
-        }
+	public function maybe_process_verification_action( string $notification_id, string $action_key ): void {
+		if ( ! $action_key ) {
+			return;
+		}
 
-        $notification = $this->get_notification_to_be_processed( $notification_id );
+		$notification = $this->get_notification_to_be_processed( $notification_id );
 
-        if ( ! $notification ) {
-            return;
-        }
+		if ( ! $notification ) {
+			return;
+		}
 
 		if ( $notification->check_verification_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
 			$notification->save();
 
-            // We need session for notices to work.
-            if ( ! WC()->session->has_session() ) {
-                // Generate a random customer ID.
-                WC()->session->set_customer_session_cookie( true );
-            }
+			// We need session for notices to work.
+			if ( ! WC()->session->has_session() ) {
+				// Generate a random customer ID.
+				WC()->session->set_customer_session_cookie( true );
+			}
 
-            $product = wc_get_product( $notification->get_product_id() );
+			$product = wc_get_product( $notification->get_product_id() );
 
-            /* translators: %s is product name */
-            $notice_text = sprintf( esc_html__( 'Successfully verified stock notifications for "%s".', 'woocommerce' ), $product->get_name() );
-            wc_add_notice( $notice_text );
-            
-            /**
-             * `woocommerce_customer_stock_notification_verified_url` filter.
-             *
-             * @since 0.0.0
-             *
-             * @param  string  $url
-             * @return string
-             */
-            $url = apply_filters( 'woocommerce_customer_stock_notification_verified_url', get_permalink( wc_get_page_id( 'shop' ) ) );
-            wp_safe_redirect( $url );
+			/* translators: %s is product name */
+			$notice_text = sprintf( esc_html__( 'Successfully verified stock notifications for "%s".', 'woocommerce' ), $product->get_name() );
+			wc_add_notice( $notice_text );
+			/**
+			 * `woocommerce_customer_stock_notification_verified_url` filter.
+			 *
+			 * @since 0.0.0
+			 *
+			 * @param  string  $url
+			 * @return string
+			 */
+			$url = apply_filters( 'woocommerce_customer_stock_notification_verified_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+			wp_safe_redirect( $url );
 		}
 	}
 
 	/**
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
-	 * TODO: redirect the request, notify the user of successful unsubscription.
-     *
-     * @param string|null $notification_id The ID of the notification to process.
-     * @param string|null $action_key The action key to verify.
-     * @return void
+	 *
+	 * @param string $notification_id The ID of the notification to process.
+	 * @param string $action_key The action key to verify.
+	 * @return void
 	 */
-    public function maybe_process_unsubscribe_action( string|null $notification_id, string|null $action_key ): void {
-        if ( ! $action_key ) {
-            return;
-        }
+	public function maybe_process_unsubscribe_action( string $notification_id, string $action_key ): void {
+		if ( ! $action_key ) {
+			return;
+		}
 
-        $notification = $this->get_notification_to_be_processed( $notification_id );
+		$notification = $this->get_notification_to_be_processed( $notification_id );
 
-        if ( ! $notification ) {
-            return;
-        }
+		if ( ! $notification ) {
+			return;
+		}
 
-        if ( $notification->check_unsubscribe_key( $action_key) ) {
+		if ( $notification->check_unsubscribe_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::CANCELLED );
-            $notification->set_cancellation_source( NotificationCancellationSource::USER );
-            $notification->set_date_cancelled( time() );
+			$notification->set_cancellation_source( NotificationCancellationSource::USER );
+			$notification->set_date_cancelled( time() );
 			$notification->save();
 
-            // We need session for notices to work.
-            if ( ! WC()->session->has_session() ) {
-                // Generate a random customer ID.
-                WC()->session->set_customer_session_cookie( true );
-            }
+			// We need session for notices to work.
+			if ( ! WC()->session->has_session() ) {
+				// Generate a random customer ID.
+				WC()->session->set_customer_session_cookie( true );
+			}
 
-            $product = wc_get_product( $notification->get_product_id() );
+			$product = wc_get_product( $notification->get_product_id() );
 
-            /* translators: %2$s product name, %1$s user email */
-            $notice_text = sprintf( esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available.', 'woocommerce-back-in-stock-notifications' ), $notification->get_user_email(), $product->get_name() );
-            wc_add_notice( $notice_text );
-            /**
-             * `woocommerce_customer_stock_notification_unsubscribe_url` filter.
-             *
-             * @since 0.0.0
-             *
-             * @param  string  $url
-             * @return string
-             */
-            $url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_url', get_permalink( wc_get_page_id( 'shop' ) ) );
-            wp_safe_redirect( $url );
+			/* translators: %2$s product name, %1$s user email */
+			$notice_text = sprintf( esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available.', 'woocommerce' ), $notification->get_user_email(), $product->get_name() );
+			wc_add_notice( $notice_text );
+			/**
+			 * `woocommerce_customer_stock_notification_unsubscribe_url` filter.
+			 *
+			 * @since 0.0.0
+			 *
+			 * @param  string  $url
+			 * @return string
+			 */
+			$url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+			wp_safe_redirect( $url );
 		}
 	}
 
-    /**
-     * Retrieves the notification to be processed based on the provided notification ID and action key.
-     *
-     * @param string|null $notification_id The ID of the notification to process.
-     * @return Notification|null The notification object if found and has an action key, null otherwise.
-     */
-    public function get_notification_to_be_processed( string|null $notification_id ): Notification | null {
-        $notification = Factory::get_notification( (int) $notification_id );
+	/**
+	 * Retrieves the notification to be processed based on the provided notification ID and action key.
+	 *
+	 * @param string $notification_id The ID of the notification to process.
+	 * @return Notification The notification object if found and has an action key, null otherwise.
+	 */
+	public function get_notification_to_be_processed( string $notification_id ): Notification|false {
+		$notification = Factory::get_notification( (int) $notification_id );
 
-        if ( ! $notification ) {
-            return null;
-        }
+		if ( ! $notification ) {
+			return false;
+		}
 
-        if ( empty( $notification->get_meta( 'email_link_action_key' ) ) ) {
-            return null;
-        }
+		if ( empty( $notification->get_meta( 'email_link_action_key' ) ) ) {
+			return false;
+		}
 
-        return $notification;
-    }
+		return $notification;
+	}
 }

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -34,18 +34,18 @@ class EmailActionController {
 		if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
 			return;
 		}
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$this->validate_request( wp_unslash( $_GET['notification_id'] ), wp_unslash( $_GET['email_link_action_key'] ) );
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->validate_and_maybe_process_request( absint( $_GET['notification_id'] ), sanitize_text_field( $_GET['email_link_action_key'] ) );
 	}
 
 	/**
 	 * Checks request parameters and processes the notification based on the action key.
 	 *
-	 * @param string $notification_id The ID of the notification to process.
+	 * @param int $notification_id The ID of the notification to process.
 	 * @param string $email_link_action_key The action key from the email link.
 	 * @return void
 	 */
-	public function validate_request( string $notification_id, string $email_link_action_key ): void {
+	private function validate_and_maybe_process_request( int $notification_id, string $email_link_action_key ): void {
 		if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
 			return;
 		}
@@ -71,7 +71,7 @@ class EmailActionController {
 	 * @param string       $action_key The action key to verify.
 	 * @return void
 	 */
-	public function process_verification_action( Notification $notification, string $action_key ): void {
+	private function process_verification_action( Notification $notification, string $action_key ): void {
 		if ( $notification->check_verification_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
@@ -89,14 +89,14 @@ class EmailActionController {
 			$notice_text = sprintf( esc_html__( 'Successfully verified stock notifications for "%s".', 'woocommerce' ), $product->get_name() );
 			wc_add_notice( $notice_text );
 			/**
-			 * `woocommerce_customer_stock_notification_verified_url` filter.
+			 * `woocommerce_customer_stock_notification_verified_redirect_url` filter.
 			 *
 			 * @since 0.0.0
 			 *
 			 * @param  string  $url
 			 * @return string
 			 */
-			$url = apply_filters( 'woocommerce_customer_stock_notification_verified_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+			$url = apply_filters( 'woocommerce_customer_stock_notification_verified_redirect_url', get_permalink( wc_get_page_id( 'shop' ) ) );
 			wp_safe_redirect( $url );
 		}
 	}
@@ -108,7 +108,7 @@ class EmailActionController {
 	 * @param string       $action_key The action key to verify.
 	 * @return void
 	 */
-	public function process_unsubscribe_action( Notification $notification, string $action_key ): void {
+	private function process_unsubscribe_action( Notification $notification, string $action_key ): void {
 		if ( $notification->check_unsubscribe_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::CANCELLED );
 			$notification->set_cancellation_source( NotificationCancellationSource::USER );
@@ -127,14 +127,14 @@ class EmailActionController {
 			$notice_text = sprintf( esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available.', 'woocommerce' ), $notification->get_user_email(), $product->get_name() );
 			wc_add_notice( $notice_text );
 			/**
-			 * `woocommerce_customer_stock_notification_unsubscribe_url` filter.
+			 * `woocommerce_customer_stock_notification_unsubscribe_redirect_url` filter.
 			 *
 			 * @since 0.0.0
 			 *
 			 * @param  string  $url
 			 * @return string
 			 */
-			$url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+			$url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_redirect_url', get_permalink( wc_get_page_id( 'shop' ) ) );
 			wp_safe_redirect( $url );
 		}
 	}
@@ -142,10 +142,10 @@ class EmailActionController {
 	/**
 	 * Retrieves the notification to be processed based on the provided notification ID and action key.
 	 *
-	 * @param string $notification_id The ID of the notification to process.
+	 * @param int $notification_id The ID of the notification to process.
 	 * @return Notification|false The notification object if found and has an action key, null otherwise.
 	 */
-	public function get_notification_to_be_processed( string $notification_id ): ?Notification {
+	private function get_notification_to_be_processed( int $notification_id ): ?Notification {
 		$notification = Factory::get_notification( (int) $notification_id );
 
 		if ( ! $notification ) {

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
 
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 
 /**
  * Class EmailActionController
@@ -15,54 +16,89 @@ use Automattic\WooCommerce\Internal\StockNotifications\Factory;
  * @package Automattic\WooCommerce\Internal\StockNotifications\Emails
  */
 class EmailActionController {
+    public function __construct() {
+        add_action( 'template_redirect', array( $this, 'maybe_process_verification_action_from_request' ) );
+        add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe_action_from_request' ) );
+    }
 
-	public $notification;
+    public function maybe_process_verification_action_from_request(): void {
+        $this->maybe_process_verification_action(
+            $_GET['notification_id'] ?? null,
+            $_GET['email_link_action_key'] ?? null
+        );
+    }
 
-	/**
-	 * Checks for email actions in the request and processes them.
-	 */
-	public function __construct() {
-		if (
-			! isset( $_GET['notification_id'] ) ||
-			! isset( $_GET['email_link_action_key'] )
-		) {
-			return;
-		}
-
-		$this->notification = Factory::get_notification( $_GET['notification_id'] );
-
-		if ( ! $this->notification ) {
-			return;
-		}
-
-		if ( empty( $this->notification->get_meta( 'email_link_action_key' ) ) ) {
-			return;
-		}
-
-		add_action( 'template_redirect', array( $this, 'process_verification_action' ) );
-		add_action( 'template_redirect', array( $this, 'process_unsubscribe_action' ) );
-	}
+    // Wrapper for production use
+    public function maybe_process_unsubscribe_action_from_request(): void {
+        $this->maybe_process_unsubscribe_action(
+            $_GET['notification_id'] ?? null,
+            $_GET['email_link_action_key'] ?? null
+        );
+    }
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
 	 * TODO: redirect the request, notify the user of successful verification.
+     *
+     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $action_key The action key to verify.
 	 */
-	public function process_verification_action(): void {
-		if ( $this->notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
-			$this->notification->set_status( NotificationStatus::ACTIVE );
-			$this->notification->set_date_confirmed( time() );
-			$this->notification->save();
+    public function maybe_process_verification_action( $notification_id, $action_key ): void  {
+        $notification = $this->get_notification_to_be_processed();
+
+        if ( ! $notification ) {
+            return;
+        }
+
+		if ( $notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
+			$notification->set_status( NotificationStatus::ACTIVE );
+			$notification->set_date_confirmed( time() );
+			$notification->save();
 		}
 	}
 
 	/**
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
 	 * TODO: redirect the request, notify the user of successful unsubscription.
+     *
+     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $action_key The action key to verify.
 	 */
-	public function process_unsubscribe_action(): void {
-		if ( $this->notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {
+    public function maybe_process_unsubscribe_action( $notification_id, $action_key ): void {
+        $notification = $this->get_notification_to_be_processed();
+
+        if ( ! $notification ) {
+            return;
+        }
+
+        if ( $notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {
 			$this->notification->set_status( NotificationStatus::CANCELLED );
 			$this->notification->save();
 		}
 	}
+
+    /**
+     * Retrieves the notification to be processed based on the provided notification ID and action key.
+     *
+     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $action_key The action key to verify.
+     * @return Notification|null The notification object if found, otherwise null.
+     */
+    public function get_notification_to_be_processed( $notification_id, $action_key ): Notification | null {
+        if ( ! isset( $notification_id ) || ! isset( $action_key ) ) {
+            return null;
+        }
+
+        $notification = Factory::get_notification( $_GET['notification_id'] );
+
+        if ( ! $notification ) {
+            return null;
+        }
+
+        if ( empty( $notification->get_meta( 'email_link_action_key' ) ) ) {
+            return null;
+        }
+
+        return $notification;
+    }
 }

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -70,6 +70,8 @@ class EmailActionController {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
 			$notification->save();
+            $confirmation_email = new CustomerStockNotificationVerifiedEmail();
+            $confirmation_email->trigger( $notification );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -70,6 +70,29 @@ class EmailActionController {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
 			$notification->save();
+
+            // We need session for notices to work.
+            if ( ! WC()->session->has_session() ) {
+                // Generate a random customer ID.
+                WC()->session->set_customer_session_cookie( true );
+            }
+
+            $product = wc_get_product( $notification->get_product_id() );
+
+            /* translators: %s is product name */
+            $notice_text = sprintf( esc_html__( 'Successfully verified stock notifications for "%s".', 'woocommerce' ), $product->get_name() );
+            wc_add_notice( $notice_text );
+            
+            /**
+             * `woocommerce_customer_stock_notification_verified_url` filter.
+             *
+             * @since 0.0.0
+             *
+             * @param  string  $url
+             * @return string
+             */
+            $url = apply_filters( 'woocommerce_customer_stock_notification_verified_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+            wp_safe_redirect( $url );
 		}
 	}
 
@@ -97,6 +120,28 @@ class EmailActionController {
             $notification->set_cancellation_source( NotificationCancellationSource::USER );
             $notification->set_date_cancelled( time() );
 			$notification->save();
+
+            // We need session for notices to work.
+            if ( ! WC()->session->has_session() ) {
+                // Generate a random customer ID.
+                WC()->session->set_customer_session_cookie( true );
+            }
+
+            $product = wc_get_product( $notification->get_product_id() );
+
+            /* translators: %2$s product name, %1$s user email */
+            $notice_text = sprintf( esc_html__( 'Successfully unsubscribed %1$s. You will not receive a notification when "%2$s" becomes available.', 'woocommerce-back-in-stock-notifications' ), $notification->get_user_email(), $product->get_name() );
+            wc_add_notice( $notice_text );
+            /**
+             * `woocommerce_customer_stock_notification_unsubscribe_url` filter.
+             *
+             * @since 0.0.0
+             *
+             * @param  string  $url
+             * @return string
+             */
+            $url = apply_filters( 'woocommerce_customer_stock_notification_unsubscribe_url', get_permalink( wc_get_page_id( 'shop' ) ) );
+            wp_safe_redirect( $url );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -1,0 +1,61 @@
+<?php
+
+
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+
+class EmailActionController {
+
+	public $notification;
+
+	/**
+	 * Constructor to set up hooks for managing data retention tasks.
+	 */
+	public function __construct() {
+		if (
+			isset( $_GET['notification_id'] ) &&
+			isset( $_GET['key'] )
+		) {
+			$this->maybe_process_email_action();
+		}
+	}
+
+	private function maybe_process_email_action() {
+		$this->notification = Factory::get_notification( $_GET['notification_id'] );
+
+		if ( ! $this->notification ) {
+			return;
+		}
+
+		if ( ! $this->notification->is_valid_key( $_GET['key'] ) ) {
+			return;
+		}
+
+		if ( empty( $this->notification->get_meta( 'email_action_key' ) ) ) {
+			return;
+		}
+
+		if ( str_contains( $this->notification->get_meta('email_action_key'), ':' ) ) {
+			$this->process_verification_action();
+		} elseif ( 'unsubscribe' === $_GET['action'] ) {
+			$this->process_unsubscribe_action();
+		}
+	}
+
+	private function process_verification_action() {
+
+	}
+
+	private function process_unsubscribe_action() {
+		if ( ! $this->notification ) {
+			return;
+		}
+
+		$this->notification->delete();
+		wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
+		exit;
+	}
+}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -30,12 +30,21 @@ class EmailActionController {
 	 * This method checks if the request contains indicators to process an action from an email link.
 	 */
 	public function maybe_process_email_action(): void {
+        // phpcs:disable WordPress.Security.NonceVerification.Recommended
         if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
             return;
         }
-		$this->validate_request( $_GET['notification_id'], $_GET['email_link_action_key'] );
+        // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$this->validate_request( wp_unslash( $_GET['notification_id'] ), wp_unslash( $_GET['email_link_action_key'] ) );
 	}
 
+    /**
+     * Checks request parameters and processes the notification based on the action key.
+     * 
+     * @param string $notification_id
+     * @param string $email_link_action_key
+     * @return void
+     */
     public function validate_request( string $notification_id, string $email_link_action_key ): void {
         if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
             return;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -34,15 +34,15 @@ class EmailActionController {
 		if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
 			return;
 		}
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$this->validate_request( wp_unslash( $_GET['notification_id'] ), wp_unslash( $_GET['email_link_action_key'] ) );
 	}
 
 	/**
 	 * Checks request parameters and processes the notification based on the action key.
 	 *
-	 * @param string $notification_id
-	 * @param string $email_link_action_key
+	 * @param string $notification_id The ID of the notification to process.
+	 * @param string $email_link_action_key The action key from the email link.
 	 * @return void
 	 */
 	public function validate_request( string $notification_id, string $email_link_action_key ): void {
@@ -68,10 +68,10 @@ class EmailActionController {
 	 * If the verification key matches, it updates the notification status to active.
 	 *
 	 * @param Notification $notification The notification to process.
-	 * @param string $action_key The action key to verify.
+	 * @param string       $action_key The action key to verify.
 	 * @return void
 	 */
-	public function process_verification_action( Notification $notification, string $action_key): void {
+	public function process_verification_action( Notification $notification, string $action_key ): void {
 		if ( $notification->check_verification_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
@@ -105,7 +105,7 @@ class EmailActionController {
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
 	 *
 	 * @param Notification $notification The Notification to process.
-	 * @param string $action_key The action key to verify.
+	 * @param string       $action_key The action key to verify.
 	 * @return void
 	 */
 	public function process_unsubscribe_action( Notification $notification, string $action_key ): void {
@@ -143,9 +143,9 @@ class EmailActionController {
 	 * Retrieves the notification to be processed based on the provided notification ID and action key.
 	 *
 	 * @param string $notification_id The ID of the notification to process.
-	 * @return Notification The notification object if found and has an action key, null otherwise.
+	 * @return Notification|false The notification object if found and has an action key, null otherwise.
 	 */
-	public function get_notification_to_be_processed( string $notification_id ): Notification|false {
+	public function get_notification_to_be_processed( string $notification_id ): ?Notification {
 		$notification = Factory::get_notification( (int) $notification_id );
 
 		if ( ! $notification ) {

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -23,42 +23,46 @@ class EmailActionController {
 	 * Initializes the controller by adding actions to process verification and unsubscribe actions from requests.
 	 */
 	public function __construct() {
-		add_action( 'template_redirect', array( $this, 'maybe_process_verification_action_from_request' ) );
-		add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe_action_from_request' ) );
+		add_action( 'template_redirect', array( $this, 'maybe_process_email_action' ) );
 	}
 
 	/**
-	 * This method checks if the request contains a verification action and processes it.
+	 * This method checks if the request contains indicators to process an action from an email link.
 	 */
-	public function maybe_process_verification_action_from_request(): void {
-		$this->maybe_process_verification_action( $_GET['notification_id'] ?? null, $_GET['email_link_action_key'] ?? null);
+	public function maybe_process_email_action(): void {
+        if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
+            return;
+        }
+		$this->validate_request( $_GET['notification_id'], $_GET['email_link_action_key'] );
 	}
 
-	/**
-	 * This method checks if the request contains an unsubscribe action and processes it.
-	 */
-	public function maybe_process_unsubscribe_action_from_request(): void {
-		$this->maybe_process_unsubscribe_action( $_GET['notification_id'] ?? null, $_GET['email_link_action_key'] ?? null );
-	}
+    public function validate_request( string $notification_id, string $email_link_action_key ): void {
+        if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
+            return;
+        }
+
+        $notification = $this->get_notification_to_be_processed( $notification_id );
+
+        if ( ! $notification ) {
+            return;
+        }
+
+        $action_key = $notification->get_meta( 'email_link_action_key' );
+        if ( str_contains( $action_key, ':' ) ) {
+            $this->process_verification_action( $notification, $email_link_action_key );
+        } else {
+            $this->process_unsubscribe_action( $notification, $email_link_action_key );
+        }
+    }
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
 	 *
-	 * @param string $notification_id The ID of the notification to process.
+	 * @param Notification $notification The notification to process.
 	 * @param string $action_key The action key to verify.
 	 * @return void
 	 */
-	public function maybe_process_verification_action( string $notification_id, string $action_key ): void {
-		if ( ! $action_key ) {
-			return;
-		}
-
-		$notification = $this->get_notification_to_be_processed( $notification_id );
-
-		if ( ! $notification ) {
-			return;
-		}
-
+	public function process_verification_action( Notification $notification, string $action_key): void {
 		if ( $notification->check_verification_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
@@ -91,21 +95,11 @@ class EmailActionController {
 	/**
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
 	 *
-	 * @param string $notification_id The ID of the notification to process.
+	 * @param Notification $notification The Notification to process.
 	 * @param string $action_key The action key to verify.
 	 * @return void
 	 */
-	public function maybe_process_unsubscribe_action( string $notification_id, string $action_key ): void {
-		if ( ! $action_key ) {
-			return;
-		}
-
-		$notification = $this->get_notification_to_be_processed( $notification_id );
-
-		if ( ! $notification ) {
-			return;
-		}
-
+	public function process_unsubscribe_action( Notification $notification, string $action_key ): void {
 		if ( $notification->check_unsubscribe_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::CANCELLED );
 			$notification->set_cancellation_source( NotificationCancellationSource::USER );

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
 
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
@@ -16,11 +17,19 @@ use Automattic\WooCommerce\Internal\StockNotifications\Notification;
  * @package Automattic\WooCommerce\Internal\StockNotifications\Emails
  */
 class EmailActionController {
+    /**
+     * EmailActionController constructor.
+     *
+     * Initializes the controller by adding actions to process verification and unsubscribe actions from requests.
+     */
     public function __construct() {
         add_action( 'template_redirect', array( $this, 'maybe_process_verification_action_from_request' ) );
         add_action( 'template_redirect', array( $this, 'maybe_process_unsubscribe_action_from_request' ) );
     }
 
+    /**
+     * This method checks if the request contains a verification action and processes it.
+     */
     public function maybe_process_verification_action_from_request(): void {
         $this->maybe_process_verification_action(
             $_GET['notification_id'] ?? null,
@@ -28,7 +37,9 @@ class EmailActionController {
         );
     }
 
-    // Wrapper for production use
+    /**
+     * This method checks if the request contains an unsubscribe action and processes it.
+     */
     public function maybe_process_unsubscribe_action_from_request(): void {
         $this->maybe_process_unsubscribe_action(
             $_GET['notification_id'] ?? null,
@@ -42,15 +53,20 @@ class EmailActionController {
      *
      * @param int|null $notification_id The ID of the notification to process.
      * @param string|null $action_key The action key to verify.
+     * @return void
 	 */
-    public function maybe_process_verification_action( $notification_id, $action_key ): void  {
-        $notification = $this->get_notification_to_be_processed();
+    public function maybe_process_verification_action( int|null $notification_id, string|null $action_key ): void  {
+        if ( ! $action_key ) {
+            return;
+        }
+
+        $notification = $this->get_notification_to_be_processed( $notification_id );
 
         if ( ! $notification ) {
             return;
         }
 
-		if ( $notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
+		if ( $notification->check_verification_key( $action_key ) ) {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
 			$notification->save();
@@ -63,17 +79,24 @@ class EmailActionController {
      *
      * @param int|null $notification_id The ID of the notification to process.
      * @param string|null $action_key The action key to verify.
+     * @return void
 	 */
-    public function maybe_process_unsubscribe_action( $notification_id, $action_key ): void {
-        $notification = $this->get_notification_to_be_processed();
+    public function maybe_process_unsubscribe_action( int|null $notification_id, string|null $action_key ): void {
+        if ( ! $action_key ) {
+            return;
+        }
+
+        $notification = $this->get_notification_to_be_processed( $notification_id );
 
         if ( ! $notification ) {
             return;
         }
 
-        if ( $notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {
-			$this->notification->set_status( NotificationStatus::CANCELLED );
-			$this->notification->save();
+        if ( $notification->check_unsubscribe_key( $action_key) ) {
+			$notification->set_status( NotificationStatus::CANCELLED );
+            $notification->set_cancellation_source( NotificationCancellationSource::USER );
+            $notification->set_date_cancelled( time() );
+			$notification->save();
 		}
 	}
 
@@ -81,15 +104,10 @@ class EmailActionController {
      * Retrieves the notification to be processed based on the provided notification ID and action key.
      *
      * @param int|null $notification_id The ID of the notification to process.
-     * @param string|null $action_key The action key to verify.
-     * @return Notification|null The notification object if found, otherwise null.
+     * @return Notification|null The notification object if found and has an action key, null otherwise.
      */
-    public function get_notification_to_be_processed( $notification_id, $action_key ): Notification | null {
-        if ( ! isset( $notification_id ) || ! isset( $action_key ) ) {
-            return null;
-        }
-
-        $notification = Factory::get_notification( $_GET['notification_id'] );
+    public function get_notification_to_be_processed( int|null $notification_id ): Notification | null {
+        $notification = Factory::get_notification( $notification_id );
 
         if ( ! $notification ) {
             return null;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -49,7 +49,7 @@ class EmailActionController {
 	 * @param string $email_link_action_key The action key from the email link.
 	 * @return void
 	 */
-	private function validate_and_maybe_process_request( int $notification_id, string $email_link_action_key ): void {
+	public function validate_and_maybe_process_request( int $notification_id, string $email_link_action_key ): void {
 		if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -51,11 +51,11 @@ class EmailActionController {
 	 * If the verification key matches, it updates the notification status to active.
 	 * TODO: redirect the request, notify the user of successful verification.
      *
-     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $notification_id The ID of the notification to process.
      * @param string|null $action_key The action key to verify.
      * @return void
 	 */
-    public function maybe_process_verification_action( int|null $notification_id, string|null $action_key ): void  {
+    public function maybe_process_verification_action( string|null $notification_id, string|null $action_key ): void  {
         if ( ! $action_key ) {
             return;
         }
@@ -77,11 +77,11 @@ class EmailActionController {
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
 	 * TODO: redirect the request, notify the user of successful unsubscription.
      *
-     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $notification_id The ID of the notification to process.
      * @param string|null $action_key The action key to verify.
      * @return void
 	 */
-    public function maybe_process_unsubscribe_action( int|null $notification_id, string|null $action_key ): void {
+    public function maybe_process_unsubscribe_action( string|null $notification_id, string|null $action_key ): void {
         if ( ! $action_key ) {
             return;
         }
@@ -103,11 +103,11 @@ class EmailActionController {
     /**
      * Retrieves the notification to be processed based on the provided notification ID and action key.
      *
-     * @param int|null $notification_id The ID of the notification to process.
+     * @param string|null $notification_id The ID of the notification to process.
      * @return Notification|null The notification object if found and has an action key, null otherwise.
      */
-    public function get_notification_to_be_processed( int|null $notification_id ): Notification | null {
-        $notification = Factory::get_notification( $notification_id );
+    public function get_notification_to_be_processed( string|null $notification_id ): Notification | null {
+        $notification = Factory::get_notification( (int) $notification_id );
 
         if ( ! $notification ) {
             return null;

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -34,10 +34,10 @@ class EmailActionController {
 		if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
 			return;
 		}
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        $notification_id = absint( wp_unslash( $_GET['notification_id'] ) );
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        $action_key = sanitize_text_field( wp_unslash( $_GET['email_link_action_key'] ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$notification_id = absint( wp_unslash( $_GET['notification_id'] ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$action_key = sanitize_text_field( wp_unslash( $_GET['email_link_action_key'] ) );
 
 		$this->validate_and_maybe_process_request( $notification_id, $action_key );
 	}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -5,14 +5,22 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
 
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 
+/**
+ * Class EmailActionController
+ *
+ * Handles email actions such as verification and unsubscribe.
+ *
+ * @package Automattic\WooCommerce\Internal\StockNotifications\Emails
+ */
 class EmailActionController {
 
 	public $notification;
 
 	/**
-	 * Constructor to set up hooks for managing data retention tasks.
+	 * Checks for email actions in the request and processes them.
 	 */
 	public function __construct() {
 		if (
@@ -23,14 +31,14 @@ class EmailActionController {
 		}
 	}
 
-	private function maybe_process_email_action() {
+	/**
+	 * Checks the request for valid notification ID. If found, processes the email action based on
+	 * the shape of the action key.
+	 */
+	private function maybe_process_email_action(): void {
 		$this->notification = Factory::get_notification( $_GET['notification_id'] );
 
 		if ( ! $this->notification ) {
-			return;
-		}
-
-		if ( ! $this->notification->is_valid_key( $_GET['key'] ) ) {
 			return;
 		}
 
@@ -45,17 +53,26 @@ class EmailActionController {
 		}
 	}
 
-	private function process_verification_action() {
-
+	/**
+	 * If the verification key matches, it updates the notification status to active.
+	 * TODO: set a notification and redirect the request.
+	 */
+	private function process_verification_action(): void {
+		if ( $this->notification->check_verification_key( $_GET['key'] ) ) {
+			$this->notification->set_status( NotificationStatus::ACTIVE );
+			$this->notification->set_date_confirmed( time() );
+			$this->notification->save();
+		}
 	}
 
-	private function process_unsubscribe_action() {
-		if ( ! $this->notification ) {
-			return;
+	/**
+	 * If the unsubscribe key matches, it updates the notification status to cancelled.
+	 * TODO: set a notification and redirect the request.
+	 */
+	private function process_unsubscribe_action(): void {
+		if ( $this->notification->check_unsubscribe_key( $_GET['key'] ) ) {
+			$this->notification->set_status( NotificationStatus::CANCELLED );
+			$this->notification->save();
 		}
-
-		$this->notification->delete();
-		wp_safe_redirect( wc_get_page_permalink( 'myaccount' ) );
-		exit;
 	}
 }

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -30,11 +30,11 @@ class EmailActionController {
 	 * This method checks if the request contains indicators to process an action from an email link.
 	 */
 	public function maybe_process_email_action(): void {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
 			return;
 		}
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$this->validate_request( wp_unslash( $_GET['notification_id'] ), wp_unslash( $_GET['email_link_action_key'] ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -31,20 +31,14 @@ class EmailActionController {
 	 * This method checks if the request contains a verification action and processes it.
 	 */
 	public function maybe_process_verification_action_from_request(): void {
-		$this->maybe_process_verification_action(
-			$_GET['notification_id'] ?? null,
-			$_GET['email_link_action_key'] ?? null
-		);
+		$this->maybe_process_verification_action( $_GET['notification_id'] ?? null, $_GET['email_link_action_key'] ?? null);
 	}
 
 	/**
 	 * This method checks if the request contains an unsubscribe action and processes it.
 	 */
 	public function maybe_process_unsubscribe_action_from_request(): void {
-		$this->maybe_process_unsubscribe_action(
-            $_GET['notification_id'] ?? null,
-            $_GET['email_link_action_key'] ?? null
-		);
+		$this->maybe_process_unsubscribe_action( $_GET['notification_id'] ?? null, $_GET['email_link_action_key'] ?? null );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -70,8 +70,6 @@ class EmailActionController {
 			$notification->set_status( NotificationStatus::ACTIVE );
 			$notification->set_date_confirmed( time() );
 			$notification->save();
-            $confirmation_email = new CustomerStockNotificationVerifiedEmail();
-            $confirmation_email->trigger( $notification );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -25,7 +25,7 @@ class EmailActionController {
 	public function __construct() {
 		if (
 			isset( $_GET['notification_id'] ) &&
-			isset( $_GET['key'] )
+			isset( $_GET['email_link_action_key'] )
 		) {
 			$this->maybe_process_email_action();
 		}
@@ -42,13 +42,13 @@ class EmailActionController {
 			return;
 		}
 
-		if ( empty( $this->notification->get_meta( 'email_action_key' ) ) ) {
+		if ( empty( $this->notification->get_meta( 'email_link_action_key' ) ) ) {
 			return;
 		}
 
-		if ( str_contains( $this->notification->get_meta('email_action_key'), ':' ) ) {
+		if ( str_contains( $this->notification->get_meta('email_link_action_key'), ':' ) ) {
 			$this->process_verification_action();
-		} elseif ( 'unsubscribe' === $_GET['action'] ) {
+		} else {
 			$this->process_unsubscribe_action();
 		}
 	}
@@ -58,7 +58,7 @@ class EmailActionController {
 	 * TODO: set a notification and redirect the request.
 	 */
 	private function process_verification_action(): void {
-		if ( $this->notification->check_verification_key( $_GET['key'] ) ) {
+		if ( $this->notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
 			$this->notification->set_status( NotificationStatus::ACTIVE );
 			$this->notification->set_date_confirmed( time() );
 			$this->notification->save();
@@ -70,7 +70,7 @@ class EmailActionController {
 	 * TODO: set a notification and redirect the request.
 	 */
 	private function process_unsubscribe_action(): void {
-		if ( $this->notification->check_unsubscribe_key( $_GET['key'] ) ) {
+		if ( $this->notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {
 			$this->notification->set_status( NotificationStatus::CANCELLED );
 			$this->notification->save();
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -23,18 +23,12 @@ class EmailActionController {
 	 */
 	public function __construct() {
 		if (
-			isset( $_GET['notification_id'] ) &&
-			isset( $_GET['email_link_action_key'] )
+			! isset( $_GET['notification_id'] ) ||
+			! isset( $_GET['email_link_action_key'] )
 		) {
-			$this->maybe_process_email_action();
+			return;
 		}
-	}
 
-	/**
-	 * Checks the request for valid notification ID. If found, processes the email action based on
-	 * the shape of the action key.
-	 */
-	private function maybe_process_email_action(): void {
 		$this->notification = Factory::get_notification( $_GET['notification_id'] );
 
 		if ( ! $this->notification ) {
@@ -45,18 +39,15 @@ class EmailActionController {
 			return;
 		}
 
-		if ( str_contains( $this->notification->get_meta('email_link_action_key'), ':' ) ) {
-			$this->process_verification_action();
-		} else {
-			$this->process_unsubscribe_action();
-		}
+		add_action( 'template_redirect', array( $this, 'process_verification_action' ) );
+		add_action( 'template_redirect', array( $this, 'process_unsubscribe_action' ) );
 	}
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
 	 * TODO: redirect the request, notify the user of successful verification.
 	 */
-	private function process_verification_action(): void {
+	public function process_verification_action(): void {
 		if ( $this->notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
 			$this->notification->set_status( NotificationStatus::ACTIVE );
 			$this->notification->set_date_confirmed( time() );
@@ -68,7 +59,7 @@ class EmailActionController {
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
 	 * TODO: redirect the request, notify the user of successful unsubscription.
 	 */
-	private function process_unsubscribe_action(): void {
+	public function process_unsubscribe_action(): void {
 		if ( $this->notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {
 			$this->notification->set_status( NotificationStatus::CANCELLED );
 			$this->notification->save();

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -37,7 +37,7 @@ class EmailActionController {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
         $notification_id = absint( wp_unslash( $_GET['notification_id'] ) );
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        $action_key      = sanitize_text_field( wp_unslash( $_GET['email_link_action_key'] ) );
+        $action_key = sanitize_text_field( wp_unslash( $_GET['email_link_action_key'] ) );
 
 		$this->validate_and_maybe_process_request( $notification_id, $action_key );
 	}
@@ -45,7 +45,7 @@ class EmailActionController {
 	/**
 	 * Checks request parameters and processes the notification based on the action key.
 	 *
-	 * @param int $notification_id The ID of the notification to process.
+	 * @param int    $notification_id The ID of the notification to process.
 	 * @param string $email_link_action_key The action key from the email link.
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\StockNotifications\Emails;
@@ -55,7 +54,7 @@ class EmailActionController {
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
-	 * TODO: set a notification and redirect the request.
+	 * TODO: redirect the request, notify the user of successful verification.
 	 */
 	private function process_verification_action(): void {
 		if ( $this->notification->check_verification_key( $_GET['email_link_action_key'] ) ) {
@@ -67,7 +66,7 @@ class EmailActionController {
 
 	/**
 	 * If the unsubscribe key matches, it updates the notification status to cancelled.
-	 * TODO: set a notification and redirect the request.
+	 * TODO: redirect the request, notify the user of successful unsubscription.
 	 */
 	private function process_unsubscribe_action(): void {
 		if ( $this->notification->check_unsubscribe_key( $_GET['email_link_action_key'] ) ) {

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -30,39 +30,39 @@ class EmailActionController {
 	 * This method checks if the request contains indicators to process an action from an email link.
 	 */
 	public function maybe_process_email_action(): void {
-        // phpcs:disable WordPress.Security.NonceVerification.Recommended
-        if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
-            return;
-        }
-        // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['notification_id'] ) || ! isset( $_GET['email_link_action_key'] ) ) {
+			return;
+		}
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$this->validate_request( wp_unslash( $_GET['notification_id'] ), wp_unslash( $_GET['email_link_action_key'] ) );
 	}
 
-    /**
-     * Checks request parameters and processes the notification based on the action key.
-     * 
-     * @param string $notification_id
-     * @param string $email_link_action_key
-     * @return void
-     */
-    public function validate_request( string $notification_id, string $email_link_action_key ): void {
-        if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
-            return;
-        }
+	/**
+	 * Checks request parameters and processes the notification based on the action key.
+	 *
+	 * @param string $notification_id
+	 * @param string $email_link_action_key
+	 * @return void
+	 */
+	public function validate_request( string $notification_id, string $email_link_action_key ): void {
+		if ( empty( $email_link_action_key ) || empty( $notification_id ) ) {
+			return;
+		}
 
-        $notification = $this->get_notification_to_be_processed( $notification_id );
+		$notification = $this->get_notification_to_be_processed( $notification_id );
 
-        if ( ! $notification ) {
-            return;
-        }
+		if ( ! $notification ) {
+			return;
+		}
 
-        $action_key = $notification->get_meta( 'email_link_action_key' );
-        if ( str_contains( $action_key, ':' ) ) {
-            $this->process_verification_action( $notification, $email_link_action_key );
-        } else {
-            $this->process_unsubscribe_action( $notification, $email_link_action_key );
-        }
-    }
+		$action_key = $notification->get_meta( 'email_link_action_key' );
+		if ( str_contains( $action_key, ':' ) ) {
+			$this->process_verification_action( $notification, $email_link_action_key );
+		} else {
+			$this->process_unsubscribe_action( $notification, $email_link_action_key );
+		}
+	}
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Emails/EmailActionController.php
@@ -32,8 +32,8 @@ class EmailActionController {
 	 */
 	public function maybe_process_verification_action_from_request(): void {
 		$this->maybe_process_verification_action(
-			$_GET['notification_id'] ? wp_unslash( $_GET['notification_id'] ) : null,
-			$_GET['email_link_action_key'] ? wp_unslash( $_GET['email_link_action_key'] ) : null
+			$_GET['notification_id'] ?? null,
+			$_GET['email_link_action_key'] ?? null
 		);
 	}
 
@@ -42,14 +42,13 @@ class EmailActionController {
 	 */
 	public function maybe_process_unsubscribe_action_from_request(): void {
 		$this->maybe_process_unsubscribe_action(
-			$_GET['notification_id'] ? wp_unslash( $_GET['notification_id'] ) : null,
-			$_GET['email_link_action_key'] ? wp_unslash( $_GET['email_link_action_key'] ) : null
+            $_GET['notification_id'] ?? null,
+            $_GET['email_link_action_key'] ?? null
 		);
 	}
 
 	/**
 	 * If the verification key matches, it updates the notification status to active.
-	 * TODO: redirect the request, notify the user of successful verification.
 	 *
 	 * @param string $notification_id The ID of the notification to process.
 	 * @param string $action_key The action key to verify.

--- a/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
@@ -460,6 +460,7 @@ class Notification extends \WC_Data {
 	 */
 	public function check_verification_key( string $key ): bool {
 		$action_key = $this->get_meta( 'email_link_action_key' );
+
 		if ( ! str_contains( $action_key, ':' ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/Notification.php
@@ -460,7 +460,6 @@ class Notification extends \WC_Data {
 	 */
 	public function check_verification_key( string $key ): bool {
 		$action_key = $this->get_meta( 'email_link_action_key' );
-
 		if ( ! str_contains( $action_key, ':' ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
+++ b/plugins/woocommerce/src/Internal/StockNotifications/StockNotifications.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\StockNotifications;
 
 use Automattic\WooCommerce\Internal\DataStores\StockNotifications\StockNotificationsDataStore;
+use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailActionController;
 use Automattic\WooCommerce\Internal\StockNotifications\StockSyncController;
 use Automattic\WooCommerce\Internal\StockNotifications\Privacy\PrivacyEraser;
 use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailManager;
@@ -48,6 +49,7 @@ class StockNotifications {
 		$container->get( NotificationsProcessor::class );
 		$container->get( PrivacyEraser::class );
 		$container->get( DataRetentionController::class );
+		$container->get( EmailActionController::class );
 
 		if ( is_admin() ) {
 			$container->get( AdminManager::class );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -28,9 +28,9 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
         $id = $notification->save();
 
         $controller = new EmailActionController();
-        $controller->maybe_process_verification_action($id, 'test');
+        $controller->maybe_process_verification_action( (string) $id, 'test');
         $notification = Factory::get_notification( $id );
-        $this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
+        $this->assertEquals( NotificationStatus::ACTIVE, $notification->get_status() );
     }
 
     /**
@@ -46,7 +46,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
         $id = $notification->save();
 
         $controller = new EmailActionController();
-        $controller->maybe_process_unsubscribe_action($id, 'test');
+        $controller->maybe_process_unsubscribe_action( (string) $id, 'test');
         $notification = Factory::get_notification( $id );
         $this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
         $this->assertEquals( NotificationCancellationSource::USER, $notification->get_cancellation_source() );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -9,70 +9,34 @@ use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\HasherHelper;
 
-/**
- * EmailActionController tests.
- */
 class EmailActionControllerTests extends \WC_Unit_Test_Case {
-	public function setUp(): void {
-		parent::setUp();
-		$_GET = [];
-	}
+    public function test_process_verification_action_sets_status_active() {
+        $notification = new Notification();
+        $notification->set_product_id( 1 );
+        $notification->set_status( NotificationStatus::PENDING );
+        $notification->set_user_email( 'test@example.com' );
+        $key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
+        $notification->update_meta_data('email_link_action_key', $key );
+        $id = $notification->save();
 
-	public function tearDown(): void {
-		parent::tearDown();
-		$_GET = [];
-	}
+        $controller = new EmailActionController();
+        $controller->maybe_process_verification_action($id, 'test');
+        $notification = Factory::get_notification( $id );
+        $this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
+    }
 
-	/**
-	 * Test that the controller processes email verification links.
-	 */
-	public function test_process_verification_action_sets_status_active() {
-		$notification = new Notification();
-		$notification->set_product_id( 1 );
-		$notification->set_status(NotificationStatus::PENDING);
-		$notification->set_user_email( 'test@example.com' );
-		$key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
-		$notification->update_meta_data('email_link_action_key', $key );
-		$id = $notification->save();
+    public function test_process_unsubscribe_action_sets_status_cancelled() {
+        $notification = new Notification();
+        $notification->set_product_id( 1 );
+        $notification->set_status( NotificationStatus::ACTIVE );
+        $notification->set_user_email( 'test@example.com' );
+        $key = HasherHelper::wp_fast_hash( 'test' );
+        $notification->update_meta_data( 'email_link_action_key', $key );
+        $id = $notification->save();
 
-		$_GET['notification_id'] = $id;
-		$_GET['email_link_action_key'] = 'test';
-
-		$controller = new EmailActionController();
-		$controller->process_verification_action();
-		$notification = Factory::get_notification( $id );
-		$this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
-	}
-
-	/**
-	 * Test that the controller processes unsubscribe links.
-	 */
-	public function test_process_unsubscribe_action_sets_status_cancelled() {
-		$notification = new Notification();
-		$notification->set_product_id( 1 );
-		$notification->set_status( NotificationStatus::ACTIVE );
-		$notification->set_user_email( 'test@example.com' );
-		$key = HasherHelper::wp_fast_hash( 'test' );
-		$notification->update_meta_data( 'email_link_action_key', $key );
-		$id = $notification->save();
-
-		$_GET['notification_id'] = $id;
-		$_GET['email_link_action_key'] = 'test';
-
-		$controller = new EmailActionController();
-		$controller->process_unsubscribe_action();
-		$notification = Factory::get_notification( $id );
-		$this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
-	}
-
-	/**
-	 * Test that the controller does nothing if the action key is not found.
-	 */
-	public function test_invalid_notification_id_does_nothing() {
-		$_GET['notification_id'] = 999;
-		$_GET['email_link_action_key'] = 'any_key';
-
-		$controller = new EmailActionController();
-		$this->assertFalse( $controller->notification );
-	}
+        $controller = new EmailActionController();
+        $controller->maybe_process_unsubscribe_action($id, 'test');
+        $notification = Factory::get_notification( $id );
+        $this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
+    }
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\HasherHelper;
+use WC_Helper_Product;
 
 /**
  * EmailActionControllerTests tests.
@@ -19,8 +20,9 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 * Test that verification action is sets notification status to active.
 	 */
 	public function test_process_verification_action_sets_status_active() {
+        $product = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
-		$notification->set_product_id( 1 );
+		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::PENDING );
 		$notification->set_user_email( 'test@example.com' );
 		$key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
@@ -28,17 +30,18 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$id = $notification->save();
 
 		$controller = new EmailActionController();
-		$controller->maybe_process_verification_action( (string) $id, 'test');
-		$notification = Factory::get_notification( $id );
-		$this->assertEquals( NotificationStatus::ACTIVE, $notification->get_status() );
+		$controller->process_verification_action( $notification, 'test');
+        $updated_notification = Factory::get_notification( $id );
+		$this->assertEquals( NotificationStatus::ACTIVE, $updated_notification->get_status() );
 	}
 
 	/**
 	 * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
 	 */
 	public function test_process_unsubscribe_action_sets_status_cancelled() {
+        $product = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
-		$notification->set_product_id( 1 );
+		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::ACTIVE );
 		$notification->set_user_email( 'test@example.com' );
 		$key = HasherHelper::wp_fast_hash( 'test' );
@@ -46,9 +49,9 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$id = $notification->save();
 
 		$controller = new EmailActionController();
-		$controller->maybe_process_unsubscribe_action( (string) $id, 'test' );
-		$notification = Factory::get_notification( $id );
-		$this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
-		$this->assertEquals( NotificationCancellationSource::USER, $notification->get_cancellation_source() );
+		$controller->process_unsubscribe_action( $notification, 'test' );
+		$updated_notification = Factory::get_notification( $id );
+		$this->assertEquals( NotificationStatus::CANCELLED, $updated_notification->get_status() );
+		$this->assertEquals( NotificationCancellationSource::USER, $updated_notification->get_cancellation_source() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -4,12 +4,20 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Emails;
 
 use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailActionController;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationCancellationSource;
 use Automattic\WooCommerce\Internal\StockNotifications\Notification;
 use Automattic\WooCommerce\Internal\StockNotifications\Factory;
 use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
 use Automattic\WooCommerce\Internal\StockNotifications\Utilities\HasherHelper;
 
+/**
+ * EmailActionControllerTests tests.
+ */
 class EmailActionControllerTests extends \WC_Unit_Test_Case {
+
+    /**
+     * Test that verification action is sets notification status to active.
+     */
     public function test_process_verification_action_sets_status_active() {
         $notification = new Notification();
         $notification->set_product_id( 1 );
@@ -25,6 +33,9 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
         $this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
     }
 
+    /**
+     * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
+     */
     public function test_process_unsubscribe_action_sets_status_cancelled() {
         $notification = new Notification();
         $notification->set_product_id( 1 );
@@ -38,5 +49,6 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
         $controller->maybe_process_unsubscribe_action($id, 'test');
         $notification = Factory::get_notification( $id );
         $this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
+        $this->assertEquals( NotificationCancellationSource::USER, $notification->get_cancellation_source() );
     }
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -30,7 +30,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$id = $notification->save();
 
 		$controller = new EmailActionController();
-		$controller->process_verification_action( $notification, 'test' );
+		$controller->validate_and_maybe_process_request( $id, 'test' );
 		$updated_notification = Factory::get_notification( $id );
 		$this->assertEquals( NotificationStatus::ACTIVE, $updated_notification->get_status() );
 	}
@@ -49,7 +49,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$id = $notification->save();
 
 		$controller = new EmailActionController();
-		$controller->process_unsubscribe_action( $notification, 'test' );
+		$controller->validate_and_maybe_process_request( $id, 'test' );
 		$updated_notification = Factory::get_notification( $id );
 		$this->assertEquals( NotificationStatus::CANCELLED, $updated_notification->get_status() );
 		$this->assertEquals( NotificationCancellationSource::USER, $updated_notification->get_cancellation_source() );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -15,40 +15,40 @@ use Automattic\WooCommerce\Internal\StockNotifications\Utilities\HasherHelper;
  */
 class EmailActionControllerTests extends \WC_Unit_Test_Case {
 
-    /**
-     * Test that verification action is sets notification status to active.
-     */
-    public function test_process_verification_action_sets_status_active() {
-        $notification = new Notification();
-        $notification->set_product_id( 1 );
-        $notification->set_status( NotificationStatus::PENDING );
-        $notification->set_user_email( 'test@example.com' );
-        $key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
-        $notification->update_meta_data('email_link_action_key', $key );
-        $id = $notification->save();
+	/**
+	 * Test that verification action is sets notification status to active.
+	 */
+	public function test_process_verification_action_sets_status_active() {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_status( NotificationStatus::PENDING );
+		$notification->set_user_email( 'test@example.com' );
+		$key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
+		$notification->update_meta_data( 'email_link_action_key', $key );
+		$id = $notification->save();
 
-        $controller = new EmailActionController();
-        $controller->maybe_process_verification_action( (string) $id, 'test');
-        $notification = Factory::get_notification( $id );
-        $this->assertEquals( NotificationStatus::ACTIVE, $notification->get_status() );
-    }
+		$controller = new EmailActionController();
+		$controller->maybe_process_verification_action( (string) $id, 'test');
+		$notification = Factory::get_notification( $id );
+		$this->assertEquals( NotificationStatus::ACTIVE, $notification->get_status() );
+	}
 
-    /**
-     * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
-     */
-    public function test_process_unsubscribe_action_sets_status_cancelled() {
-        $notification = new Notification();
-        $notification->set_product_id( 1 );
-        $notification->set_status( NotificationStatus::ACTIVE );
-        $notification->set_user_email( 'test@example.com' );
-        $key = HasherHelper::wp_fast_hash( 'test' );
-        $notification->update_meta_data( 'email_link_action_key', $key );
-        $id = $notification->save();
+	/**
+	 * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
+	 */
+	public function test_process_unsubscribe_action_sets_status_cancelled() {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_status( NotificationStatus::ACTIVE );
+		$notification->set_user_email( 'test@example.com' );
+		$key = HasherHelper::wp_fast_hash( 'test' );
+		$notification->update_meta_data( 'email_link_action_key', $key );
+		$id = $notification->save();
 
-        $controller = new EmailActionController();
-        $controller->maybe_process_unsubscribe_action( (string) $id, 'test');
-        $notification = Factory::get_notification( $id );
-        $this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
-        $this->assertEquals( NotificationCancellationSource::USER, $notification->get_cancellation_source() );
-    }
+		$controller = new EmailActionController();
+		$controller->maybe_process_unsubscribe_action( (string) $id, 'test' );
+		$notification = Factory::get_notification( $id );
+		$this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
+		$this->assertEquals( NotificationCancellationSource::USER, $notification->get_cancellation_source() );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -38,7 +38,8 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$_GET['notification_id'] = $id;
 		$_GET['email_link_action_key'] = 'test';
 
-		new EmailActionController();
+		$controller = new EmailActionController();
+		$controller->process_verification_action();
 		$notification = Factory::get_notification( $id );
 		$this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
 	}
@@ -58,7 +59,8 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$_GET['notification_id'] = $id;
 		$_GET['email_link_action_key'] = 'test';
 
-		new EmailActionController();
+		$controller = new EmailActionController();
+		$controller->process_unsubscribe_action();
 		$notification = Factory::get_notification( $id );
 		$this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -20,7 +20,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 * Test that verification action is sets notification status to active.
 	 */
 	public function test_process_verification_action_sets_status_active() {
-        $product      = WC_Helper_Product::create_simple_product();
+		$product      = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
 		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::PENDING );
@@ -31,7 +31,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 
 		$controller = new EmailActionController();
 		$controller->process_verification_action( $notification, 'test' );
-        $updated_notification = Factory::get_notification( $id );
+		$updated_notification = Factory::get_notification( $id );
 		$this->assertEquals( NotificationStatus::ACTIVE, $updated_notification->get_status() );
 	}
 
@@ -39,7 +39,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
 	 */
 	public function test_process_unsubscribe_action_sets_status_cancelled() {
-        $product      = WC_Helper_Product::create_simple_product();
+		$product      = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
 		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::ACTIVE );

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types = 1 );
+namespace Automattic\WooCommerce\Tests\Internal\StockNotifications\Emails;
+
+use Automattic\WooCommerce\Internal\StockNotifications\Emails\EmailActionController;
+use Automattic\WooCommerce\Internal\StockNotifications\Notification;
+use Automattic\WooCommerce\Internal\StockNotifications\Factory;
+use Automattic\WooCommerce\Internal\StockNotifications\Enums\NotificationStatus;
+use Automattic\WooCommerce\Internal\StockNotifications\Utilities\HasherHelper;
+
+/**
+ * EmailActionController tests.
+ */
+class EmailActionControllerTests extends \WC_Unit_Test_Case {
+	public function setUp(): void {
+		parent::setUp();
+		$_GET = [];
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$_GET = [];
+	}
+
+	/**
+	 * Test that the controller processes email verification links.
+	 */
+	public function test_process_verification_action_sets_status_active() {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_status(NotificationStatus::PENDING);
+		$notification->set_user_email( 'test@example.com' );
+		$key = time() . ':' . HasherHelper::wp_fast_hash( 'test' );
+		$notification->update_meta_data('email_link_action_key', $key );
+		$id = $notification->save();
+
+		$_GET['notification_id'] = $id;
+		$_GET['email_link_action_key'] = 'test';
+
+		new EmailActionController();
+		$notification = Factory::get_notification( $id );
+		$this->assertEquals(NotificationStatus::ACTIVE, $notification->get_status());
+	}
+
+	/**
+	 * Test that the controller processes unsubscribe links.
+	 */
+	public function test_process_unsubscribe_action_sets_status_cancelled() {
+		$notification = new Notification();
+		$notification->set_product_id( 1 );
+		$notification->set_status( NotificationStatus::ACTIVE );
+		$notification->set_user_email( 'test@example.com' );
+		$key = HasherHelper::wp_fast_hash( 'test' );
+		$notification->update_meta_data( 'email_link_action_key', $key );
+		$id = $notification->save();
+
+		$_GET['notification_id'] = $id;
+		$_GET['email_link_action_key'] = 'test';
+
+		new EmailActionController();
+		$notification = Factory::get_notification( $id );
+		$this->assertEquals( NotificationStatus::CANCELLED, $notification->get_status() );
+	}
+
+	/**
+	 * Test that the controller does nothing if the action key is not found.
+	 */
+	public function test_invalid_notification_id_does_nothing() {
+		$_GET['notification_id'] = 999;
+		$_GET['email_link_action_key'] = 'any_key';
+
+		$controller = new EmailActionController();
+		$this->assertFalse( $controller->notification );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/StockNotifications/Emails/EmailActionControllerTests.php
@@ -20,7 +20,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 * Test that verification action is sets notification status to active.
 	 */
 	public function test_process_verification_action_sets_status_active() {
-        $product = WC_Helper_Product::create_simple_product();
+        $product      = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
 		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::PENDING );
@@ -30,7 +30,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 		$id = $notification->save();
 
 		$controller = new EmailActionController();
-		$controller->process_verification_action( $notification, 'test');
+		$controller->process_verification_action( $notification, 'test' );
         $updated_notification = Factory::get_notification( $id );
 		$this->assertEquals( NotificationStatus::ACTIVE, $updated_notification->get_status() );
 	}
@@ -39,7 +39,7 @@ class EmailActionControllerTests extends \WC_Unit_Test_Case {
 	 * Test that unsubscribe action sets notification status to cancelled, and sets cancellation source to user.
 	 */
 	public function test_process_unsubscribe_action_sets_status_cancelled() {
-        $product = WC_Helper_Product::create_simple_product();
+        $product      = WC_Helper_Product::create_simple_product();
 		$notification = new Notification();
 		$notification->set_product_id( $product->get_id() );
 		$notification->set_status( NotificationStatus::ACTIVE );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR will handle incoming unsubscribe and verification links that are included in customer stock notification emails.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Set-up
1. apply this PR to your test site.
2. Add [these CLI commands](https://mc.a8c.com/pb/38790/) to a helper plugin on your test site. 

#### Test Unsubscribe action
1. Run this command on your site's shell: ` wp wc stock-notification email $email_address $product_id` to send an active stock notification email to the given address. (If you are using Local, the email address doesn't matter, because MailPit will catch all outgoing mail)
2. Visit `/wp-admin/admin.php?page=wc-customer-stock-notifications` to see the newly created notification from step 1. The status should be 'Active'.
3. Click the "unsubscribe" link in the email generated in step 1.
4. You should be redirected to the shop page and see a success notification.
5. Back in wp-admin, the notification should now have a Canceled status.

#### Test verification email
1. Run this command on your site's shell: ` wc stock-notification verify-email $email_address $product_id` to send a verification email to the given address. (If you are using Local, the email address doesn't matter, because MailPit will catch all outgoing mail)
2. Visit `/wp-admin/admin.php?page=wc-customer-stock-notifications` to see the newly created notification from step 1. The status should be 'Pending'.
3. Click the "Confirm" button in the email generated in step 1.
4. You should be redirected to the shop page and see a success notification.
5. Back in wp-admin, the notification should now have an Active status.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
