### PR TITLE
Make `version` mandatory to run the `release-commits-and-contributors.yml` workflow

### DIFF
--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Check for database updates
         id: check-db-updates
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -364,6 +364,7 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
+          slack-optional-unfurl_links: false
           slack-text: |
             :woo: *WooCommerce ${{ needs.extract-versions.outputs.current_version }} Release Summary*
 

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -76,31 +76,6 @@ jobs:
             core.setOutput('major', major);
             core.setOutput('minor', minor);
 
-      - name: Extract version from the branch name
-        id: version-from-branch
-        if: ${{ github.event.inputs.version == '' && github.event_name != 'release' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          script: |
-            const branchName = '${{ github.ref_name }}';
-            console.log(`Branch name: ${branchName}`);
-
-            const branchMatch = branchName.match(/^release\/(\d+)\.(\d+)$/);
-            if (!branchMatch) {
-              core.setFailed(`Branch name must be in format 'release/x.y', got: ${branchName}`);
-              process.exit(1);
-            }
-
-            const major = parseInt(branchMatch[1]);
-            const minor = parseInt(branchMatch[2]);
-            const currentVersion = `${major}.${minor}`;
-
-            console.log(`Extracted current version: ${currentVersion}`);
-            console.log(`Parsed version: major=${major}, minor=${minor}`);
-
-            core.setOutput('major', major);
-            core.setOutput('minor', minor);
-
       - name: Calculate current and previous version
         id: calculate-versions
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -4,8 +4,8 @@ on:
     inputs:
       version:
         type: string
-        required: false
-        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
+        required: true
+        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors.'
 
   release:
     types: [prereleased]
@@ -56,7 +56,7 @@ jobs:
 
       - name: Extract version from the provided input version
         id: version-from-input
-        if: ${{ github.event.inputs.version != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
@@ -113,16 +113,11 @@ jobs:
               major = parseInt('${{ steps.version-from-prerelease.outputs.major }}');
               minor = parseInt('${{ steps.version-from-prerelease.outputs.minor }}');
               console.log(`Using version from RC pre-release: ${major}.${minor}`);
-            } else if ('${{ github.event.inputs.version }}' !== '') {
+            } else {
               // Manual trigger with input version
               major = parseInt('${{ steps.version-from-input.outputs.major }}');
               minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
               console.log(`Using version from input: ${major}.${minor}`);
-            } else {
-              // Manual trigger from branch name
-              major = parseInt('${{ steps.version-from-branch.outputs.major }}');
-              minor = parseInt('${{ steps.version-from-branch.outputs.minor }}');
-              console.log(`Using version from branch: ${major}.${minor}`);
             }
 
             let previousVersion;
@@ -251,7 +246,7 @@ jobs:
 
       - name: Check for database updates
         id: check-db-updates
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR is the first step for fixing https://github.com/woocommerce/woocommerce/issues/59533
It includes making the input version field mandatory and stop relying on the branch the workflow is running on (eventually it will always use `trunk`).
It also contains a small change in the Slack notification to avoid unfurling links.

Part of #59533 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


⚠️ If you want to test on your own Slack workspace, follow the instructions from the Steps to set up a Slack app from https://github.com/woocommerce/woocommerce/pull/58417, otherwise follow these 👇

1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
3. In the forked repo, create a PR with the branch `59533/make-input-version-mandatory` and merge it (to get this new workflow into `trunk`).
4. Now go to `Actions`, click on the ` Release: Generate Number of Commits and Contributors`, try to run the workflow with an empty `version` input, and make sure you are not able to run it.
5. Now write a version in the input and run it.
6. Check the flow finishes without error, and that you receive a Slack message similar to the following:
<img width="474" alt="Screenshot 2025-06-12 at 12 47 07" src="https://github.com/user-attachments/assets/91300f65-8a4c-496b-9e6f-0f0813772bc6" />

<!-- End testing instructions -->

### Testing that has already taken place:

It was tested successfully on this fork https://github.com/albarin/woocommerce/actions/runs/16289411482
<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
