### PR TITLE
Enhancement for the Woo settings: added the "desc" value for the "General options" section

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -165,7 +165,7 @@ class WC_Settings_General extends WC_Settings_Page {
 				array(
 					'title' => __( 'General options', 'woocommerce' ),
 					'type'  => 'title',
-					'desc'  => __( 'Control store-wide options such as allowed billing and shipping countries, default customer location, and whether to enable taxes and coupons.' ),
+					'desc'  => __( 'Control store-wide options such as allowed billing and shipping countries, default customer location, and whether to enable taxes and coupons.', 'woocommerce' ),
 					'id'    => 'general_options',
 					'order' => 20,
 				),

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -165,7 +165,7 @@ class WC_Settings_General extends WC_Settings_Page {
 				array(
 					'title' => __( 'General options', 'woocommerce' ),
 					'type'  => 'title',
-					'desc'  => '',
+					'desc'  => __( 'Control store-wide options such as allowed billing and shipping countries, default customer location, and whether to enable taxes and coupons.' ),
 					'id'    => 'general_options',
 					'order' => 20,
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This simply adds a description to the "General Options" settings, because it's missing.

#### Significance

-   [x] Minor

#### Type

-   [x] Tweak - A minor adjustment to the codebase
