### PR TITLE
iAPI powered Mini-Cart - Disable scrolling on body when the mini-cart drawer is open

### DIFF
--- a/plugins/woocommerce/changelog/59715-wooplug-4973-iapi-powered-mini-cart-hide-scrollbar-when-minicart-is-open
+++ b/plugins/woocommerce/changelog/59715-wooplug-4973-iapi-powered-mini-cart-hide-scrollbar-when-minicart-is-open
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable scrolling on body when the mini-cart drawer is open.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -63,6 +63,7 @@ type MiniCart = {
 		closeDrawer: () => void;
 		overlayCloseDrawer: ( e: MouseEvent ) => void;
 		setupOpenDrawerListener: () => void;
+		disableScrollingOnBody: () => void;
 	};
 };
 
@@ -185,6 +186,25 @@ store< MiniCart >(
 				if ( e.target === e.currentTarget ) {
 					const ctx = getContext< MiniCartContext >();
 					ctx.isOpen = false;
+				}
+			},
+
+			disableScrollingOnBody() {
+				const { isOpen } = getContext< MiniCartContext >();
+				const { body } = document;
+				const scrollBarWidth =
+					window.innerWidth - document.documentElement.clientWidth;
+
+				if ( isOpen ) {
+					Object.assign( body.style, {
+						overflow: 'hidden',
+						paddingRight: scrollBarWidth + 'px',
+					} );
+				} else {
+					Object.assign( body.style, {
+						overflow: '',
+						paddingRight: 0,
+					} );
 				}
 			},
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -191,17 +191,16 @@ store< MiniCart >(
 
 			disableScrollingOnBody() {
 				const { isOpen } = getContext< MiniCartContext >();
-				const { body } = document;
-				const scrollBarWidth =
-					window.innerWidth - document.documentElement.clientWidth;
-
 				if ( isOpen ) {
-					Object.assign( body.style, {
+					Object.assign( document.body.style, {
 						overflow: 'hidden',
-						paddingRight: scrollBarWidth + 'px',
+						paddingRight:
+							window.innerWidth -
+							document.documentElement.clientWidth +
+							'px',
 					} );
 				} else {
-					Object.assign( body.style, {
+					Object.assign( document.body.style, {
 						overflow: '',
 						paddingRight: 0,
 					} );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -544,6 +544,7 @@ class MiniCart extends AbstractBlock {
 			<div
 				data-wp-interactive="woocommerce/mini-cart"
 				data-wp-init="callbacks.setupOpenDrawerListener"
+				data-wp-watch="callbacks.disableScrollingOnBody"
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo wp_interactivity_data_wp_context( $context ); ?>
 				class="<?php echo esc_attr( $wrapper_classes ); ?>"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents the body element from scrolling when the mini-cart drawer is open. The implementation is based on the previous code used in the React version ([here](https://github.com/woocommerce/woocommerce/blob/c28fbb4dbc1b8cce53540ad516bcd859867e23a3/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/block.tsx#L95-L109)).

Closes #59593.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <video src=https://github.com/user-attachments/assets/b852e60a-7857-4870-a956-de5294829252 alt="video before"></video>    |    <video src=https://github.com/user-attachments/assets/fc38603a-6a0e-429e-82a7-493ef874ea61></video>   |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit a page containing the mini-cart block.
2. Ensure scrolling on body is enabled.
3. Open the mini-cart drawer.
4. Ensure scrolling on body is disabled.
5. Ensure there is no horizontal shift caused by the scrolling bar disappearing.
6. Close the mini-cart drawer.
7. Ensure scrolling on body is enabled again.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Disable scrolling on body when the mini-cart drawer is open.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
