### PR TITLE
Add fallback for store notice

### DIFF
--- a/plugins/woocommerce/changelog/59729-theme-37-woocommerce-store-notice-doesnt-show-up
+++ b/plugins/woocommerce/changelog/59729-theme-37-woocommerce-store-notice-doesnt-show-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fallback to displaying store notices via the `wp_footer` hook if the `wp_body_open` hook didn't fire. This improves compatibility with themes that haven't been updated to include the `wp_body_open` hook.

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -256,6 +256,12 @@ add_action( 'woocommerce_cart_is_empty', 'wc_empty_cart_message', 10 );
  */
 add_action( 'wp_footer', 'wc_print_js', 25 );
 add_action( 'wp_body_open', 'woocommerce_demo_store' );
+add_action( 'wp_footer', function() {
+    // Fallback for pre-WP5.2 themes that don't support wp_body_open.
+    if ( 0 === did_action( 'wp_body_open' ) ) {
+        woocommerce_demo_store();
+    }
+} );
 
 /**
  * Order details.

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -256,12 +256,15 @@ add_action( 'woocommerce_cart_is_empty', 'wc_empty_cart_message', 10 );
  */
 add_action( 'wp_footer', 'wc_print_js', 25 );
 add_action( 'wp_body_open', 'woocommerce_demo_store' );
-add_action( 'wp_footer', function() {
-    // Fallback for pre-WP5.2 themes that don't support wp_body_open.
-    if ( 0 === did_action( 'wp_body_open' ) ) {
-        woocommerce_demo_store();
-    }
-} );
+add_action(
+	'wp_footer',
+	function () {
+		// Fallback for pre-WP5.2 themes that don't support wp_body_open.
+		if ( 0 === did_action( 'wp_body_open' ) ) {
+			woocommerce_demo_store();
+		}
+	}
+);
 
 /**
  * Order details.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The store notice hook changed from wp_footer to wp_body_open in #55494 to improve accessibility. Old themes don't necessarily have support for wp_body_open - it was introduced in WP5.2 which means that the store notice wasn't appearing.

This change fixes the problem by outputting the store notice in the footer again if the wp_body_open hook hasn't been called.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://linear.app/a8c/issue/THEME-37 .

(For Bug Fixes) Bug introduced in PR #55494 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1163" height="521" alt="Screenshot 2025-07-17 at 11 15 25" src="https://github.com/user-attachments/assets/7c04f310-57e0-4b36-9353-d30104caf503" />     |    <img width="1163" height="521" alt="Screenshot 2025-07-17 at 11 14 36" src="https://github.com/user-attachments/assets/9a0373bf-c9d4-4c09-85c6-f799973e9b53" />   |



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch to an old theme like lodestar
2. Go to /wp-admin/customize.php, open up WooCommerce → Store Notice
3. Tick the "Enable store notice" checkbox
4. Look at the front-end of the website

Before this change, the store notice wasn't being displayed, now it is.

You should also check:
 * The page html to ensure it's not being output twice etc.
 * That the dismiss button works

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

I followed my own steps above on a fresh new checkout of WooCommerce using a fresh new wp-env'd wp.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fallback to displaying store notices via the `wp_footer` hook if the `wp_body_open` hook didn't fire. This improves compatibility with themes that haven't been updated to include the `wp_body_open` hook.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
