### PR TITLE
Improve 'doesn't allow selecting invalid variations in dropdown mode' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-57718-flaky-test
+++ b/plugins/woocommerce/changelog/fix-57718-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'doesn't allow selecting invalid variations in dropdown mode' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -237,7 +237,9 @@ test.describe( 'Add to Cart + Options Block', () => {
 	} ) => {
 		await pageObject.updateSingleProductTemplate();
 
-		await pageObject.switchProductType( 'Variable Product' );
+		await pageObject.switchProductType( 'Variable product' );
+
+		await page.getByRole( 'tab', { name: 'Block' } ).click();
 
 		// Verify inner blocks have loaded.
 		await expect(
@@ -268,10 +270,19 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.goto( '/hoodie' );
 
-		const colorGreenOption = page.getByRole( 'option', {
+		let colorGreenOption = page.getByRole( 'option', {
 			name: 'Green',
 			exact: true,
 		} );
+
+		// Workaround for the template not being updated on the first load.
+		if ( ! ( await colorGreenOption.isVisible() ) ) {
+			await page.reload();
+			colorGreenOption = page.getByRole( 'option', {
+				name: 'Green',
+				exact: true,
+			} );
+		}
 
 		await expect( colorGreenOption ).toBeEnabled();
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -26,20 +26,17 @@ class AddToCartWithOptionsPage {
 	}
 
 	async switchProductType( productType: string ) {
+		await this.page.getByRole( 'tab', { name: 'Template' } ).click();
+		await this.page
+			.getByRole( 'button', { name: 'Product Type', exact: true } )
+			.click();
+		await this.page
+			.getByLabel( 'Type switcher' )
+			.selectOption( { label: productType } );
+
 		const addToCartWithOptionsBlock = await this.editor.getBlockByName(
 			this.BLOCK_SLUG
 		);
-		await this.editor.selectBlocks( addToCartWithOptionsBlock );
-
-		const productTypeSwitcher = this.page.getByRole( 'button', {
-			name: 'Switch product type',
-		} );
-		await productTypeSwitcher.click();
-
-		const customProductTypeButton = this.page.getByRole( 'menuitem', {
-			name: productType,
-		} );
-		await customProductTypeButton.click();
 
 		await addToCartWithOptionsBlock
 			.locator( '.components-spinner' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/57718.

This is another attempt at fixing or reducing the flakiness of the 'doesn't allow selecting invalid variations in dropdown mode' e2e test.

This PR:

* Refactors `switchProductType()` so instead of using the toolbar, we use the sidebar. Using the toolbar added some flakiness because redraws as blocks were being rendered caused the menus to move around, sometimes causing clicks not to happens.
* Adds a work-around for the template not being ready on first load by reloading the page.

Kudos to @kmanijak for his help and guidance on investigating and resolving this. :raised_hands: 

### How to test the changes in this Pull Request:

1. Verify e2e tests pass and 'doesn't allow selecting invalid variations in dropdown mode' isn't flaky anymore.