### PR TITLE
Fix Add to Cart + Options not updating Product SKU block after a variation has been selected

### DIFF
--- a/plugins/woocommerce/changelog/fix-59440
+++ b/plugins/woocommerce/changelog/fix-59440
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the issue where blockified Add to Cart + Options doesn't update Product SKU block after a variation has been selected.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/block.json
@@ -35,9 +35,7 @@
 	],
 	"supports": {
 		"html": false,
-		"interactivity": {
-			"clientNavigation": true
-		},
+		"interactivity": true,
 		"color": {
 			"text": true,
 			"background": true

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/frontend.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { getElement, store } from '@wordpress/interactivity';
+import '@woocommerce/stores/woocommerce/product-data';
+import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
+
+// Stores are locked to prevent 3PD usage until the API is stable.
+const universalLock =
+	'I acknowledge that using a private store means my plugin will inevitably break on the next store release.';
+
+const { state: productDataState } = store< ProductDataStore >(
+	'woocommerce/product-data',
+	{},
+	{ lock: universalLock }
+);
+
+const productSkuStore = store(
+	'woocommerce/product-sku',
+	{
+		callbacks: {
+			updateSku: () => {
+				const element = getElement();
+				if ( ! element.ref ) return;
+
+				const skuElement = element.ref.querySelector( '.sku' );
+				if ( ! skuElement ) return;
+
+				const newSku =
+					productDataState?.productData?.sku ??
+					productDataState?.originalProductData?.sku;
+
+				if ( newSku !== null ) {
+					skuElement.textContent = newSku;
+				}
+			},
+		},
+	},
+	{ lock: true }
+);
+
+export type ProductSkuStore = typeof productSkuStore;

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/sku/frontend.ts
@@ -4,6 +4,7 @@
 import { getElement, store } from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/product-data';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
+import { sanitize } from 'dompurify'; // eslint-disable-line import/named
 
 // Stores are locked to prevent 3PD usage until the API is stable.
 const universalLock =
@@ -21,17 +22,17 @@ const productSkuStore = store(
 		callbacks: {
 			updateSku: () => {
 				const element = getElement();
-				if ( ! element.ref ) return;
 
-				const skuElement = element.ref.querySelector( '.sku' );
-				if ( ! skuElement ) return;
+				if ( ! element.ref ) {
+					return;
+				}
 
 				const newSku =
 					productDataState?.productData?.sku ??
 					productDataState?.originalProductData?.sku;
 
 				if ( newSku !== null ) {
-					skuElement.textContent = newSku;
+					element.ref.textContent = sanitize( newSku );
 				}
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/product-data.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/product-data.ts
@@ -5,6 +5,7 @@ import { getContext, store } from '@wordpress/interactivity';
 
 type ProductData = {
 	price_html: string | null;
+	sku: string | null;
 };
 
 export type Context = {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -15,6 +15,7 @@ export type AvailableVariation = {
 	variation_id: number;
 	price_html: string;
 	is_in_stock: boolean;
+	sku: string;
 };
 
 export type Context = {
@@ -426,8 +427,13 @@ const addToCartWithOptionsStore = store(
 						'price_html',
 						matchedVariation.price_html
 					);
+					actions.setProductData(
+						'sku',
+						matchedVariation.sku || null
+					);
 				} else {
 					actions.setProductData( 'price_html', null );
+					actions.setProductData( 'sku', null );
 				}
 			},
 		},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -218,6 +218,7 @@ class AddToCartWithOptions extends AbstractBlock {
 							'attributes'   => $variation['attributes'],
 							'price_html'   => $variation['price_html'],
 							'is_in_stock'  => $variation['is_in_stock'],
+							'sku'          => $variation['sku'],
 						);
 					},
 					$available_variations

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -79,15 +79,28 @@ class ProductSKU extends AbstractBlock {
 			$suffix = sprintf( '<span class="wp-block-post-terms__suffix">%s</span>', $suffix );
 		}
 
+		// Add interactive attributes for variable products.
+		$wrapper_attributes = array();
+		$watch_attribute = '';
+		
+		if ( $product->is_type( 'variable' ) ) {
+			wp_enqueue_script_module( 'woocommerce/product-sku' );
+			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-sku';
+			$watch_attribute = 'data-wp-watch="callbacks.updateSku"';
+		}
+
 		return sprintf(
-			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta wp-block-post-terms %1$s" style="%2$s">
-				%3$s
-				<span class="sku">%4$s</span>
+			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta wp-block-post-terms %1$s" style="%2$s" %3$s %4$s>
 				%5$s
+				<span class="sku" %6$s>%7$s</span>
+				%8$s
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			$watch_attribute,
 			$prefix,
+			$watch_attribute,
 			$product_sku,
 			$suffix
 		);

--- a/plugins/woocommerce/src/Blocks/Utils/ProductDataUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductDataUtils.php
@@ -17,6 +17,7 @@ class ProductDataUtils {
 	public static function get_product_data( \WC_Product $product ) {
 		return array(
 			'price_html' => $product->get_price_html(),
+			'sku'        => $product->get_sku(),
 		);
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds dynamic SKU value updates for Variable Products after a variation has been selected for Add to Cart + Options (blockified version). This is done by using the Context (Data Store), interactivity API and additional frontend code for Product SKU block similar to [`price_html`](https://github.com/woocommerce/woocommerce/pull/58384)

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/473b5733-5920-4ea8-b3ba-99049b29296b

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Appearance > Editor > Templates > Single Product.
2. Click on the Add to Cart with Options block and update to the blockified version.
3. Go to the page of a variable product in the frontend.
4. Select a variation.
5. Notice the Product SKU block updates as a variation is selected.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
