### PR TITLE
[PRR] Product Details: prevent the default template to be auto applied for existing blocks (10.0)

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5015-woo-1002-products-details-block-regression-compatibility
+++ b/plugins/woocommerce/changelog/wooplug-5015-woo-1002-products-details-block-regression-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Details: prevent the default template to be auto applied for existing blocks.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -13,6 +13,9 @@
 		"align": [ "wide", "full" ]
 	},
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"hideTabTitle": {
 			"type": "boolean",
 			"default": false

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -12,6 +12,11 @@
 		},
 		"align": [ "wide", "full" ]
 	},
-	"attributes": {},
+	"attributes": {
+		"hideTabTitle": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"usesContext": [ "query", "queryId", "postId", "postType" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -9,8 +9,9 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 	Warning,
+	InspectorControls,
 } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -106,8 +107,14 @@ const useIsInvalidQueryLoopContext = ( clientId: string, postType: string ) => {
 	);
 };
 
-const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
+const Edit = ( {
+	clientId,
+	context,
+	attributes,
+	setAttributes,
+}: ProductDetailsEditProps ) => {
 	const blockProps = useBlockProps();
+	const { hideTabTitle } = attributes;
 
 	const { hasInnerBlocks, wasBlockJustInserted } = useSelect(
 		( select ) => {
@@ -116,7 +123,7 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 				hasInnerBlocks: blocks.length > 0,
 				wasBlockJustInserted:
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore method exists but not typed
+					// @ts-expected-error method exists but not typed
 					select( blockEditorStore ).wasBlockJustInserted( clientId ),
 			};
 		},
@@ -150,8 +157,24 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 
 	return (
 		<div { ...blockProps }>
+			<InspectorControls key="inspector">
+				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+					<ToggleControl
+						label={ __(
+							'Show tab title in content',
+							'woocommerce'
+						) }
+						checked={ ! hideTabTitle }
+						onChange={ () =>
+							setAttributes( {
+								hideTabTitle: ! hideTabTitle,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<Disabled>
-				<LegacyProductDetailsPreview hideTabTitle={ true } />
+				<LegacyProductDetailsPreview hideTabTitle={ hideTabTitle } />
 			</Disabled>
 		</div>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/editor.scss
@@ -1,0 +1,44 @@
+/*
+ * Classic style - Editor Preview only.
+ *
+ * Hint: Front-end is handled by the WooCommerce base styles.
+ */
+ .wp-block-woocommerce-product-details {
+	ul.wc-tabs {
+		list-style: none;
+		padding: 0 0 0 1em;
+		margin: 0 0 1.618em;
+		overflow: hidden;
+		position: relative;
+		border-bottom: 1px solid $gray-200;
+
+		li {
+			border: 1px solid $gray-200;
+			display: inline-block;
+			position: relative;
+			z-index: 0;
+			border-radius: $universal-border-radius $universal-border-radius 0 0;
+			margin: 0;
+			padding: 0 1em;
+
+			a {
+				display: inline-block;
+				padding: 0.5em 0;
+				font-weight: 700;
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: none;
+				}
+			}
+
+			&.active {
+				z-index: 2;
+
+				a {
+					text-shadow: inherit;
+				}
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -11,6 +11,7 @@ import save from './save';
 import edit from './edit';
 import icon from './icon';
 import './style.scss';
+import { Attributes } from './types';
 
 const blockConfig = {
 	...metadata,
@@ -27,6 +28,15 @@ const blockConfig = {
 			},
 			save() {
 				return null;
+			},
+			migrate( attributes: Attributes ) {
+				return {
+					...attributes,
+					// In the previous version of this block, we didn't define the align attribute.
+					// Because of that, align is missing from attributes argument here.
+					// We need to add it manually as wide is the previous default value.
+					align: 'wide',
+				};
 			},
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -28,10 +28,6 @@ const blockConfig = {
 			save() {
 				return null;
 			},
-			migrate( attributes ) {
-				const { hideTabTitle, ...restAttributes } = attributes;
-				return restAttributes;
-			},
 		},
 	],
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -17,6 +17,19 @@ const blockConfig = {
 	icon,
 	edit,
 	save,
+	deprecated: [
+		{
+			attributes: {
+				hideTabTitle: {
+					type: 'boolean',
+					default: false,
+				},
+			},
+			save() {
+				return null;
+			},
+		},
+	],
 };
 // @ts-expect-error blockConfig is not typed.
 registerProductBlockType( blockConfig );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -17,19 +17,6 @@ const blockConfig = {
 	icon,
 	edit,
 	save,
-	deprecated: [
-		{
-			attributes: {
-				hideTabTitle: {
-					type: 'boolean',
-					default: false,
-				},
-			},
-			save() {
-				return null;
-			},
-		},
-	],
 };
 // @ts-expect-error blockConfig is not typed.
 registerProductBlockType( blockConfig );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/legacy-preview.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/legacy-preview.tsx
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { __ } from '@wordpress/i18n';
+
+interface SingleProductTab {
+	id: string;
+	title: string;
+	active: boolean;
+	content: React.JSX.Element | undefined;
+}
+
+const ProductTabTitle = ( {
+	id,
+	title,
+	active,
+}: Pick< SingleProductTab, 'id' | 'title' | 'active' > ) => {
+	return (
+		<li
+			className={ clsx( `${ id }_tab`, {
+				active,
+			} ) }
+			id={ `tab-title-${ id }` }
+			role="tab"
+			aria-controls={ `tab-${ id }` }
+		>
+			<a href={ `#tab-${ id }` }>{ title }</a>
+		</li>
+	);
+};
+
+const ProductTabContent = ( {
+	id,
+	content,
+}: Pick< SingleProductTab, 'id' | 'content' > ) => {
+	return (
+		<div
+			className={ `${ id }_tab` }
+			id={ `tab-title-${ id }` }
+			role="tab"
+			aria-controls={ `tab-${ id }` }
+		>
+			{ content }
+		</div>
+	);
+};
+
+export const LegacyProductDetailsPreview = ( {
+	hideTabTitle,
+}: {
+	hideTabTitle: boolean;
+} ) => {
+	const productTabs = [
+		{
+			id: 'description',
+			title: 'Description',
+			active: true,
+			content: (
+				<>
+					{ ! hideTabTitle && (
+						<h2>{ __( 'Description', 'woocommerce' ) }</h2>
+					) }
+					<p>
+						{ __(
+							'This block lists description, attributes and reviews for a single product.',
+							'woocommerce'
+						) }
+					</p>
+				</>
+			),
+		},
+		{
+			id: 'additional_information',
+			title: 'Additional Information',
+			active: false,
+		},
+		{ id: 'reviews', title: 'Reviews', active: false },
+	];
+	const tabsTitle = productTabs.map( ( { id, title, active } ) => (
+		<ProductTabTitle
+			key={ id }
+			id={ id }
+			title={ title }
+			active={ active }
+		/>
+	) );
+	const tabsContent = productTabs.map( ( { id, content } ) => (
+		<ProductTabContent key={ id } id={ id } content={ content } />
+	) );
+
+	return (
+		<>
+			<ul className="wc-tabs tabs" role="tablist">
+				{ tabsTitle }
+			</ul>
+			{ tabsContent }
+		</>
+	);
+};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -7,7 +7,8 @@ type Context = {
 	context: { postId: string; postType: string };
 };
 
-export type ProductDetailsEditProps = BlockEditProps<
-	Record< string, never >
-> &
-	Context;
+type Attributes = {
+	hideTabTitle: boolean;
+};
+
+export type ProductDetailsEditProps = BlockEditProps< Attributes > & Context;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -7,7 +7,7 @@ type Context = {
 	context: { postId: string; postType: string };
 };
 
-type Attributes = {
+export type Attributes = {
 	hideTabTitle: boolean;
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

~Same as~ Based on https://github.com/woocommerce/woocommerce/pull/59691, with an update to bring the 'Show tab title in content' setting back, targeting 10.0.

See https://github.com/woocommerce/woocommerce/issues/59663

This PR prevents the existing Product Details blocks from upgrading to the new Accordion layout automatically and ensures the new layout will only be applied to newly inserted blocks.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using Code Editor, add this to the Single Product template: `<!-- wp:woocommerce/product-details {"className":"is-style-minimal"} /-->`. This simulates the existing Product Details block.
2. Still in the Code editor, update and reload the editor.
3. Switch to the visual editor.
4. See the Product Details block unchanged, still a single block without any nested blocks.
5. Add a new Product Details block to the template.
6. See the Accordion layout is used for the newly inserted block.
7. Reload the editor again.
8. Delete the Accordion Group block inside Product Details.
9. See the legacy editor preview of the previous version of the block rendered.
10. See the 'Show tab title in content' in the sidebar.
11. Verify the setting works on the front end.

Note: If the Accordion Group block is deleted right after being inserted into the editor, the legacy preview won't show. The preview is added to maintain backward compatibility for existing instances of the block.

<!-- End testing instructions -->