### PR TITLE
Revert: Related Products: avoids querying results on each page load

### DIFF
--- a/plugins/woocommerce/changelog/59642-fix-revert-as-job
+++ b/plugins/woocommerce/changelog/59642-fix-revert-as-job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert: Related Products: avoids querying results on each page load.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -159,6 +159,57 @@ function wc_delete_product_transients( $post_id = 0 ) {
 }
 
 /**
+ * Delete all related products transients when a product is updated/created.
+ * This is necessary because changing one product affects all related products too.
+ *
+ * @since 9.8.0
+ * @deprecated 10.1.0 This function is deprecated and will be removed in a future version.
+ * @param int $post_id The product ID updated/created.
+ */
+function wc_delete_related_product_transients( $post_id ) {
+	wc_deprecated_function( 'wc_delete_related_product_transients', '10.1.0', 'This function is deprecated and will be removed in a future version.' );
+
+	if ( ! is_numeric( $post_id ) ) {
+		return;
+	}
+
+	$transient_name          = 'wc_related_' . $post_id;
+	$old_transient           = get_transient( $transient_name );
+	$old_related_product_ids = array();
+
+	if ( is_array( $old_transient ) && ! empty( $old_transient ) ) {
+		$old_related_product_ids = $old_transient[ array_key_first( $old_transient ) ];
+	}
+
+	// Delete current product transient so that it can be refreshed below.
+	delete_transient( $transient_name );
+
+	// Gets new related products and sets current product transient.
+	$new_related_product_ids = wc_get_related_products( $post_id, 1000 );
+
+	// Combine all product IDs that need their transients cleared.
+	$related_product_ids = array_unique(
+		array_merge(
+			$old_related_product_ids,
+			$new_related_product_ids
+		)
+	);
+
+	if ( empty( $related_product_ids ) ) {
+		return;
+	}
+
+	// Create the list of transient names to delete.
+	$related_product_transients = array_map(
+		function ( $id ) {
+			return 'wc_related_' . $id;
+		},
+		$related_product_ids
+	);
+	_wc_delete_transients( $related_product_transients );
+}
+
+/**
  * Function that returns an array containing the IDs of the products that are on sale.
  *
  * @since 2.0

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -8,6 +8,8 @@
  * @version 3.0.0
  */
 
+declare(strict_types=1);
+
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -165,12 +165,17 @@ function wc_delete_product_transients( $post_id = 0 ) {
 			$queue            = WC()->queue();
 
 			if ( ! isset( $scheduled[ $cache_key ] ) ) {
-				$existing                = $queue->get_next(
-					'wc_delete_related_product_transients_async',
-					array( 'post_id' => $post_id ),
-					'wc_delete_related_product_transients_group'
+				$queue                   = WC()->queue();
+				$existing                = $queue->search(
+					array(
+						'hook'     => 'wc_delete_related_product_transients_async',
+						'args'     => array( 'post_id' => $post_id ),
+						'status'   => 'pending',
+						'group'    => 'wc_delete_related_product_transients_group',
+						'per_page' => 1,
+					)
 				);
-				$scheduled[ $cache_key ] = null !== $existing;
+				$scheduled[ $cache_key ] = ! empty( $existing );
 			}
 
 			if ( ! $scheduled[ $cache_key ] ) {

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -456,12 +456,10 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 				} else {
 					$variation_list[] = '<dt>' . wc_attribute_label( $name, $product ) . ':</dt><dd>' . rawurldecode( $value ) . '</dd>';
 				}
-			} else {
-				if ( $flat ) {
+			} elseif ( $flat ) {
 					$variation_list[] = rawurldecode( $value );
-				} else {
-					$variation_list[] = '<li>' . rawurldecode( $value ) . '</li>';
-				}
+			} else {
+				$variation_list[] = '<li>' . rawurldecode( $value ) . '</li>';
 			}
 		}
 

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -8,8 +8,6 @@
  * @version 3.0.0
  */
 
-declare(strict_types=1);
-
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Enums\ProductStatus;
 use Automattic\WooCommerce\Enums\ProductStockStatus;
@@ -144,27 +142,13 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		$post_transient_names = array(
 			'wc_product_children_',
 			'wc_var_prices_',
+			'wc_related_',
 			'wc_child_has_weight_',
 			'wc_child_has_dimensions_',
 		);
 
 		foreach ( $post_transient_names as $transient ) {
 			delete_transient( $transient . $post_id );
-		}
-
-		$is_cli = Constants::is_true( 'WP_CLI' );
-		if ( $is_cli ) {
-			wc_delete_related_product_transients( $post_id );
-		} else {
-			// Schedule the async deletion of related product transients.
-			// This should run async cause it also fetches all related products
-			// of the current product to be deleted which we can can't be sure how many there are.
-			WC()->queue()->schedule_single(
-				time(),
-				'wc_delete_related_product_transients_async',
-				array( 'post_id' => $post_id ),
-				'wc_delete_related_product_transients_group'
-			);
 		}
 	}
 
@@ -173,57 +157,6 @@ function wc_delete_product_transients( $post_id = 0 ) {
 
 	do_action( 'woocommerce_delete_product_transients', $post_id );
 }
-
-/**
- * Delete all related products transients when a product is updated/created.
- * This is necessary because changing one product affects all related products too.
- *
- * @since 9.8.0
- * @param int $post_id The product ID updated/created.
- */
-function wc_delete_related_product_transients( $post_id ) {
-	global $wpdb;
-
-	if ( ! is_numeric( $post_id ) ) {
-		return;
-	}
-
-	$transient_name          = 'wc_related_' . $post_id;
-	$old_transient           = get_transient( $transient_name );
-	$old_related_product_ids = array();
-
-	if ( is_array( $old_transient ) && ! empty( $old_transient ) ) {
-		$old_related_product_ids = $old_transient[ array_key_first( $old_transient ) ];
-	}
-
-	// Delete current product transient so that it can be refreshed below.
-	delete_transient( $transient_name );
-
-	// Gets new related products and sets current product transient.
-	$new_related_product_ids = wc_get_related_products( $post_id, 1000 );
-
-	// Combine all product IDs that need their transients cleared.
-	$related_product_ids = array_unique(
-		array_merge(
-			$old_related_product_ids,
-			$new_related_product_ids
-		)
-	);
-
-	if ( empty( $related_product_ids ) ) {
-		return;
-	}
-
-	// Create the list of transient names to delete.
-	$related_product_transients = array_map(
-		function ( $id ) {
-			return 'wc_related_' . $id;
-		},
-		$related_product_ids
-	);
-	_wc_delete_transients( $related_product_transients );
-}
-add_action( 'wc_delete_related_product_transients_async', 'wc_delete_related_product_transients' );
 
 /**
  * Function that returns an array containing the IDs of the products that are on sale.
@@ -512,9 +445,6 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 				}
 			}
 
-			// Cast to string once before using.
-			$value = (string) $value;
-
 			// Do not list attributes already part of the variation name.
 			if ( '' === $value || ( $skip_attributes_in_name && wc_is_attribute_in_product_name( $value, $variation_name ) ) ) {
 				continue;
@@ -526,10 +456,12 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 				} else {
 					$variation_list[] = '<dt>' . wc_attribute_label( $name, $product ) . ':</dt><dd>' . rawurldecode( $value ) . '</dd>';
 				}
-			} elseif ( $flat ) {
-				$variation_list[] = rawurldecode( $value );
 			} else {
-				$variation_list[] = '<li>' . rawurldecode( $value ) . '</li>';
+				if ( $flat ) {
+					$variation_list[] = rawurldecode( $value );
+				} else {
+					$variation_list[] = '<li>' . rawurldecode( $value ) . '</li>';
+				}
 			}
 		}
 
@@ -1132,9 +1064,8 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 	$transient     = get_transient( $transient_name );
 	$related_posts = $transient && is_array( $transient ) && isset( $transient[ $query_args ] ) ? $transient[ $query_args ] : false;
 
-	// Query related posts if they are not cached
-	// Should happen only once per day due to transient expiration set to 1 DAY_IN_SECONDS, to avoid performance issues.
-	if ( false === $related_posts ) {
+	// We want to query related posts if they are not cached, or we don't have enough.
+	if ( false === $related_posts || count( $related_posts ) < $limit ) {
 
 		$cats_array = apply_filters( 'woocommerce_product_related_posts_relate_by_category', true, $product_id ) ? apply_filters( 'woocommerce_get_related_product_cat_terms', wc_get_product_term_ids( $product_id, 'product_cat' ), $product_id ) : array();
 		$tags_array = apply_filters( 'woocommerce_product_related_posts_relate_by_tag', true, $product_id ) ? apply_filters( 'woocommerce_get_related_product_tag_terms', wc_get_product_term_ids( $product_id, 'product_tag' ), $product_id ) : array();

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -157,36 +157,12 @@ function wc_delete_product_transients( $post_id = 0 ) {
 			// Schedule the async deletion of related product transients.
 			// This should run async cause it also fetches all related products
 			// of the current product to be deleted which we can can't be sure how many there are.
-
-			// Add static cache here which is used to check if the transient is already scheduled.
-			// The cache exists ONLY on the current request to prevent searching the DB for every product.
-			static $scheduled = array();
-			$cache_key        = (int) $post_id;
-			$queue            = WC()->queue();
-
-			if ( ! isset( $scheduled[ $cache_key ] ) ) {
-				$queue                   = WC()->queue();
-				$existing                = $queue->search(
-					array(
-						'hook'     => 'wc_delete_related_product_transients_async',
-						'args'     => array( 'post_id' => $post_id ),
-						'status'   => 'pending',
-						'group'    => 'wc_delete_related_product_transients_group',
-						'per_page' => 1,
-					)
-				);
-				$scheduled[ $cache_key ] = ! empty( $existing );
-			}
-
-			if ( ! $scheduled[ $cache_key ] ) {
-				$queue->schedule_single(
-					time(),
-					'wc_delete_related_product_transients_async',
-					array( 'post_id' => $post_id ),
-					'wc_delete_related_product_transients_group'
-				);
-				$scheduled[ $cache_key ] = true;
-			}
+			WC()->queue()->schedule_single(
+				time(),
+				'wc_delete_related_product_transients_async',
+				array( 'post_id' => $post_id ),
+				'wc_delete_related_product_transients_group'
+			);
 		}
 	}
 
@@ -204,6 +180,8 @@ function wc_delete_product_transients( $post_id = 0 ) {
  * @param int $post_id The product ID updated/created.
  */
 function wc_delete_related_product_transients( $post_id ) {
+	global $wpdb;
+
 	if ( ! is_numeric( $post_id ) ) {
 		return;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts:
- https://github.com/woocommerce/woocommerce/pull/55843
- https://github.com/woocommerce/woocommerce/pull/56797
- https://github.com/woocommerce/woocommerce/pull/57588
- https://github.com/woocommerce/woocommerce/pull/57630

This PR reverts a series of changes that moved the deletion of related product transients in WooCommerce to an asynchronous (Action Scheduler) job, as well as subsequent refinements that attempted to limit job duplication. The original intent of those changes, introduced in PR #55843 and follow-ups, was to improve performance by avoiding synchronous deletion of related product transients, especially when updating products with many related items.

However, extensive discussion (https://github.com/woocommerce/woocommerce/pull/58817) and reports have shown that the async job approach, while theoretically beneficial, has led to significant performance and operational issues in real-world scenarios. Notably, when third-party plugins call ‎`wc_delete_product_transients()` on the frontend or in bulk, it can result in millions of scheduled actions, overwhelming the database and making wp-admin unusable for affected stores.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install Query Monitor
2. Update a Product Variation.
3. Visit the Product
4. see list of 'UPDATE' queries from QM console.



<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->


<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Revert: Related Products: avoids querying results on each page load.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
