### PR TITLE
Bubble change event in Add to Cart + Options and Add to Cart with Options blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-59681-add-to-cart-with-options-bubble-change-event
+++ b/plugins/woocommerce/changelog/fix-59681-add-to-cart-with-options-bubble-change-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Bubble change even in Add to Cart + Options and Add to Cart with Options blocks
+Bubble change event in Add to Cart + Options and Add to Cart with Options blocks

--- a/plugins/woocommerce/changelog/fix-59681-add-to-cart-with-options-bubble-change-event
+++ b/plugins/woocommerce/changelog/fix-59681-add-to-cart-with-options-bubble-change-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bubble change even in Add to Cart + Options and Add to Cart with Options blocks

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -139,7 +139,7 @@ const getNewQuantity = ( productId: number, quantity: number ) => {
 };
 
 const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
-	const event = new Event( 'change' );
+	const event = new Event( 'change', { bubbles: true } );
 	inputElement.dispatchEvent( event );
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/frontend.ts
@@ -43,7 +43,7 @@ const getInputData = ( event: HTMLElementEvent< HTMLButtonElement > ) => {
 };
 
 const dispatchChangeEvent = ( inputElement: HTMLInputElement ) => {
-	const event = new Event( 'change' );
+	const event = new Event( 'change', { bubbles: true } );
 
 	inputElement.dispatchEvent( event );
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59681.

This PR adds `bubbles: true` to the change events we are programatically triggering after interacting with the plus and minus buttons in the quantity selectors.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Set the non-blockified _Add to Cart with Options_ block to _Stepper_ display style.
3. In the frontend, copy this code to your browser console:

```JS
jQuery( '.woocommerce' ).on( 'change', 'input.qty', function() {
  console.log( 'This should also work.' );
});
jQuery( '.woocommerce input.qty' ).on( 'change', function() {
  console.log( 'This works.' );
});
```
4. Click on the plus and minus buttons of the quantity selector, verify for every click, both `This works.` and `This should also work.` strings are logged.
5. Repeat the same after updating the non-blockified _Add to Cart with Options_ block to the blockified _Add to Cart + Options_ block.