### PR TITLE
Email Editor: Implement Styles_Helper inline styles helper methods

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-4688-add-style-factory-methods-for-emails
+++ b/packages/php/email-editor/changelog/wooplug-4688-add-style-factory-methods-for-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `Styles_Helper` methods to generate inline styles from block attributes, and refactor blocks to utilize them.

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -404,7 +404,14 @@ public static function parse_styles_to_array( string $styles ): array
 ```php
 $styles = 'margin: 10px; padding: 5px; color: red;';
 $parsed = Styles_Helper::parse_styles_to_array( $styles );
-// Returns: array( 'margin' => '10px', 'padding' => '5px', 'color' => 'red' )
+/*
+Example return value:
+array(
+    'margin' => '10px',
+    'padding' => '5px',
+    'color'   => 'red',
+)
+*/
 ```
 
 #### `get_normalized_block_styles()`
@@ -432,7 +439,18 @@ $block_attributes = array(
 );
 
 $normalized = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
-```
+/*
+Example return value:
+array(
+    'spacing' => array(
+        'padding' => '10px',
+    ),
+    'color' => array(
+        'background' => '#ff0000', // assuming 'primary' translates to '#ff0000'
+        'text'       => '#00ff00', // assuming 'secondary' translates to '#00ff00'
+    ),
+)
+*/
 
 #### `get_styles_from_block()`
 
@@ -453,7 +471,17 @@ public static function get_styles_from_block( array $block_styles, $skip_convert
 
 ```php
 $result = Styles_Helper::get_styles_from_block( $block_styles );
-// Returns: array( 'css' => '...', 'declarations' => array(), 'classnames' => '' )
+/*
+Example return value:
+array(
+    'css' => 'padding: 10px; color: red;',
+    'declarations' => array(
+        'padding' => '10px',
+        'color'   => 'red',
+    ),
+    'classnames' => 'has-padding has-color-red',
+)
+*/
 ```
 
 #### `extend_block_styles()`
@@ -478,6 +506,19 @@ $extended = Styles_Helper::extend_block_styles( $block_styles, array(
     'margin' => '20px',
     'color' => 'red'
 ) );
+
+/*
+Example return value:
+array(
+    'declarations' => array(
+        'padding' => '10px',
+        'margin'  => '20px',
+        'color'   => 'red',
+    ),
+    'css' => 'padding: 10px; margin: 20px; color: red;',
+    'classnames' => 'test-class',
+)
+*/
 ```
 
 #### `get_block_styles()`
@@ -491,10 +532,9 @@ Comprehensive method to get processed block styles with filtering and return typ
  * @param array             $block_attributes Block attributes.
  * @param Rendering_Context $rendering_context Rendering context.
  * @param array             $properties Properties to include.
- * @param string            $return_type Return type. Can be 'full' (default, includes all three), 'css', 'declarations', or 'classnames'.
  * @return array
  */
-public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties, string $return_type = 'full' )
+public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties )
 ```
 
 **Supported Properties:**
@@ -502,13 +542,24 @@ public static function get_block_styles( array $block_attributes, Rendering_Cont
 -   `spacing`, `padding`, `margin`
 -   `border`, `border-width`, `border-style`, `border-radius`, `border-color`
 -   `background`, `background-color`, `color`
--   `typography`, `font-size`, `font-family`, `font-weight`
+-   `typography`, `font-size`, `font-family`, `font-weight`, `text-align`
 
 **Example Usage:**
 
 ```php
 $styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'color' ) );
-$css_only = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'css' );
+
+/*
+Example return value:
+array(
+    'declarations' => array(
+        'padding' => '10px',
+        'color'   => '#ff0000',
+    ),
+    'css' => 'padding: 10px; color: #ff0000;',
+    'classnames' => 'has-text-color',
+)
+*/
 ```
 
 ## Integration Example

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -13,6 +13,7 @@ The email rendering system includes **Core Blocks Integration** that provides de
     -   [Content_Renderer](#content_renderer)
 -   [Core Blocks Integration](#core-blocks-integration)
 -   [Table Wrapper Helper](#table-wrapper-helper)
+-   [Styles Helper](#styles-helper)
 -   [Integration Example](#integration-example)
 
 ## Retrieving Services via DI Container
@@ -352,6 +353,161 @@ $outlook_cell = Table_Wrapper_Helper::render_outlook_table_cell(
 <!--[if mso | IE]><td align="center"><![endif]-->
 <p>Outlook-specific content</p>
 <!--[if mso | IE]></td><![endif]-->
+```
+
+## Styles Helper
+
+The `Styles_Helper` class provides utility methods for generating email-compatible inline styles from WordPress block attributes.
+
+### Available Methods
+
+#### `parse_value()`
+
+Parse numeric values from CSS strings with units.
+
+```php
+/**
+ * Parse number value from a string.
+ *
+ * @param string $value String value with value and unit.
+ * @return float
+ */
+public static function parse_value( string $value ): float
+```
+
+**Example Usage:**
+
+```php
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
+
+$width = Styles_Helper::parse_value( '12.5px' );  // Returns 12.5
+$height = Styles_Helper::parse_value( '100%' );   // Returns 100.0
+$invalid = Styles_Helper::parse_value( 'invalid' ); // Returns 0.0
+```
+
+#### `parse_styles_to_array()`
+
+Convert CSS style string to associative array.
+
+```php
+/**
+ * Parse styles string to array.
+ *
+ * @param string $styles Styles string.
+ * @return array
+ */
+public static function parse_styles_to_array( string $styles ): array
+```
+
+**Example Usage:**
+
+```php
+$styles = 'margin: 10px; padding: 5px; color: red;';
+$parsed = Styles_Helper::parse_styles_to_array( $styles );
+// Returns: array( 'margin' => '10px', 'padding' => '5px', 'color' => 'red' )
+```
+
+#### `get_normalized_block_styles()`
+
+Normalize block attributes by translating color slugs to actual color values.
+
+```php
+/**
+ * Get normalized block styles by translating color slugs to actual color values.
+ *
+ * @param array             $block_attributes Block attributes containing color slugs.
+ * @param Rendering_Context $rendering_context Rendering context for color translation.
+ * @return array Normalized block styles with translated color values.
+ */
+public static function get_normalized_block_styles( array $block_attributes, Rendering_Context $rendering_context ): array
+```
+
+**Example Usage:**
+
+```php
+$block_attributes = array(
+    'backgroundColor' => 'primary',
+    'textColor' => 'secondary',
+    'style' => array( 'spacing' => array( 'padding' => '10px' ) )
+);
+
+$normalized = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
+```
+
+#### `get_styles_from_block()`
+
+Wrapper for WordPress Style Engine with guaranteed return structure.
+
+```php
+/**
+ * Wrapper for wp_style_engine_get_styles which ensures all values are returned.
+ *
+ * @param array $block_styles Array of block styles.
+ * @param bool  $skip_convert_vars If true, --wp_preset--spacing--x type values will be left in the original var:preset:spacing:x format.
+ * @return array
+ */
+public static function get_styles_from_block( array $block_styles, $skip_convert_vars = false )
+```
+
+**Example Usage:**
+
+```php
+$result = Styles_Helper::get_styles_from_block( $block_styles );
+// Returns: array( 'css' => '...', 'declarations' => array(), 'classnames' => '' )
+```
+
+#### `extend_block_styles()`
+
+Extend existing block styles with additional CSS declarations.
+
+```php
+/**
+ * Extend block styles with CSS declarations.
+ *
+ * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
+ * @param array $css_declarations Array of CSS declarations.
+ * @return array
+ */
+public static function extend_block_styles( array $block_styles, $css_declarations )
+```
+
+**Example Usage:**
+
+```php
+$extended = Styles_Helper::extend_block_styles( $block_styles, array(
+    'margin' => '20px',
+    'color' => 'red'
+) );
+```
+
+#### `get_block_styles()`
+
+Comprehensive method to get processed block styles with filtering and return type control.
+
+```php
+/**
+ * Get block styles.
+ *
+ * @param array             $block_attributes Block attributes.
+ * @param Rendering_Context $rendering_context Rendering context.
+ * @param array             $properties Properties to include.
+ * @param string            $return_type Return type. Can be 'full' (default, includes all three), 'css', 'declarations', or 'classnames'.
+ * @return array
+ */
+public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties, string $return_type = 'full' )
+```
+
+**Supported Properties:**
+- `spacing`, `padding`, `margin`
+- `border`, `border-width`, `border-style`, `border-radius`, `border-color`
+- `background`, `background-color`, `color`
+- `typography`, `font-size`, `font-family`, `font-weight`
+
+**Example Usage:**
+
+```php
+$styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'color' ) );
+$css_only = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'css' );
 ```
 
 ## Integration Example

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -422,6 +422,10 @@ Normalize block attributes by translating color slugs to actual color values.
 /**
  * Get normalized block styles by translating color slugs to actual color values.
  *
+ * This method handles the normalization of color-related attributes like backgroundColor,
+ * textColor, borderColor, and linkColor by translating them from slugs to actual color values
+ * using the rendering context.
+ *
  * @param array             $block_attributes Block attributes containing color slugs.
  * @param Rendering_Context $rendering_context Rendering context for color translation.
  * @return array Normalized block styles with translated color values.
@@ -451,6 +455,7 @@ array(
     ),
 )
 */
+```
 
 #### `get_styles_from_block()`
 
@@ -462,7 +467,13 @@ Wrapper for WordPress Style Engine with guaranteed return structure.
  *
  * @param array $block_styles Array of block styles.
  * @param bool  $skip_convert_vars If true, --wp_preset--spacing--x type values will be left in the original var:preset:spacing:x format.
- * @return array
+ * @return array {
+ *     @type string   $css          A CSS ruleset or declarations block
+ *                                  formatted to be placed in an HTML `style` attribute or tag.
+ *     @type string[] $declarations An associative array of CSS definitions,
+ *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+ *     @type string   $classnames   Classnames separated by a space.
+ * }
  */
 public static function get_styles_from_block( array $block_styles, $skip_convert_vars = false )
 ```
@@ -493,8 +504,15 @@ Extend existing block styles with additional CSS declarations.
  * Extend block styles with CSS declarations.
  *
  * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
- * @param array $css_declarations Array of CSS declarations.
- * @return array
+ * @param array $css_declarations An associative array of CSS definitions,
+ *                                e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+ * @return array {
+ *     @type string   $css          A CSS ruleset or declarations block
+ *                                  formatted to be placed in an HTML `style` attribute or tag.
+ *     @type string[] $declarations An associative array of CSS definitions,
+ *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+ *     @type string   $classnames   Classnames separated by a space.
+ * }
  */
 public static function extend_block_styles( array $block_styles, $css_declarations )
 ```
@@ -529,10 +547,20 @@ Comprehensive method to get processed block styles with filtering and return typ
 /**
  * Get block styles.
  *
- * @param array             $block_attributes Block attributes.
- * @param Rendering_Context $rendering_context Rendering context.
- * @param array             $properties Properties to include.
- * @return array
+ * @param array             $block_attributes   Block attributes.
+ * @param Rendering_Context $rendering_context  Rendering context.
+ * @param array             $properties         List of style properties to include. Supported values:
+ *                                              'spacing', 'padding', 'margin',
+ *                                              'border', 'border-width', 'border-style', 'border-radius', 'border-color',
+ *                                              'background', 'background-color', 'color',
+ *                                              'typography', 'font-size', 'font-family', 'font-weight', 'text-align'.
+ * @return array {
+ *     @type string   $css          A CSS ruleset or declarations block
+ *                                  formatted to be placed in an HTML `style` attribute or tag.
+ *     @type string[] $declarations An associative array of CSS definitions,
+ *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+ *     @type string   $classnames   Classnames separated by a space.
+ * }
  */
 public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties )
 ```

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -498,10 +498,11 @@ public static function get_block_styles( array $block_attributes, Rendering_Cont
 ```
 
 **Supported Properties:**
-- `spacing`, `padding`, `margin`
-- `border`, `border-width`, `border-style`, `border-radius`, `border-color`
-- `background`, `background-color`, `color`
-- `typography`, `font-size`, `font-family`, `font-weight`
+
+-   `spacing`, `padding`, `margin`
+-   `border`, `border-width`, `border-style`, `border-radius`, `border-color`
+-   `background`, `background-color`, `color`
+-   `typography`, `font-size`, `font-family`, `font-weight`
 
 **Example Usage:**
 

--- a/packages/php/email-editor/docs/rendering.md
+++ b/packages/php/email-editor/docs/rendering.md
@@ -357,7 +357,7 @@ $outlook_cell = Table_Wrapper_Helper::render_outlook_table_cell(
 
 ## Styles Helper
 
-The `Styles_Helper` class provides utility methods for generating email-compatible inline styles from WordPress block attributes.
+The `Styles_Helper` class provides utility methods to assist with handling email-compatible inline styles derived from WordPress block attributes.
 
 ### Available Methods
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-abstract-block-renderer.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Block_Renderer;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 use WP_Style_Engine;
 
@@ -25,15 +26,7 @@ abstract class Abstract_Block_Renderer implements Block_Renderer {
 	 * @return array
 	 */
 	protected function get_styles_from_block( array $block_styles, $skip_convert_vars = false ) {
-		$styles = wp_style_engine_get_styles( $block_styles, array( 'convert_vars_to_classnames' => $skip_convert_vars ) );
-		return wp_parse_args(
-			$styles,
-			array(
-				'css'          => '',
-				'declarations' => array(),
-				'classnames'   => '',
-			)
-		);
+		return Styles_Helper::get_styles_from_block( $block_styles, $skip_convert_vars );
 	}
 
 	/**

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
@@ -25,12 +25,12 @@ class Button extends Abstract_Block_Renderer {
 	 *
 	 * @param array             $block_attributes Block attributes.
 	 * @param Rendering_Context $rendering_context Rendering context.
-	 * @return object{css: string, declarations: array, classnames: string}
+	 * @return array
 	 */
 	private function get_wrapper_styles( array $block_attributes, Rendering_Context $rendering_context ) {
 		$block_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background-color', 'color', 'typography', 'spacing' ) );
 
-		return (object) Styles_Helper::extend_block_styles(
+		return Styles_Helper::extend_block_styles(
 			$block_styles,
 			array(
 				'word-break' => 'break-word',
@@ -44,12 +44,12 @@ class Button extends Abstract_Block_Renderer {
 	 *
 	 * @param array             $block_attributes Block attributes.
 	 * @param Rendering_Context $rendering_context Rendering context.
-	 * @return object{css: string, declarations: array, classnames: string}
+	 * @return array
 	 */
 	private function get_link_styles( array $block_attributes, Rendering_Context $rendering_context ) {
 		$block_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'color', 'typography' ) );
 
-		return (object) Styles_Helper::extend_block_styles(
+		return Styles_Helper::extend_block_styles(
 			$block_styles,
 			array( 'display' => 'block' )
 		);
@@ -110,8 +110,8 @@ class Button extends Abstract_Block_Renderer {
 		);
 
 		$cell_attrs = array(
-			'class'  => $wrapper_styles->classnames . ' ' . $block_classname,
-			'style'  => $wrapper_styles->css,
+			'class'  => $wrapper_styles['classnames'] . ' ' . $block_classname,
+			'style'  => $wrapper_styles['css'],
 			'align'  => $block_attributes['textAlign'],
 			'valign' => 'middle',
 			'role'   => 'presentation',
@@ -119,8 +119,8 @@ class Button extends Abstract_Block_Renderer {
 
 		$button_content = sprintf(
 			'<a class="button-link %1$s" style="%2$s" href="%3$s" target="_blank">%4$s</a>',
-			esc_attr( $link_styles->classnames ),
-			esc_attr( $link_styles->css ),
+			esc_attr( $link_styles['classnames'] ),
+			esc_attr( $link_styles['css'] ),
 			esc_url( $button_url ),
 			$button_text
 		);

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-button.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 
 /**
  * Renders a button block.
@@ -22,42 +23,35 @@ class Button extends Abstract_Block_Renderer {
 	/**
 	 * Get styles for the wrapper element.
 	 *
-	 * @param array $block_styles Block styles.
-	 * @return object{css: string, classname: string}
+	 * @param array             $block_attributes Block attributes.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return object{css: string, declarations: array, classnames: string}
 	 */
-	private function get_wrapper_styles( array $block_styles ) {
-		$properties = array( 'border', 'color', 'typography', 'spacing' );
-		$styles     = $this->get_styles_from_block( array_intersect_key( $block_styles, array_flip( $properties ) ) );
-		return (object) array(
-			'css'       => $this->compile_css(
-				$styles['declarations'],
-				array(
-					'word-break' => 'break-word',
-					'display'    => 'block',
-				)
-			),
-			'classname' => $styles['classnames'],
+	private function get_wrapper_styles( array $block_attributes, Rendering_Context $rendering_context ) {
+		$block_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background-color', 'color', 'typography', 'spacing' ) );
+
+		return (object) Styles_Helper::extend_block_styles(
+			$block_styles,
+			array(
+				'word-break' => 'break-word',
+				'display'    => 'block',
+			)
 		);
 	}
 
 	/**
 	 * Get styles for the link element.
 	 *
-	 * @param array $block_styles Block styles.
-	 * @return object{css: string, classname: string}
+	 * @param array             $block_attributes Block attributes.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @return object{css: string, declarations: array, classnames: string}
 	 */
-	private function get_link_styles( array $block_styles ) {
-		$styles = $this->get_styles_from_block(
-			array(
-				'color'      => array(
-					'text' => $block_styles['color']['text'] ?? '',
-				),
-				'typography' => $block_styles['typography'] ?? array(),
-			)
-		);
-		return (object) array(
-			'css'       => $this->compile_css( $styles['declarations'], array( 'display' => 'block' ) ),
-			'classname' => $styles['classnames'],
+	private function get_link_styles( array $block_attributes, Rendering_Context $rendering_context ) {
+		$block_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'color', 'typography' ) );
+
+		return (object) Styles_Helper::extend_block_styles(
+			$block_styles,
+			array( 'display' => 'block' )
 		);
 	}
 
@@ -108,31 +102,15 @@ class Button extends Abstract_Block_Renderer {
 			)
 		);
 
-		$block_styles = array_replace_recursive(
-			array(
-				'color' => array_filter(
-					array(
-						'background' => $block_attributes['backgroundColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['backgroundColor'] ) : null,
-						'text'       => $block_attributes['textColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['textColor'] ) : null,
-					)
-				),
-			),
-			$block_attributes['style'] ?? array()
-		);
-
-		if ( ! empty( $block_styles['border'] ) && empty( $block_styles['border']['style'] ) ) {
-			$block_styles['border']['style'] = 'solid';
-		}
-
-		$wrapper_styles = $this->get_wrapper_styles( $block_styles );
-		$link_styles    = $this->get_link_styles( $block_styles );
+		$wrapper_styles = $this->get_wrapper_styles( $block_attributes, $rendering_context );
+		$link_styles    = $this->get_link_styles( $block_attributes, $rendering_context );
 
 		$table_attrs = array(
 			'style' => 'width:' . ( $block_attributes['width'] ? '100%' : 'auto' ) . ';',
 		);
 
 		$cell_attrs = array(
-			'class'  => $wrapper_styles->classname . ' ' . $block_classname,
+			'class'  => $wrapper_styles->classnames . ' ' . $block_classname,
 			'style'  => $wrapper_styles->css,
 			'align'  => $block_attributes['textAlign'],
 			'valign' => 'middle',
@@ -141,7 +119,7 @@ class Button extends Abstract_Block_Renderer {
 
 		$button_content = sprintf(
 			'<a class="button-link %1$s" style="%2$s" href="%3$s" target="_blank">%4$s</a>',
-			esc_attr( $link_styles->classname ),
+			esc_attr( $link_styles->classnames ),
 			esc_attr( $link_styles->css ),
 			esc_url( $button_url ),
 			$button_text

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
@@ -74,13 +74,7 @@ class Column extends Abstract_Block_Renderer {
 		$padding_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding' ) );
 		$padding_styles = Styles_Helper::extend_block_styles( $padding_styles, array( 'text-align' => 'left' ) );
 
-		$cell_styles = $this->get_styles_from_block(
-			array(
-				'color'      => $block_attributes['style']['color'] ?? array(),
-				'background' => $block_attributes['style']['background'] ?? array(),
-			)
-		)['declarations'];
-		$cell_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'color' ) );
+		$cell_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'background-color', 'color' ) );
 		$cell_styles = Styles_Helper::extend_block_styles(
 			$cell_styles,
 			array_filter(

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-column.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
-use WP_Style_Engine;
 
 /**
  * Renders a column block.
@@ -72,52 +71,51 @@ class Column extends Abstract_Block_Renderer {
 		// to create a feeling of a stretched column. This also needs to apply to CSS classnames which can also apply styles.
 		$is_stretched = empty( $block_attributes['verticalAlignment'] ) || 'stretch' === $block_attributes['verticalAlignment'];
 
-		$padding_css = $this->get_styles_from_block( array( 'spacing' => array( 'padding' => $block_attributes['style']['spacing']['padding'] ?? array() ) ) )['css'];
+		$padding_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding' ) );
+		$padding_styles = Styles_Helper::extend_block_styles( $padding_styles, array( 'text-align' => 'left' ) );
+
 		$cell_styles = $this->get_styles_from_block(
 			array(
 				'color'      => $block_attributes['style']['color'] ?? array(),
 				'background' => $block_attributes['style']['background'] ?? array(),
 			)
 		)['declarations'];
-
-		$border_styles = $this->get_styles_from_block( array( 'border' => $block_attributes['style']['border'] ?? array() ) )['declarations'];
-
-		if ( ! empty( $border_styles ) ) {
-			$cell_styles = array_merge( $cell_styles, array( 'border-style' => 'solid' ), $border_styles );
-		}
-
-		if ( ! empty( $cell_styles['background-image'] ) && empty( $cell_styles['background-size'] ) ) {
-			$cell_styles['background-size'] = 'cover';
-		}
+		$cell_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'color' ) );
+		$cell_styles = Styles_Helper::extend_block_styles(
+			$cell_styles,
+			array_filter(
+				array(
+					'background-size' => ! empty( $cell_styles['background-image'] ) && empty( $cell_styles['background-size'] ) ? 'cover' : null,
+				)
+			)
+		);
 
 		$wrapper_classname = 'block wp-block-column email-block-column';
 		$content_classname = 'email-block-column-content';
-		$wrapper_css       = WP_Style_Engine::compile_css(
-			array(
-				'vertical-align' => $is_stretched ? 'top' : $block_attributes['verticalAlignment'],
-			),
-			''
+		$wrapper_styles    = Styles_Helper::extend_block_styles(
+			Styles_Helper::$empty_block_styles,
+			array( 'vertical-align' => $is_stretched ? 'top' : $block_attributes['verticalAlignment'] ),
 		);
-		$content_css       = 'vertical-align: top;';
+		$content_styles    = Styles_Helper::extend_block_styles( Styles_Helper::$empty_block_styles, array( 'vertical-align' => 'top' ) );
 
 		if ( $is_stretched ) {
 			$wrapper_classname .= ' ' . $original_wrapper_classname;
-			$wrapper_css       .= ' ' . WP_Style_Engine::compile_css( $cell_styles, '' );
+			$wrapper_styles     = Styles_Helper::extend_block_styles( $wrapper_styles, $cell_styles['declarations'] );
 		} else {
 			$content_classname .= ' ' . $original_wrapper_classname;
-			$content_css       .= ' ' . WP_Style_Engine::compile_css( $cell_styles, '' );
+			$content_styles     = Styles_Helper::extend_block_styles( $content_styles, $cell_styles['declarations'] );
 		}
 
 		// Create the inner table using the helper.
 		$inner_table_attrs = array(
 			'class' => $content_classname,
-			'style' => $content_css,
+			'style' => $content_styles['css'],
 			'width' => '100%',
 		);
 
 		$inner_cell_attrs = array(
 			'align' => 'left',
-			'style' => 'text-align:left;' . $padding_css,
+			'style' => $padding_styles['css'],
 		);
 
 		$inner_table = Table_Wrapper_Helper::render_table_wrapper( '{column_content}', $inner_table_attrs, $inner_cell_attrs );
@@ -125,7 +123,7 @@ class Column extends Abstract_Block_Renderer {
 		// Create the outer td element (since this is meant to be used within a columns structure).
 		$wrapper_cell_attrs = array(
 			'class' => $wrapper_classname,
-			'style' => $wrapper_css,
+			'style' => $wrapper_styles['css'],
 			'width' => Styles_Helper::parse_value( $block_attributes['width'] ),
 		);
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
@@ -57,7 +57,7 @@ class Columns extends Abstract_Block_Renderer {
 			)
 		);
 
-		$columns_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding', 'border', 'background', 'color' ) );
+		$columns_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding', 'border', 'background', 'background-color', 'color' ) );
 		$columns_styles = Styles_Helper::extend_block_styles(
 			$columns_styles,
 			array(

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
-use WP_Style_Engine;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 
 /**
  * Renders a columns block.
@@ -57,27 +57,20 @@ class Columns extends Abstract_Block_Renderer {
 			)
 		);
 
-		$columns_styles = $this->get_styles_from_block(
+		$columns_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding', 'border', 'background', 'color' ) );
+		$columns_styles = Styles_Helper::extend_block_styles(
+			$columns_styles,
 			array(
-				'spacing'    => array( 'padding' => $block_attributes['style']['spacing']['padding'] ?? array() ),
-				'color'      => $block_attributes['style']['color'] ?? array(),
-				'background' => $block_attributes['style']['background'] ?? array(),
+				'width'           => '100%',
+				'border-collapse' => 'separate',
+				'text-align'      => 'left',
+				'background-size' => $columns_styles['background-size'] ?? 'cover',
 			)
-		)['declarations'];
-
-		$border_styles = $this->get_styles_from_block( array( 'border' => $block_attributes['style']['border'] ?? array() ) )['declarations'];
-
-		if ( ! empty( $border_styles ) ) {
-			$columns_styles = array_merge( $columns_styles, array( 'border-style' => 'solid' ), $border_styles );
-		}
-
-		if ( empty( $columns_styles['background-size'] ) ) {
-			$columns_styles['background-size'] = 'cover';
-		}
+		);
 
 		$columns_table_attrs = array(
 			'class' => 'email-block-columns ' . $original_wrapper_classname,
-			'style' => 'width:100%;border-collapse:separate;text-align:left;' . WP_Style_Engine::compile_css( $columns_styles, '' ),
+			'style' => $columns_styles['css'],
 			'align' => 'center',
 		);
 
@@ -87,21 +80,24 @@ class Columns extends Abstract_Block_Renderer {
 		$margins = $block_attributes['style']['spacing']['margin'] ?? array();
 
 		if ( ! empty( $margins ) ) {
-			$margin_to_padding_styles = $this->get_styles_from_block(
+			$magin_to_padding_attributes = array( 'style' => array( 'spacing' => array( 'padding' => $margins ) ) );
+			$margin_wrapper_styles       = Styles_Helper::get_block_styles( $magin_to_padding_attributes, $rendering_context, array( 'padding' ) );
+			$margin_wrapper_styles       = Styles_Helper::extend_block_styles(
+				$margin_wrapper_styles,
 				array(
-					'spacing' => array( 'margin' => $margins ),
+					'width'           => '100%',
+					'border-collapse' => 'separate',
+					'text-align'      => 'left',
 				)
-			)['css'];
+			);
 
 			$wrapper_table_attrs = array(
 				'class' => 'email-block-columns-wrapper',
-				'style' => 'width:100%;border-collapse:separate;text-align:left;' . $margin_to_padding_styles,
+				'style' => $margin_wrapper_styles['css'],
 				'align' => 'center',
 			);
 
-			$wrapper_cell_attrs = array();
-
-			return Table_Wrapper_Helper::render_table_wrapper( $columns_content, $wrapper_table_attrs, $wrapper_cell_attrs );
+			return Table_Wrapper_Helper::render_table_wrapper( $columns_content, $wrapper_table_attrs );
 		}
 
 		return $columns_content;

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-columns.php
@@ -64,7 +64,7 @@ class Columns extends Abstract_Block_Renderer {
 				'width'           => '100%',
 				'border-collapse' => 'separate',
 				'text-align'      => 'left',
-				'background-size' => $columns_styles['background-size'] ?? 'cover',
+				'background-size' => $columns_styles['declarations']['background-size'] ?? 'cover',
 			)
 		);
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
-use WP_Style_Engine;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 
 /**
  * Renders a group block.
@@ -60,44 +60,31 @@ class Group extends Abstract_Block_Renderer {
 			)
 		);
 
-		// Layout, background, borders need to be on the outer table element.
-		$table_styles = $this->get_styles_from_block(
-			array(
-				'color'      => array_filter(
-					array(
-						'background' => $block_attributes['backgroundColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['backgroundColor'] ) : null,
-						'text'       => $block_attributes['textColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['textColor'] ) : null,
-						'border'     => $block_attributes['borderColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['borderColor'] ) : null,
-					)
-				),
-				'background' => $block_attributes['style']['background'] ?? array(),
-				'border'     => $block_attributes['style']['border'] ?? array(),
-				'spacing'    => array( 'padding' => $block_attributes['style']['spacing']['margin'] ?? array() ),
+		$table_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'color', 'text-align' ) );
+		$table_styles = Styles_Helper::extend_block_styles(
+			$table_styles,
+			array_filter(
+				array(
+					'padding'         => $block_attributes['style']['spacing']['margin'] ?? null,
+					'border-collapse' => 'separate',
+					'background-size' => $table_styles['background-size'] ?? 'cover',
+				)
 			)
-		)['declarations'];
-
-		$table_styles['border-collapse'] = 'separate'; // Needed for the border radius to work.
+		);
 
 		// Padding properties need to be added to the table cell.
-		$cell_styles = $this->get_styles_from_block(
-			array(
-				'spacing' => array( 'padding' => $block_attributes['style']['spacing']['padding'] ?? array() ),
-			)
-		)['declarations'];
-
-		$table_styles['background-size'] = empty( $table_styles['background-size'] ) ? 'cover' : $table_styles['background-size'];
-		$width                           = $parsed_block['email_attrs']['width'] ?? '100%';
+		$cell_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding' ) );
 
 		$table_attrs = array(
 			'class' => 'email-block-group ' . $original_classname,
-			'style' => WP_Style_Engine::compile_css( $table_styles, '' ),
+			'style' => $table_styles['css'],
 			'width' => '100%',
 		);
 
 		$cell_attrs = array(
 			'class' => 'email-block-group-content',
-			'style' => WP_Style_Engine::compile_css( $cell_styles, '' ),
-			'width' => $width,
+			'style' => $cell_styles['css'],
+			'width' => $parsed_block['email_attrs']['width'] ?? '100%',
 		);
 
 		return Table_Wrapper_Helper::render_table_wrapper( '{group_content}', $table_attrs, $cell_attrs );

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-group.php
@@ -60,7 +60,7 @@ class Group extends Abstract_Block_Renderer {
 			)
 		);
 
-		$table_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'color', 'text-align' ) );
+		$table_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'background-color', 'color', 'text-align' ) );
 		$table_styles = Styles_Helper::extend_block_styles(
 			$table_styles,
 			array_filter(

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-quote.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-quote.php
@@ -107,7 +107,7 @@ class Quote extends Abstract_Block_Renderer {
 			$table_styles,
 			array(
 				'border-collapse' => 'separate',
-				'background-size' => $table_styles['background-size'] ?? 'cover',
+				'background-size' => $table_styles['declarations']['background-size'] ?? 'cover',
 			)
 		);
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-quote.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-quote.php
@@ -11,7 +11,7 @@ namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Dom_Document_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
-use WP_Style_Engine;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 
 /**
  * Renders a quote block.
@@ -67,20 +67,16 @@ class Quote extends Abstract_Block_Renderer {
 		}
 
 		// The HTML cite tag should use block gap as margin-top.
-		$theme_styles = $rendering_context->get_theme_styles();
-		$margin_top   = $theme_styles['spacing']['blockGap'] ?? '0px';
+		$theme_styles    = $rendering_context->get_theme_styles();
+		$margin_top      = $theme_styles['spacing']['blockGap'] ?? '0px';
+		$citation_styles = Styles_Helper::get_block_styles( $parsed_block['attrs'], $rendering_context, array( 'text-align' ) );
+		$citation_styles = Styles_Helper::extend_block_styles( $citation_styles, array( 'margin' => "{$margin_top} 0px 0px 0px" ) );
 
 		return $this->add_spacer(
 			sprintf(
 				'<p style="%2$s"><cite class="email-block-quote-citation" style="display: block; margin: 0;">%1$s</cite></p>',
 				$citation_content,
-				WP_Style_Engine::compile_css(
-					array(
-						'margin'     => "{$margin_top} 0px 0px 0px",
-						'text-align' => $parsed_block['attrs']['textAlign'] ?? '',
-					),
-					''
-				),
+				$citation_styles['css'],
 			),
 			$parsed_block['email_attrs'] ?? array()
 		);
@@ -106,51 +102,27 @@ class Quote extends Abstract_Block_Renderer {
 		);
 
 		// Layout, background, borders need to be on the outer table element.
-		$border                 = $block_attributes['style']['border'] ?? array();
-		$border_color_attribute = $block_attributes['borderColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['borderColor'] ) : null;
-		if ( ! isset( $border['color'] ) && ! is_null( $border_color_attribute ) ) {
-			$border['color'] = $border_color_attribute;
-		}
-
-		$table_styles = $this->get_styles_from_block(
+		$table_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'border', 'background', 'background-color', 'color', 'text-align' ) );
+		$table_styles = Styles_Helper::extend_block_styles(
+			$table_styles,
 			array(
-				'color'      => array_filter(
-					array(
-						'background' => $block_attributes['backgroundColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['backgroundColor'] ) : null,
-						'text'       => $block_attributes['textColor'] ? $rendering_context->translate_slug_to_color( $block_attributes['textColor'] ) : null,
-					)
-				),
-				'background' => $block_attributes['style']['background'] ?? array(),
-				'border'     => $border,
+				'border-collapse' => 'separate',
+				'background-size' => $table_styles['background-size'] ?? 'cover',
 			)
-		)['declarations'];
-
-		// Set the text align attribute to the wrapper if present.
-		if ( isset( $parsed_block['attrs']['textAlign'] ) ) {
-			$table_styles['text-align'] = $parsed_block['attrs']['textAlign'];
-		}
-
-		$table_styles['border-collapse'] = 'separate'; // Needed for the border radius to work.
-
-		// Add default background size.
-		$table_styles['background-size'] = empty( $table_styles['background-size'] ) ? 'cover' : $table_styles['background-size'];
+		);
 
 		// Padding properties need to be added to the table cell.
-		$cell_styles = $this->get_styles_from_block(
-			array(
-				'spacing' => array( 'padding' => $block_attributes['style']['spacing']['padding'] ?? array() ),
-			)
-		)['declarations'];
+		$cell_styles = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'padding' ) );
 
 		$table_attrs = array(
 			'class' => 'email-block-quote ' . $original_classname,
-			'style' => WP_Style_Engine::compile_css( $table_styles, '' ),
+			'style' => $table_styles['css'],
 			'width' => '100%',
 		);
 
 		$cell_attrs = array(
 			'class' => 'email-block-quote-content',
-			'style' => WP_Style_Engine::compile_css( $cell_styles, '' ),
+			'style' => $cell_styles['css'],
 			'width' => '100%',
 		);
 

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper;
 use Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper;
 
 /**
@@ -52,36 +53,25 @@ class Text extends Abstract_Block_Renderer {
 			$block_content = $html->get_updated_html();
 		}
 
-		// Add fallback text color when no custom text color or preset text color is set.
-		// Color styles are set on $block_attributes['style']['color'] only when custom values are used.
-		// In case of preset they are set on $block_attributes['textColor'] and $block_attributes['backgroundColor'].
-		$color_styles = $block_attributes['style']['color'] ?? array();
-		if ( empty( $color_styles['text'] ) && empty( $block_attributes['textColor'] ) ) {
-			$email_styles         = $rendering_context->get_theme_styles();
-			$color_styles['text'] = $email_styles['color']['text'] ?? '#000000'; // Fallback for the text color.
-		}
-
-		$block_styles = $this->get_styles_from_block(
-			array(
-				'color'      => $color_styles,
-				'spacing'    => $block_attributes['style']['spacing'] ?? array(),
-				'typography' => $block_attributes['style']['typography'] ?? array(),
-				'border'     => $block_attributes['style']['border'] ?? array(),
-			)
-		);
-
-		$styles = array(
+		$block_styles      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'border', 'typography' ) );
+		$additional_styles = array(
 			'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices.
 		);
 
-		$styles['text-align'] = 'left';
-		if ( ! empty( $parsed_block['attrs']['textAlign'] ) ) { // in this case, textAlign needs to be one of 'left', 'center', 'right'.
-			$styles['text-align'] = $parsed_block['attrs']['textAlign'];
-		} elseif ( in_array( $parsed_block['attrs']['align'] ?? null, array( 'left', 'center', 'right' ), true ) ) {
-			$styles['text-align'] = $parsed_block['attrs']['align'];
+		// Add fallback text color when no custom text color or preset text color is set.
+		if ( empty( $block_styles['declarations']['color'] ) ) {
+			$email_styles               = $rendering_context->get_theme_styles();
+			$additional_styles['color'] = $email_styles['color']['text'] ?? '#000000'; // Fallback for the text color.
 		}
 
-		$compiled_styles = $this->compile_css( $block_styles['declarations'], $styles );
+		$additional_styles['text-align'] = 'left';
+		if ( ! empty( $parsed_block['attrs']['textAlign'] ) ) { // in this case, textAlign needs to be one of 'left', 'center', 'right'.
+			$additional_styles['text-align'] = $parsed_block['attrs']['textAlign'];
+		} elseif ( in_array( $parsed_block['attrs']['align'] ?? null, array( 'left', 'center', 'right' ), true ) ) {
+			$additional_styles['text-align'] = $parsed_block['attrs']['align'];
+		}
+
+		$block_styles = Styles_Helper::extend_block_styles( $block_styles, $additional_styles );
 
 		$table_attrs = array(
 			'style' => 'border-collapse: separate;', // Needed because of border radius.
@@ -90,8 +80,8 @@ class Text extends Abstract_Block_Renderer {
 
 		$cell_attrs = array(
 			'class' => $classes,
-			'style' => $compiled_styles,
-			'align' => $styles['text-align'],
+			'style' => $block_styles['css'],
+			'align' => $additional_styles['text-align'],
 		);
 
 		return Table_Wrapper_Helper::render_table_wrapper( $block_content, $table_attrs, $cell_attrs );

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -53,7 +53,7 @@ class Text extends Abstract_Block_Renderer {
 			$block_content = $html->get_updated_html();
 		}
 
-		$block_styles      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'border', 'typography' ) );
+		$block_styles      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'border', 'background-color', 'color', 'typography' ) );
 		$additional_styles = array(
 			'min-width' => '100%', // prevent Gmail App from shrinking the table on mobile devices.
 		);

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -121,7 +121,8 @@ class Styles_Helper {
 	 * Extend block styles with CSS declarations.
 	 *
 	 * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
-	 * @param array $css_declarations Array of CSS declarations.
+	 * @param array $css_declarations An associative array of CSS definitions,
+	 *                                e.g. `array( "$property" => "$value", "$property" => "$value" )`.
 	 * @return array {
 	 *     @type string   $css          A CSS ruleset or declarations block
 	 *                                  formatted to be placed in an HTML `style` attribute or tag.
@@ -133,6 +134,11 @@ class Styles_Helper {
 	public static function extend_block_styles( array $block_styles, $css_declarations ) {
 		if ( ! is_array( $css_declarations ) ) {
 			return $block_styles;
+		}
+
+		// Ensure block_styles has the required WP_Style_Engine structure.
+		if ( ! isset( $block_styles['declarations'] ) || ! is_array( $block_styles['declarations'] ) ) {
+			$block_styles = self::$empty_block_styles;
 		}
 
 		$block_styles['declarations'] = array_merge( $block_styles['declarations'], $css_declarations );

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -132,10 +132,6 @@ class Styles_Helper {
 	 * }
 	 */
 	public static function extend_block_styles( array $block_styles, array $css_declarations ) {
-		if ( ! is_array( $css_declarations ) ) {
-			return $block_styles;
-		}
-
 		// Ensure block_styles has the required WP_Style_Engine structure.
 		if ( ! isset( $block_styles['declarations'] ) || ! is_array( $block_styles['declarations'] ) ) {
 			$block_styles = self::$empty_block_styles;

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -102,7 +102,13 @@ class Styles_Helper {
 	 *
 	 * @param array $block_styles Array of block styles.
 	 * @param bool  $skip_convert_vars If true, --wp_preset--spacing--x type values will be left in the original var:preset:spacing:x format.
-	 * @return array
+	 * @return array {
+	 *     @type string   $css          A CSS ruleset or declarations block
+	 *                                  formatted to be placed in an HTML `style` attribute or tag.
+	 *     @type string[] $declarations An associative array of CSS definitions,
+	 *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+	 *     @type string   $classnames   Classnames separated by a space.
+	 * }
 	 */
 	public static function get_styles_from_block( array $block_styles, $skip_convert_vars = false ) {
 		return wp_parse_args(
@@ -116,7 +122,13 @@ class Styles_Helper {
 	 *
 	 * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
 	 * @param array $css_declarations Array of CSS declarations.
-	 * @return array
+	 * @return array {
+	 *     @type string   $css          A CSS ruleset or declarations block
+	 *                                  formatted to be placed in an HTML `style` attribute or tag.
+	 *     @type string[] $declarations An associative array of CSS definitions,
+	 *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+	 *     @type string   $classnames   Classnames separated by a space.
+	 * }
 	 */
 	public static function extend_block_styles( array $block_styles, $css_declarations ) {
 		if ( ! is_array( $css_declarations ) ) {
@@ -132,10 +144,20 @@ class Styles_Helper {
 	/**
 	 * Get block styles.
 	 *
-	 * @param array             $block_attributes Block attributes.
-	 * @param Rendering_Context $rendering_context Rendering context.
-	 * @param array             $properties Properties.
-	 * @return array
+	 * @param array             $block_attributes   Block attributes.
+	 * @param Rendering_Context $rendering_context  Rendering context.
+	 * @param array             $properties         List of style properties to include. Supported values:
+	 *                                              'spacing', 'padding', 'margin',
+	 *                                              'border', 'border-width', 'border-style', 'border-radius', 'border-color',
+	 *                                              'background', 'background-color', 'color',
+	 *                                              'typography', 'font-size', 'font-family', 'font-weight', 'text-align'.
+	 * @return array {
+	 *     @type string   $css          A CSS ruleset or declarations block
+	 *                                  formatted to be placed in an HTML `style` attribute or tag.
+	 *     @type string[] $declarations An associative array of CSS definitions,
+	 *                                  e.g. `array( "$property" => "$value", "$property" => "$value" )`.
+	 *     @type string   $classnames   Classnames separated by a space.
+	 * }
 	 */
 	public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties ) {
 		$styles          = self::get_normalized_block_styles( $block_attributes, $rendering_context );

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -131,7 +131,7 @@ class Styles_Helper {
 	 *     @type string   $classnames   Classnames separated by a space.
 	 * }
 	 */
-	public static function extend_block_styles( array $block_styles, $css_declarations ) {
+	public static function extend_block_styles( array $block_styles, array $css_declarations ) {
 		if ( ! is_array( $css_declarations ) ) {
 			return $block_styles;
 		}

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -8,10 +8,23 @@
 declare( strict_types = 1 );
 namespace Automattic\WooCommerce\EmailEditor\Integrations\Utils;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+use WP_Style_Engine;
+
 /**
  * This class should guarantee that our work with the DOMDocument is unified and safe.
  */
 class Styles_Helper {
+	/**
+	 * Default empty styles block structure.
+	 *
+	 * @var array
+	 */
+	public static $empty_block_styles = array(
+		'css'          => '',
+		'declarations' => array(),
+		'classnames'   => '',
+	);
 	/**
 	 * Parse number value from a string.
 	 *
@@ -42,5 +55,153 @@ class Styles_Helper {
 			}
 		}
 		return $parsed_styles;
+	}
+
+	/**
+	 * Get normalized block styles by translating color slugs to actual color values.
+	 *
+	 * This method handles the normalization of color-related attributes like backgroundColor,
+	 * textColor, borderColor, and linkColor by translating them from slugs to actual color values
+	 * using the rendering context.
+	 *
+	 * @param array             $block_attributes Block attributes containing color slugs.
+	 * @param Rendering_Context $rendering_context Rendering context for color translation.
+	 * @return array Normalized block styles with translated color values.
+	 */
+	public static function get_normalized_block_styles( array $block_attributes, Rendering_Context $rendering_context ): array {
+		$normalized_colors = array_filter(
+			array(
+				'color'  => array_filter(
+					array(
+						'background' => isset( $block_attributes['backgroundColor'] ) && $block_attributes['backgroundColor']
+							? $rendering_context->translate_slug_to_color( $block_attributes['backgroundColor'] )
+							: null,
+						'text'       => isset( $block_attributes['textColor'] ) && $block_attributes['textColor']
+							? $rendering_context->translate_slug_to_color( $block_attributes['textColor'] )
+							: null,
+					)
+				),
+				'border' => array_filter(
+					array(
+						'color' => isset( $block_attributes['borderColor'] ) && $block_attributes['borderColor']
+							? $rendering_context->translate_slug_to_color( $block_attributes['borderColor'] )
+							: null,
+					)
+				),
+			)
+		);
+
+		return array_replace_recursive(
+			$normalized_colors,
+			$block_attributes['style'] ?? array()
+		);
+	}
+
+	/**
+	 * Wrapper for wp_style_engine_get_styles which ensures all values are returned.
+	 *
+	 * @param array $block_styles Array of block styles.
+	 * @param bool  $skip_convert_vars If true, --wp_preset--spacing--x type values will be left in the original var:preset:spacing:x format.
+	 * @return array
+	 */
+	public static function get_styles_from_block( array $block_styles, $skip_convert_vars = false ) {
+		return wp_parse_args(
+			wp_style_engine_get_styles( $block_styles, array( 'convert_vars_to_classnames' => $skip_convert_vars ) ),
+			self::$empty_block_styles
+		);
+	}
+
+	/**
+	 * Extend block styles with CSS declarations.
+	 *
+	 * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
+	 * @param array $css_declaractions Array of CSS declarations.
+	 * @return array
+	 */
+	public static function extend_block_styles( array $block_styles, $css_declaractions ) {
+		$block_styles['declarations'] = array_merge( $block_styles['declarations'], $css_declaractions );
+		$block_styles['css']          = WP_Style_Engine::compile_css( $block_styles['declarations'], '' );
+
+		return $block_styles;
+	}
+
+	/**
+	 * Get block styles.
+	 *
+	 * @param array             $block_attributes Block attributes.
+	 * @param Rendering_Context $rendering_context Rendering context.
+	 * @param array             $properties Properties.
+	 * @param string            $return_type Return type. Can be 'full' (default, includes all three), 'css', 'declarations', or 'classnames'.
+	 * @return array
+	 */
+	public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties, string $return_type = 'full' ) {
+		$styles          = self::get_normalized_block_styles( $block_attributes, $rendering_context );
+		$filtered_styles = array();
+
+		$style_mappings = array(
+			'spacing'          => array( 'spacing' ),
+			'padding'          => array( 'spacing', 'padding' ),
+			'margin'           => array( 'spacing', 'margin' ),
+			'border'           => array( 'border' ),
+			'border-width'     => array( 'border', 'width' ),
+			'border-style'     => array( 'border', 'style' ),
+			'border-radius'    => array( 'border', 'radius' ),
+			'border-color'     => array( 'border', 'color' ),
+			'background'       => array( 'background' ),
+			'background-color' => array( 'color', 'background' ),
+			'color'            => array( 'color', 'text' ),
+			'typography'       => array( 'typography' ),
+			'font-size'        => array( 'typography', 'fontSize' ),
+			'font-family'      => array( 'typography', 'fontFamily' ),
+			'font-weight'      => array( 'typography', 'fontWeight' ),
+		);
+
+		foreach ( $properties as $property ) {
+			if ( ! isset( $style_mappings[ $property ] ) ) {
+				continue;
+			}
+
+
+			$style_pointer = $styles;
+			foreach ( $style_mappings[ $property ] as $path_segment ) {
+				if ( ! isset( $style_pointer[ $path_segment ] ) ) {
+					continue 2;
+				}
+
+				$style_pointer = $style_pointer[ $path_segment ];
+			}
+
+			$filtered_styles_pointer = & $filtered_styles;
+			foreach ( $style_mappings[ $property ] as $path_index => $path_segment ) {
+				if ( count( $style_mappings[ $property ] ) - 1 === $path_index ) {
+					$filtered_styles_pointer[ $path_segment ] = $style_pointer;
+					break;
+				}
+
+				if ( ! isset( $filtered_styles_pointer[ $path_segment ] ) ) {
+					$filtered_styles_pointer[ $path_segment ] = array();
+				}
+
+				$filtered_styles_pointer = & $filtered_styles_pointer[ $path_segment ];
+			}
+		}
+
+		$additional_css_declarations = array_filter(
+			array_intersect_key(
+				array(
+					'text-align' => $block_attributes['textAlign'] ?? null,
+				),
+				array_flip( $properties )
+			)
+		);
+
+		$output_styles = ! empty( $filtered_styles ) ? self::get_styles_from_block( $filtered_styles ) : self::$empty_block_styles;
+		$output_styles = self::extend_block_styles( $output_styles, $additional_css_declarations );
+
+		if ( 'full' === $return_type ) {
+			return $output_styles;
+		}
+
+		return $output_styles[ $return_type ] ?? '';
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -170,14 +170,20 @@ class Styles_Helper {
 				$style_pointer = $style_pointer[ $path_segment ];
 			}
 
+			/**
+			 * Pointer to filtered styles.
+			 *
+			 * @var array<string, mixed> $filtered_styles_pointer
+			 */
 			$filtered_styles_pointer = & $filtered_styles;
+
 			foreach ( $style_mappings[ $property ] as $path_index => $path_segment ) {
 				if ( count( $style_mappings[ $property ] ) - 1 === $path_index ) {
 					$filtered_styles_pointer[ $path_segment ] = $style_pointer;
 					break;
 				}
 
-				if ( ! isset( $filtered_styles_pointer[ $path_segment ] ) ) {
+				if ( ! isset( $filtered_styles_pointer[ $path_segment ] ) || ! is_array( $filtered_styles_pointer[ $path_segment ] ) ) {
 					$filtered_styles_pointer[ $path_segment ] = array();
 				}
 
@@ -194,7 +200,7 @@ class Styles_Helper {
 			)
 		);
 
-		$output_styles = ! empty( $filtered_styles ) ? self::get_styles_from_block( $filtered_styles ) : self::$empty_block_styles;
+		$output_styles = count( $filtered_styles ) > 0 ? self::get_styles_from_block( $filtered_styles ) : self::$empty_block_styles;
 		$output_styles = self::extend_block_styles( $output_styles, $additional_css_declarations );
 
 		if ( 'full' === $return_type ) {

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -135,14 +135,9 @@ class Styles_Helper {
 	 * @param array             $block_attributes Block attributes.
 	 * @param Rendering_Context $rendering_context Rendering context.
 	 * @param array             $properties Properties.
-	 * @param string            $return_type Return type. Can be 'full' (default, includes all three), 'css', 'declarations', or 'classnames'.
 	 * @return array
 	 */
-	public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties, string $return_type = 'full' ) {
-		if ( ! in_array( $return_type, array( 'full', 'css', 'declarations', 'classnames' ), true ) ) {
-			$return_type = 'full';
-		}
-
+	public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties ) {
 		$styles          = self::get_normalized_block_styles( $block_attributes, $rendering_context );
 		$filtered_styles = array();
 		$style_mappings  = array(
@@ -207,13 +202,8 @@ class Styles_Helper {
 			)
 		);
 
-		$output_styles = count( $filtered_styles ) > 0 ? self::get_styles_from_block( $filtered_styles ) : self::$empty_block_styles;
-		$output_styles = self::extend_block_styles( $output_styles, $additional_css_declarations );
+		$styles = count( $filtered_styles ) > 0 ? self::get_styles_from_block( $filtered_styles ) : self::$empty_block_styles;
 
-		if ( 'full' === $return_type ) {
-			return $output_styles;
-		}
-
-		return $output_styles[ $return_type ] ?? '';
+		return self::extend_block_styles( $styles, $additional_css_declarations );
 	}
 }

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -161,7 +161,6 @@ class Styles_Helper {
 				continue;
 			}
 
-
 			$style_pointer = $styles;
 			foreach ( $style_mappings[ $property ] as $path_segment ) {
 				if ( ! isset( $style_pointer[ $path_segment ] ) ) {

--- a/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
+++ b/packages/php/email-editor/src/Integrations/Utils/class-styles-helper.php
@@ -115,11 +115,15 @@ class Styles_Helper {
 	 * Extend block styles with CSS declarations.
 	 *
 	 * @param array $block_styles WP_Style_Engine styles array (must contain 'declarations' and 'css' keys).
-	 * @param array $css_declaractions Array of CSS declarations.
+	 * @param array $css_declarations Array of CSS declarations.
 	 * @return array
 	 */
-	public static function extend_block_styles( array $block_styles, $css_declaractions ) {
-		$block_styles['declarations'] = array_merge( $block_styles['declarations'], $css_declaractions );
+	public static function extend_block_styles( array $block_styles, $css_declarations ) {
+		if ( ! is_array( $css_declarations ) ) {
+			return $block_styles;
+		}
+
+		$block_styles['declarations'] = array_merge( $block_styles['declarations'], $css_declarations );
 		$block_styles['css']          = WP_Style_Engine::compile_css( $block_styles['declarations'], '' );
 
 		return $block_styles;
@@ -135,10 +139,13 @@ class Styles_Helper {
 	 * @return array
 	 */
 	public static function get_block_styles( array $block_attributes, Rendering_Context $rendering_context, array $properties, string $return_type = 'full' ) {
+		if ( ! in_array( $return_type, array( 'full', 'css', 'declarations', 'classnames' ), true ) ) {
+			$return_type = 'full';
+		}
+
 		$styles          = self::get_normalized_block_styles( $block_attributes, $rendering_context );
 		$filtered_styles = array();
-
-		$style_mappings = array(
+		$style_mappings  = array(
 			'spacing'          => array( 'spacing' ),
 			'padding'          => array( 'spacing', 'padding' ),
 			'margin'           => array( 'spacing', 'margin' ),

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Button_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Button_Test.php
@@ -120,6 +120,7 @@ class Button_Test extends \Email_Editor_Integration_Test_Case {
 		$this->parsed_button['attrs']['style']['border'] = array(
 			'width' => '10px',
 			'color' => '#111111',
+			'style' => 'solid',
 		);
 		$output = $this->button_renderer->render( $this->parsed_button['innerHTML'], $this->parsed_button, $this->rendering_context );
 		$this->assertStringContainsString( 'border-color:#111111;', $output );
@@ -135,34 +136,40 @@ class Button_Test extends \Email_Editor_Integration_Test_Case {
 			'top'    => array(
 				'width' => '1px',
 				'color' => '#111111',
+				'style' => 'solid',
 			),
 			'right'  => array(
 				'width' => '2px',
 				'color' => '#222222',
+				'style' => 'dashed',
 			),
 			'bottom' => array(
 				'width' => '3px',
 				'color' => '#333333',
+				'style' => 'solid',
 			),
 			'left'   => array(
 				'width' => '4px',
 				'color' => '#444444',
+				'style' => 'dashed',
 			),
 		);
 		$output = $this->button_renderer->render( $this->parsed_button['innerHTML'], $this->parsed_button, $this->rendering_context );
 		$this->assertStringContainsString( 'border-top-width:1px;', $output );
 		$this->assertStringContainsString( 'border-top-color:#111111;', $output );
+		$this->assertStringContainsString( 'border-top-style:solid;', $output );
 
 		$this->assertStringContainsString( 'border-right-width:2px;', $output );
 		$this->assertStringContainsString( 'border-right-color:#222222;', $output );
+		$this->assertStringContainsString( 'border-right-style:dashed;', $output );
 
 		$this->assertStringContainsString( 'border-bottom-width:3px;', $output );
 		$this->assertStringContainsString( 'border-bottom-color:#333333;', $output );
+		$this->assertStringContainsString( 'border-bottom-style:solid;', $output );
 
 		$this->assertStringContainsString( 'border-left-width:4px;', $output );
 		$this->assertStringContainsString( 'border-left-color:#444444;', $output );
-
-		$this->assertStringContainsString( 'border-style:solid;', $output );
+		$this->assertStringContainsString( 'border-left-style:dashed;', $output );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Column_Test.php
@@ -93,6 +93,7 @@ class Column_Test extends \Email_Editor_Integration_Test_Case {
 					'left'   => array(
 						'color' => '#222222',
 						'width' => '2px',
+						'style' => 'dashed',
 					),
 					'right'  => array(
 						'color' => '#333333',
@@ -137,7 +138,7 @@ class Column_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'border-bottom-width:1px;', $rendered );
 		$this->assertStringContainsString( 'border-left-color:#222222;', $rendered );
 		$this->assertStringContainsString( 'border-left-width:2px;', $rendered );
-		$this->assertStringContainsString( 'border-style:solid;', $rendered );
+		$this->assertStringContainsString( 'border-left-style:dashed;', $rendered );
 		$this->assertStringContainsString( 'padding-bottom:5px;', $rendered );
 		$this->assertStringContainsString( 'padding-left:15px;', $rendered );
 		$this->assertStringContainsString( 'padding-right:20px;', $rendered );

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Columns_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Columns_Test.php
@@ -96,6 +96,7 @@ class Columns_Test extends \Email_Editor_Integration_Test_Case {
 					'color'  => '#123456',
 					'radius' => '10px',
 					'width'  => '2px',
+					'style'  => 'solid',
 				),
 				'color'   => array(
 					'background' => '#abcdef',

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Renderer_Test.php
@@ -215,7 +215,7 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItInlinesColumnsColors(): void {
 		$email_post_id = $this->factory->post->create(
 			array(
-				'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+				'post_content' => '<!-- wp:columns {"backgroundColor":"black", "textColor":"luminous-vivid-orange"} -->
         <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --></div>
         <!-- /wp:columns -->',
 			)
@@ -235,7 +235,7 @@ class Renderer_Test extends \Email_Editor_Integration_Test_Case {
 	public function testItRendersTextVersion(): void {
 		$email_post_id = $this->factory->post->create(
 			array(
-				'post_content' => '<!-- wp:columns {"backgroundColor":"vivid-green-cyan", "textColor":"black"} -->
+				'post_content' => '<!-- wp:columns {"backgroundColor":"black", "textColor":"luminous-vivid-orange"} -->
         <div class="wp-block-columns has-black-background-color has-luminous-vivid-orange-color"><!-- wp:column --><!-- /wp:column --></div>
         <!-- /wp:columns -->',
 			)

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -314,23 +314,6 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 	}
 
 	/**
-	 * Test it extends block styles with invalid CSS declarations parameter.
-	 */
-	public function testItExtendsBlockStylesWithInvalidCssDeclarations(): void {
-		$block_styles = array(
-			'declarations' => array(
-				'padding' => '10px',
-			),
-			'css'          => 'padding: 10px;',
-			'classnames'   => 'test-class',
-		);
-
-		$result = Styles_Helper::extend_block_styles( $block_styles, 'invalid-declarations' );
-
-		$this->assertSame( $block_styles, $result );
-	}
-
-	/**
 	 * Test it gets block styles.
 	 */
 	public function testItGetsBlockStyles(): void {

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -295,38 +295,73 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 		$this->assertSame( 'test-class', $result['classnames'] );
 	}
 
-    /**
-     * Test it gets block styles.
-     */
-    public function testItGetsBlockStyles(): void {
-        $block_attributes = array(
-            'backgroundColor' => 'primary',
-            'textAlign'       => 'center',
-            'style'           => array(
-                'spacing' => array(
-                    'padding' => '10px',
-                ),
-            ),
-        );
+	/**
+	 * Test it extends block styles with invalid WP_Style_Engine structure.
+	 */
+	public function testItExtendsBlockStylesWithInvalidStructure(): void {
+		$css_declarations = array(
+			'margin' => '20px',
+			'color'  => 'red',
+		);
 
-        /**
-         * Rendering_Context mock for using in test.
-         *
-         * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-         */
-        $rendering_context = $this->createMock( Rendering_Context::class );
-        $rendering_context->method( 'translate_slug_to_color' )
-            ->willReturn( '#ff0000' );
+		$result = Styles_Helper::extend_block_styles( array( 'something' => 'else' ), $css_declarations );
 
-        $result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'background-color', 'text-align' ) );
+		$this->assertSame( $css_declarations, $result['declarations'] );
 
-        $this->assertArrayHasKey( 'css', $result );
-        $this->assertArrayHasKey( 'declarations', $result );
-        $this->assertArrayHasKey( 'classnames', $result );
-        $this->assertIsString( $result['css'] );
-        $this->assertIsArray( $result['declarations'] );
-        $this->assertIsString( $result['classnames'] );
-    }
+		$result = Styles_Helper::extend_block_styles( array( 'declarations' => 'invalid-declarations' ), $css_declarations );
+
+		$this->assertSame( $css_declarations, $result['declarations'] );
+	}
+
+	/**
+	 * Test it extends block styles with invalid CSS declarations parameter.
+	 */
+	public function testItExtendsBlockStylesWithInvalidCssDeclarations(): void {
+		$block_styles = array(
+			'declarations' => array(
+				'padding' => '10px',
+			),
+			'css'          => 'padding: 10px;',
+			'classnames'   => 'test-class',
+		);
+
+		$result = Styles_Helper::extend_block_styles( $block_styles, 'invalid-declarations' );
+
+		$this->assertSame( $block_styles, $result );
+	}
+
+	/**
+	 * Test it gets block styles.
+	 */
+	public function testItGetsBlockStyles(): void {
+		$block_attributes = array(
+			'backgroundColor' => 'primary',
+			'textAlign'       => 'center',
+			'style'           => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+		$rendering_context->method( 'translate_slug_to_color' )
+			->willReturn( '#ff0000' );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'background-color', 'text-align' ) );
+
+		$this->assertArrayHasKey( 'css', $result );
+		$this->assertArrayHasKey( 'declarations', $result );
+		$this->assertArrayHasKey( 'classnames', $result );
+		$this->assertIsString( $result['css'] );
+		$this->assertIsArray( $result['declarations'] );
+		$this->assertIsString( $result['classnames'] );
+	}
 
 	/**
 	 * Test it gets block styles with empty properties.

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -128,20 +128,22 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 		 */
 		$rendering_context = $this->createMock( Rendering_Context::class );
 		$rendering_context->method( 'translate_slug_to_color' )
-			->willReturnMap( array(
-				array( 'primary', '#ff0000' ),
-				array( 'secondary', '#00ff00' ),
-				array( 'accent', '#0000ff' ),
-			) );
+			->willReturnMap(
+				array(
+					array( 'primary', '#ff0000' ),
+					array( 'secondary', '#00ff00' ),
+					array( 'accent', '#0000ff' ),
+				)
+			);
 
 		$result = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
 
 		$expected = array(
-			'color'  => array(
+			'color'   => array(
 				'background' => '#ff0000',
 				'text'       => '#00ff00',
 			),
-			'border' => array(
+			'border'  => array(
 				'color' => '#0000ff',
 			),
 			'spacing' => array(
@@ -255,8 +257,8 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 		);
 
 		$css_declarations = array(
-			'margin'  => '20px',
-			'color'   => 'red',
+			'margin' => '20px',
+			'color'  => 'red',
 		);
 
 		$result = Styles_Helper::extend_block_styles( $block_styles, $css_declarations );

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -295,139 +295,38 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 		$this->assertSame( 'test-class', $result['classnames'] );
 	}
 
-	/**
-	 * Test it gets block styles with full return type.
-	 */
-	public function testItGetsBlockStylesWithFullReturnType(): void {
-		$block_attributes = array(
-			'backgroundColor' => 'primary',
-			'textAlign'       => 'center',
-			'style'           => array(
-				'spacing' => array(
-					'padding' => '10px',
-				),
-			),
-		);
+    /**
+     * Test it gets block styles.
+     */
+    public function testItGetsBlockStyles(): void {
+        $block_attributes = array(
+            'backgroundColor' => 'primary',
+            'textAlign'       => 'center',
+            'style'           => array(
+                'spacing' => array(
+                    'padding' => '10px',
+                ),
+            ),
+        );
 
-		/**
-		 * Rendering_Context mock for using in test.
-		 *
-		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-		 */
-		$rendering_context = $this->createMock( Rendering_Context::class );
-		$rendering_context->method( 'translate_slug_to_color' )
-			->willReturn( '#ff0000' );
+        /**
+         * Rendering_Context mock for using in test.
+         *
+         * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+         */
+        $rendering_context = $this->createMock( Rendering_Context::class );
+        $rendering_context->method( 'translate_slug_to_color' )
+            ->willReturn( '#ff0000' );
 
-		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'background-color', 'text-align' ) );
+        $result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'background-color', 'text-align' ) );
 
-		$this->assertArrayHasKey( 'css', $result );
-		$this->assertArrayHasKey( 'declarations', $result );
-		$this->assertArrayHasKey( 'classnames', $result );
-		$this->assertIsString( $result['css'] );
-		$this->assertIsArray( $result['declarations'] );
-		$this->assertIsString( $result['classnames'] );
-	}
-
-	/**
-	 * Test it gets block styles with css return type.
-	 */
-	public function testItGetsBlockStylesWithCssReturnType(): void {
-		$block_attributes = array(
-			'style' => array(
-				'spacing' => array(
-					'padding' => '10px',
-				),
-			),
-		);
-
-		/**
-		 * Rendering_Context mock for using in test.
-		 *
-		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-		 */
-		$rendering_context = $this->createMock( Rendering_Context::class );
-
-		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'css' );
-
-		$this->assertIsString( $result );
-		$this->assertStringContainsString( 'padding: 10px', $result );
-	}
-
-	/**
-	 * Test it gets block styles with declarations return type.
-	 */
-	public function testItGetsBlockStylesWithDeclarationsReturnType(): void {
-		$block_attributes = array(
-			'style' => array(
-				'spacing' => array(
-					'padding' => '10px',
-				),
-			),
-		);
-
-		/**
-		 * Rendering_Context mock for using in test.
-		 *
-		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-		 */
-		$rendering_context = $this->createMock( Rendering_Context::class );
-
-		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'declarations' );
-
-		$this->assertIsArray( $result );
-		$this->assertSame( '10px', $result['padding'] );
-	}
-
-	/**
-	 * Test it gets block styles with classnames return type.
-	 */
-	public function testItGetsBlockStylesWithClassnamesReturnType(): void {
-		$block_attributes = array(
-			'style' => array(
-				'spacing' => array(
-					'padding' => '10px',
-				),
-			),
-		);
-
-		/**
-		 * Rendering_Context mock for using in test.
-		 *
-		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-		 */
-		$rendering_context = $this->createMock( Rendering_Context::class );
-
-		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'classnames' );
-
-		$this->assertIsString( $result );
-	}
-
-	/**
-	 * Test it gets return type for block styles falls back to full with unknown return type.
-	 */
-	public function testItGetsBlockStylesWithUnknownReturnType(): void {
-		$block_attributes = array(
-			'style' => array(
-				'spacing' => array(
-					'padding' => '10px',
-				),
-			),
-		);
-
-		/**
-		 * Rendering_Context mock for using in test.
-		 *
-		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
-		 */
-		$rendering_context = $this->createMock( Rendering_Context::class );
-
-		$properties = array( 'spacing' );
-
-		$result      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'unknown' );
-		$result_full = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'full' );
-
-		$this->assertSame( $result, $result_full );
-	}
+        $this->assertArrayHasKey( 'css', $result );
+        $this->assertArrayHasKey( 'declarations', $result );
+        $this->assertArrayHasKey( 'classnames', $result );
+        $this->assertIsString( $result['css'] );
+        $this->assertIsArray( $result['declarations'] );
+        $this->assertIsString( $result['classnames'] );
+    }
 
 	/**
 	 * Test it gets block styles with empty properties.

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -9,6 +9,8 @@ declare(strict_types = 1);
 
 namespace Automattic\WooCommerce\EmailEditor\Integrations\Utils;
 
+use Automattic\WooCommerce\EmailEditor\Engine\Renderer\ContentRenderer\Rendering_Context;
+
 /**
  * Unit test for Styles_Helper class.
  */
@@ -28,6 +30,23 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 	public function testItParsesValueWithCustomUnit(): void {
 		$this->assertSame( 1.25, Styles_Helper::parse_value( '1.25em' ) );
 		$this->assertSame( 80.0, Styles_Helper::parse_value( '80%' ) );
+	}
+
+	/**
+	 * Test it parses negative values.
+	 */
+	public function testItParsesNegativeValues(): void {
+		$this->assertSame( -12.5, Styles_Helper::parse_value( '-12.5px' ) );
+		$this->assertSame( -100.0, Styles_Helper::parse_value( '-100em' ) );
+	}
+
+	/**
+	 * Test it handles invalid values.
+	 */
+	public function testItHandlesInvalidValues(): void {
+		$this->assertSame( 0.0, Styles_Helper::parse_value( 'invalid' ) );
+		$this->assertSame( 0.0, Styles_Helper::parse_value( '' ) );
+		$this->assertSame( 0.0, Styles_Helper::parse_value( 'px' ) );
 	}
 
 	/**
@@ -65,5 +84,395 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 			'color'  => 'blue',
 		);
 		$this->assertSame( $expected, Styles_Helper::parse_styles_to_array( $input ) );
+	}
+
+	/**
+	 * Test it handles empty styles string.
+	 */
+	public function testItHandlesEmptyStylesString(): void {
+		$this->assertSame( array(), Styles_Helper::parse_styles_to_array( '' ) );
+		$this->assertSame( array(), Styles_Helper::parse_styles_to_array( '   ' ) );
+	}
+
+	/**
+	 * Test it handles styles with colons in values.
+	 */
+	public function testItHandlesStylesWithColonsInValues(): void {
+		$input    = 'background: url(http://example.com); color: red;';
+		$expected = array(
+			'background' => 'url(http://example.com)',
+			'color'      => 'red',
+		);
+		$this->assertSame( $expected, Styles_Helper::parse_styles_to_array( $input ) );
+	}
+
+	/**
+	 * Test it gets normalized block styles with color translations.
+	 */
+	public function testItGetsNormalizedBlockStylesWithColorTranslations(): void {
+		$block_attributes = array(
+			'backgroundColor' => 'primary',
+			'textColor'       => 'secondary',
+			'borderColor'     => 'accent',
+			'style'           => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+		$rendering_context->method( 'translate_slug_to_color' )
+			->willReturnMap( array(
+				array( 'primary', '#ff0000' ),
+				array( 'secondary', '#00ff00' ),
+				array( 'accent', '#0000ff' ),
+			) );
+
+		$result = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
+
+		$expected = array(
+			'color'  => array(
+				'background' => '#ff0000',
+				'text'       => '#00ff00',
+			),
+			'border' => array(
+				'color' => '#0000ff',
+			),
+			'spacing' => array(
+				'padding' => '10px',
+			),
+		);
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test it gets normalized block styles without color attributes.
+	 */
+	public function testItGetsNormalizedBlockStylesWithoutColorAttributes(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
+
+		$expected = array(
+			'spacing' => array(
+				'padding' => '10px',
+			),
+		);
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test it gets normalized block styles with empty color values.
+	 */
+	public function testItGetsNormalizedBlockStylesWithEmptyColorValues(): void {
+		$block_attributes = array(
+			'backgroundColor' => '',
+			'textColor'       => null,
+			'borderColor'     => false,
+			'style'           => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_normalized_block_styles( $block_attributes, $rendering_context );
+
+		$expected = array(
+			'spacing' => array(
+				'padding' => '10px',
+			),
+		);
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test it gets styles from block with default parameters.
+	 */
+	public function testItGetsStylesFromBlockWithDefaultParameters(): void {
+		$block_styles = array(
+			'spacing' => array(
+				'padding' => '10px',
+			),
+		);
+
+		$result = Styles_Helper::get_styles_from_block( $block_styles );
+
+		$this->assertIsArray( $result['declarations'] );
+		$this->assertIsString( $result['css'] );
+		$this->assertIsString( $result['classnames'] );
+	}
+
+	/**
+	 * Test it gets styles from empty block.
+	 */
+	public function testItGetsStylesFromEmptyBlock(): void {
+		$result = Styles_Helper::get_styles_from_block( array() );
+
+		$expected = Styles_Helper::$empty_block_styles;
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test it extends block styles with CSS declarations.
+	 */
+	public function testItExtendsBlockStylesWithCssDeclarations(): void {
+		$block_styles = array(
+			'declarations' => array(
+				'padding' => '10px',
+			),
+			'css'          => 'padding: 10px;',
+			'classnames'   => 'test-class',
+		);
+
+		$css_declarations = array(
+			'margin'  => '20px',
+			'color'   => 'red',
+		);
+
+		$result = Styles_Helper::extend_block_styles( $block_styles, $css_declarations );
+
+		$expected_declarations = array(
+			'padding' => '10px',
+			'margin'  => '20px',
+			'color'   => 'red',
+		);
+
+		$this->assertSame( $expected_declarations, $result['declarations'] );
+		$this->assertStringContainsString( 'padding: 10px', $result['css'] );
+		$this->assertStringContainsString( 'margin: 20px', $result['css'] );
+		$this->assertStringContainsString( 'color: red', $result['css'] );
+		$this->assertSame( 'test-class', $result['classnames'] );
+	}
+
+	/**
+	 * Test it extends block styles with empty declarations.
+	 */
+	public function testItExtendsBlockStylesWithEmptyDeclarations(): void {
+		$block_styles = array(
+			'declarations' => array(
+				'padding' => '10px',
+			),
+			'css'          => 'padding: 10px;',
+			'classnames'   => 'test-class',
+		);
+
+		$result = Styles_Helper::extend_block_styles( $block_styles, array() );
+
+		$this->assertSame( array( 'padding' => '10px' ), $result['declarations'] );
+		$this->assertSame( 'padding: 10px;', $result['css'] );
+		$this->assertSame( 'test-class', $result['classnames'] );
+	}
+
+	/**
+	 * Test it gets block styles with full return type.
+	 */
+	public function testItGetsBlockStylesWithFullReturnType(): void {
+		$block_attributes = array(
+			'backgroundColor' => 'primary',
+			'textAlign'       => 'center',
+			'style'           => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+		$rendering_context->method( 'translate_slug_to_color' )
+			->willReturn( '#ff0000' );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing', 'background-color', 'text-align' ) );
+
+		$this->assertArrayHasKey( 'css', $result );
+		$this->assertArrayHasKey( 'declarations', $result );
+		$this->assertArrayHasKey( 'classnames', $result );
+		$this->assertIsString( $result['css'] );
+		$this->assertIsArray( $result['declarations'] );
+		$this->assertIsString( $result['classnames'] );
+	}
+
+	/**
+	 * Test it gets block styles with css return type.
+	 */
+	public function testItGetsBlockStylesWithCssReturnType(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'css' );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'padding: 10px', $result );
+	}
+
+	/**
+	 * Test it gets block styles with declarations return type.
+	 */
+	public function testItGetsBlockStylesWithDeclarationsReturnType(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'declarations' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '10px', $result['padding'] );
+	}
+
+	/**
+	 * Test it gets block styles with classnames return type.
+	 */
+	public function testItGetsBlockStylesWithClassnamesReturnType(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array( 'spacing' ), 'classnames' );
+
+		$this->assertIsString( $result );
+	}
+
+	/**
+	 * Test it gets empty string for block styles with unknown return type.
+	 */
+	public function testItGetsBlockStylesWithUnknownReturnType(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$properties = array( 'spacing' );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'unknown' );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test it gets block styles with empty properties.
+	 */
+	public function testItGetsBlockStylesWithEmptyProperties(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, array() );
+
+		$this->assertSame( Styles_Helper::$empty_block_styles, $result );
+	}
+
+	/**
+	 * Test it gets block styles with unknown properties.
+	 */
+	public function testItGetsBlockStylesWithUnknownProperties(): void {
+		$block_attributes = array(
+			'style' => array(
+				'spacing' => array(
+					'padding' => '10px',
+				),
+			),
+		);
+
+		/**
+		 * Rendering_Context mock for using in test.
+		 *
+		 * @var Rendering_Context&\PHPUnit\Framework\MockObject\MockObject $rendering_context
+		 */
+		$rendering_context = $this->createMock( Rendering_Context::class );
+
+		$properties = array( 'unknown-property' );
+
+		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties );
+
+		$this->assertSame( Styles_Helper::$empty_block_styles, $result );
 	}
 }

--- a/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
+++ b/packages/php/email-editor/tests/unit/Integrations/Utils/Styles_Helper_Test.php
@@ -403,7 +403,7 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 	}
 
 	/**
-	 * Test it gets empty string for block styles with unknown return type.
+	 * Test it gets return type for block styles falls back to full with unknown return type.
 	 */
 	public function testItGetsBlockStylesWithUnknownReturnType(): void {
 		$block_attributes = array(
@@ -423,9 +423,10 @@ class Styles_Helper_Test extends \Email_Editor_Unit_Test {
 
 		$properties = array( 'spacing' );
 
-		$result = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'unknown' );
+		$result      = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'unknown' );
+		$result_full = Styles_Helper::get_block_styles( $block_attributes, $rendering_context, $properties, 'full' );
 
-		$this->assertSame( '', $result );
+		$this->assertSame( $result, $result_full );
 	}
 
 	/**

--- a/packages/php/email-editor/tests/unit/stubs.php
+++ b/packages/php/email-editor/tests/unit/stubs.php
@@ -7,6 +7,59 @@
 
 declare(strict_types = 1);
 
+// Dummy WP functions.
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	/**
+	 * Mock wp_parse_args function.
+	 *
+	 * @param array|object $args     Value to merge with $defaults.
+	 * @param array        $defaults Array that serves as the defaults.
+	 * @return array Merged user defined values with defaults.
+	 */
+	function wp_parse_args( $args, $defaults = array() ) {
+		if ( is_object( $args ) ) {
+			$parsed_args = get_object_vars( $args );
+		} elseif ( is_array( $args ) ) {
+			$parsed_args =& $args;
+		} else {
+			$parsed_args = array();
+		}
+
+		if ( is_array( $defaults ) && $defaults ) {
+			return array_merge( $defaults, $parsed_args );
+		}
+
+		return $parsed_args;
+	}
+}
+
+if ( ! function_exists( 'wp_style_engine_get_styles' ) ) {
+	/**
+	 * Mock wp_style_engine_get_styles function.
+	 *
+	 * @param array $block_styles Array of block styles.
+	 * @param array $options      Optional. An array of options.
+	 * @return array
+	 */
+	function wp_style_engine_get_styles( $block_styles, $options = array() ) {
+		// Return empty structure for empty input
+		if ( empty( $block_styles ) ) {
+			return array(
+				'css'          => '',
+				'declarations' => array(),
+				'classnames'   => '',
+			);
+		}
+
+		// Return basic structure for non-empty input
+		return array(
+			'css'          => 'padding: 10px;',
+			'declarations' => array( 'padding' => '10px' ),
+			'classnames'   => '',
+		);
+	}
+}
+
 // Dummy WP classes.
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 // phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
@@ -101,6 +154,28 @@ if ( ! class_exists( \WP_Theme_JSON::class ) ) {
 		 */
 		public function get_stylesheet( $types = array( 'variables', 'styles', 'presets' ), $origins = null, $options = array() ): string {
 			return '';
+		}
+	}
+}
+
+if ( ! class_exists( \WP_Style_Engine::class ) ) {
+	/**
+	 * Class WP_Style_Engine
+	 */
+	class WP_Style_Engine {
+		/**
+		 * Compile CSS from declarations.
+		 *
+		 * @param array  $declarations Array of CSS declarations.
+		 * @param string $selector     CSS selector.
+		 * @return string
+		 */
+		public static function compile_css( $declarations, $selector = '' ) {
+			$css = '';
+			foreach ( $declarations as $property => $value ) {
+				$css .= $property . ': ' . $value . '; ';
+			}
+			return trim( $css );
 		}
 	}
 }

--- a/packages/php/email-editor/tests/unit/stubs.php
+++ b/packages/php/email-editor/tests/unit/stubs.php
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed, Generic.Files.OneObjectStructurePerFile.MultipleFound
+
 // Dummy WP functions.
 if ( ! function_exists( 'wp_parse_args' ) ) {
 	/**
@@ -38,11 +40,10 @@ if ( ! function_exists( 'wp_style_engine_get_styles' ) ) {
 	 * Mock wp_style_engine_get_styles function.
 	 *
 	 * @param array $block_styles Array of block styles.
-	 * @param array $options      Optional. An array of options.
 	 * @return array
 	 */
-	function wp_style_engine_get_styles( $block_styles, $options = array() ) {
-		// Return empty structure for empty input
+	function wp_style_engine_get_styles( $block_styles ) {
+		// Return empty structure for empty input.
 		if ( empty( $block_styles ) ) {
 			return array(
 				'css'          => '',
@@ -51,7 +52,7 @@ if ( ! function_exists( 'wp_style_engine_get_styles' ) ) {
 			);
 		}
 
-		// Return basic structure for non-empty input
+		// Return basic structure for non-empty input.
 		return array(
 			'css'          => 'padding: 10px;',
 			'declarations' => array( 'padding' => '10px' ),
@@ -61,7 +62,6 @@ if ( ! function_exists( 'wp_style_engine_get_styles' ) ) {
 }
 
 // Dummy WP classes.
-// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 // phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
 if ( ! class_exists( \WP_Theme_JSON::class ) ) {
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Implement helper methods in `Styles_Helper` utility class to help with generating inline styles in the email block renderers.
* Update the email blocks to utilize the new methods.

Note that some blocks were previously enforcing `border-style: solid` if any border styles have been applied to the block. However, the border styles are handled in the [Border_Style_Postprocessor](https://github.com/woocommerce/woocommerce/blob/2e2f529d34d9099431797b9221c70e0166ee7d84/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Postprocessors/class-border-style-postprocessor.php) and thus these parts of the block renderers have been removed.

Closes [WOOPLUG-4688: Add style factory method(s) for emails](https://linear.app/a8c/issue/WOOPLUG-4688/add-style-factory-methods-for-emails) (https://github.com/woocommerce/woocommerce/issues/58957).

### Screenshots or screen recordings:

N/A

### How to test the changes in this Pull Request:

1. Code review.
2. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
3. Open an email in the editor WooCommerce → Settings → **Emails**
4. For all updated blocks - **Button, Column(s), Group, Quote, Paragraph, Heading** - insert the block and apply various styles - background, color, padding, etc. - and confirm they are all rendered correctly in the email preview.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Add `Styles_Helper` methods to generate inline styles from block attributes, and refactor blocks to utilize them.

</details>
