### PR TITLE
Redirect to core profiler from dashboard if incomplete

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4993-starting-from-wp-dashboard-leads-to-cys-and-not-woo-setup
+++ b/plugins/woocommerce/changelog/wooplug-4993-starting-from-wp-dashboard-leads-to-cys-and-not-woo-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Onboarding button will direct to core profiler if incomplete

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -9,6 +9,7 @@
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -91,6 +92,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return string
 		 */
 		public function get_button_link( $task ) {
+			// Check if core profiler needs completion and redirect to it.
+			if ( class_exists( OnboardingProfile::class ) ) {
+				if ( OnboardingProfile::needs_completion() ) {
+					return wc_admin_url( '&path=/setup-wizard' );
+				}
+			}
+
 			$url = (string) $task->get_json()['actionUrl'];
 
 			if ( substr( $url, 0, 4 ) === 'http' ) {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -72,7 +72,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Force the "payments" task to be considered incomplete.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			function () {
 				return array();
 			}
 		);
@@ -98,7 +98,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 			}
 		};
 		// phpcs:enable Squiz.Commenting
-		$widget    = $this->get_widget();
+		$widget = $this->get_widget();
 		$widget->set_task_list( $task_list );
 
 		$this->assertFalse( $widget->should_display_widget() );
@@ -118,8 +118,8 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 	 * Tests widget does not display when user cannot manage woocommerce.
 	 */
 	public function test_widget_does_not_display_when_missing_capabilities() {
-		$password  = wp_generate_password( 8, false, false );
-		$author    = wp_insert_user(
+		$password = wp_generate_password( 8, false, false );
+		$author   = wp_insert_user(
 			array(
 				'user_login' => "test_author$password",
 				'user_pass'  => $password,
@@ -151,7 +151,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Force the "payments" task to be considered incomplete.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			function () {
 				return array();
 			}
 		);
@@ -177,7 +177,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// by faking a valid payment gateway.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			function () {
 				return array(
 					new class() extends WC_Payment_Gateway {
 					},

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -194,4 +194,96 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 			$this->assertMatchesRegularExpression( "/Step {$step_number} of {$tasks_count}/", $this->get_widget_output() );
 		}
 	}
+
+	/**
+	 * Tests get_button_link redirects to core profiler when it needs completion.
+	 */
+	public function test_get_button_link_redirects_to_core_profiler_when_needed() {
+		// Set up onboarding profile data to indicate profiler is not completed.
+		update_option( 'woocommerce_onboarding_profile', array( 'completed' => false ) );
+
+		$widget    = $this->get_widget();
+		$task_list = $widget->get_task_list();
+		$tasks     = $task_list->get_viewable_tasks();
+
+		if ( ! empty( $tasks ) ) {
+			$first_task  = $tasks[0];
+			$button_link = $widget->get_button_link( $first_task );
+
+			// Should redirect to setup wizard when profiler is not completed.
+			$this->assertStringContainsString( 'path=/setup-wizard', $button_link );
+		}
+
+		delete_option( 'woocommerce_onboarding_profile' );
+	}
+
+	/**
+	 * Tests get_button_link redirects to core profiler when option does not exist.
+	 */
+	public function test_get_button_link_redirects_to_core_profiler_when_option_does_not_exist() {
+		// Set up onboarding profile data to indicate profiler is not completed.
+		delete_option( 'woocommerce_onboarding_profile' );
+
+		$widget    = $this->get_widget();
+		$task_list = $widget->get_task_list();
+		$tasks     = $task_list->get_viewable_tasks();
+
+		if ( ! empty( $tasks ) ) {
+			$first_task  = $tasks[0];
+			$button_link = $widget->get_button_link( $first_task );
+
+			// Should redirect to setup wizard when profiler is not completed.
+			$this->assertStringContainsString( 'path=/setup-wizard', $button_link );
+		}
+
+		delete_option( 'woocommerce_onboarding_profile' );
+	}
+
+	/**
+	 * Tests get_button_link returns normal task URL when core profiler is completed.
+	 */
+	public function test_get_button_link_returns_normal_url_when_profiler_completed() {
+		// Set up onboarding profile data to indicate profiler is completed.
+		update_option( 'woocommerce_onboarding_profile', array( 'completed' => true ) );
+
+		$widget    = $this->get_widget();
+		$task_list = $widget->get_task_list();
+		$tasks     = $task_list->get_viewable_tasks();
+
+		if ( ! empty( $tasks ) ) {
+			$first_task  = $tasks[0];
+			$button_link = $widget->get_button_link( $first_task );
+
+			// Should NOT redirect to setup wizard when profiler is completed.
+			$this->assertStringNotContainsString( 'path=/setup-wizard', $button_link );
+			// Should contain the task ID or actionUrl.
+			$this->assertMatchesRegularExpression( '/(task=|path=)/', $button_link );
+		}
+
+		delete_option( 'woocommerce_onboarding_profile' );
+	}
+
+	/**
+	 * Tests get_button_link returns normal task URL when core profiler is skipped.
+	 */
+	public function test_get_button_link_returns_normal_url_when_profiler_skipped() {
+		// Set up onboarding profile data to indicate profiler is skipped.
+		update_option( 'woocommerce_onboarding_profile', array( 'skipped' => true ) );
+
+		$widget    = $this->get_widget();
+		$task_list = $widget->get_task_list();
+		$tasks     = $task_list->get_viewable_tasks();
+
+		if ( ! empty( $tasks ) ) {
+			$first_task  = $tasks[0];
+			$button_link = $widget->get_button_link( $first_task );
+
+			// Should NOT redirect to setup wizard when profiler is skipped.
+			$this->assertStringNotContainsString( 'path=/setup-wizard', $button_link );
+			// Should contain the task ID or actionUrl.
+			$this->assertMatchesRegularExpression( '/(task=|path=)/', $button_link );
+		}
+
+		delete_option( 'woocommerce_onboarding_profile' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- This PR changes the onboarding button's link location on the WP Dashboard to the core profiler if it is incomplete.

Closes WOOPLUG-4993

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a fresh site and install WooCommerce (if testing locally, go to `wp_options` and delete the options: `woocommerce_onboarding_profile_progress`, and `woocommerce_onboarding_profile`, OR even better, change your database prefix in wp-config.php)
2. Go to WP Admin -> Dashboard.
3. Find the WooCommerce card, and click the button that says "Start selling" (If you don't see it, disable all payment methods)
4. You should be directed to complete the core profiler.
5. After completing this, go back to the dashboard.
6. Click "Start selling" again, you should be taken to customize your store.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
