### PR TITLE
Refactor layout controls to use ToolsPanel instead of PanelBody

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4919-migrate-panelbody-to-toolspanel-in-the-email-editor
+++ b/packages/js/email-editor/changelog/wooplug-4919-migrate-panelbody-to-toolspanel-in-the-email-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Use ToolsPanel component instead of PanelBody component

--- a/packages/js/email-editor/src/layouts/flex-email.tsx
+++ b/packages/js/email-editor/src/layouts/flex-email.tsx
@@ -11,7 +11,8 @@ import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
 import {
 	Flex,
 	FlexItem,
-	PanelBody,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
@@ -112,19 +113,39 @@ function LayoutControls( { setAttributes, attributes, name: blockName } ) {
 		} );
 	};
 
+	const resetAll = () => {
+		const { justifyContent: _discarded, ...restLayout } =
+			attributes.layout || {};
+		setAttributes( {
+			layout: restLayout,
+		} );
+	};
+
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Layout', 'woocommerce' ) }>
-					<Flex>
-						<FlexItem>
-							<JustificationControls
-								justificationValue={ justifyContent }
-								onChange={ onJustificationChange }
-							/>
-						</FlexItem>
-					</Flex>
-				</PanelBody>
+				<ToolsPanel
+					label={ __( 'Layout', 'woocommerce' ) }
+					resetAll={ resetAll }
+				>
+					<ToolsPanelItem
+						isShownByDefault
+						onDeselect={ resetAll } // This attribute is usually used to reset the panel item value.
+						hasValue={ () =>
+							attributes.layout?.justifyContent || false
+						}
+						label={ __( 'Justification', 'woocommerce' ) }
+					>
+						<Flex>
+							<FlexItem>
+								<JustificationControls
+									justificationValue={ justifyContent }
+									onChange={ onJustificationChange }
+								/>
+							</FlexItem>
+						</Flex>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			{ /* @ts-expect-error No types for this exist yet. */ }
 			<BlockControls group="block" __experimentalShareWithChildBlocks>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4919

- This PR replaces usage of the PanelBody component with the ToolsPanel component.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="292" height="353" alt="Screenshot 2025-07-14 at 12 20 32" src="https://github.com/user-attachments/assets/4d114a2a-2d72-40ba-93c4-e9b2674ccf05" />| <img width="293" height="328" alt="Screenshot 2025-07-14 at 12 15 55" src="https://github.com/user-attachments/assets/0eeab7b6-92c4-49f4-b0c5-a3c570859e6c" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the email editor feature in __WooCommerce > Settings > Advanced> Features__
2. Go to __WooCommerce > Settings > Emails__ and open an email in the editor
3. Verify the functionality of the `core/buttons` block and its configuration

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
