### PR TITLE
Interactivity API powered Mini Cart: Backward compatibility for `registerCheckoutFilters`/`applyCheckoutFilter`

### DIFF
--- a/plugins/woocommerce/changelog/59693-wooplug-4753-interactivity-api-powered-mini-cart-analyze-existing
+++ b/plugins/woocommerce/changelog/59693-wooplug-4753-interactivity-api-powered-mini-cart-analyze-existing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Adds backward compatibility for `registerCheckoutFilters` in the new iAPI-powered Mini-Cart.

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -56,6 +56,9 @@ table.wc-block-cart-items {
 
 				text-transform: none;
 				white-space: nowrap;
+				&[hidden] {
+					display: none;
+				}
 			}
 		}
 		.wc-block-components-product-name {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -238,10 +238,33 @@ const { state: cartItemState } = store(
 					.convertPrecision( cartItemState.currency.minorUnit )
 					.getAmount();
 
-				return formatPriceWithCurrency(
+				const price = formatPriceWithCurrency(
 					discountPrice,
 					cartItemState.currency
 				);
+
+				// TODO: Add deprecation notice urging to replace with a
+				// `data-wp-text` directive or an alternative solution.
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					const priceText = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'saleBadgePriceFormat',
+						defaultValue: '<price/>',
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+
+					return priceText.replace( '<price/>', price );
+				}
+
+				return price;
 			},
 
 			get lineItemDiscount(): string {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -288,10 +288,33 @@ const { state: cartItemState } = store(
 					.convertPrecision( cartItemState.currency.minorUnit )
 					.getAmount();
 
-				return formatPriceWithCurrency(
+				const price = formatPriceWithCurrency(
 					totalLineItemDiscount,
 					cartItemState.currency
 				);
+
+				// TODO: Add deprecation notice urging to replace with a
+				// `data-wp-text` directive or an alternative solution.
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					const priceText = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'saleBadgePriceFormat',
+						defaultValue: '<price/>',
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+
+					return priceText.replace( '<price/>', price );
+				}
+
+				return price;
 			},
 
 			get cartItemHasDiscount(): boolean {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -246,20 +246,23 @@ const { state: cartItemState } = store(
 				// TODO: Add deprecation notice urging to replace with a
 				// `data-wp-text` directive or an alternative solution.
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					const priceText = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'saleBadgePriceFormat',
-						defaultValue: '<price/>',
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					const priceText =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'saleBadgePriceFormat',
+								defaultValue: '<price/>',
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 
 					return priceText.replace( '<price/>', price );
 				}
@@ -296,20 +299,23 @@ const { state: cartItemState } = store(
 				// TODO: Add deprecation notice urging to replace with a
 				// `data-wp-text` directive or an alternative solution.
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					const priceText = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'saleBadgePriceFormat',
-						defaultValue: '<price/>',
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					const priceText =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'saleBadgePriceFormat',
+								defaultValue: '<price/>',
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 
 					return priceText.replace( '<price/>', price );
 				}
@@ -373,20 +379,23 @@ const { state: cartItemState } = store(
 				const txt = document.createElement( 'textarea' );
 				let { name } = cartItemState.cartItem;
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					name = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'itemName',
-						defaultValue: name,
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					name =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'itemName',
+								defaultValue: name,
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 				}
 				txt.innerHTML = name;
 				return txt.value;
@@ -407,20 +416,23 @@ const { state: cartItemState } = store(
 				// TODO: Add deprecation notice urging to replace with a
 				// `data-wp-text` directive or an alternative solution.
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					const priceText = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'subtotalPriceFormat',
-						defaultValue: '<price/>',
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					const priceText =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'subtotalPriceFormat',
+								defaultValue: '<price/>',
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 					return priceText.split( '<price/>' )[ 0 ];
 				}
 				return null;
@@ -430,20 +442,23 @@ const { state: cartItemState } = store(
 				// TODO: Add deprecation notice urging to replace with a
 				// `data-wp-text` directive or an alternative solution.
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					const priceText = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'subtotalPriceFormat',
-						defaultValue: '<price/>',
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					const priceText =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'subtotalPriceFormat',
+								defaultValue: '<price/>',
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 					return priceText.split( '<price/>' )[ 1 ];
 				}
 				return null;
@@ -473,20 +488,23 @@ const { state: cartItemState } = store(
 				// TODO: Add deprecation notice urging to replace with a
 				// `data-wp-text` directive or an alternative solution.
 				if (
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
 				) {
-					const priceText = (
-						window.wc as any
-					 ).blocksCheckout.applyCheckoutFilter( {
-						filterName: 'cartItemPrice',
-						defaultValue: '<price/>',
-						extensions: cartItemState.cartItem.extensions,
-						arg: {
-							context: 'cart',
-							cartItem: cartItemState.cartItem,
-							cart: woocommerceState.cart,
-						},
-					} );
+					const priceText =
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						( window.wc as any ).blocksCheckout.applyCheckoutFilter(
+							{
+								filterName: 'cartItemPrice',
+								defaultValue: '<price/>',
+								extensions: cartItemState.cartItem.extensions,
+								arg: {
+									context: 'cart',
+									cartItem: cartItemState.cartItem,
+									cart: woocommerceState.cart,
+								},
+							}
+						);
 
 					return priceText.replace( '<price/>', price );
 				}
@@ -525,8 +543,10 @@ const { state: cartItemState } = store(
 			},
 
 			get itemShowRemoveItemLink(): boolean {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				return ( window.wc as any )?.blocksCheckout.applyCheckoutFilter
-					? ( window.wc as any ).blocksCheckout.applyCheckoutFilter( {
+					? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+					  ( window.wc as any ).blocksCheckout.applyCheckoutFilter( {
 							filterName: 'showRemoveItemLink',
 							defaultValue: true,
 							extensions: cartItemState.cartItem.extensions,
@@ -614,11 +634,15 @@ const { state: cartItemState } = store(
 			},
 			filterCartItemClass() {
 				// TODO: Add deprecation notice urging to replace with a `data-wp-class` directive.
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				const applyCheckoutFilter = ( window.wc as any )?.blocksCheckout
 					?.applyCheckoutFilter;
+				// eslint-disable-next-line react-hooks/rules-of-hooks
 				const previouslyAppliedClasses = useRef< string[] >( [] );
 
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore -- It must run on every render.
+				// eslint-disable-next-line react-hooks/rules-of-hooks
 				useLayoutEffect( () => {
 					if ( applyCheckoutFilter ) {
 						const { ref } = getElement();

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -321,34 +321,51 @@ const { state: cartItemState } = store(
 			get reduceQuantityLabel(): string {
 				return reduceQuantityLabel.replace(
 					'%s',
-					cartItemState.cartItem.name
+					cartItemState.cartItemName
 				);
 			},
 
 			get increaseQuantityLabel(): string {
 				return increaseQuantityLabel.replace(
 					'%s',
-					cartItemState.cartItem.name
+					cartItemState.cartItemName
 				);
 			},
 
 			get quantityDescriptionLabel(): string {
 				return quantityDescriptionLabel.replace(
 					'%s',
-					cartItemState.cartItem.name
+					cartItemState.cartItemName
 				);
 			},
 
 			get removeFromCartLabel(): string {
 				return removeFromCartLabel.replace(
 					'%s',
-					cartItemState.cartItem.name
+					cartItemState.cartItemName
 				);
 			},
 
-			get cartItemName() {
+			get cartItemName(): string {
 				const txt = document.createElement( 'textarea' );
-				txt.innerHTML = cartItemState.cartItem.name;
+				let { name } = cartItemState.cartItem;
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					name = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'itemName',
+						defaultValue: name,
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+				}
+				txt.innerHTML = name;
 				return txt.value;
 			},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -483,6 +483,21 @@ const { state: cartItemState } = store(
 					cartItemState.cartItem.low_stock_remaining
 				);
 			},
+
+			get itemShowRemoveItemLink(): boolean {
+				return ( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					? ( window.wc as any ).blocksCheckout.applyCheckoutFilter( {
+							filterName: 'showRemoveItemLink',
+							defaultValue: true,
+							extensions: cartItemState.cartItem.extensions,
+							arg: {
+								context: 'cart',
+								cartItem: cartItemState.cartItem,
+								cart: woocommerceState.cart,
+							},
+					  } )
+					: true;
+			},
 		},
 
 		actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -340,6 +340,52 @@ const { state: cartItemState } = store(
 				);
 			},
 
+			get beforeItemPrice(): string | null {
+				// TODO: Add deprecation notice urging to replace with a
+				// `data-wp-text` directive or an alternative solution.
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					const priceText = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'subtotalPriceFormat',
+						defaultValue: '<price/>',
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+					return priceText.split( '<price/>' )[ 0 ];
+				}
+				return null;
+			},
+
+			get afterItemPrice(): string | null {
+				// TODO: Add deprecation notice urging to replace with a
+				// `data-wp-text` directive or an alternative solution.
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					const priceText = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'subtotalPriceFormat',
+						defaultValue: '<price/>',
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+					return priceText.split( '<price/>' )[ 1 ];
+				}
+				return null;
+			},
+
 			get itemPrice(): string {
 				return formatPriceWithCurrency(
 					parseInt( cartItemState.cartItem.prices.price, 10 ),

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -356,7 +356,33 @@ const { state: cartItemState } = store(
 					  parseInt( totals.line_subtotal_tax, 10 )
 					: parseInt( totals.line_subtotal, 10 );
 
-				return formatPriceWithCurrency( totalLinePrice, itemCurrency );
+				const price = formatPriceWithCurrency(
+					totalLinePrice,
+					itemCurrency
+				);
+
+				// TODO: Add deprecation notice urging to replace with a
+				// `data-wp-text` directive or an alternative solution.
+				if (
+					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				) {
+					const priceText = (
+						window.wc as any
+					 ).blocksCheckout.applyCheckoutFilter( {
+						filterName: 'cartItemPrice',
+						defaultValue: '<price/>',
+						extensions: cartItemState.cartItem.extensions,
+						arg: {
+							context: 'cart',
+							cartItem: cartItemState.cartItem,
+							cart: woocommerceState.cart,
+						},
+					} );
+
+					return priceText.replace( '<price/>', price );
+				}
+
+				return price;
 			},
 
 			get isLineItemTotalDiscountVisible(): boolean {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -6,6 +6,8 @@ import {
 	getContext,
 	getConfig,
 	getElement,
+	useLayoutEffect,
+	useRef,
 } from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/cart';
 import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
@@ -331,22 +333,6 @@ const { state: cartItemState } = store(
 				return cartItemState.cartItem.images[ 0 ]?.thumbnail || '';
 			},
 
-			itemShortDescription() {
-				const el = getElement();
-
-				if ( el.ref ) {
-					const innerEl = el.ref.querySelector(
-						'.wc-block-components-product-metadata__description'
-					);
-
-					// A workaround for the lack of dangerous set HTML directive in interactivity API
-					if ( innerEl ) {
-						innerEl.innerHTML =
-							cartItemState.cartItem.short_description;
-					}
-				}
-			},
-
 			get priceWithoutDiscount(): string {
 				return formatPriceWithCurrency(
 					parseInt( cartItemState.cartItem.prices.regular_price, 10 ),
@@ -456,6 +442,61 @@ const { state: cartItemState } = store(
 				yield actions.addCartItem( {
 					id: cartItemState.cartItem.id,
 					quantity: cartItemState.cartItem.quantity - multipleOf,
+				} );
+			},
+		},
+
+		callbacks: {
+			itemShortDescription() {
+				const el = getElement();
+
+				if ( el.ref ) {
+					const innerEl = el.ref.querySelector(
+						'.wc-block-components-product-metadata__description'
+					);
+
+					// A workaround for the lack of dangerous set HTML directive in interactivity API
+					if ( innerEl ) {
+						innerEl.innerHTML =
+							cartItemState.cartItem.short_description;
+					}
+				}
+			},
+			filterCartItemClass() {
+				// TODO: Add deprecation notice urging to replace with a `data-wp-class` directive.
+				const applyCheckoutFilter = ( window.wc as any )?.blocksCheckout
+					?.applyCheckoutFilter;
+				const previouslyAppliedClasses = useRef< string[] >( [] );
+
+				// @ts-ignore -- It must run on every render.
+				useLayoutEffect( () => {
+					if ( applyCheckoutFilter ) {
+						const { ref } = getElement();
+
+						// Remove previously applied classes.
+						ref!.classList.remove(
+							...previouslyAppliedClasses.current
+						);
+
+						const newClassesString = applyCheckoutFilter( {
+							filterName: 'cartItemClass',
+							defaultValue: '',
+							extensions: cartItemState.cartItem.extensions,
+							arg: {
+								context: 'cart',
+								cartItem: cartItemState.cartItem,
+								cart: woocommerceState.cart,
+							},
+						} );
+
+						// Apply new classes.
+						previouslyAppliedClasses.current = newClassesString
+							.split( ' ' )
+							.filter( Boolean );
+						ref!.classList.add(
+							...previouslyAppliedClasses.current
+						);
+					}
 				} );
 			},
 		},

--- a/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
+++ b/plugins/woocommerce/client/blocks/bin/webpack-config-interactive-blocks.js
@@ -69,7 +69,11 @@ module.exports = {
 			combineAssets: true,
 			combinedOutputFile: './interactivity-blocks-frontend-assets.php',
 			requestToExternalModule( request ) {
-				if ( request.startsWith( '@woocommerce/stores/' ) ) {
+				if (
+					request.startsWith( '@woocommerce/stores/woocommerce/' )
+				) {
+					return `module ${ request }`;
+				} else if ( request.startsWith( '@woocommerce/stores/' ) ) {
 					return `import ${ request }`;
 				}
 			},

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -132,7 +132,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									>
 									</div>
 									<div class="wc-block-cart-item__prices">
-										<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price" hidden>
+										<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price">
 											<span class="screen-reader-text">
 												<?php esc_html_e( 'Previous price:', 'woocommerce' ); ?>
 											</span>
@@ -142,7 +142,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											</span>
 											<ins data-wp-text="state.itemPrice" class="wc-block-components-product-price__value is-discounted"></ins>
 										</span>
-										<span data-wp-bind--hidden="state.cartItemHasDiscount" class="price wc-block-components-product-price" hidden>
+										<span data-wp-bind--hidden="state.cartItemHasDiscount" class="price wc-block-components-product-price">
 											<span data-wp-text="state.itemPrice" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value">
 											</span>
 										</span>
@@ -213,7 +213,6 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									<div 
 										data-wp-bind--hidden="!state.isLineItemTotalDiscountVisible" 
 										class="wc-block-components-product-badge wc-block-components-sale-badge"
-										hidden
 									>
 										<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 										<?php echo $save_label; ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -200,7 +200,12 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 												＋
 											</button>
 										</div>
-										<button data-wp-on--click="actions.removeItemFromCart" data-wp-bind--aria-label="state.removeFromCartLabel" class="wc-block-cart-item__remove-link" >
+										<button
+											data-wp-bind--hidden="!state.itemShowRemoveItemLink"
+											data-wp-on--click="actions.removeItemFromCart"
+											data-wp-bind--aria-label="state.removeFromCartLabel"
+											class="wc-block-cart-item__remove-link"
+										>
 											<?php echo esc_html( $remove_item_label ); ?>
 										</button>
 									</div>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -132,6 +132,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									>
 									</div>
 									<div class="wc-block-cart-item__prices">
+										<span data-wp-text="state.beforeItemPrice"></span>
 										<span data-wp-bind--hidden="!state.cartItemHasDiscount" class="price wc-block-components-product-price">
 											<span class="screen-reader-text">
 												<?php esc_html_e( 'Previous price:', 'woocommerce' ); ?>
@@ -146,6 +147,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 											<span data-wp-text="state.itemPrice" class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value">
 											</span>
 										</span>
+										<span data-wp-text="state.afterItemPrice"></span>
 									</div>
 									<div 
 										data-wp-bind--hidden="!state.cartItemHasDiscount" 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -152,10 +152,8 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 									<div 
 										data-wp-bind--hidden="!state.cartItemHasDiscount" 
 										class="wc-block-components-product-badge wc-block-components-sale-badge"
-										hidden
 									>
-										<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-										<?php echo $save_label; ?>
+										<?php echo $save_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 										<span
 											data-wp-text="state.cartItemDiscount" 
 											class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -111,7 +111,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 						data-wp-each--cart-item="woocommerce::state.cart.items"
 						data-wp-each-key="state.cartItem.key"
 					>
-						<tr class="wc-block-cart-items__row" tabindex="-1">
+						<tr class="wc-block-cart-items__row" data-wp-run="callbacks.filterCartItemClass" tabindex="-1">
 							<td class="wc-block-cart-item__image" aria-hidden="true">
 								<img data-wp-bind--hidden="!state.isProductHiddenFromCatalog" data-wp-bind--src="state.itemThumbnail" data-wp-bind--alt="state.cartItemName">
 								<a data-wp-bind--hidden="state.isProductHiddenFromCatalog" data-wp-bind--href="state.cartItem.permalink" tabindex="-1">
@@ -161,7 +161,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										</span>
 									</div>
 									<div class="wc-block-components-product-metadata">
-										<div data-wp-watch="state.itemShortDescription" >
+										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
 									</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

#### What

This PR implements backward compatibility for `registerCheckoutFilters`/`applyCheckoutFilter` in the new Interactivity API-powered Mini Cart.

Official documentation: https://developer.woocommerce.com/docs/block-development/cart-and-checkout-blocks/available-filters/cart-line-items

#### Why

Because the previous mini cart was using components from the cart that were using `applyCheckoutFilter`.

#### How

For now, these filters have been implemented:

- `cartItemClass`: Adds a new class to the cart items table.
- `cartItemPrice`: Prepend or append a text to the total price of a cart item.
- `subtotalPriceFormat`: Prepend or append a text to the subtotal price of a cart item.
- `saleBadgePriceFormat`: Prepend or append a text to the sales badge of a cart item.
- `showRemoveItemLink`: Shows/hides the remove item link.

Closes #59112.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I've made a video explaining how to test this pull request:

<div>
    <a href="https://www.loom.com/share/627c3b172e30434c9cc9aa61012bf682">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/627c3b172e30434c9cc9aa61012bf682-a4194bd123ee64ac-full-play.gif">
    </a>
  </div>

https://www.loom.com/share/627c3b172e30434c9cc9aa61012bf682

#### Test with the old Mini Cart to see how they are supposed to work

1.  First, ensure the experimental Mini Cart is turned off.

2.  Navigate to a page where the Mini Cart is visible. Before opening it, hover over the cart icon to ensure the necessary libraries are loaded.

3.  Open the browser's developer console and paste the following JavaScript code. This code registers two sets of checkout filters for demonstration purposes.

    ```javascript
    const { registerCheckoutFilters } = window.wc.blocksCheckout;

    registerCheckoutFilters( 'example-extension', {
    	cartItemClass: ( defaultValue, extensions, args ) => {
    		return `${ defaultValue } my-custom-class`;
    	},
    	cartItemPrice: ( defaultValue, extensions, args ) => {
    		if ( args?.cartItem.quantity > 2 ) {
    			return `${ defaultValue } // cartItem`;
    		}
    		return defaultValue;
    	},
    	subtotalPriceFormat: ( defaultValue, extensions, args ) => {
    		if ( args?.cartItem.quantity > 2 ) {
    			return `${ defaultValue } // subtotal`;
    		}
    		return defaultValue;
    	},
    	saleBadgePriceFormat: ( defaultValue, extensions, args ) => {
    		if ( args?.cartItem.quantity > 2 ) {
    			return `${ defaultValue } // saleBadge`;
    		}
    		return defaultValue;
    	},
    	itemName: ( defaultValue, extensions, args ) => {
    		if ( args?.cartItem.quantity > 2 ) {
    			return `${ defaultValue } // itemName`;
    		}
    		return defaultValue;
    	},
    	showRemoveItemLink: ( defaultValue, extensions, args ) => {
    		if ( args?.cartItem.quantity > 2 ) {
    			return false;
    		}
    		return true;
    	},
    } );

    registerCheckoutFilters( 'example-extension-2', {
    	cartItemClass: ( defaultValue, extensions, args ) => {
    		return args?.cartItem.quantity <= 2
    			? `${ defaultValue } my-custom-class-2`
    			: defaultValue;
    	},
    	cartItemPrice: ( defaultValue, extensions, args ) => {
    		return `✅ ${ defaultValue }`;
    	},
    	subtotalPriceFormat: ( defaultValue, extensions, args ) => {
    		return `✅ ${ defaultValue }`;
    	},
    	saleBadgePriceFormat: ( defaultValue, extensions, args ) => {
    		return `✅ ${ defaultValue }`;
    	},
    	itemName: ( defaultValue, extensions, args ) => {
    		return `✅ ${ defaultValue }`;
    	},
    } );
    ```

4.  Add items to the cart and observe the changes. You should see checkmarks (`✅`) next to the item price, subtotal, sale badge, and item name.

5.  When the cart contains more than two items, the "Remove" link will disappear, and additional text will be appended to the price fields.

6.  Inspect the cart item's HTML to confirm that the custom CSS classes (`my-custom-class` and `my-custom-class-2`) and aria labels are correctly applied based on the item quantity.

-----

#### Test with the new Interactivity API-powered Mini Cart

1.  Enable the experimental Mini Cart feature.

2.  Run the build process and refresh the page.

3.  To simulate a third-party developer's environment, you may need to ensure the `wc-blocks-checkout` script is enqueued. You can do this by adding the following line inside a `render_experimental_iapi_mini_cart` function:

    ```php
    wp_enqueue_script( 'wc-blocks-checkout' );
    ```

4.  Add the same JavaScript code from the previous test to the top of the `iapi-frontend.ts` file.

5.  Open the Mini Cart and verify that all the filters are applied correctly, just as they were in the old Mini Cart. Check for the checkmarks, the dynamic text, the aria labels and the conditional visibility of the "Remove" link.

-----

#### Test `data-wp-class` directive for dynamic classes

1.  To test the compatibility with the `data-wp-class` directive, add the following attribute to the `tr` element in the `MiniCartProductsTable` block:

    ```html
    data-wp-class--iapi-class="state.isIapiClass"
    ```

3.  Next, add the corresponding logic to the `view.js` file of the `mini-cart-contents-block` to define the `isIapiClass` state:

    ```javascript
    get isIapiClass(): boolean {
        if ( cartItemState.cartItem.quantity >= 4 ) {
            return true;
        }
        return false;
    },
    ```

4.  Run the build and test the Mini Cart. When the quantity of an item is four or more, the `iapi-class` CSS class should be dynamically added to the cart item's row.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds backward compatibility for `registerCheckoutFilters` in the new iAPI-powered Mini-Cart.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
