### PR TITLE
Create proxy release workflow and adapt `release-commits-and-contributors.yml` to run only on dispatch

### DIFF
--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Check for database updates
         id: check-db-updates
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -6,6 +6,12 @@ on:
         type: string
         required: true
         description: 'The release version (in X.Y or X.Y.Z-rc.N formats) to generate the release summary for.'
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: 'The release version (in X.Y or X.Y.Z-rc.N formats) to generate the release summary for.'
 
 jobs:
   extract-versions:
@@ -17,7 +23,7 @@ jobs:
     steps:
       - name: Ensure running from trunk branch
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
+          if [ "${{ github.ref }}" != "refs/heads/trunk" ] && [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "::error::This workflow should only run from trunk branch, currently running from ${{ github.ref }}."
             exit 1
           fi

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -364,6 +364,7 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL }}
+          slack-optional-unfurl_links: false
           slack-text: |
             :woo: *WooCommerce ${{ needs.extract-versions.outputs.current_version }} Release Summary*
 

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -76,31 +76,6 @@ jobs:
             core.setOutput('major', major);
             core.setOutput('minor', minor);
 
-      - name: Extract version from the branch name
-        id: version-from-branch
-        if: ${{ github.event.inputs.version == '' && github.event_name != 'release' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          script: |
-            const branchName = '${{ github.ref_name }}';
-            console.log(`Branch name: ${branchName}`);
-
-            const branchMatch = branchName.match(/^release\/(\d+)\.(\d+)$/);
-            if (!branchMatch) {
-              core.setFailed(`Branch name must be in format 'release/x.y', got: ${branchName}`);
-              process.exit(1);
-            }
-
-            const major = parseInt(branchMatch[1]);
-            const minor = parseInt(branchMatch[2]);
-            const currentVersion = `${major}.${minor}`;
-
-            console.log(`Extracted current version: ${currentVersion}`);
-            console.log(`Parsed version: major=${major}, minor=${minor}`);
-
-            core.setOutput('major', major);
-            core.setOutput('minor', minor);
-
       - name: Calculate current and previous version
         id: calculate-versions
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -4,8 +4,8 @@ on:
     inputs:
       version:
         type: string
-        required: false
-        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors. If not provided, it will be derived from the branch name.'
+        required: true
+        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors.'
 
   release:
     types: [prereleased]
@@ -56,7 +56,7 @@ jobs:
 
       - name: Extract version from the provided input version
         id: version-from-input
-        if: ${{ github.event.inputs.version != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
@@ -113,16 +113,11 @@ jobs:
               major = parseInt('${{ steps.version-from-prerelease.outputs.major }}');
               minor = parseInt('${{ steps.version-from-prerelease.outputs.minor }}');
               console.log(`Using version from RC pre-release: ${major}.${minor}`);
-            } else if ('${{ github.event.inputs.version }}' !== '') {
+            } else {
               // Manual trigger with input version
               major = parseInt('${{ steps.version-from-input.outputs.major }}');
               minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
               console.log(`Using version from input: ${major}.${minor}`);
-            } else {
-              // Manual trigger from branch name
-              major = parseInt('${{ steps.version-from-branch.outputs.major }}');
-              minor = parseInt('${{ steps.version-from-branch.outputs.minor }}');
-              console.log(`Using version from branch: ${major}.${minor}`);
             }
 
             let previousVersion;
@@ -251,7 +246,7 @@ jobs:
 
       - name: Check for database updates
         id: check-db-updates
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -5,10 +5,7 @@ on:
       version:
         type: string
         required: true
-        description: 'The release version (X.Y format) to be used to calculate the number of commits and contributors.'
-
-  release:
-    types: [prereleased]
+        description: 'The release version (in X.Y or X.Y.Z-rc.N formats) to generate the release summary for.'
 
 jobs:
   extract-versions:
@@ -18,82 +15,45 @@ jobs:
       current_version: ${{ steps.calculate-versions.outputs.current_version }}
       previous_version: ${{ steps.calculate-versions.outputs.previous_version }}
     steps:
-      - name: Check pre-release and extract RC version
-        id: version-from-prerelease
-        if: ${{ github.event_name == 'release' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          script: |
-            const tagName = '${{ github.event.release.tag_name }}';
-            const isPrerelease = ${{ github.event.release.prerelease }};
-
-            console.log(`Release tag: ${tagName}, prerelease: ${isPrerelease}`);
-
-            if (!isPrerelease) {
-              core.setFailed(`This workflow only runs for pre-releases`);
-              process.exit(1);
-            }
-
-            // Check if it's an RC format: x.y.z-rc.N
-            const rcPattern = /^v?(\d+)\.(\d+)\.(\d+)-rc\.(\d+)$/;
-            const rcMatch = tagName.match(rcPattern);
-
-            if (!rcMatch) {
-              console.log(`⛔ Not an RC pre-release format: ${tagName}`);
-              console.log(`Expected format: x.y.z-rc.N (e.g., 9.8.0-rc.1)`);
-              core.setFailed(`This workflow only runs for RC pre-releases with format x.y.z-rc.N`);
-              process.exit(1);
-            }
-
-            const major = parseInt(rcMatch[1]);
-            const minor = parseInt(rcMatch[2]);
-
-            console.log(`✅ Valid RC pre-release: ${tagName}`);
-            console.log(`Extracted version: major=${major}, minor=${minor}`);
-
-            core.setOutput('major', major);
-            core.setOutput('minor', minor);
+      - name: Ensure running from trunk branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
+            echo "::error::This workflow should only run from trunk branch, currently running from ${{ github.ref }}."
+            exit 1
+          fi
 
       - name: Extract version from the provided input version
         id: version-from-input
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
-            const currentVersion = '${{ github.event.inputs.version }}';
+            const currentVersion = '${{ inputs.version }}';
             console.log(`Current version from input: ${currentVersion}`);
 
-            const versionMatch = currentVersion.match(/^(\d+)\.(\d+)$/);
+            const versionMatch = currentVersion.match(/^(\d+)\.(\d+)(?:\.\d+)?(?:-(rc)\.(\d+))?$/);
             if (!versionMatch) {
-              core.setFailed(`Version format must be 'x.y', got: ${currentVersion}`);
+              core.setFailed(`Version format must be 'x.y' or 'x.y.z-rc.N'. Provided: ${currentVersion}`);
               process.exit(1);
             }
 
             const major = parseInt(versionMatch[1]);
             const minor = parseInt(versionMatch[2]);
-            console.log(`Parsed version: major=${major}, minor=${minor}`);
+            const prereleaseType = versionMatch[3] || '';
+            const prereleaseVersion = versionMatch[4] || '';
+
+            console.log(`Parsed version: major=${major}, minor=${minor}, prerelease_type=${prereleaseType}, prerelease_version=${prereleaseVersion}`);
 
             core.setOutput('major', major);
             core.setOutput('minor', minor);
+            core.setOutput('is_prerelease', prereleaseType !== '');
 
       - name: Calculate current and previous version
         id: calculate-versions
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
-            let major, minor;
-
-            if ('${{ github.event_name }}' === 'release') {
-              // Pre-release trigger - use RC tag version
-              major = parseInt('${{ steps.version-from-prerelease.outputs.major }}');
-              minor = parseInt('${{ steps.version-from-prerelease.outputs.minor }}');
-              console.log(`Using version from RC pre-release: ${major}.${minor}`);
-            } else {
-              // Manual trigger with input version
-              major = parseInt('${{ steps.version-from-input.outputs.major }}');
-              minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
-              console.log(`Using version from input: ${major}.${minor}`);
-            }
+            const major = parseInt('${{ steps.version-from-input.outputs.major }}');
+            const minor = parseInt('${{ steps.version-from-input.outputs.minor }}');
 
             let previousVersion;
             if (minor > 0) {

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Extract version from the provided input version
         id: version-from-input
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -1,0 +1,34 @@
+name: 'Release: Release events proxy workflow'
+description: 'Proxy workflow to dispatch workflows from trunk branch for release events (published and pre-release).'
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  dispatch-to-trunk:
+    name: 'Dispatch to trunk workflow'
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    steps:
+      - name: 'Trigger pre-release workflow from trunk'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'release-commits-and-contributors.yml',
+                ref: 'trunk',
+                inputs: {
+                  version: '${{ github.event.release.tag_name }}',
+                }
+              });
+
+              console.log('✅ Workflow dispatched successfully for release version:', '${{ github.event.release.tag_name }}');
+
+            } catch (error) {
+              console.error('❌ Failed to dispatch workflow:', error);
+              throw error;
+            }

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -1,5 +1,4 @@
 name: 'Release: Release events proxy workflow'
-description: 'Proxy workflow to dispatch workflows from trunk branch for release events (published and pre-release).'
 on:
   release:
     types: [prereleased]

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -5,30 +5,10 @@ on:
     types: [prereleased]
 
 jobs:
-  dispatch-to-trunk:
-    name: 'Dispatch to trunk workflow'
-    runs-on: ubuntu-latest
+  call-release-workflow:
+    name: 'Call release commits and contributors workflow'
     if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
-    steps:
-      - name: 'Trigger pre-release workflow from trunk'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'release-commits-and-contributors.yml',
-                ref: 'trunk',
-                inputs: {
-                  version: '${{ github.event.release.tag_name }}',
-                }
-              });
-
-              console.log('✅ Workflow dispatched successfully for release version:', '${{ github.event.release.tag_name }}');
-
-            } catch (error) {
-              console.error('❌ Failed to dispatch workflow:', error);
-              throw error;
-            }
+    uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

#### Problem
Previously, workflows triggered by release events (like release or prereleased) would run using the workflow code from the tagged commit. This meant that if a release branch was created weeks ago, any improvements made to the workflow files since then would not be applied during the release process.

#### Solution
This can be fixed by having a "proxy" workflow that runs on the `prereleased` and calls a dispatchable workflow pinned at trunk. This PR implements this with two workflows:
- Proxy Workflow (`release-release-events-proxy.yml`) - Triggers on pre-release events and dispatches to the main workflow in `trunk`.
- Main Workflow (`release-commits-and-contributors.yml`) - Contains the actual logic and always runs from `trunk`. Changes to this workflow are: added a step to ensure it's running from `trunk`, removed steps related to extracting version from pre-release events, unifying logic to always get versions from input.

Related to https://github.com/woocommerce/woocommerce/pull/59660

Part of https://github.com/woocommerce/woocommerce/issues/59533

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Preparation**
1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
3. In the forked repo, create a PR with the branch `59433/add-proxy-flow` and merge it (to get this new workflow into `trunk`). 
4. 🚨Important: in your fork replace `woocommerce/woocommerce` with you fork name: `YOUR_REPO/woocommerce` in https://github.com/woocommerce/woocommerce/pull/59676/files#diff-3c8529cff79ec0ff84a98e76e3342aea9f65b8e7c309ae16b04008f6e6169ef2R11

**Test 1: Run with branch not trunk** ❌
1. Create a new branch with a random name.
2. Now go to `Actions`, click on the ` Release: Generate Number of Commits and Contributors`, and manually run the workflow from the branch from step 2 (write anything in the `version` input).
3. Make sure the workflow fails with error: `This workflow should only run from trunk branch, currently running from...`.

**Test 2: Run with wrong version format** ❌
1. Manually run the workflow again with a wrong version format and from `trunk`.
2. Make sure the workflow fails with error: `Error: Version format must be 'x.y' or 'x.y.z-rc.N'. Provided: ...`.

**Test 3: Run with pre-release version with wrong format** ❌
1. Go to `Releases`, click on `Draft a new release`, create a new release with a wrong version format tag (like `foobar`) and save it as `pre-release`.
2. Make sure this triggers the `Release: Release events proxy workflow` and finishes successfully.
3. That should trigger the `Release: Generate Number of Commits and Contributors`.
5. Make sure the workflow fails with error: `Error: Version format must be 'x.y' or 'x.y.z-rc.N'. Provided: ...`.

**Test 3: Run with pre-release version with correct format** ✅
1. Go to `Releases`, click on `Draft a new release`, create a new release with a correct version format tag (like `9.9-rc.1` and branch `release/9.9`), and save it as `pre-release`.
2. Make sure this triggers the `Release: Release events proxy workflow` and the `Release: Generate Number of Commits and Contributors` inside.
2. Make sure the job `Extract release current and previous versions` finishes successfully, and the next parallel 3 steps start running (there's no need to wait for the whole workflow to finish, there were no changes after the first job).

**Test 5: Run with correct version from `trunk`** ✅
1. Manually run the workflow again with a correct version format and from `trunk` (like `9.9`).
2. Make sure the job `Extract release current and previous versions` finishes successfully, and the next parallel 3 steps start running (there's no need to wait for the whole workflow to finish, there were no changes after the first job).

**Test 6: Run with correct pre-release version from `trunk`** ✅
1. Manually run the workflow again with a correct pre-release version format and from `trunk` (like `9.9.0-rc.1`).
2. Make sure the job `Extract release current and previous versions` finishes successfully, and the next parallel 3 steps start running (there's no need to wait for the whole workflow to finish, there were no changes after the first job).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
