### PR TITLE
 Product Details: prevent the default template to be auto applied for existing blocks

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5015-woo-1002-products-details-block-regression-compatibility
+++ b/plugins/woocommerce/changelog/wooplug-5015-woo-1002-products-details-block-regression-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Details: prevent the default template to be auto applied for existing blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -10,11 +10,14 @@ import {
 	store as blockEditorStore,
 	Warning,
 } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { ProductDetailsEditProps } from './types';
+import { LegacyProductDetailsPreview } from './legacy-preview';
+import './editor.scss';
 
 const TEMPLATE: InnerBlockTemplate[] = [
 	[
@@ -106,8 +109,22 @@ const useIsInvalidQueryLoopContext = ( clientId: string, postType: string ) => {
 const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 	const blockProps = useBlockProps();
 
+	const { hasInnerBlocks, wasBlockJustInserted } = useSelect(
+		( select ) => {
+			const blocks = select( blockEditorStore ).getBlocks( clientId );
+			return {
+				hasInnerBlocks: blocks.length > 0,
+				wasBlockJustInserted:
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore method exists but not typed
+					select( blockEditorStore ).wasBlockJustInserted( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: TEMPLATE,
+		template: wasBlockJustInserted ? TEMPLATE : undefined,
 	} );
 
 	const isInvalidQueryLoopContext = useIsInvalidQueryLoopContext(
@@ -126,7 +143,19 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 			</div>
 		);
 	}
-	return <div { ...innerBlocksProps } />;
+
+	console.log( hasInnerBlocks, wasBlockJustInserted );
+	if ( hasInnerBlocks || wasBlockJustInserted ) {
+		return <div { ...innerBlocksProps } />;
+	}
+
+	return (
+		<div { ...blockProps }>
+			<Disabled>
+				<LegacyProductDetailsPreview hideTabTitle={ true } />
+			</Disabled>
+		</div>
+	);
 };
 
 export default Edit;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -144,7 +144,6 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 		);
 	}
 
-	console.log( hasInnerBlocks, wasBlockJustInserted );
 	if ( hasInnerBlocks || wasBlockJustInserted ) {
 		return <div { ...innerBlocksProps } />;
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/editor.scss
@@ -1,0 +1,44 @@
+/*
+ * Classic style - Editor Preview only.
+ *
+ * Hint: Front-end is handled by the WooCommerce base styles.
+ */
+ .wp-block-woocommerce-product-details {
+	ul.wc-tabs {
+		list-style: none;
+		padding: 0 0 0 1em;
+		margin: 0 0 1.618em;
+		overflow: hidden;
+		position: relative;
+		border-bottom: 1px solid $gray-200;
+
+		li {
+			border: 1px solid $gray-200;
+			display: inline-block;
+			position: relative;
+			z-index: 0;
+			border-radius: $universal-border-radius $universal-border-radius 0 0;
+			margin: 0;
+			padding: 0 1em;
+
+			a {
+				display: inline-block;
+				padding: 0.5em 0;
+				font-weight: 700;
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: none;
+				}
+			}
+
+			&.active {
+				z-index: 2;
+
+				a {
+					text-shadow: inherit;
+				}
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -28,10 +28,6 @@ const blockConfig = {
 			save() {
 				return null;
 			},
-			migrate( attributes ) {
-				const { hideTabTitle, ...restAttributes } = attributes;
-				return restAttributes;
-			},
 		},
 	],
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/legacy-preview.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/legacy-preview.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { __ } from '@wordpress/i18n';
+
+interface SingleProductTab {
+	id: string;
+	title: string;
+	active: boolean;
+	content: React.JSX.Element | undefined;
+}
+
+const ProductTabTitle = ( {
+	id,
+	title,
+	active,
+}: Pick< SingleProductTab, 'id' | 'title' | 'active' > ) => {
+	return (
+		<li
+			className={ clsx( `${ id }_tab`, {
+				active,
+			} ) }
+			id={ `tab-title-${ id }` }
+			role="tab"
+			aria-controls={ `tab-${ id }` }
+		>
+			<a href={ `#tab-${ id }` }>{ title }</a>
+		</li>
+	);
+};
+
+const ProductTabContent = ( {
+	id,
+	content,
+}: Pick< SingleProductTab, 'id' | 'content' > ) => {
+	return (
+		<div
+			className={ `${ id }_tab` }
+			id={ `tab-title-${ id }` }
+			role="tab"
+			aria-controls={ `tab-${ id }` }
+		>
+			{ content }
+		</div>
+	);
+};
+
+export const LegacyProductDetailsPreview = ( {
+	hideTabTitle,
+}: {
+	hideTabTitle: boolean;
+} ) => {
+	const productTabs = [
+		{
+			id: 'description',
+			title: 'Description',
+			active: true,
+			content: (
+				<>
+					{ ! hideTabTitle && (
+						<h2>{ __( 'Description', 'woocommerce' ) }</h2>
+					) }
+					<p>
+						{ __(
+							'This block lists description, attributes and reviews for a single product.',
+							'woocommerce'
+						) }
+					</p>
+				</>
+			),
+		},
+		{
+			id: 'additional_information',
+			title: 'Additional Information',
+			active: false,
+		},
+		{ id: 'reviews', title: 'Reviews', active: false },
+	];
+	const tabsTitle = productTabs.map( ( { id, title, active } ) => (
+		<ProductTabTitle
+			key={ id }
+			id={ id }
+			title={ title }
+			active={ active }
+		/>
+	) );
+	const tabsContent = productTabs.map( ( { id, content } ) => (
+		<ProductTabContent key={ id } id={ id } content={ content } />
+	) );
+
+	return (
+		<>
+			<ul className="wc-tabs tabs" role="tablist">
+				{ tabsTitle }
+			</ul>
+			{ tabsContent }
+		</>
+	);
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR prevents the existing Product Details blocks from upgrading to the new Accordion layout automatically and ensures the new layout will only be applied to newly inserted blocks. 

Closes https://github.com/woocommerce/woocommerce/issues/59663
Closes wooplug-5015

(For Bug Fixes) Bug introduced in PR #59005

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


https://github.com/user-attachments/assets/663a42a5-42e3-495e-ae07-5237c53e9cb5

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using Code Editor, add this to the Single Product template: `<!-- wp:woocommerce/product-details {"className":"is-style-minimal"} /-->`. This simulates the existing Product Details block.
2. Update and reload the editor.
3. Switch to the visual editor.
4. See the Product Details block unchanged, still a single block without any nested blocks.
5. Add a new Product Details block to the template.
6. See the Accordion layout is used for the newly inserted block.
7. Reload the editor again.
8. Delete the Accordion Group block inside Product Details.
9. See the legacy editor preview of the previous version of the block rendered.

Note: If the Accordion Group block is deleted right after being inserted into the editor, the legacy preview won't show. The preview is added to maintain backward compatibility for existing instances of the block.

<!-- End testing instructions -->