### PR TITLE
Add to Cart + Options: Display error message when adding 0 items to cart in the grouped product form

### DIFF
--- a/plugins/woocommerce/changelog/fix-59267-add-to-cart-with-options-grouped-products
+++ b/plugins/woocommerce/changelog/fix-59267-add-to-cart-with-options-grouped-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: Display error message when adding 0 items to cart in the grouped product form

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -224,7 +224,14 @@ const productButtonStore = {
 		},
 		handlePressedState() {
 			const context = getContext< Context >();
-			context.hasPressedButton = true;
+
+			// Only handle the pressed state if the form is valid.
+			if (
+				addToCartWithOptionsState?.isFormValid === undefined ||
+				addToCartWithOptionsState?.isFormValid
+			) {
+				context.hasPressedButton = true;
+			}
 		},
 	},
 	callbacks: {
@@ -245,8 +252,7 @@ const productButtonStore = {
 			// We start the animation if the temporary quantity is out of
 			// sync with the quantity in the cart and the animation hasn't
 			// started yet.
-			// We skip the animation altogether if the single product page Add to Cart + Options form is invalid.
-
+			// We skip the animation altogether if the Add to Cart + Options form is invalid.
 			if (
 				context.tempQuantity !== state.quantity &&
 				context.animationStatus === AnimationStatus.IDLE &&

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -33,6 +33,9 @@ export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
 
 export type Store = {
 	state: {
+		errorMessages?: {
+			[ key: string ]: string;
+		};
 		restUrl: string;
 		nonce: string;
 		cart: Omit< Cart, 'items' > & {
@@ -89,19 +92,6 @@ function emitSyncEvent( {
 			},
 		} )
 	);
-}
-
-function getUserFriendlyErrorMessage(
-	error: Error | ApiErrorResponse
-): string {
-	const code = ( error as ApiErrorResponse )?.code;
-
-	switch ( code ) {
-		case 'woocommerce_rest_missing_attributes':
-			return 'Please select product attributes before adding to cart.';
-		default:
-			return error.message;
-	}
 }
 
 // Todo: export this store once the store is public.
@@ -388,9 +378,14 @@ const { state, actions } = store< Store >(
 					}
 				);
 
+				const { code, message } = error as ApiErrorResponse;
+
+				const userFriendlyMessage =
+					state.errorMessages?.[ code ] || message;
+
 				// Todo: Check what should happen if the notice is already displayed.
 				noticeActions.addNotice( {
-					notice: getUserFriendlyErrorMessage( error ),
+					notice: userFriendlyMessage,
 					type: 'error',
 					dismissible: true,
 				} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -70,7 +70,7 @@
 
 // `cursor` needs to override some styles from WordPress core, that's why we
 // need extra specificity.
-:where(.wc-block-add-to-cart-with-options.is-invalid) .wp-block-woocommerce-product-button .add_to_cart_button {
+:where(.wc-block-add-to-cart-with-options.is-invalid) .wp-block-woocommerce-product-button .wc-block-components-product-button__button {
 	cursor: not-allowed;
 	opacity: 0.5;
 }

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -186,19 +186,31 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.goto( '/logo-collection' );
 
-		const increaseQuantityButton = page.getByLabel(
-			'Increase quantity of Beanie'
-		);
-		await increaseQuantityButton.click();
-		await increaseQuantityButton.click();
-
 		const addToCartButton = page.getByText( 'Add to cart' ).first();
 
-		await addToCartButton.click();
+		await test.step( 'displays an error when attempting to add grouped products with zero quantity', async () => {
+			await addToCartButton.click();
 
-		await expect( page.getByText( 'Added to cart' ) ).toBeVisible();
+			await expect(
+				page.getByText(
+					'Please select some products to add to the cart.'
+				)
+			).toBeVisible();
+		} );
 
-		await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
+		await test.step( 'successfully adds to cart when child products are selected', async () => {
+			const increaseQuantityButton = page.getByLabel(
+				'Increase quantity of Beanie'
+			);
+			await increaseQuantityButton.click();
+			await increaseQuantityButton.click();
+
+			await addToCartButton.click();
+
+			await expect( page.getByText( 'Added to cart' ) ).toBeVisible();
+
+			await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
+		} );
 	} );
 
 	test( "doesn't allow selecting invalid variations in pills mode", async ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -202,6 +202,24 @@ class AddToCartWithOptions extends AbstractBlock {
 				)
 			);
 
+			wp_interactivity_state(
+				'woocommerce',
+				array(
+					// Use camelCase for error messages generated from the frontend,
+					// and snake_case for error messages generated from the backend.
+					'errorMessages' => array(
+						'groupedProductAddToCartMissingItems' => __(
+							'Please select some products to add to the cart.',
+							'woocommerce'
+						),
+						'woocommerce_rest_missing_attributes' => __(
+							'Please select product attributes before adding to cart.',
+							'woocommerce'
+						),
+					),
+				)
+			);
+
 			$context = array(
 				'productId'   => $product->get_id(),
 				'productType' => $product->get_type(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59267.

This PR makes some changes to the grouped product form so:

1. The Add to Cart button looks disabled when no products have a quantity of >0.
2. The text of the button doesn't change to _Added to cart_ when trying to add 0 items.
3. An error is displayed when trying to add 0 items to cart.

**Before:**

https://github.com/user-attachments/assets/21eb36d1-f013-4db3-a5a8-8e9cdc3ab0c3

**After:**

https://github.com/user-attachments/assets/225ca7dc-586d-438f-b8a4-65b6be698930

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Go to the frontend of a grouped product.
5. Verify by default the _Add to cart_ button looks disabled.
6. Click on it and verify the text doesn't change to _Added to cart_ and an error is displayed.
7. Now, increase the quantity of a child product and verify you can add to cart normally.