### PR TITLE
Fix 'allows switching to 3rd-party product types' flaky test (II)

### DIFF
--- a/plugins/woocommerce/changelog/fix-55053-flaky-test-ii
+++ b/plugins/woocommerce/changelog/fix-55053-flaky-test-ii
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix 'allows switching to 3rd-party product types' flaky test (II)
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -52,21 +52,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 	test( 'allows switching to 3rd-party product types', async ( {
 		pageObject,
 		editor,
-		admin,
 		requestUtils,
 	} ) => {
 		await requestUtils.activatePlugin(
 			'woocommerce-blocks-test-custom-product-type'
 		);
 
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		await editor.insertBlock( { name: pageObject.BLOCK_SLUG } );
-
+		await pageObject.updateSingleProductTemplate();
 		await pageObject.switchProductType( 'Custom Product Type' );
 
 		const block = editor.canvas.getByLabel(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -31,12 +31,6 @@ class AddToCartWithOptionsPage {
 		);
 		await this.editor.selectBlocks( addToCartWithOptionsBlock );
 
-		await addToCartWithOptionsBlock
-			.locator( '.components-spinner' )
-			.waitFor( {
-				state: 'hidden',
-			} );
-
 		const productTypeSwitcher = this.page.getByRole( 'button', {
 			name: 'Switch product type',
 		} );
@@ -44,9 +38,6 @@ class AddToCartWithOptionsPage {
 
 		const customProductTypeButton = this.page.getByRole( 'menuitem', {
 			name: productType,
-		} );
-		await customProductTypeButton.waitFor( {
-			state: 'visible',
 		} );
 		await customProductTypeButton.click();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -31,19 +31,22 @@ class AddToCartWithOptionsPage {
 		);
 		await this.editor.selectBlocks( addToCartWithOptionsBlock );
 
+		await addToCartWithOptionsBlock
+			.locator( '.components-spinner' )
+			.waitFor( {
+				state: 'hidden',
+			} );
+
 		const productTypeSwitcher = this.page.getByRole( 'button', {
 			name: 'Switch product type',
 		} );
 		await productTypeSwitcher.click();
 
-		// Wait for the menu to open.
-		const menu = this.page.getByRole( 'menu', {
-			name: 'Switch product type',
-		} );
-		await menu.waitFor( { state: 'visible' } );
-
 		const customProductTypeButton = this.page.getByRole( 'menuitem', {
 			name: productType,
+		} );
+		await customProductTypeButton.waitFor( {
+			state: 'visible',
 		} );
 		await customProductTypeButton.click();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/55053.

This PR is another attempt at fixing the 'allows switching to 3rd-party product types' flaky test, as https://github.com/woocommerce/woocommerce/pull/59333 didn't seem to be enough. With these changes, we use the `updateSingleProductTemplate()` util instead of inserting the block manually, which should help with the menu not being visible due to being below the fold.

### How to test the changes in this Pull Request:

1. Make sure the 'allows switching to 3rd-party product types' test passes and is not flaky.
