### PR TITLE
Add workflow to bump Action Scheduler version requirement

### DIFF
--- a/.github/workflows/maintenance-bump-as-requirement.yml
+++ b/.github/workflows/maintenance-bump-as-requirement.yml
@@ -61,18 +61,17 @@ jobs:
 
         composer update woocommerce/action-scheduler --no-scripts
 
-        branch_name="update-action-scheduler-${{ steps.get-as-version.outputs.version }}"
+        branch_name="update/action-scheduler-${{ steps.get-as-version.outputs.version }}"
         git checkout -b ${branch_name}
 
         composer exec -- changelogger add \
           --significance minor \
           --type update \
           --entry "Update the Action Scheduler package to version ${{ steps.get-as-version.outputs.version }}." \
-          --filename ${branch_name} \
           --no-interaction
 
         # Push changes.
-        git add composer.lock composer.json changelog/${branch_name}
+        git add composer.lock composer.json changelog/
         git commit \
           --message "Update Action Scheduler to '${{ steps.get-as-version.outputs.version }}'."
         git push origin ${branch_name}

--- a/.github/workflows/release-bump-as-requirement.yml
+++ b/.github/workflows/release-bump-as-requirement.yml
@@ -1,0 +1,86 @@
+name: 'Maintenance: Bump Action Scheduler version'
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Action Scheduler version (defaults to latest in repository)'
+        required: false
+        default: ''
+
+jobs:
+  bump-version:
+    name: Bump Action Scheduler version
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch Action Scheduler version
+      id: get-as-version
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        if [ -z "$INPUT_VERSION" ]; then
+          VERSION=$(gh release view --repo "woocommerce/action-scheduler" --json tagName -q .tagName)
+        else
+          if gh release view "$INPUT_VERSION" --repo "woocommerce/action-scheduler" > /dev/null 2>&1; then
+            VERSION="$INPUT_VERSION"
+          else
+            echo "::error::Action Scheduler version '$INPUT_VERSION' is not valid."
+            exit 1
+          fi
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Check out trunk
+      uses: actions/checkout@v4
+      with:
+        ref: trunk
+    - name: Set up dev environment
+      run: |
+        cd plugins/woocommerce
+
+        # Install dev packages. Required for changelogger use.
+        composer install --quiet
+
+        # Configure Git.
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - name: Bump Action Scheduler requirement
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd plugins/woocommerce
+
+        # Update A-S version.
+        jq --tab -r ".require[\"woocommerce/action-scheduler\"] |= \"${{ steps.get-as-version.outputs.version }}\"" composer.json > composer.json.new
+        mv composer.json.new composer.json
+
+        if git diff --quiet; then
+          echo "::error::No changes to commit."
+          exit 1
+        fi
+
+        composer update woocommerce/action-scheduler --no-scripts
+
+        branch_name="update-action-scheduler-${{ steps.get-as-version.outputs.version }}"
+        git checkout -b ${branch_name}
+
+        composer exec -- changelogger add \
+          --significance minor \
+          --type update \
+          --entry "Update the Action Scheduler package to version ${{ steps.get-as-version.outputs.version }}." \
+          --filename ${branch_name} \
+          --no-interaction
+
+        # Push changes.
+        git add composer.lock composer.json changelog/${branch_name}
+        git commit \
+          --message "Update Action Scheduler to '${{ steps.get-as-version.outputs.version }}'."
+        git push origin ${branch_name}
+
+        # Open PR.
+        gh pr create \
+          --title 'Bump Action Scheduler version to ${{ steps.get-as-version.outputs.version }}' \
+          --body 'This PR updates the Action Scheduler package requirement for WooCommerce core.' \
+          --base trunk \
+          --head ${branch_name} \
+          --reviewer "${{ github.actor }}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR adds workflow `Release: Bump Action Scheduler version` which can be used to bump the Action Scheduler requirement in core. For example, after any Action Scheduler release.

<img width="359" height="229" alt="Screenshot 2025-07-15 at 13 21 25" src="https://github.com/user-attachments/assets/190cadb0-8708-40a7-a901-cbcbd2fb402c" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fork of this repository with `release/10.0` as `trunk`.
1. Ensure this branch (`bump-action-scheduler-workflow`) is merged to `trunk`.
1. Go to **Actions > Release: Bump Action Scheduler version** and run the workflow using `3.9.4` as version. The workflow should fail as this version doesn't exist.
1. Run the workflow again, using `3.9.3` as version. The workflow should succeed and create a PR bumping A-S package version. **Do not merge** this PR: close it and delete the branch that was created.
1. Run the workflow again, this time specifying no version. The workflow should succeed and create a PR bumping A-S to `3.9.3` (the latest version from the A-S repository).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
