### PR TITLE
Fix console error on email listing page when custom email classes are registered

### DIFF
--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-listing-listview.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Post } from '@wordpress/core-data';
 import { useState, useMemo } from '@wordpress/element';
 import { edit, external } from '@wordpress/icons';
 import { Icon } from '@wordpress/components';
@@ -202,7 +201,9 @@ export const ListView = ( { emailTypes }: { emailTypes: EmailType[] } ) => {
 				},
 			} }
 			showLayoutSwitcher={ false }
-			getItemId={ ( item: Post ) => item.id }
+			getItemId={ ( item: EmailType ) =>
+				`${ item.id }_${ item?.email_key || '' }`
+			}
 		/>
 	);
 };


### PR DESCRIPTION


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR fixes a console error that occurs on the email listing page when custom email classes are registered and the email editor is enabled.

The issue was in the `getItemId` function within the `ListView` component (`settings-email-listing-listview.tsx`), which was incorrectly typed to accept `Post` objects but was actually receiving `EmailType` objects. Additionally, the unique ID generation was insufficient for distinguishing between different email types that might share the same `id`.

**Root Cause:**
- The `getItemId` function parameter was typed as `Post` instead of `EmailType`
- The function only used `item.id` for unique identification, which could cause conflicts when multiple email types have the same ID but different `email_key` values
- This resulted in console errors when the DataViews component tried to process email items

**Solution:**
- Updated the function parameter type from `Post` to `EmailType` to match the actual data structure
- Enhanced the unique ID generation to include both `item.id` and `item.email_key` with safe optional chaining
- The new format: `${item.id}_${item?.email_key || ''}` ensures unique identification even when `email_key` is undefined

Closes #59639 WOOPLUG-5007.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="838" height="806" alt="Screenshot 2025-07-14 at 2 00 09 PM" src="https://github.com/user-attachments/assets/d8af16bf-0d1f-4c4a-8ab7-e8e244cb654a" />  |     <img width="839" height="586" alt="Screenshot 2025-07-14 at 3 19 58 PM" src="https://github.com/user-attachments/assets/49a3e943-650f-4176-9bed-c079162b972c" />  |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Enable the email editor feature in WooCommerce settings
2. Enable script debugging by adding `define('SCRIPT_DEBUG', true);` to wp-config.php
3. Add the following code to your theme's functions.php or a custom plugin to register a custom email class:

```php
function register_my_custom_test_email_class( array $emails ) {
    if(class_exists('My_Custom_Test_Email')) {
        return $emails;
    }
    class My_Custom_Test_Email extends \WC_Email_Customer_Completed_Order {
        public $plugin_id = 'x_';

        public function __construct() {
            $this->id = 'my_custom_test_email';
            $this->title = 'My Custom Test Email';
            $this->description = 'This is a custom test email';

            $this->heading = 'My Custom Test Email Heading';
            $this->subject = 'My Custom Test Email Subject';

            add_filter( 'woocommerce_email_preview_email_content_setting_ids', function( $setting_ids ) {
                $setting_ids[] = 'x_customer_completed_order_heading';
                return $setting_ids;
            } );
            parent::__construct();
        }

        public function get_default_subject() {
            return $this->subject;
        }

        public function get_default_heading() {
            return $this->heading;
        }
    }

    $emails['Test_Email'] = new My_Custom_Test_Email();

    return $emails;
}
add_filter( 'woocommerce_email_classes', 'register_my_custom_test_email_class' );
```

4. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=email`
5. Open browser developer tools and check the console
6. Verify that no console errors related to the DataViews component or getItemId function appear
7. Confirm that the email listing page loads correctly and displays all email types including the custom one
8. Test filtering and sorting functionality to ensure the unique ID generation works properly

### Testing that has already taken place:

- Tested on a local development environment with WordPress 6.4+ and WooCommerce 9.5+
- Verified the fix resolves the console error when custom email classes are registered
- Confirmed that existing email functionality remains unaffected
- Tested with both standard WooCommerce emails and custom email implementations
- No performance impact observed as the change is minimal and only affects ID generation


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix console error on email listing page when custom email classes are registered by correcting getItemId function type and improving unique ID generation.

</details>
