### PR TITLE
Feature compatibility: Make declarations lazy to avoid get_plugins() calls on frontend

### DIFF
--- a/plugins/woocommerce/changelog/lazy-plugin-feature-registration
+++ b/plugins/woocommerce/changelog/lazy-plugin-feature-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Feature compatibility: Make declarations lazy to avoid get_plugins() calls on frontend

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -705,18 +705,14 @@ class FeaturesController {
 		}
 
 		// Late call: Normalize and register immediately.
-		$plugin_id = $this->plugin_util->get_wp_plugin_id( $plugin_file );
-		if ( ! $plugin_id ) {
-			$this->proxy->call_function( 'wc_get_logger' )->error( "Invalid plugin file: {$plugin_file}" );
-			return false;
-		}
-		return $this->register_compatibility_internal( $feature_id, $plugin_id, $positive_compatibility );
+		return $this->register_compatibility_internal( $feature_id, $plugin_file, $positive_compatibility );
 	}
 
 	/**
-	 * Registers compatibility information internally for a given feature and plugin.
+	 * Registers compatibility information internally for a given feature and plugin file.
 	 *
-	 * This method handles the actual registration of compatibility data after plugin ID normalization.
+	 * This method normalizes the plugin file path to a plugin ID, handles validation and logging for invalid plugins,
+	 * and registers the compatibility data if valid.
 	 * It updates the internal compatibility arrays, checks for conflicts (e.g., a plugin declaring both
 	 * compatible and incompatible with the same feature), and throws an exception if a conflict is detected.
 	 * Duplicate declarations (same compatibility type) are ignored.
@@ -727,18 +723,25 @@ class FeaturesController {
 	 * @since 10.1.0
 	 *
 	 * @param string $feature_id Unique feature ID.
-	 * @param string $plugin_id Normalized plugin ID (e.g., 'directory/file.php').
+	 * @param string $plugin_file Raw plugin file path (full or 'directory/file.php').
 	 * @param bool   $positive_compatibility True if declaring compatibility, false if declaring incompatibility.
 	 * @return bool True on successful registration, false if the feature does not exist.
 	 * @throws \Exception If the plugin attempts to declare both compatibility and incompatibility for the same feature.
 	 */
-	private function register_compatibility_internal( string $feature_id, string $plugin_id, bool $positive_compatibility ): bool {
+	private function register_compatibility_internal( string $feature_id, string $plugin_file, bool $positive_compatibility ): bool {
 		if ( ! $this->feature_exists( $feature_id ) ) {
 			return false;
 		}
 
-		// Register compatibility by plugin.
+		// Normalize and validate plugin file.
+		$plugin_id = $this->plugin_util->get_wp_plugin_id( $plugin_file );
+		if ( ! $plugin_id ) {
+			$logger = $this->proxy->call_function( 'wc_get_logger' );
+			$logger->error( "FeaturesController: Invalid plugin file '{$plugin_file}' for feature '{$feature_id}'." );
+			return false;
+		}
 
+		// Register compatibility by plugin.
 		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin, $plugin_id );
 
 		$key          = $positive_compatibility ? 'compatible' : 'incompatible';
@@ -789,15 +792,8 @@ class FeaturesController {
 		foreach ( $this->pending_declarations as $declaration ) {
 			[ $feature_id, $plugin_file, $positive_compatibility ] = $declaration;
 
-			$plugin_id = $plugin_util->get_wp_plugin_id( $plugin_file );
-
-			if ( ! $plugin_id ) {
-				$logger->error( "FeaturesController::process_pending_declarations: {$plugin_file} is not a known WordPress plugin." );
-				continue;
-			}
-
 			// Register internally.
-			$this->register_compatibility_internal( $feature_id, $plugin_id, $positive_compatibility );
+			$this->register_compatibility_internal( $feature_id, $plugin_file, $positive_compatibility );
 		}
 
 		$this->pending_declarations = array();

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -801,7 +801,7 @@ class FeaturesController {
 		}
 
 		$this->pending_declarations = array();
-		$this->lazy = false;
+		$this->lazy                 = false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -60,6 +60,8 @@ class FeaturesController {
 
 	/**
 	 * Pending compatibility declarations. Format is [feature_id, plugin_file, positive_compatibility].
+	 *
+	 * @var array
 	 */
 	private $pending_declarations = array();
 
@@ -676,7 +678,7 @@ class FeaturesController {
 	 * @param string $plugin_name Plugin name, in the form 'directory/file.php'.
 	 * @param bool   $positive_compatibility True if the plugin declares being compatible with the feature, false if it declares being incompatible.
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
-	 * @param bool $internal_call Optional. If true, skips the 'before_woocommerce_init' hook check for internal calls after init. Default false.
+	 * @param bool   $internal_call Optional. If true, skips the 'before_woocommerce_init' hook check for internal calls after init. Default false.
 	 * @throws \Exception A plugin attempted to declare itself as compatible and incompatible with a given feature at the same time.
 	 */
 	public function declare_compatibility( string $feature_id, string $plugin_name, bool $positive_compatibility = true, bool $internal_call = false ): bool {
@@ -747,7 +749,7 @@ class FeaturesController {
 			return false;
 		}
 
-		$this->pending_declarations[] = [ $feature_id, $plugin_file, $positive_compatibility ];
+		$this->pending_declarations[] = array( $feature_id, $plugin_file, $positive_compatibility );
 		return true;
 	}
 
@@ -769,7 +771,7 @@ class FeaturesController {
 		}
 
 		$plugin_util = $this->plugin_util;
-		$logger = $this->proxy->call_function( 'wc_get_logger' );
+		$logger      = $this->proxy->call_function( 'wc_get_logger' );
 
 		foreach ( $this->pending_declarations as $declaration ) {
 			[ $feature_id, $plugin_file, $positive_compatibility ] = $declaration;
@@ -785,7 +787,7 @@ class FeaturesController {
 			$this->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility, true );
 		}
 
-		$this->pending_declarations = [];
+		$this->pending_declarations = array();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -119,6 +119,13 @@ class FeaturesController {
 	private bool $registered_additional_features_via_class_calls = false;
 
 	/**
+	 * Flag indicating if we are currently delaying plugin normalization.
+	 *
+	 * @var bool
+	 */
+	private bool $lazy = true;
+
+	/**
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
@@ -675,82 +682,86 @@ class FeaturesController {
 	 * FeaturesUtil::declare_compatibility instead, passing the full plugin file path instead of the plugin name.
 	 *
 	 * @param string $feature_id Unique feature id.
-	 * @param string $plugin_name Plugin name, in the form 'directory/file.php'.
+	 * @param string $plugin_file Plugin file path, either full or in the form 'directory/file.php'.
 	 * @param bool   $positive_compatibility True if the plugin declares being compatible with the feature, false if it declares being incompatible.
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
-	 * @param bool   $internal_call Optional. If true, skips the 'before_woocommerce_init' hook check for internal calls after init. Default false.
 	 * @throws \Exception A plugin attempted to declare itself as compatible and incompatible with a given feature at the same time.
 	 */
-	public function declare_compatibility( string $feature_id, string $plugin_name, bool $positive_compatibility = true, bool $internal_call = false ): bool {
-		if ( ! $internal_call && ! $this->proxy->call_function( 'doing_action', 'before_woocommerce_init' ) ) {
-			$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
-			/* translators: 1: class::method 2: before_woocommerce_init */
-			$this->proxy->call_function( 'wc_doing_it_wrong', $class_and_method, sprintf( __( '%1$s should be called inside the %2$s action.', 'woocommerce' ), $class_and_method, 'before_woocommerce_init' ), '7.0' );
-			return false;
-		}
-
-		if ( ! $this->feature_exists( $feature_id ) ) {
-			return false;
-		}
-
-		$plugin_name = str_replace( '\\', '/', $plugin_name );
-
-		// Register compatibility by plugin.
-
-		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin, $plugin_name );
-
-		$key          = $positive_compatibility ? 'compatible' : 'incompatible';
-		$opposite_key = $positive_compatibility ? 'incompatible' : 'compatible';
-		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_name ], $key );
-		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_name ], $opposite_key );
-
-		if ( in_array( $feature_id, $this->compatibility_info_by_plugin[ $plugin_name ][ $opposite_key ], true ) ) {
-			throw new \Exception( esc_html( "Plugin $plugin_name is trying to declare itself as $key with the '$feature_id' feature, but it already declared itself as $opposite_key" ) );
-		}
-
-		if ( ! in_array( $feature_id, $this->compatibility_info_by_plugin[ $plugin_name ][ $key ], true ) ) {
-			$this->compatibility_info_by_plugin[ $plugin_name ][ $key ][] = $feature_id;
-		}
-
-		// Register compatibility by feature.
-
-		$key = $positive_compatibility ? 'compatible' : 'incompatible';
-
-		if ( ! in_array( $plugin_name, $this->compatibility_info_by_feature[ $feature_id ][ $key ], true ) ) {
-			$this->compatibility_info_by_feature[ $feature_id ][ $key ][] = $plugin_name;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Declare compatibility lazily using plugin file path (normalization deferred until queried).
-	 *
-	 * This internal method queues declarations without immediate disk I/O from get_plugins().
-	 * Normalization and registration happen only when compatibility info is queried (e.g., in admin contexts).
-	 *
-	 * This method MUST be called from inside 'before_woocommerce_init'.
-	 *
-	 * @internal For usage by WooCommerce core, backwards compatibility not guaranteed.
-	 * @since 10.2.0
-	 * @param string $feature_id Unique feature id.
-	 * @param string $plugin_file The full plugin file path (not normalized).
-	 * @param bool   $positive_compatibility True if compatible, false if incompatible.
-	 * @return bool True if queued successfully, false on error (e.g., wrong hook or feature doesn't exist).
-	 */
-	public function declare_compatibility_by_file( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
+	public function declare_compatibility( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
 		if ( ! $this->proxy->call_function( 'doing_action', 'before_woocommerce_init' ) ) {
 			$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 			/* translators: 1: class::method 2: before_woocommerce_init */
 			$this->proxy->call_function( 'wc_doing_it_wrong', $class_and_method, sprintf( __( '%1$s should be called inside the %2$s action.', 'woocommerce' ), $class_and_method, 'before_woocommerce_init' ), '7.0' );
 			return false;
 		}
-
 		if ( ! $this->feature_exists( $feature_id ) ) {
 			return false;
 		}
 
-		$this->pending_declarations[] = array( $feature_id, $plugin_file, $positive_compatibility );
+		if ( $this->lazy ) {
+			// Lazy mode: Queue to be normalized later.
+			$this->pending_declarations[] = array( $feature_id, $plugin_file, $positive_compatibility );
+			return true;
+		}
+
+		// Late call: Normalize and register immediately.
+		$plugin_id = $this->plugin_util->get_wp_plugin_id( $plugin_file );
+		if ( ! $plugin_id ) {
+			$this->proxy->call_function( 'wc_get_logger' )->error( "Invalid plugin file: {$plugin_file}" );
+			return false;
+		}
+		return $this->register_compatibility_internal( $feature_id, $plugin_id, $positive_compatibility );
+	}
+
+	/**
+	 * Registers compatibility information internally for a given feature and plugin.
+	 *
+	 * This method handles the actual registration of compatibility data after plugin ID normalization.
+	 * It updates the internal compatibility arrays, checks for conflicts (e.g., a plugin declaring both
+	 * compatible and incompatible with the same feature), and throws an exception if a conflict is detected.
+	 * Duplicate declarations (same compatibility type) are ignored.
+	 *
+	 * This is an internal helper method and should not be called directly.
+	 *
+	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
+	 * @since 10.2.0
+	 *
+	 * @param string $feature_id Unique feature ID.
+	 * @param string $plugin_id Normalized plugin ID (e.g., 'directory/file.php').
+	 * @param bool   $positive_compatibility True if declaring compatibility, false if declaring incompatibility.
+	 * @return bool True on successful registration, false if the feature does not exist.
+	 * @throws \Exception If the plugin attempts to declare both compatibility and incompatibility for the same feature.
+	 */
+	private function register_compatibility_internal( string $feature_id, string $plugin_id, bool $positive_compatibility ): bool {
+		if ( ! $this->feature_exists( $feature_id ) ) {
+			return false;
+		}
+
+		// Register compatibility by plugin.
+
+		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin, $plugin_id );
+
+		$key          = $positive_compatibility ? 'compatible' : 'incompatible';
+		$opposite_key = $positive_compatibility ? 'incompatible' : 'compatible';
+		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_id ], $key );
+		ArrayUtil::ensure_key_is_array( $this->compatibility_info_by_plugin[ $plugin_id ], $opposite_key );
+
+		if ( in_array( $feature_id, $this->compatibility_info_by_plugin[ $plugin_id ][ $opposite_key ], true ) ) {
+			throw new \Exception( esc_html( "Plugin $plugin_id is trying to declare itself as $key with the '$feature_id' feature, but it already declared itself as $opposite_key" ) );
+		}
+
+		if ( ! in_array( $feature_id, $this->compatibility_info_by_plugin[ $plugin_id ][ $key ], true ) ) {
+			$this->compatibility_info_by_plugin[ $plugin_id ][ $key ][] = $feature_id;
+		}
+
+		// Register compatibility by feature.
+
+		$key = $positive_compatibility ? 'compatible' : 'incompatible';
+
+		if ( ! in_array( $plugin_id, $this->compatibility_info_by_feature[ $feature_id ][ $key ], true ) ) {
+			$this->compatibility_info_by_feature[ $feature_id ][ $key ][] = $plugin_id;
+		}
+
 		return true;
 	}
 
@@ -785,11 +796,12 @@ class FeaturesController {
 				continue;
 			}
 
-			// Register internally, skipping the hook check.
-			$this->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility, true );
+			// Register internally.
+			$this->register_compatibility_internal( $feature_id, $plugin_id, $positive_compatibility );
 		}
 
 		$this->pending_declarations = array();
+		$this->lazy = false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -724,7 +724,7 @@ class FeaturesController {
 	 * This is an internal helper method and should not be called directly.
 	 *
 	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
-	 * @since 10.2.0
+	 * @since 10.1.0
 	 *
 	 * @param string $feature_id Unique feature ID.
 	 * @param string $plugin_id Normalized plugin ID (e.g., 'directory/file.php').
@@ -775,7 +775,7 @@ class FeaturesController {
 	 * Pending declarations are cleared after processing to avoid redundant work.
 	 *
 	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
-	 * @since 10.2.0
+	 * @since 10.1.0
 	 * @return void
 	 */
 	private function process_pending_declarations(): void {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -59,6 +59,11 @@ class FeaturesController {
 	private $compatibility_info_by_feature = array();
 
 	/**
+	 * Pending compatibility declarations. Format is [feature_id, plugin_file, positive_compatibility].
+	 */
+	private $pending_declarations = array();
+
+	/**
 	 * The LegacyProxy instance to use.
 	 *
 	 * @var LegacyProxy
@@ -671,10 +676,11 @@ class FeaturesController {
 	 * @param string $plugin_name Plugin name, in the form 'directory/file.php'.
 	 * @param bool   $positive_compatibility True if the plugin declares being compatible with the feature, false if it declares being incompatible.
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
+	 * @param bool $internal_call Optional. If true, skips the 'before_woocommerce_init' hook check for internal calls after init. Default false.
 	 * @throws \Exception A plugin attempted to declare itself as compatible and incompatible with a given feature at the same time.
 	 */
-	public function declare_compatibility( string $feature_id, string $plugin_name, bool $positive_compatibility = true ): bool {
-		if ( ! $this->proxy->call_function( 'doing_action', 'before_woocommerce_init' ) ) {
+	public function declare_compatibility( string $feature_id, string $plugin_name, bool $positive_compatibility = true, bool $internal_call = false ): bool {
+		if ( ! $internal_call && ! $this->proxy->call_function( 'doing_action', 'before_woocommerce_init' ) ) {
 			$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 			/* translators: 1: class::method 2: before_woocommerce_init */
 			$this->proxy->call_function( 'wc_doing_it_wrong', $class_and_method, sprintf( __( '%1$s should be called inside the %2$s action.', 'woocommerce' ), $class_and_method, 'before_woocommerce_init' ), '7.0' );
@@ -716,6 +722,73 @@ class FeaturesController {
 	}
 
 	/**
+	 * Declare compatibility lazily using plugin file path (normalization deferred until queried).
+	 *
+	 * This internal method queues declarations without immediate disk I/O from get_plugins().
+	 * Normalization and registration happen only when compatibility info is queried (e.g., in admin contexts).
+	 *
+	 * This method MUST be called from inside 'before_woocommerce_init'.
+	 *
+	 * @internal For usage by WooCommerce core, backwards compatibility not guaranteed.
+	 * @param string $feature_id Unique feature id.
+	 * @param string $plugin_file The full plugin file path (not normalized).
+	 * @param bool   $positive_compatibility True if compatible, false if incompatible.
+	 * @return bool True if queued successfully, false on error (e.g., wrong hook or feature doesn't exist).
+	 */
+	public function declare_compatibility_by_file( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
+		if ( ! $this->proxy->call_function( 'doing_action', 'before_woocommerce_init' ) ) {
+			$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
+			/* translators: 1: class::method 2: before_woocommerce_init */
+			$this->proxy->call_function( 'wc_doing_it_wrong', $class_and_method, sprintf( __( '%1$s should be called inside the %2$s action.', 'woocommerce' ), $class_and_method, 'before_woocommerce_init' ), '7.0' );
+			return false;
+		}
+
+		if ( ! $this->feature_exists( $feature_id ) ) {
+			return false;
+		}
+
+		$this->pending_declarations[] = [ $feature_id, $plugin_file, $positive_compatibility ];
+		return true;
+	}
+
+	/**
+	 * Processes any pending compatibility declarations by normalizing plugin file paths
+	 * and registering them internally.
+	 *
+	 * This method is called lazily when compatibility information is queried (via
+	 * get_compatible_features_for_plugin() or get_compatible_plugins_for_feature()).
+	 * It resolves plugin IDs using PluginUtil and logs errors for unrecognized plugins.
+	 * Pending declarations are cleared after processing to avoid redundant work.
+	 *
+	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
+	 * @return void
+	 */
+	private function process_pending_declarations(): void {
+		if ( empty( $this->pending_declarations ) ) {
+			return;
+		}
+
+		$plugin_util = $this->plugin_util;
+		$logger = $this->proxy->call_function( 'wc_get_logger' );
+
+		foreach ( $this->pending_declarations as $declaration ) {
+			[ $feature_id, $plugin_file, $positive_compatibility ] = $declaration;
+
+			$plugin_id = $plugin_util->get_wp_plugin_id( $plugin_file );
+
+			if ( ! $plugin_id ) {
+				$logger->error( "FeaturesController::process_pending_declarations: {$plugin_file} is not a known WordPress plugin." );
+				continue;
+			}
+
+			// Register internally, skipping the hook check.
+			$this->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility, true );
+		}
+
+		$this->pending_declarations = [];
+	}
+
+	/**
 	 * Check whether a feature exists with a given id.
 	 *
 	 * @param string $feature_id The feature id to check.
@@ -737,6 +810,7 @@ class FeaturesController {
 	 * @return array An array having a 'compatible' and an 'incompatible' key, each holding an array of feature ids.
 	 */
 	public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
+		$this->process_pending_declarations();
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
 		$features = $this->get_feature_definitions();
@@ -772,6 +846,7 @@ class FeaturesController {
 	 * @return array An array having a 'compatible', an 'incompatible' and an 'uncertain' key, each holding an array of plugin names.
 	 */
 	public function get_compatible_plugins_for_feature( string $feature_id, bool $active_only = false ): array {
+		$this->process_pending_declarations();
 		$this->verify_did_woocommerce_init( __FUNCTION__ );
 
 		$woo_aware_plugins = $this->plugin_util->get_woocommerce_aware_plugins( $active_only );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -786,9 +786,6 @@ class FeaturesController {
 			return;
 		}
 
-		$plugin_util = $this->plugin_util;
-		$logger      = $this->proxy->call_function( 'wc_get_logger' );
-
 		foreach ( $this->pending_declarations as $declaration ) {
 			[ $feature_id, $plugin_file, $positive_compatibility ] = $declaration;
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -732,6 +732,7 @@ class FeaturesController {
 	 * This method MUST be called from inside 'before_woocommerce_init'.
 	 *
 	 * @internal For usage by WooCommerce core, backwards compatibility not guaranteed.
+	 * @since 10.2.0
 	 * @param string $feature_id Unique feature id.
 	 * @param string $plugin_file The full plugin file path (not normalized).
 	 * @param bool   $positive_compatibility True if compatible, false if incompatible.
@@ -763,6 +764,7 @@ class FeaturesController {
 	 * Pending declarations are cleared after processing to avoid redundant work.
 	 *
 	 * @internal For usage by WooCommerce core only. Backwards compatibility not guaranteed.
+	 * @since 10.2.0
 	 * @return void
 	 */
 	private function process_pending_declarations(): void {

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -55,15 +55,11 @@ class FeaturesUtil {
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
 	 */
 	public static function declare_compatibility( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
-		$plugin_id = wc_get_container()->get( PluginUtil::class )->get_wp_plugin_id( $plugin_file );
-
-		if ( ! $plugin_id ) {
-			$logger = wc_get_logger();
-			$logger->error( "FeaturesUtil::declare_compatibility: {$plugin_file} is not a known WordPress plugin." );
-			return false;
-		}
-
-		return wc_get_container()->get( FeaturesController::class )->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility );
+		return wc_get_container()->get( FeaturesController::class )->declare_compatibility_by_file(
+			$feature_id,
+			$plugin_file,
+			$positive_compatibility
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -55,7 +55,7 @@ class FeaturesUtil {
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
 	 */
 	public static function declare_compatibility( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
-		return wc_get_container()->get( FeaturesController::class )->declare_compatibility_by_file(
+		return wc_get_container()->get( FeaturesController::class )->declare_compatibility(
 			$feature_id,
 			$plugin_file,
 			$positive_compatibility

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -1033,12 +1033,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
 		// been set, and crash.
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
 
 		// Inject the mock into $sut's $plugin_util via reflection.
-		$sut_reflection = new \ReflectionClass( $this->sut );
+		$sut_reflection   = new \ReflectionClass( $this->sut );
 		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
 		$plugin_util_prop->setAccessible( true );
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
@@ -1061,9 +1061,9 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$compat = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
 		$this->assertEquals(
 			array(
-				'compatible' => array( 'plugin1/plugin1.php' ),
+				'compatible'   => array( 'plugin1/plugin1.php' ),
 				'incompatible' => array(),
-				'uncertain' => array()
+				'uncertain'    => array(),
 			),
 			$compat
 		);
@@ -1099,12 +1099,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
 		// been set, and crash.
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
 
 		// Inject mock into $sut.
-		$sut_reflection = new \ReflectionClass( $this->sut );
+		$sut_reflection   = new \ReflectionClass( $this->sut );
 		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
 		$plugin_util_prop->setAccessible( true );
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
@@ -1136,42 +1136,42 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			->onlyMethods( array( 'get_wp_plugin_id', 'get_woocommerce_aware_plugins' ) )
 			->getMock();
 
-		$plugin_util_mock->expects($this->atLeastOnce())
+		$plugin_util_mock->expects( $this->atLeastOnce() )
 			->method( 'get_wp_plugin_id' )
 			->willReturn( 'plugin/plugin.php' );
 
 		// Control get_woocommerce_aware_plugins to simulate before/after deactivation.
-		$deactivated = false; // Flag to toggle in callback.
+		$deactivated   = false; // Flag to toggle in callback.
 		$aware_plugins = array( 'plugin/plugin.php', 'other/plugin.php' ); // Controlled list.
 		$plugin_util_mock->method( 'get_woocommerce_aware_plugins' )
 					->will(
 						$this->returnCallback(
 							function ( $active_only ) use ( &$deactivated, $aware_plugins ) {
-									if ( $deactivated && $active_only ) {
-										// After deactivation, exclude from active-only list.
-										return array_filter(
-											$aware_plugins,
-											function($p) {
-												return $p !== 'plugin/plugin.php';
-											}
-										);
-									}
-									// Otherwise, return full list (includes inactive if !active_only).
-									return $aware_plugins;
+								if ( $deactivated && $active_only ) {
+									// After deactivation, exclude from active-only list.
+									return array_filter(
+										$aware_plugins,
+										function( $p ) {
+											return $p !== 'plugin/plugin.php';
+										}
+									);
+								}
+								// Otherwise, return full list (includes inactive if !active_only).
+								return $aware_plugins;
 							}
-					)
+						)
 		);
 
 		// Set private $proxy on mock via parent reflection.
 		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
 		// been set, and crash.
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
 
 		// Inject mock into sut.
-		$sut_reflection = new \ReflectionClass( $this->sut );
+		$sut_reflection   = new \ReflectionClass( $this->sut );
 		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
 		$plugin_util_prop->setAccessible( true );
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
@@ -1183,8 +1183,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Trigger processing and check before deactivation.
 		$compat_before = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
-		$this->assertContains( 'plugin/plugin.php', $compat_before[ 'compatible' ] );
-		$this->assertNotContains( 'plugin/plugin.php', $compat_before[ 'uncertain' ] );
+		$this->assertContains( 'plugin/plugin.php', $compat_before['compatible'] );
+		$this->assertNotContains( 'plugin/plugin.php', $compat_before['uncertain'] );
 
 		// Simulate deactivation: set flag (for mock callback) and trigger action (to unset compatibility).
 		$deactivated = true;

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -134,7 +134,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Set private $proxy via reflection (fixes null error).
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $this->fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
 
@@ -872,7 +872,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Set private $proxy via reflection (fixes null error).
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
 
@@ -970,7 +970,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Set private $proxy via reflection.
 		$parent_reflection = new \ReflectionClass( PluginUtil::class );
-		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop        = $parent_reflection->getProperty( 'proxy' );
 		$proxy_prop->setAccessible( true );
 		$proxy_prop->setValue( $fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
 
@@ -1015,7 +1015,6 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$local_sut->declare_compatibility( 'custom_order_tables', 'compatible_plugin' );
 		$local_sut->declare_compatibility( 'cart_checkout_blocks', 'compatible_plugin' );
 		$local_sut->declare_compatibility( 'custom_order_tables', 'incompatible_plugin', false );
-
 
 		$cot_controller   = new CustomOrdersTableController();
 		$cot_setting_call = function () use ( $fake_plugin_util, $local_sut ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -124,8 +124,19 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 				return $plugins;
 			}
+
+			public function get_wp_plugin_id( $plugin_file ) {
+				// For test fakes like 'the_plugin', return as-is (assume normalized).
+				return $plugin_file;
+			}
 		};
 		// phpcs:enable Squiz.Commenting
+
+		// Set private $proxy via reflection (fixes null error).
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $this->fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
 
 		$this->fake_plugin_util->set_active_plugins(
 			array(
@@ -358,6 +369,9 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$result = $this->sut->declare_compatibility( 'experimental2', 'the_plugin', false );
 		$this->assertTrue( $result );
 
+		// Allow the lazy/deffered processing to happen.
+		$this->sut->get_compatible_plugins_for_feature( '' );
+
 		$compatibility_info_prop = new \ReflectionProperty( $this->sut, 'compatibility_info_by_plugin' );
 		$compatibility_info_prop->setAccessible( true );
 		$compatibility_info = $compatibility_info_prop->getValue( $this->sut );
@@ -393,6 +407,9 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$this->assertTrue( $result );
 		$result = $this->sut->declare_compatibility( 'experimental2', 'the_plugin_2', true );
 		$this->assertTrue( $result );
+
+		// Allow the lazy/deffered processing to happen.
+		$this->sut->get_compatible_plugins_for_feature( '' );
 
 		$compatibility_info_prop = new \ReflectionProperty( $this->sut, 'compatibility_info_by_feature' );
 		$compatibility_info_prop->setAccessible( true );
@@ -440,6 +457,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->sut->declare_compatibility( 'mature1', 'the_plugin', true );
 		$this->sut->declare_compatibility( 'mature1', 'the_plugin', false );
+		// Allow the lazy/deffered processing to happen.
+		$this->sut->get_compatible_plugins_for_feature( '' );
 	}
 
 	/**
@@ -851,6 +870,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			}
 		};
 
+		// Set private $proxy via reflection (fixes null error).
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
+
 		$this->register_legacy_proxy_function_mocks(
 			array(
 				'is_plugin_active' => function ( $plugin ) {
@@ -937,7 +962,17 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			public function get_plugins_excluded_from_compatibility_ui() {
 				return array();
 			}
+			public function get_wp_plugin_id( $plugin_file ) {
+				// For test fakes like 'the_plugin', return as-is (assume normalized).
+				return $plugin_file;
+			}
 		};
+
+		// Set private $proxy via reflection.
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $fake_plugin_util, wc_get_container()->get( LegacyProxy::class ) );
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
@@ -980,6 +1015,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$local_sut->declare_compatibility( 'custom_order_tables', 'compatible_plugin' );
 		$local_sut->declare_compatibility( 'cart_checkout_blocks', 'compatible_plugin' );
 		$local_sut->declare_compatibility( 'custom_order_tables', 'incompatible_plugin', false );
+
 
 		$cot_controller   = new CustomOrdersTableController();
 		$cot_setting_call = function () use ( $fake_plugin_util, $local_sut ) {
@@ -1044,8 +1080,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
 
 		// Queue declarations without processing.
-		$result1 = $this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin1.php', true );
-		$result2 = $this->sut->declare_compatibility_by_file( 'experimental1', '/path/to/plugin2.php', false );
+		$result1 = $this->sut->declare_compatibility( 'mature1', '/path/to/plugin1.php', true );
+		$result2 = $this->sut->declare_compatibility( 'experimental1', '/path/to/plugin2.php', false );
 		$this->assertTrue( $result1 );
 		$this->assertTrue( $result2 );
 
@@ -1110,8 +1146,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
 
 		// Queue conflicting declarations (same file/path).
-		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', true );
-		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', false );
+		$this->sut->declare_compatibility( 'mature1', '/path/to/plugin.php', true );
+		$this->sut->declare_compatibility( 'mature1', '/path/to/plugin.php', false );
 
 		$this->simulate_after_woocommerce_init_hook();
 
@@ -1177,7 +1213,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
 
 		// Queue declaration.
-		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', true );
+		$this->sut->declare_compatibility( 'mature1', '/path/to/plugin.php', true );
 
 		$this->simulate_after_woocommerce_init_hook();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -1000,4 +1000,199 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$expected = $hpos_is_enabled ? array( 'incompatible_plugin' ) : array();
 		$this->assertEquals( $expected, array_keys( $incompatible_plugins->call( $local_sut ) ) );
 	}
+
+	/**
+	 * @testdox Declarations are queued lazily and processed only on query.
+	 */
+	public function test_lazy_declaration_and_processing() {
+		$this->simulate_inside_before_woocommerce_init_hook();
+
+		// Goal: Replace $this->sut's ->plugin_util with a mocked version that
+		// doesn't scan the disk, but resolves fake paths for plugin1 and plugin2, and
+		// checks how often get_wp_plugin_id() is called.
+
+		// Mock PluginUtil, including methods that could introduce environmental noise.
+		$plugin_util_mock = $this->getMockBuilder( PluginUtil::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_wp_plugin_id', 'get_woocommerce_aware_plugins' ) )
+			->getMock();
+
+		$plugin_util_mock->expects( $this->exactly( 2 ) ) // Called once per each file during processing.
+			->method( 'get_wp_plugin_id' )
+			->willReturnMap(
+				array(
+					array( '/path/to/plugin1.php', 'plugin1/plugin1.php' ),
+					array( '/path/to/plugin2.php', 'plugin2/plugin2.php' ),
+				)
+			);
+
+		$plugin_util_mock->method( 'get_woocommerce_aware_plugins' )
+			->willReturn( array() ); // Mock to empty to avoid real/environmental plugins in 'uncertain'.
+
+		// Manually set private $proxy on the mock via reflection on the parent class.
+		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
+		// been set, and crash.
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
+
+		// Inject the mock into $sut's $plugin_util via reflection.
+		$sut_reflection = new \ReflectionClass( $this->sut );
+		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
+		$plugin_util_prop->setAccessible( true );
+		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
+
+		// Queue declarations without processing.
+		$result1 = $this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin1.php', true );
+		$result2 = $this->sut->declare_compatibility_by_file( 'experimental1', '/path/to/plugin2.php', false );
+		$this->assertTrue( $result1 );
+		$this->assertTrue( $result2 );
+
+		// Inspect pending queue - there should be 2 pending declarations.
+		$pending_prop = $sut_reflection->getProperty( 'pending_declarations' );
+		$pending_prop->setAccessible( true );
+		$pending = $pending_prop->getValue( $this->sut );
+		$this->assertCount( 2, $pending );
+
+		$this->simulate_after_woocommerce_init_hook();
+
+		// Query triggers processing.
+		$compat = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
+		$this->assertEquals(
+			array(
+				'compatible' => array( 'plugin1/plugin1.php' ),
+				'incompatible' => array(),
+				'uncertain' => array()
+			),
+			$compat
+		);
+
+		// Pending queue should be cleared after processing.
+		$pending = $pending_prop->getValue( $this->sut );
+		$this->assertEmpty( $pending );
+
+		// Second query shouldn't re-process.
+		$this->sut->get_compatible_plugins_for_feature( 'experimental1' );
+		$pending = $pending_prop->getValue( $this->sut );
+		$this->assertEmpty( $pending );
+	}
+
+	/**
+	 * @testdox Conflicts are detected after lazy processing.
+	 */
+	public function test_lazy_conflict_detection() {
+		$this->simulate_inside_before_woocommerce_init_hook();
+
+		// Goal: Replace $this->sut's ->plugin_util with a mocked version that
+		// doesn't scan the disk, but resolves fake paths for our non-existant plugin.php.
+		$plugin_util_mock = $this->getMockBuilder( PluginUtil::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_wp_plugin_id' ) )
+			->getMock();
+
+		$plugin_util_mock->expects( $this->atLeastOnce() )
+			->method( 'get_wp_plugin_id' )
+			->willReturn( 'plugin/plugin.php' ); // All plugins resolve to the same path (we only register 1 anyway).
+
+		// Set private $proxy on the mock via reflection on parent.
+		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
+		// been set, and crash.
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
+
+		// Inject mock into $sut.
+		$sut_reflection = new \ReflectionClass( $this->sut );
+		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
+		$plugin_util_prop->setAccessible( true );
+		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
+
+		// Queue conflicting declarations (same file/path).
+		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', true );
+		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', false );
+
+		$this->simulate_after_woocommerce_init_hook();
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessageMatches( '/trying to declare itself as incompatible.*already declared itself as compatible/' );
+
+		// Query triggers processing and throws on conflict.
+		$this->sut->get_compatible_features_for_plugin( 'plugin/plugin.php' );
+	}
+
+	/**
+	 * @testdox Deactivation clears compatibility info even after lazy processing.
+	 */
+	public function test_deactivation_after_lazy_processing() {
+		$this->simulate_inside_before_woocommerce_init_hook();
+
+		// Goal: Replace $this->sut's ->plugin_util with a mocked version that
+		// doesn't scan the disk, but resolves fake paths for our non-existant plugin.php.
+		// Also replace get_woocommerce_aware_plugins to simulate deactivation.
+		$plugin_util_mock = $this->getMockBuilder( PluginUtil::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_wp_plugin_id', 'get_woocommerce_aware_plugins' ) )
+			->getMock();
+
+		$plugin_util_mock->expects($this->atLeastOnce())
+			->method( 'get_wp_plugin_id' )
+			->willReturn( 'plugin/plugin.php' );
+
+		// Control get_woocommerce_aware_plugins to simulate before/after deactivation.
+		$deactivated = false; // Flag to toggle in callback.
+		$aware_plugins = array( 'plugin/plugin.php', 'other/plugin.php' ); // Controlled list.
+		$plugin_util_mock->method( 'get_woocommerce_aware_plugins' )
+					->will(
+						$this->returnCallback(
+							function ( $active_only ) use ( &$deactivated, $aware_plugins ) {
+									if ( $deactivated && $active_only ) {
+										// After deactivation, exclude from active-only list.
+										return array_filter(
+											$aware_plugins,
+											function($p) {
+												return $p !== 'plugin/plugin.php';
+											}
+										);
+									}
+									// Otherwise, return full list (includes inactive if !active_only).
+									return $aware_plugins;
+							}
+					)
+		);
+
+		// Set private $proxy on mock via parent reflection.
+		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
+		// been set, and crash.
+		$parent_reflection = new \ReflectionClass( PluginUtil::class );
+		$proxy_prop = $parent_reflection->getProperty( 'proxy' );
+		$proxy_prop->setAccessible( true );
+		$proxy_prop->setValue( $plugin_util_mock, wc_get_container()->get( LegacyProxy::class ) );
+
+		// Inject mock into sut.
+		$sut_reflection = new \ReflectionClass( $this->sut );
+		$plugin_util_prop = $sut_reflection->getProperty( 'plugin_util' );
+		$plugin_util_prop->setAccessible( true );
+		$plugin_util_prop->setValue( $this->sut, $plugin_util_mock );
+
+		// Queue declaration.
+		$this->sut->declare_compatibility_by_file( 'mature1', '/path/to/plugin.php', true );
+
+		$this->simulate_after_woocommerce_init_hook();
+
+		// Trigger processing and check before deactivation.
+		$compat_before = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
+		$this->assertContains( 'plugin/plugin.php', $compat_before[ 'compatible' ] );
+		$this->assertNotContains( 'plugin/plugin.php', $compat_before[ 'uncertain' ] );
+
+		// Simulate deactivation: set flag (for mock callback) and trigger action (to unset compatibility).
+		$deactivated = true;
+		do_action( 'deactivated_plugin', 'plugin/plugin.php' );
+
+		// Check after: compatibility unset, so moves to 'uncertain' (still in aware list when ! active_only).
+		$compat_after = $this->sut->get_compatible_plugins_for_feature( 'mature1' );
+		$this->assertNotContains( 'plugin/plugin.php', $compat_after['compatible'] );
+		$this->assertContains( 'plugin/plugin.php', $compat_after['uncertain'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -1151,8 +1151,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 									// After deactivation, exclude from active-only list.
 									return array_filter(
 										$aware_plugins,
-										function( $p ) {
-											return $p !== 'plugin/plugin.php';
+										function ( $p ) {
+											return 'plugin/plugin.php' !== $p;
 										}
 									);
 								}
@@ -1160,7 +1160,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 								return $aware_plugins;
 							}
 						)
-		);
+					);
 
 		// Set private $proxy on mock via parent reflection.
 		// If we don't, the mocked PluginUtil will try to call things using ->proxy, which hasn't
@@ -1188,7 +1188,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		// Simulate deactivation: set flag (for mock callback) and trigger action (to unset compatibility).
 		$deactivated = true;
-		do_action( 'deactivated_plugin', 'plugin/plugin.php' );
+		do_action( 'deactivated_plugin', 'plugin/plugin.php' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		// Check after: compatibility unset, so moves to 'uncertain' (still in aware list when ! active_only).
 		$compat_after = $this->sut->get_compatible_plugins_for_feature( 'mature1' );

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * A collection of tests for the PluginUtil class.
@@ -310,5 +311,72 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		$actual = $this->sut->get_items_considered_incompatible( 'test_feature_3', $plugin_compatibility_info );
 		sort( $actual );
 		$this->assertEquals( $expected, $actual );
+	}
+
+
+	/**
+	 * @testdox Test 'get_wp_plugin_id' is not called during declaration but is called during query in lazy mode.
+	 */
+	public function test_lazy_normalization_during_query() {
+		$this->reset_container_resolutions();
+		$this->reset_legacy_proxy_mocks();
+
+		$get_plugins_call_count = 0;
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_plugins' => function () use ( &$get_plugins_call_count ) {
+					$get_plugins_call_count++;
+					return array(
+						'test-plugin/test-plugin.php' => array( 'Name' => 'Test Plugin' ),
+					);
+				},
+				'plugin_basename' => function ( $file ) {
+					return basename($file);
+				},
+			)
+		);
+
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$features_controller->add_feature_definition( 'test_feature', 'Test Feature' );
+
+		// Simulate declaration (should not call get_plugins yet).
+		$this->simulate_inside_before_woocommerce_init_hook();
+		FeaturesUtil::declare_compatibility( 'test_feature', __DIR__ . '/test-plugin/test-plugin.php', true );
+		$this->simulate_after_woocommerce_init_hook();
+		$this->assertEquals( 0, $get_plugins_call_count, 'get_plugins should not be called during declaration.' );
+
+		// Trigger query (should process pending and call get_plugins once).
+		$features_controller->get_compatible_features_for_plugin( 'test-plugin/test-plugin.php' );
+		$this->assertEquals( 1, $get_plugins_call_count, 'get_plugins should be called once during query.' );
+
+		// Second query should not call again (since we already processed, we don't call get_wp_plugin_id again).
+		$features_controller->get_compatible_features_for_plugin( 'test-plugin/test-plugin.php' );
+		$this->assertEquals( 1, $get_plugins_call_count, 'get_plugins should not be called again on subsequent queries.' );
+	}
+
+	/**
+	 * Simulates that the code is running inside the 'before_woocommerce_init' action.
+	 */
+	private function simulate_inside_before_woocommerce_init_hook() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'doing_action' => function ( $action_name ) {
+					return 'before_woocommerce_init' === $action_name || doing_action( $action_name );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Simulates that the code is running after the 'woocommerce_init' action has been fired.
+	 */
+	private function simulate_after_woocommerce_init_hook() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'did_action' => function ( $action_name ) {
+					return 'woocommerce_init' === $action_name || did_action( $action_name );
+				},
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -324,14 +324,14 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		$get_plugins_call_count = 0;
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_plugins' => function () use ( &$get_plugins_call_count ) {
+				'get_plugins'     => function () use ( &$get_plugins_call_count ) {
 					$get_plugins_call_count++;
 					return array(
 						'test-plugin/test-plugin.php' => array( 'Name' => 'Test Plugin' ),
 					);
 				},
 				'plugin_basename' => function ( $file ) {
-					return basename($file);
+					return basename( $file );
 				},
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -352,6 +352,10 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		// Second query should not call again (since we already processed, we don't call get_wp_plugin_id again).
 		$features_controller->get_compatible_features_for_plugin( 'test-plugin/test-plugin.php' );
 		$this->assertEquals( 1, $get_plugins_call_count, 'get_plugins should not be called again on subsequent queries.' );
+
+		// Test-plugin should be compatible with test_feature.
+		$result = $features_controller->get_compatible_features_for_plugin( 'test-plugin/test-plugin.php' );
+		$this->assertContains( 'test_feature', $result['compatible'] );
 	}
 
 	/**


### PR DESCRIPTION
### Description

WooCommerce addons declare compatibility with features (like `cart_checkout_blocks`) with `FeaturesUtil::declare_compatability` during `before_woocommerce_init`, which is fired on every request, including the frontend. This calls `get_plugins()` to normalize plugin paths, causing unneeded disk IO on front-end requests where the compat information isn't used.


### Changes proposed in this Pull Request:

Make declarations lazy. Raw file paths are queued without normalizing them right away. When compatibility is queried (via either `get_compatible_plugins_for_feature()` or `get_compatible_features_for_plugin()`), only then does normalization happen (which calls `get_plugins()`). Since the queries only happens in admin, the frontend disk scans from `get_plugins()` will be eliminated. 


Closes #41391.

### Explanation of new `$internal_call` Parameter

The `$internal_call` parameter (defaulting to `false`) was added to `FeaturesController::declare_compatibility` to bypass the `doing_action('before_woocommerce_init')` check when the method is called internally during lazy processing of pending declarations. 

Without it, the check would fail because processing happens after `before_woocommerce_init` has completed (when the first query like `get_compatible_plugins_for_feature` is run).

## Testing (Calls to `get_plugins()` removed from front-end)

* Stay on trunk.
* Edit `src/Utilities/PluginUtil.php` and find these lines:

```php
	public function get_wp_plugin_id( $plugin_file ) {
		$wp_plugins = array_keys( $this->proxy->call_function( 'get_plugins' ) );
```

* Add error logging:

```php
$actual_link = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
error_log("Calling get_plugins. [$actual_link]");
```

* Visit the front-end and admin sides of the site.
* Notice that both sides call get_plugins.
* Apply this branch/patch.
* Repeat and notice the calls are gone from the front-end side but remain on the admin side.

_(Note: You may also do the same with `get_plugins()` in wp-admin/includes/plugin.php from WP. I found the same results)._

## Testing (Admin Notices Keep Working)

* Have a Woo site with HPOS on.
* Create the following plugins and activate them:

`wc-hpos-compatible-test.php`
--
```php
<?php
/**
 * Plugin Name: WC – HPOS Compatible Test
 * Description: Declares compatibility with HPOS (custom_order_tables).
 * Version:     0.1.0
 * Author:      Example
 *
 * WC requires at least: 8.0
 * WC tested up to:    10.9
 */

add_action( 'before_woocommerce_init', function () {
	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
			'custom_order_tables',
			__FILE__,
			true // compatible
		);
	}
} );


```


`wc-hpos-incompatible-test.php`
--
```php
<?php
/**
 * Plugin Name: WC – HPOS Incompatible Test
 * Description: Explicitly marks itself as NOT compatible with HPOS.
 * Version:     0.1.0
 * Author:      Example
 *
 * WC requires at least: 8.0
 * WC tested up to:    10.9
 */

add_action( 'before_woocommerce_init', function () {
	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
			'custom_order_tables',
			__FILE__,
			false // incompatible
		);
	}
} );


```

`wc-product-editor-compatible-test.php`
--
```php
<?php
/**
 * Plugin Name: WC – Product Block Editor Compatible Test
 * Description: Declares compatibility with the new block-based product editor.
 * Version:     0.1.0
 * Author:      Example
 *
 * WC requires at least: 8.0
 * WC tested up to:    10.9
 */

add_action( 'before_woocommerce_init', function () {
	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
			'product_block_editor',
			__FILE__,
			true // compatible
		);
	}
} );


```

`wc-cart-checkout-incompatible-test.php`
--
```php
<?php
/**
 * Plugin Name: WC - Cart/Checkout Incompatible
 * Description: Declares incompatibility with WooCommerce Cart/Checkout Blocks for testing.
 * Version:     0.1.0
 * Author:      Example
 *
 * WC requires at least: 8.0
 * WC tested up to:    10.9
 */

add_action( 'before_woocommerce_init', function() {
    if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
			'cart_checkout_blocks',
			__FILE__,
			false
	   	);
    }
} );

```

_Note that 3 of the 4 will be HPOS incompatible. One explicitly declares custom_order_tables=false, and two do not make custom_order_tables declarations._

<img width="985" height="649" alt="Screenshot 2025-07-15 at 1 02 30 PM" src="https://github.com/user-attachments/assets/c0bd343b-ba14-4cd7-a9d5-f9ff2100a743" />


* First, do not use this PR. Use a trunk or release version instead.
* Check the warnings on these pages:
  * `/wp-admin/plugins.php?plugin_status=all&paged=1&s`
    * WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please [review the details](http://localhost:8081/wp-admin/plugins.php?plugin_status=incompatible_with_feature).
  * `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
    * ⚠ Incompatible plugins detected (WC – HPOS Incompatible Test, WC - Cart/Checkout Incompatible and 1 other).
[View and manage](http://localhost:8081/wp-admin/plugins.php?plugin_status=incompatible_with_feature&feature_id=custom_order_tables)
  * `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&feature_id=custom_order_tables`
    * There should be a `Incompatible with 'High-Performance order storage'` section
    * ⚠ This plugin is incompatible with the enabled WooCommerce feature 'High-Performance order storage', it shouldn't be activated. [Manage WooCommerce features](http://localhost:8081/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features)
* Next, switch to this PR. You should see that all the warnings continue to act the same as before.

## Testing (PHPUnit)

If running PHPUnit for the first time, follow setup directions [here](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests)

```
pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env --filter=PluginUtilTests
```
--
```
npm --filter=@woocommerce/plugin-woocommerce test:unit:env --filter=FeaturesControllerTest
```

### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>
