### PR TITLE
Add role='button' to product grid Add to Cart anchors when they act as buttons

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-button-role
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-button-role
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add role='button' to product grid Add to Cart buttons when they act as a button
+Add role='button' to product grid Add to Cart anchors when they act as a button

--- a/plugins/woocommerce/changelog/fix-add-to-cart-button-role
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-button-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add role='button' to product grid Add to Cart buttons when they act as a button

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1442,6 +1442,22 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 			$args['attributes']['aria-label'] = wp_strip_all_tags( $args['attributes']['aria-label'] );
 		}
 
+		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
+		$ajax_add_to_cart_enabled = get_option( 'woocommerce_enable_ajax_add_to_cart' ) === 'yes';
+
+		// The template is using an anchor instead of a button. For AJAX
+		// add-to-cart, it needs to be a button for accessibility reasons.
+		// See https://github.com/woocommerce/woocommerce/issues/59382.
+		if (
+			! $cart_redirect_after_add &&
+			$ajax_add_to_cart_enabled &&
+			$product->supports( 'ajax_add_to_cart' ) &&
+			$product->is_purchasable() &&
+			$product->is_in_stock()
+		) {
+			$args['attributes']['role'] = 'button';
+		}
+
 		wc_get_template( 'loop/add-to-cart.php', $args );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59382.

This PR adds `role="button"` to _Add to cart_ buttons in certain cases. Those buttons are actually anchors, so they need to have the button role when clicking on them doesn't trigger a navigation.

### How to test the changes in this Pull Request:

1. In a classic theme like Storefront, go to the _Shop_ page.
2. Verify all _Add to cart_ buttons have `role="button"`.
3. Verify all other buttons like _Read more_ don't have `role="button"`.
4. Now, go to WooCommerce > Settings and check _Redirect to the cart page after successful addition_.
5. Go back to the _Shop_ page and verify _Add to cart_ buttons don't have `role="button"` anymore.