### PR TITLE
Email Editor: Fix color inheritance in Paragraph and Heading blocks

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-5034-fix-text-color-inheritance-in-paragraph-and-heading-blocks
+++ b/packages/php/email-editor/changelog/wooplug-5034-fix-text-color-inheritance-in-paragraph-and-heading-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix color inheritance in Paragraph and Heading blocks.

--- a/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-typography-preprocessor.php
+++ b/packages/php/email-editor/src/Engine/Renderer/ContentRenderer/Preprocessors/class-typography-preprocessor.php
@@ -93,6 +93,9 @@ class Typography_Preprocessor implements Preprocessor {
 		if ( isset( $block['attrs']['style']['color']['text'] ) ) {
 			$email_attrs['color'] = $block['attrs']['style']['color']['text'];
 		}
+		if ( isset( $block['attrs']['textColor'] ) && ! isset( $email_attrs['color'] ) ) {
+			$email_attrs['color'] = $this->settings_controller->translate_slug_to_color( $block['attrs']['textColor'] );
+		}
 		// In case the fontSize is set via a slug (small, medium, large, etc.) we translate it to a number
 		// The font size slug is set in $block['attrs']['fontSize'] and value in $block['attrs']['style']['typography']['fontSize'].
 		if ( isset( $block['attrs']['fontSize'] ) ) {

--- a/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
+++ b/packages/php/email-editor/src/Integrations/Core/Renderer/Blocks/class-text.php
@@ -61,7 +61,7 @@ class Text extends Abstract_Block_Renderer {
 		// Add fallback text color when no custom text color or preset text color is set.
 		if ( empty( $block_styles['declarations']['color'] ) ) {
 			$email_styles               = $rendering_context->get_theme_styles();
-			$additional_styles['color'] = $email_styles['color']['text'] ?? '#000000'; // Fallback for the text color.
+			$additional_styles['color'] = $parsed_block['email_attrs']['color'] ?? $email_styles['color']['text'] ?? '#000000'; // Fallback for the text color.
 		}
 
 		$additional_styles['text-align'] = 'left';

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Heading_Test.php
@@ -108,4 +108,21 @@ class Heading_Test extends \Email_Editor_Integration_Test_Case {
 		$rendered = $this->heading_renderer->render( '<h1 style="font-size:clamp(10px, 20px, 24px)">This is Heading 1</h1>', $this->parsed_heading, $this->rendering_context );
 		$this->assertStringContainsString( 'font-size:24px', $rendered );
 	}
+
+	/**
+	 * Test it uses inherited color from email_attrs when no color is specified
+	 */
+	public function testItUsesInheritedColorFromEmailAttrs(): void {
+		$parsed_heading = $this->parsed_heading;
+
+		unset( $parsed_heading['attrs']['style']['color'] );
+		unset( $parsed_heading['attrs']['textColor'] );
+
+		$parsed_heading['email_attrs'] = array(
+			'color' => '#ff0000',
+		);
+
+		$rendered = $this->heading_renderer->render( '<h1>This is Heading 1</h1>', $parsed_heading, $this->rendering_context );
+		$this->assertStringContainsString( 'color:#ff0000;', $rendered );
+	}
 }

--- a/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Paragraph_Test.php
+++ b/packages/php/email-editor/tests/integration/Integrations/Core/Renderer/Blocks/Paragraph_Test.php
@@ -155,4 +155,21 @@ class Paragraph_Test extends \Email_Editor_Integration_Test_Case {
 		$this->assertStringContainsString( 'font-size:20px;', $rendered );
 		$this->assertStringContainsString( 'Lorem Ipsum', $rendered );
 	}
+
+	/**
+	 * Test it uses inherited color from email_attrs when no color is specified
+	 */
+	public function testItUsesInheritedColorFromEmailAttrs(): void {
+		$parsed_paragraph = $this->parsed_paragraph;
+
+		unset( $parsed_paragraph['attrs']['style']['color'] );
+		unset( $parsed_paragraph['attrs']['textColor'] );
+
+		$parsed_paragraph['email_attrs'] = array(
+			'color' => '#ff0000',
+		);
+
+		$rendered = $this->paragraph_renderer->render( '<p>Lorem Ipsum</p>', $parsed_paragraph, $this->rendering_context );
+		$this->assertStringContainsString( 'color:#ff0000;', $rendered );
+	}
 }

--- a/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Typography_Preprocessor_Test.php
+++ b/packages/php/email-editor/tests/unit/Engine/Renderer/ContentRenderer/Preprocessors/Typography_Preprocessor_Test.php
@@ -80,6 +80,12 @@ class Typography_Preprocessor_Test extends \Email_Editor_Unit_Test {
 				return str_replace( 'slug-', '', $slug );
 			}
 		);
+		// This slug translate mock expect slugs in format slug-color and will return color.
+		$settings_mock->method( 'translate_slug_to_color' )->willReturnMap(
+			array(
+				array( 'slug-red', '#ff0000' ),
+			)
+		);
 		$this->preprocessor = new Typography_Preprocessor( $settings_mock );
 		$this->layout       = array( 'contentSize' => '660px' );
 		$this->styles       = array(
@@ -178,6 +184,48 @@ class Typography_Preprocessor_Test extends \Email_Editor_Unit_Test {
 		$expected_email_attrs = array(
 			'color'     => '#000000',
 			'font-size' => '20px',
+		);
+		$result               = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
+		$result               = $result[0];
+		$this->assertCount( 2, $result['innerBlocks'] );
+		$this->assertEquals( $expected_email_attrs, $result['email_attrs'] );
+		$this->assertEquals( $expected_email_attrs, $result['innerBlocks'][0]['email_attrs'] );
+		$this->assertEquals( $expected_email_attrs, $result['innerBlocks'][1]['email_attrs'] );
+		$this->assertEquals( $expected_email_attrs, $result['innerBlocks'][1]['innerBlocks'][0]['email_attrs'] );
+	}
+
+	/**
+	 * Test it replaces text color slugs with values
+	 */
+	public function testItReplacesTextColorSlugsWithValues(): void {
+		$blocks               = array(
+			array(
+				'blockName'   => 'core/columns',
+				'attrs'       => array(
+					'textColor' => 'slug-red',
+					'style'     => array(),
+				),
+				'innerBlocks' => array(
+					array(
+						'blockName'   => 'core/column',
+						'innerBlocks' => array(),
+					),
+					array(
+						'blockName'   => 'core/column',
+						'innerBlocks' => array(
+							array(
+								'blockName'   => 'core/paragraph',
+								'attrs'       => array(),
+								'innerBlocks' => array(),
+							),
+						),
+					),
+				),
+			),
+		);
+		$expected_email_attrs = array(
+			'color'     => '#ff0000',
+			'font-size' => '13px',
 		);
 		$result               = $this->preprocessor->preprocess( $blocks, $this->layout, $this->styles );
 		$result               = $result[0];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is currently using `wooplug-4688-add-style-factory-methods-for-emails` as a base branch since it depends on the changes introduced there to properly resolve the issue. That being said, this PR should be considered **BLOCKED FOR MERGING** until https://github.com/woocommerce/woocommerce/pull/59678 is merged.

* Use the color presets (i.e. `$block_attributes['textColor']`) if color style is not specified and pass it to children blocks in the `$block_attributes['email_attrs']`.
* Use the color provided in `$block_attributes['email_attrs']['color']` in Text blocks (Paragraph and Heading) if a color is not specified to the block.

Closes [WOOPLUG-5034: Fix text color inheritance in Paragraph and Heading blocks](https://linear.app/a8c/issue/WOOPLUG-5034/fix-text-color-inheritance-in-paragraph-and-heading-blocks) (https://github.com/woocommerce/woocommerce/issues/59696).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Email Editor | Email Preview Before | Email Preview After |
| ------ | ------ | ----- |
| <img width="636" height="139" alt="hhzUstdR3HMcUt8y" src="https://github.com/user-attachments/assets/78513bf9-dbdc-4ccf-85c8-2a5284273286" /> | <img width="635" height="137" alt="MoP6SBExiZyWau13" src="https://github.com/user-attachments/assets/9820799f-7cee-480b-aff8-f72747a8486f" /> | <img width="635" height="138" alt="WlSsOs4JEMxmcS5E" src="https://github.com/user-attachments/assets/620a27d0-26a5-4d0b-b84c-881141c7f569" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
2. Open an email in the editor WooCommerce → Settings → **Emails**
3. Insert a Group block and set a text color - either from the color palette presets , or a custom color.
4. Insert a Heading or a Paragraph block block inside the Group block.
5. The Heading/Paragraph block should inherit the color from the parent Group block in both the email editor and the email preview.
6. If a color is set for the Heading/Paragraph, it should override the inherited color.


### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix color inheritance in Paragraph and Heading blocks.
</details>
