### PR TITLE
Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block (III)

### DIFF
--- a/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky-iii
+++ b/plugins/woocommerce/changelog/fix-57718-select-invalid-variations-flaky-iii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix 'doesn't allow selecting invalid variations in dropdown mode' flaky test in Add to Cart + Options block (III)
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -253,9 +253,12 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		// We need to make sure the block updated before saving.
 		// @see https://github.com/woocommerce/woocommerce/issues/57718
-		await expect( async () => {
-			await page.getByRole( 'radio', { name: 'Dropdown' } ).isChecked();
-		} ).toPass();
+		// Verify that `.editor-post-publish-button__button` has an attribute
+		// `aria-haspopup="dialog"`. When https://github.com/woocommerce/woocommerce/issues/48936
+		// is fixed, we can simply check that the Save button becomes enabled.
+		await expect(
+			page.getByRole( 'button', { name: 'Save', exact: true } )
+		).toHaveAttribute( 'aria-haspopup', 'dialog' );
 
 		await editor.saveSiteEditorEntities();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/59483.

Apparently, the fix we introduced in https://github.com/woocommerce/woocommerce/pull/59483 wasn't enough to fix the flakiness of the 'doesn't allow selecting invalid variations in dropdown mode', so I'm trying the original solution from #59483, which consisted of checking whether the _Save_ button in the Site Editor had updated before clicking it.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass and 'doesn't allow selecting invalid variations in dropdown mode' isn't flaky anymor (Blocks e2e tests 1/10).