### PR TITLE
Move release related jobs to `release-new-release-published.yml`

### DIFF
--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -1,14 +1,35 @@
 name: 'Release: Post-release published flows'
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      release_tag_name:
+        description: 'The release tag name'
+        required: true
+        type: string
+      release_name:
+        description: 'The release name'
+        required: true
+        type: string
+      release_html_url:
+        description: 'The release HTML URL'
+        required: true
+        type: string
 
 jobs:
-  notify-release-published:
-    name: 'Notify in Slack when a new (pre)release is published'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+  # Jobs to run after a pre-release is published (triggered by the "prereleased" GH event).
+  generate-release-commits-and-contributors:
+    name: 'Call release commits and contributors workflow'
+    if: ${{ github.event.action == 'prereleased' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets: inherit
 
+  # Jobs to run after a final release is published (triggered by the "published" GH event).
+  notify-release-published:
+    name: 'Notify in Slack when a new release is published'
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    if: ${{ github.event.action == 'publish' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
     steps:
       - name: 'Notify to release channel'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0
@@ -17,26 +38,23 @@ jobs:
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
           slack-optional-unfurl_links: false
           slack-text: |
-            :woo-bounce: *<${{ github.event.release.html_url }}|WooCommerce ${{ github.event.release.name }}>* has been released! :rocket:
-
+            :woo-bounce: *<${{ inputs.release_html_url }}|WooCommerce ${{ inputs.release_name }}>* has been released! :rocket:
             (<!subteam^S086N376UTS> could you publish the release post? :ty2:)
 
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ ! contains( github.event.release.tag_name, 'wc-beta-tester' ) && ! contains( github.event.release.tag_name, '-rc' )  }}
-
+    if: ${{ github.event.action == 'publish' && !contains( inputs.release_tag_name, 'wc-beta-tester' ) && ! contains( inputs.release_tag_name, '-rc' ) }}
     steps:
       - name: 'Fetch release readme.txt'
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.release_tag_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           gh release download "$RELEASE_TAG" --pattern 'woocommerce.zip'
           unzip -qq woocommerce.zip
-
-          if [[ ! -e woocommerce/readme.txt  ]]; then
+          if [[ ! -e woocommerce/readme.txt ]]; then
             echo "::error::Could not find readme.txt in asset for release '$RELEASE_TAG'."
             exit 1
           fi
@@ -62,19 +80,18 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Push new changelog.txt.
-          branch_name="update-changelog-${{ github.event.release.tag_name }}-$(date +%s)"
-
+          branch_name="update-changelog-${{ inputs.release_tag_name }}-$(date +%s)"
           cd trunk
           git checkout -b "$branch_name"
           git commit \
-            --all    \
-            --message 'Update changelog.txt after release ${{ github.event.release.tag_name }}'
+            --all \
+            --message 'Update changelog.txt after release ${{ inputs.release_tag_name }}'
           git push origin "$branch_name"
 
           # Open a PR.
           gh pr create \
-            --title 'Update changelog.txt after ${{ github.event.release.tag_name }}' \
-            --body 'This PR updates the global changelog.txt file following the release of version ${{ github.event.release.tag_name }}.' \
+            --title 'Update changelog.txt after ${{ inputs.release_tag_name }}' \
+            --body 'This PR updates the global changelog.txt file following the release of version ${{ inputs.release_tag_name }}.' \
             --base trunk \
             --head "$branch_name" \
             --reviewer "${{ github.actor }}"

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -21,7 +21,7 @@ jobs:
   notify-release-published:
     name: 'Notify in Slack when a new release is published'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'published' && !contains(inputs.release_tag_name, 'wc-beta-tester') }}
+    if: ${{ github.event.action == 'published' }}
     steps:
       - name: 'Notify to release channel'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -21,7 +21,7 @@ jobs:
   notify-release-published:
     name: 'Notify in Slack when a new release is published'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'publish' && !contains(inputs.release_tag_name, 'wc-beta-tester') }}
+    if: ${{ github.event.action == 'published' && !contains(inputs.release_tag_name, 'wc-beta-tester') }}
     steps:
       - name: 'Notify to release channel'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0
@@ -36,7 +36,7 @@ jobs:
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'publish' && ! contains( inputs.release_tag_name, '-rc' ) }}
+    if: ${{ github.event.action == 'published' && ! contains( inputs.release_tag_name, '-rc' ) }}
     steps:
       - name: 'Fetch release readme.txt'
         env:

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -19,7 +19,7 @@ jobs:
 
   # Jobs to run after a final release is published (triggered by the "published" GH event).
   notify-release-published:
-    name: 'Notify in Slack when a new release is published'
+    name: 'Notify in Slack when a new (pre)release is published'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     if: ${{ github.event.action == 'published' }}
     steps:

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -19,7 +19,7 @@ jobs:
   # Jobs to run after a pre-release is published (triggered by the "prereleased" GH event).
   generate-release-commits-and-contributors:
     name: 'Call release commits and contributors workflow'
-    if: ${{ github.event.action == 'prereleased' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    if: ${{ github.event.action == 'prereleased' }}
     uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
     with:
       version: ${{ github.event.release.tag_name }}
@@ -44,7 +44,7 @@ jobs:
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'publish' && !contains( inputs.release_tag_name, 'wc-beta-tester' ) && ! contains( inputs.release_tag_name, '-rc' ) }}
+    if: ${{ github.event.action == 'publish' && ! contains( inputs.release_tag_name, '-rc' ) }}
     steps:
       - name: 'Fetch release readme.txt'
         env:
@@ -54,6 +54,7 @@ jobs:
         run: |
           gh release download "$RELEASE_TAG" --pattern 'woocommerce.zip'
           unzip -qq woocommerce.zip
+
           if [[ ! -e woocommerce/readme.txt ]]; then
             echo "::error::Could not find readme.txt in asset for release '$RELEASE_TAG'."
             exit 1

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -6,14 +6,6 @@ on:
         description: 'The release tag name'
         required: true
         type: string
-      release_name:
-        description: 'The release name'
-        required: true
-        type: string
-      release_html_url:
-        description: 'The release HTML URL'
-        required: true
-        type: string
 
 jobs:
   # Jobs to run after a pre-release is published (triggered by the "prereleased" GH event).
@@ -22,14 +14,14 @@ jobs:
     if: ${{ github.event.action == 'prereleased' }}
     uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
     with:
-      version: ${{ github.event.release.tag_name }}
+      version: ${{ inputs.release_tag_name }}
     secrets: inherit
 
   # Jobs to run after a final release is published (triggered by the "published" GH event).
   notify-release-published:
     name: 'Notify in Slack when a new release is published'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'publish' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    if: ${{ github.event.action == 'publish' && !contains(inputs.release_tag_name, 'wc-beta-tester') }}
     steps:
       - name: 'Notify to release channel'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0
@@ -38,7 +30,7 @@ jobs:
           slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
           slack-optional-unfurl_links: false
           slack-text: |
-            :woo-bounce: *<${{ inputs.release_html_url }}|WooCommerce ${{ inputs.release_name }}>* has been released! :rocket:
+            :woo-bounce: *<https://github.com/woocommerce/woocommerce/releases/tag/${{ inputs.release_tag_name }}|WooCommerce ${{ inputs.release_tag_name }}>* has been released! :rocket:
             (<!subteam^S086N376UTS> could you publish the release post? :ty2:)
 
   update-global-changelog:

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -11,6 +11,4 @@ jobs:
     uses: woocommerce/woocommerce/.github/workflows/release-new-release-published.yml@trunk
     with:
       release_tag_name: ${{ github.event.release.tag_name }}
-      release_name: ${{ github.event.release.name }}
-      release_html_url: ${{ github.event.release.html_url }}
     secrets: inherit

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -1,13 +1,16 @@
+# This is a proxy workflow to dispatch workflows from trunk branch for release events (published and pre-release).
 name: 'Release: Release events proxy workflow'
 on:
   release:
-    types: [prereleased]
+    types: [prereleased, published]
 
 jobs:
-  call-release-workflow:
-    name: 'Call release commits and contributors workflow'
-    if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
-    uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
+  call-new-release-published-workflow:
+    name: 'Call the release new release published workflow'
+    if: ${{ github.event.action == 'published' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    uses: woocommerce/woocommerce/.github/workflows/release-new-release-published.yml@trunk
     with:
-      version: ${{ github.event.release.tag_name }}
+      release_tag_name: ${{ github.event.release.tag_name }}
+      release_name: ${{ github.event.release.name }}
+      release_html_url: ${{ github.event.release.html_url }}
     secrets: inherit

--- a/.github/workflows/release-release-events-proxy.yml
+++ b/.github/workflows/release-release-events-proxy.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   call-new-release-published-workflow:
     name: 'Call the release new release published workflow'
-    if: ${{ github.event.action == 'published' && !contains(github.event.release.tag_name, 'wc-beta-tester') }}
+    if: ${{ !contains(github.event.release.tag_name, 'wc-beta-tester') }}
     uses: woocommerce/woocommerce/.github/workflows/release-new-release-published.yml@trunk
     with:
       release_tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


#### Problem
Previously, workflows triggered by release events (like published or prereleased) would run using the workflow code from the tagged commit. This meant that if a release branch was created weeks ago, any improvements made to the workflow files since then would not be applied during the release process.

#### Solution
This can be fixed by having a "proxy" workflow that runs on the `prereleased` and `published` events and calls a dispatchable workflow pinned at trunk. This PR implements this with two workflows:
- Proxy Workflow (`release-release-events-proxy.yml`) - Triggers on both release events and dispatches to the main workflow in `trunk`.
- Main Workflow (`release-new-release-published.yml`) - Contains the actual logic and always runs from `trunk`. This workflow contains the logic to distinguish between `published` and `prereleased` events and calls the corresponding flows depending on the trigger.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Part of https://github.com/woocommerce/woocommerce/issues/59533

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
**Preparation**
1. Fork the `woocommerce/woocommerce` repo with all branches into your GH account.
2. In your forked repo, go to `Settings > Secrets and variables > Actions` and create 3 new repository secrets: 
- `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
- `WOO_RELEASE_SLACK_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
- `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
3. In the forked repo, create a PR with the branch `59533/proxy-new-release` and merge it (to get this new workflow into `trunk`). 
4. 🚨Important: In your fork, replace `woocommerce/woocommerce` with your fork name: `YOUR_REPO/woocommerce` in:
- https://github.com/woocommerce/woocommerce/pull/59722/files#diff-3c8529cff79ec0ff84a98e76e3342aea9f65b8e7c309ae16b04008f6e6169ef2R11 
- https://github.com/woocommerce/woocommerce/pull/59722/files#diff-0608fb03f9a714bbd99a04a1b1a4ecdcb013cd28c96ab23e6d6c7ef53a0e7892R15

**Test 1: Publishing a pre-release**
1. Go to `Releases`, click on `Draft a new release`, create a new release with a correct version pre-release format tag (like `9.9-rc.1` and branch `release/9.9`), and save it as `pre-release`.
2. Make sure this triggers the `Release: Release events proxy workflow` and calls the `release-commits-and-contributors.yml` 👇 and `Notify in Slack when a new release is published` and `Update changelog.txt after any stable release` are skipped.
<img width="312" height="293" alt="Screenshot 2025-07-17 at 13 49 39" src="https://github.com/user-attachments/assets/99dae23a-a123-4b01-a53e-29713f52988c" />


**Test 2: Publishing a release**
1. Go to `Releases`, click on `Draft a new release`, create a new release with a correct version format tag (like `9.9` and branch `release/9.9`), and save it as a final release.
2. Make sure this triggers the `Release: Release events proxy workflow` and `Notify in Slack when a new release is published`, and `Update changelog.txt after any stable release` are triggered. `release-commits-and-contributors.yml` should be skipped.
<img width="315" height="185" alt="Screenshot 2025-07-17 at 14 04 29" src="https://github.com/user-attachments/assets/d69ecd11-1e41-4618-b0e0-061a79f78e5f" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
