### PR TITLE
Consistently display shortcodes with square brackets in WooCommerce system status report

### DIFF
--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -16,7 +16,7 @@ The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/P
 - **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
 - **Changelog Section:** The changelog section in the PR description must keep the markdown structure from the PR template exactly as-is, including all checkboxes, comments, and headings. Only the appropriate checkbox may be checked, and the changelog message must be placed under the `#### Comment` heading and before the closing `</details>` tag. Do not add, remove, or reformat any part of the changelog section except for checking the box and adding the message in the correct place.
 - **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
-- **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation.
+- **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation. Do not remove any checkbox items.
 - **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
 - **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change, following these rules strictly.
 

--- a/plugins/woocommerce/changelog/59687-wooplug-5022-woocommerce-status-woocommerce-pages-box-wording-not
+++ b/plugins/woocommerce/changelog/59687-wooplug-5022-woocommerce-status-woocommerce-pages-box-wording-not
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix inconsistent shortcode display in WooCommerce Status pages section. This improvement ensures consistent formatting of shortcode display in the WooCommerce Status "WooCommerce pages" box, making all shortcodes appear with square brackets for better clarity and consistency.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -903,8 +903,13 @@ if ( 0 < $mu_plugins_count ) :
 					if ( CartCheckoutUtils::is_overriden_by_custom_template_content( $_page['block'] ) ) {
 						$additional_info = __( "This page's content is overridden by custom template content", 'woocommerce' );
 					} elseif ( $_page['shortcode_present'] ) {
-						/* Translators: %1$s: shortcode text. */
-						$additional_info = sprintf( __( 'Contains the <strong>%1$s</strong> shortcode', 'woocommerce' ), esc_html( $_page['shortcode'] ) );
+						// Always display the shortcode with square brackets for consistency.
+						$shortcode_display = $_page['shortcode'];
+						if ( $shortcode_display && '[' !== $shortcode_display[0] ) {
+							$shortcode_display = '[' . $shortcode_display . ']';
+						}
+						/* translators: %1$s: shortcode text. */
+						$additional_info = sprintf( __( 'Contains the <strong>%1$s</strong> shortcode', 'woocommerce' ), esc_html( $shortcode_display ) );
 					} elseif ( $_page['block_present'] ) {
 						/* Translators: %1$s: block slug. */
 						$additional_info = sprintf( __( 'Contains the <strong>%1$s</strong> block', 'woocommerce' ), esc_html( $_page['block'] ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR addresses the inconsistency in shortcode display within the WooCommerce Status "WooCommerce pages" box. Previously, the My Account page showed shortcodes with square brackets (e.g., `[woocommerce_my_account]`) while Cart and Checkout pages showed them without brackets (e.g., `woocommerce_cart`, `woocommerce_checkout`).

The fix ensures all shortcodes are displayed consistently with square brackets for better clarity and consistency across the status report.

Closes #59673.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| Cart: "Contains the woocommerce_cart shortcode"<br>Checkout: "Contains the woocommerce_checkout shortcode"<br>My Account: "Contains the [woocommerce_my_account] shortcode" | Cart: "Contains the [woocommerce_cart] shortcode"<br>Checkout: "Contains the [woocommerce_checkout] shortcode"<br>My Account: "Contains the [woocommerce_my_account] shortcode" |

### How to test the changes in this Pull Request:

1. Configure Cart and Checkout pages to use the relevant shortcodes instead of the blocks.
2. Navigate to WooCommerce → Status in the WordPress admin
3. Scroll down to the "WooCommerce pages" section
4. Verify that all page status messages show shortcodes with square brackets:
   - Cart page should display: "Contains the [woocommerce_cart] shortcode"
   - Checkout page should display: "Contains the [woocommerce_checkout] shortcode"  
   - My Account page should display: "Contains the [woocommerce_my_account] shortcode"

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Fix inconsistent shortcode display in WooCommerce Status pages section. This improvement ensures consistent formatting of shortcode display in the WooCommerce Status "WooCommerce pages" box, making all shortcodes appear with square brackets for better clarity and consistency.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>