### PR TITLE
Prevent required select fields choosing 'next' option during autofill

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4846-ios-autofill-selects-next-item-in-list-if-select
+++ b/plugins/woocommerce/changelog/wooplug-4846-ios-autofill-selects-next-item-in-list-if-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue where Safari on iOS would choose the "next" item in a required select list instead of the correct one during autofill.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/index.tsx
@@ -76,11 +76,8 @@ export const Select = ( props: SelectProps ) => {
 	const errorId = incomingErrorId || inputId;
 
 	const optionsWithEmpty = useMemo< SelectOption[] >( () => {
-		if ( required && value ) {
-			return options;
-		}
 		return [ emptyOption ].concat( options );
-	}, [ required, value, emptyOption, options ] );
+	}, [ emptyOption, options ] );
 
 	const { setValidationErrors, clearValidationError } =
 		useDispatch( validationStore );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- This PR prevents the "empty" option being removed from a required select field after it gets a value.

Previously, the select options would look like so

```
- ✓ [disabled] Please choose an option...
- Apple
- Pear
- Banana
```

and as soon as you selected an option, the "empty" value would be removed.

```
- ✓ Apple
- Pear
- Banana
```

This affected Safari autofill on iOS, choosing the "next" option. This appears to be a safari quirk as I couldn't find any related open webkit bug reports.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4846

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| https://www.loom.com/share/1b6109e08cf043af96ef0d138b44c97e | https://www.loom.com/share/33b791ec9495455bbcf02ad332e426ff |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> General. Set the customer's default location to "No location by default"
2. Using Safari on iOS, ensure you have an address set up so that autofill is enabled on website.
3. Add an item to your cart and go to the Checkout page.
4. Use autofill to enter the first name and last name. Then click into the address 1 field, enter the autofill address.
5. Click back into the address 1 field and enter the autofill address again. Ensure the country field has not changed to an incorrect country.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
