### PR TITLE
Add to Cart + Options: avoid JS error when removing items from the Mini-Cart block due to missing context

### DIFF
--- a/plugins/woocommerce/changelog/fix-59664-invalid-context-add-to-cart-with-options
+++ b/plugins/woocommerce/changelog/fix-59664-invalid-context-add-to-cart-with-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add to Cart + Options: avoid JS error when removing items from the Mini-Cart block due to missing context
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -148,8 +148,12 @@ const addToCartWithOptionsStore = store(
 	{
 		state: {
 			get isFormValid(): boolean {
+				const context = getContext< Context >();
+				if ( ! context ) {
+					return true;
+				}
 				const { availableVariations, selectedAttributes, productType } =
-					getContext< Context >();
+					context;
 				if ( productType !== 'variable' ) {
 					return true;
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59664.

This PR checks that _Add to Cart + Options_ store `context` exists before destructuring it, to prevent JS errors when removing items from the _Mini-Cart_ block.

### How to test the changes in this Pull Request:

(I wasn't able to consistently reproduce the issue, so the steps below in `trunk` might not always cause the JS error)

1. Add Product A to your cart.
2. Now, go to a page where Product B is rendered with the *Add to Cart + Options* block. Using the *Mini-Cart*, try to remove the Product A from your cart.
3. Verify there is no JS error in the console.