### PR TITLE
Email Editor: Enable Site Logo and Title Block and add dynamic site logo and title support to email templates

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4740-spike-synchronize-shopsite-logo-into-email-template
+++ b/packages/js/email-editor/changelog/wooplug-4740-spike-synchronize-shopsite-logo-into-email-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Register a custom variation for the site logo block to set the email editor required attributes.

--- a/packages/js/email-editor/src/blocks/core/site-logo.ts
+++ b/packages/js/email-editor/src/blocks/core/site-logo.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { registerBlockVariation } from '@wordpress/blocks';
+
+/**
+ * Register a custom variation for the site logo block
+ * This variation is used to display the site logo in the email editor by automatically adding some preset options.
+ */
+function registerCustomSiteLogoBlockVariation() {
+	registerBlockVariation( 'core/site-logo', {
+		name: 'site-logo-default',
+		title: 'Site Logo',
+		attributes: {
+			align: 'center',
+			width: 120, // set a default width for the site logo
+		},
+		isDefault: true, // set this as the default variation
+	} );
+}
+
+/**
+ * Enhance the Site Logo block.
+ */
+function enhanceSiteLogoBlock() {
+	registerCustomSiteLogoBlockVariation();
+}
+
+export { enhanceSiteLogoBlock };

--- a/packages/js/email-editor/src/blocks/index.ts
+++ b/packages/js/email-editor/src/blocks/index.ts
@@ -27,6 +27,7 @@ import { enhanceQuoteBlock } from './core/quote';
 import { filterSetUrlAttribute } from './core/block-edit';
 import { enhanceSocialLinksBlock } from './core/social-links';
 import { modifyMoveToTrashAction } from './core/move-to-trash';
+import { enhanceSiteLogoBlock } from './core/site-logo';
 
 export { getAllowedBlockNames } from './utils';
 
@@ -49,5 +50,6 @@ export function initBlocks() {
 	alterSupportConfiguration();
 	enhanceSocialLinksBlock();
 	modifyMoveToTrashAction();
+	enhanceSiteLogoBlock();
 	registerCoreBlocks();
 }

--- a/packages/php/email-editor/changelog/synchronize-shopsite-logo-into-email-template
+++ b/packages/php/email-editor/changelog/synchronize-shopsite-logo-into-email-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable Site Logo and Site Title blocks for the Email Editor

--- a/packages/php/email-editor/src/Engine/content-shared.css
+++ b/packages/php/email-editor/src/Engine/content-shared.css
@@ -19,3 +19,8 @@ ul.has-background,
 ol.has-background {
 	padding: 20px 40px;
 }
+
+/* Remove default underline from site title link */
+:where(.wp-block-site-title a:where(:not(.wp-element-button))){
+	text-decoration: none !important;
+}

--- a/packages/php/email-editor/src/Engine/content-shared.css
+++ b/packages/php/email-editor/src/Engine/content-shared.css
@@ -20,7 +20,8 @@ ol.has-background {
 	padding: 20px 40px;
 }
 
-/* Remove default underline from site title link */
-:where(.wp-block-site-title a:where(:not(.wp-element-button))){
+/* Remove default browser underline from site title link */
+.wp-block-site-title a:not(.wp-element-button) {
 	text-decoration: none !important;
+	color: inherit;
 }

--- a/packages/php/email-editor/src/Engine/theme.json
+++ b/packages/php/email-editor/src/Engine/theme.json
@@ -8,7 +8,9 @@
       "gradients": [],
       "background": true,
       "text": true,
-      "link": true
+      "link": true,
+      "customDuotone": false,
+      "defaultDuotone": false
     },
     "layout": {
       "contentSize": "660px",

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
@@ -47,12 +47,8 @@ abstract class Abstract_Block_Renderer implements Block_Renderer {
 	 * @return string
 	 */
 	protected function add_spacer( $content, $email_attrs ): string {
-		$gap_style     = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) ), '' );
-		$padding_style = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' );
-
-		if ( ! $gap_style && ! $padding_style ) {
-			return $content;
-		}
+		$gap_style     = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) ), '' ) ?? '';
+		$padding_style = WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
 
 		$table_attrs = array(
 			'align' => 'left',

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-fallback.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-fallback.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 
 /**
  * Fallback block renderer.
@@ -29,6 +30,19 @@ class Fallback extends Abstract_Block_Renderer {
 	 * @return string
 	 */
 	protected function render_content( $block_content, array $parsed_block, Rendering_Context $rendering_context ): string {
-		return $block_content;
+		$block_attrs = $parsed_block['attrs'] ?? array();
+
+		$table_attrs = array(
+			'style' => 'border-collapse: separate;', // Needed because of border radius.
+			'width' => '100%',
+		);
+
+		$align = $block_attrs['textAlign'] ?? $block_attrs['align'] ?? 'left';
+
+		$cell_attrs = array(
+			'align' => $align,
+		);
+
+		return Table_Wrapper_Helper::render_table_wrapper( $block_content, $table_attrs, $cell_attrs );
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -98,15 +98,15 @@ class Image extends Abstract_Block_Renderer {
 		if ( ! isset( $parsed_block['email_attrs']['width'] ) ) {
 			$parsed_block['attrs']['width'] = '100%';
 		}
-		$max_width                      = Styles_Helper::parse_value( $parsed_block['email_attrs']['width'] );
+		$max_width = Styles_Helper::parse_value( $parsed_block['email_attrs']['width'] );
 
 		if ( $image_url ) {
-			$upload_dir   = wp_upload_dir();
-			$image_path   = str_replace( $upload_dir[ 'baseurl' ], $upload_dir[ 'basedir' ], $image_url );
-			$image_size   = wp_getimagesize( $image_path );
+			$upload_dir = wp_upload_dir();
+			$image_path = str_replace( $upload_dir['baseurl'], $upload_dir['basedir'], $image_url );
+			$image_size = wp_getimagesize( $image_path );
 
-			$image_size                     = $image_size ? $image_size[0] : $max_width;
-			$width                          = min( $image_size, $max_width );
+			$image_size = $image_size ? $image_size[0] : $max_width;
+			$width      = min( $image_size, $max_width );
 		} else {
 			$width = $max_width;
 		}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-image.php
@@ -99,9 +99,18 @@ class Image extends Abstract_Block_Renderer {
 			$parsed_block['attrs']['width'] = '100%';
 		}
 		$max_width                      = Styles_Helper::parse_value( $parsed_block['email_attrs']['width'] );
-		$image_size                     = wp_getimagesize( $image_url );
-		$image_size                     = $image_size ? $image_size[0] : $max_width;
-		$width                          = min( $image_size, $max_width );
+
+		if ( $image_url ) {
+			$upload_dir   = wp_upload_dir();
+			$image_path   = str_replace( $upload_dir[ 'baseurl' ], $upload_dir[ 'basedir' ], $image_url );
+			$image_size   = wp_getimagesize( $image_path );
+
+			$image_size                     = $image_size ? $image_size[0] : $max_width;
+			$width                          = min( $image_size, $max_width );
+		} else {
+			$width = $max_width;
+		}
+
 		$parsed_block['attrs']['width'] = "{$width}px";
 		return $parsed_block;
 	}

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 
 /**
- * This renderer covers both core/paragraph and core/heading blocks
+ * This renderer covers both core/paragraph, core/heading and core/site-title blocks.
  */
 class Text extends Abstract_Block_Renderer {
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -146,6 +146,7 @@ class Initializer {
 		switch ( $block_name ) {
 			case 'core/heading':
 			case 'core/paragraph':
+			case 'core/site-title':
 				$renderer = new Text();
 				break;
 			case 'core/column':

--- a/packages/php/email-editor/src/Integrations/Core/class-initializer.php
+++ b/packages/php/email-editor/src/Integrations/Core/class-initializer.php
@@ -47,6 +47,8 @@ class Initializer {
 		'core/spacer',
 		'core/social-link',
 		'core/social-links',
+		'core/site-logo',
+		'core/site-title',
 	);
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
@@ -126,38 +126,41 @@ class Heading_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'color:#ff0000;', $rendered );
 	}
 
+	/**
+	 * Test it renders site title block.
+	 */
 	public function testItRendersSiteTitle(): void {
-		$parsed_heading = array (
-			'blockName' => 'core/site-title',
-			'attrs' => array (
-			  'level' => 5,
-			  'textAlign' => 'center',
-			  'isLink' => false,
-			  'linkTarget' => '_blank',
-			  'style' => array(
-				'typography' => array(
-				  'fontStyle' => 'normal',
-				  'fontWeight' => '900',
-				  'lineHeight' => '2',
-				  'letterSpacing' => '1px',
-				  'textDecoration' => 'none',
-				  'textTransform' => 'none',
-				  'fontSize' => '28px',
+		$parsed_heading = array(
+			'blockName'    => 'core/site-title',
+			'attrs'        => array(
+				'level'      => 5,
+				'textAlign'  => 'center',
+				'isLink'     => false,
+				'linkTarget' => '_blank',
+				'style'      => array(
+					'typography' => array(
+						'fontStyle'      => 'normal',
+						'fontWeight'     => '900',
+						'lineHeight'     => '2',
+						'letterSpacing'  => '1px',
+						'textDecoration' => 'none',
+						'textTransform'  => 'none',
+						'fontSize'       => '28px',
+					),
 				),
-			  ),
-			  'fontSize' => 'medium',
+				'fontSize'   => 'medium',
 			),
-			'innerBlocks' => array (),
-			'innerHTML' => '',
-			'innerContent' => array (),
-			'email_attrs' => array (
-			  'font-size' => '28px',
-			  'text-decoration' => 'none',
-			  'width' => '580px',
-			  'color' => 'var(--wp--preset--color--accent-3)',
+			'innerBlocks'  => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'email_attrs'  => array(
+				'font-size'       => '28px',
+				'text-decoration' => 'none',
+				'width'           => '580px',
+				'color'           => 'var(--wp--preset--color--accent-3)',
 			),
 		);
-		$rendered = $this->heading_renderer->render( '<h3>My Site Title</h3>', $parsed_heading, $this->rendering_context );
+		$rendered       = $this->heading_renderer->render( '<h3>My Site Title</h3>', $parsed_heading, $this->rendering_context );
 		$this->assertStringContainsString( 'My Site Title', $rendered );
 		$this->assertStringContainsString( 'font-size:28px;', $rendered );
 		$this->assertStringContainsString( 'font-weight:900;', $rendered );

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
@@ -125,4 +125,41 @@ class Heading_Test extends \Email_Editor_Integration_Test_Case {
 		$rendered = $this->heading_renderer->render( '<h1>This is Heading 1</h1>', $parsed_heading, $this->rendering_context );
 		$this->assertStringContainsString( 'color:#ff0000;', $rendered );
 	}
+
+	public function testItRendersSiteTitle(): void {
+		$parsed_heading = array (
+			'blockName' => 'core/site-title',
+			'attrs' => array (
+			  'level' => 5,
+			  'textAlign' => 'center',
+			  'isLink' => false,
+			  'linkTarget' => '_blank',
+			  'style' => array(
+				'typography' => array(
+				  'fontStyle' => 'normal',
+				  'fontWeight' => '900',
+				  'lineHeight' => '2',
+				  'letterSpacing' => '1px',
+				  'textDecoration' => 'none',
+				  'textTransform' => 'none',
+				  'fontSize' => '28px',
+				),
+			  ),
+			  'fontSize' => 'medium',
+			),
+			'innerBlocks' => array (),
+			'innerHTML' => '',
+			'innerContent' => array (),
+			'email_attrs' => array (
+			  'font-size' => '28px',
+			  'text-decoration' => 'none',
+			  'width' => '580px',
+			  'color' => 'var(--wp--preset--color--accent-3)',
+			),
+		);
+		$rendered = $this->heading_renderer->render( '<h3>My Site Title</h3>', $parsed_heading, $this->rendering_context );
+		$this->assertStringContainsString( 'My Site Title', $rendered );
+		$this->assertStringContainsString( 'font-size:28px;', $rendered );
+		$this->assertStringContainsString( 'font-weight:900;', $rendered );
+	}
 }

--- a/plugins/woocommerce/changelog/wooplug-4740-spike-synchronize-shopsite-logo-into-email-template
+++ b/plugins/woocommerce/changelog/wooplug-4740-spike-synchronize-shopsite-logo-into-email-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+The block email template now checks for a site logo and uses it when available; otherwise, it defaults to the site title.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -47,7 +47,7 @@ class WooEmailTemplate {
 		return '
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
-<!-- wp:site-logo {"width":130} /-->
+' . $this->get_site_logo_or_title() . '
 </div>
 <!-- /wp:group -->
 
@@ -59,5 +59,23 @@ class WooEmailTemplate {
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 		';
+	}
+
+	/**
+	 * Get the site logo or title.
+	 *
+	 * This is used to display the site logo or title in the email template.
+	 *
+	 * @return string HTML content for the site logo or title.
+	 */
+	private function get_site_logo_or_title(): string {
+		$custom_logo = get_custom_logo();
+
+		if ( ! empty( $custom_logo ) ) {
+			// Use Site logo if available.
+			return '<!-- wp:site-logo {"width":130} /-->';
+		}
+
+		return '<!-- wp:site-title {"level":2,"linkTarget":"_blank"} /-->';
 	}
 }

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -46,9 +46,9 @@ class WooEmailTemplate {
 	public function get_content(): string {
 		return '
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|10","bottom":"var:preset|spacing|10","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)"><!-- wp:image {"width":"130px","sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="https://woocommerce.com/wp-content/uploads/2025/01/Logo-Primary.png" alt="Your Logo" style="width:130px"/></figure>
-<!-- /wp:image --></div>
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--10);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10);padding-left:var(--wp--preset--spacing--20)">
+<!-- wp:site-logo {"width":130} /-->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:post-content {"lock":{"move":true,"remove":false},"layout":{"type":"default"}} /-->

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailTemplates/WooEmailTemplate.php
@@ -73,9 +73,9 @@ class WooEmailTemplate {
 
 		if ( ! empty( $custom_logo ) ) {
 			// Use Site logo if available.
-			return '<!-- wp:site-logo {"width":130} /-->';
+			return '<!-- wp:site-logo {"width":130, "isLink":false} /-->';
 		}
 
-		return '<!-- wp:site-title {"level":2,"linkTarget":"_blank"} /-->';
+		return '<!-- wp:site-title {"level":2} /-->';
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR adds support for the Site Logo and Title blocks in the email editor. It also implements dynamic site logo and title support in WooCommerce email templates to address the need for automatic synchronization of shop/site branding in transactional emails. 

**Key changes:**
- Enable `core/site-logo` and `core/site-title` blocks in the email editor
- Add dynamic logo/title detection method in `WooEmailTemplate` class  
- Replace hardcoded logo with dynamic content that checks for site logo using `get_custom_logo()`
- Add CSS styling to remove default browser text-decoration from site title links
- Disable duotone support in email editor theme configuration

Closes #59073 WOOPLUG-4740

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. **Test with site logo present:**
   - Go to WordPress Admin > Appearance > Customize > Site Identity
   - Upload and set a site logo
   - Navigate to WooCommerce > Settings > Emails
   - View/preview any transactional email template
   - Verify the site logo appears in the email header

2. **Test with no site logo (fallback to title):**
   - Remove the site logo from Appearance > Customize > Site Identity
   - Ensure a site title is set in Settings > General
   - View/preview any transactional email template  
   - Verify the site title appears as a text link in the email header

3. **Test in Email Editor:**
   - Navigate to WooCommerce > Settings > Emails
   - Edit any email template using the block editor
   - Verify `core/site-logo` and `core/site-title` blocks are available in the block inserter
   - Insert these blocks and verify they render correctly in the editor
   - Verify site title links do not have underlines

4. **Test across themes:**
   - Test with both classic themes and block themes
   - Verify logo detection works correctly in both scenarios


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- Verified logo detection works correctly with `get_custom_logo()` function
- Tested fallback behavior when no logo is present
- Confirmed site title links display without underlines
- Validated that duotone functionality is properly disabled in email context
- Ensured both `core/site-logo` and `core/site-title` blocks are properly registered and functional

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
