### PR TITLE
Apply consistent font sizes and spacing in checkout (shipping and billing blocks)

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -33,6 +33,14 @@ $fontSizes: (
 	line-height: 16px;
 }
 
+// We're treating mobile inputs as a special case, increasing the font-size to
+// 16px to avoid mobile Safari auto-zooming when focusing on the input. The
+// minimum font-size to prevent this behavior is 16px. Please don't change it!
+@mixin font-for-mobile-inputs-locked {
+	font-size: 16px;
+	line-height: 20px;
+}
+
 @mixin spinner-animation() {
 	@keyframes spinner__animation {
 		0% {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -9,6 +9,7 @@
 		background: $input-background-light;
 		width: 100%;
 		position: relative;
+		line-height: 0;
 
 		.has-dark-controls & {
 			background-color: $input-background-dark;
@@ -80,6 +81,15 @@
 
 		.has-error & {
 			color: $alert-red;
+		}
+	}
+
+	// For phones we're increasing the font-size of the input to 16px to avoid
+	// mobile Safari auto-zooming on the input (16px is the minimum font-size
+	// required to disable this behavior).
+	@include breakpoint("<480px") {
+		.wc-blocks-components-select__select {
+			@include font-for-mobile-inputs-locked;
 		}
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -9,6 +9,7 @@
 		background: $input-background-light;
 		width: 100%;
 		position: relative;
+		// Resetting line-height to avoid any unnecessary space around the input
 		line-height: 0;
 
 		.has-dark-controls & {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -8,7 +8,6 @@
 		box-sizing: border-box;
 		background: $input-background-light;
 		width: 100%;
-		height: 3.125em;
 		position: relative;
 
 		.has-dark-controls & {
@@ -28,15 +27,18 @@
 
 	.wc-blocks-components-select__select {
 		@include reset-typography();
-		@include font-size(regular);
+		@include font-regular-locked;
 		border-radius: $universal-border-radius;
 		width: 100%;
 		height: 100%;
 		appearance: none;
 		background: none;
-		padding: em($gap) em($gap-smaller) 0;
 		color: $input-text-light;
 		border: 1px solid $universal-border-strong;
+		box-sizing: border-box;
+
+		// Top padding = $gap-smaller + line-height of the label
+		padding: calc($gap-smaller + 16px) $gap-small $gap-smaller;
 
 		&:focus {
 			border-color: currentColor;
@@ -58,19 +60,18 @@
 
 	.wc-blocks-components-select__label {
 		@include reset-typography();
-		@include font-size(regular);
+		@include font-small-locked;
 		position: absolute;
-		line-height: 1.25; // =20px when font-size is 16px.
-		left: em($gap-smaller);
-		top: 2px;
-		transform-origin: top left;
-		transition: all 200ms ease;
-		color: $input-text-light;
+		// 1px (border) + padding of the input
+		top: 1px + $gap-smaller;
+		left: 1px + $gap-small;
+
+		color: $universal-body-low-emphasis;
 		z-index: 1;
 		margin: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - #{2 * $gap});
+		max-width: calc(100% - #{2 * $gap-small});
 		white-space: nowrap;
 
 		.has-dark-controls & {
@@ -80,12 +81,6 @@
 		.has-error & {
 			color: $alert-red;
 		}
-
-		@media screen and (prefers-reduced-motion: reduce) {
-			transition: none;
-		}
-
-		transform: translateY(15%) scale(0.75);
 	}
 
 	.wc-blocks-components-select__expand {

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -42,6 +42,14 @@
 		// Top padding = $gap-smaller + line-height of the label
 		padding: calc($gap-smaller + 16px) $gap-small $gap-smaller;
 
+		// We are hardcoding the height to reserve space for a wider border that
+		// we apply for focused state. Without it, when focusing the input its
+		// height will increase by 1px, causing the rest of the form to shift.
+		// height = font line-height + vertical padding + focused top/bottom border
+		// Don't worry, this calculation won't be performed at runtime, SCSS
+		// is transforming it into a singular value during build time.
+		height: calc(20px + 16px * 2 + 1.5px * 2);
+
 		&:focus {
 			border-color: currentColor;
 			border-width: 1.5px;

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/select/style.scss
@@ -32,7 +32,6 @@
 		@include font-regular-locked;
 		border-radius: $universal-border-radius;
 		width: 100%;
-		height: 100%;
 		appearance: none;
 		background: none;
 		color: $input-text-light;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/attribute-filter/style.scss
@@ -169,11 +169,13 @@
 	}
 }
 
-.editor-styles-wrapper .wc-block-components-checkbox {
+.editor-styles-wrapper
+	.wc-block-attribute-filter
+	.wc-block-components-checkbox {
 	margin-top: em($gap);
 }
 
-.wc-block-components-checkbox {
+.wc-block-attribute-filter .wc-block-components-checkbox {
 	margin-top: em($gap);
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -14,23 +14,21 @@ import { formatAddress } from '@woocommerce/blocks/checkout/utils';
 import { Button } from '@ariakit/react';
 import { decodeEntities } from '@wordpress/html-entities';
 import clsx from 'clsx';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-const AddressCard = ( {
-	address,
-	onEdit,
-	target,
-	isExpanded,
-}: {
+type Props = {
 	address: CartShippingAddress | CartBillingAddress;
 	onEdit: () => void;
 	target: string;
 	isExpanded: boolean;
-} ): JSX.Element | null => {
+};
+
+const getFormattedAddress = ( address: Props[ 'address' ] ) => {
 	const countryData = getSetting< Record< string, CountryData > >(
 		'countryData',
 		{}
@@ -49,14 +47,25 @@ const AddressCard = ( {
 		// `as string` is fine here because we check if it's a string above.
 		formatToUse = countryData[ address.country ].format as string;
 	}
-	const { name: formattedName, address: formattedAddress } = formatAddress(
-		address,
-		formatToUse
-	);
+
+	return formatAddress( address, formatToUse );
+};
+
+const AddressCard = ( { address, onEdit, target, isExpanded }: Props ) => {
+	const { name: formattedName, address: formattedAddress } =
+		getFormattedAddress( address );
+
 	const label =
 		target === 'shipping'
 			? __( 'Edit shipping address', 'woocommerce' )
 			: __( 'Edit billing address', 'woocommerce' );
+
+	const fullAddress = useMemo( () => {
+		return [ ...formattedAddress, address.phone ]
+			.filter( ( field ) => !! field )
+			.map( ( field ) => decodeEntities( field ) )
+			.join( ', ' );
+	}, [ formattedAddress, address.phone ] );
 
 	return (
 		<div className="wc-block-components-address-card">
@@ -75,16 +84,8 @@ const AddressCard = ( {
 						'wc-block-components-address-card__address-section--secondary'
 					) }
 				>
-					{ formattedAddress
-						.filter( ( field ) => !! field )
-						.map( ( field ) => decodeEntities( field ) )
-						.join( ', ' ) }
+					{ fullAddress }
 				</span>
-				{ address.phone ? (
-					<span className="wc-block-components-address-card__address-section">
-						{ address.phone }
-					</span>
-				) : null }
 			</address>
 			{ onEdit && (
 				<Button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/index.tsx
@@ -13,6 +13,7 @@ import { getSetting } from '@woocommerce/settings';
 import { formatAddress } from '@woocommerce/blocks/checkout/utils';
 import { Button } from '@ariakit/react';
 import { decodeEntities } from '@wordpress/html-entities';
+import clsx from 'clsx';
 
 /**
  * Internal dependencies
@@ -60,28 +61,30 @@ const AddressCard = ( {
 	return (
 		<div className="wc-block-components-address-card">
 			<address>
-				<span className="wc-block-components-address-card__address-section">
+				<span
+					className={ clsx(
+						'wc-block-components-address-card__address-section',
+						'wc-block-components-address-card__address-section--primary'
+					) }
+				>
 					{ decodeEntities( formattedName ) }
 				</span>
-				<div className="wc-block-components-address-card__address-section">
+				<span
+					className={ clsx(
+						'wc-block-components-address-card__address-section',
+						'wc-block-components-address-card__address-section--secondary'
+					) }
+				>
 					{ formattedAddress
 						.filter( ( field ) => !! field )
-						.map( ( field, index ) => (
-							<span key={ `address-` + index }>
-								{ decodeEntities( field ) }
-							</span>
-						) ) }
-				</div>
+						.map( ( field ) => decodeEntities( field ) )
+						.join( ', ' ) }
+				</span>
 				{ address.phone ? (
-					<div
-						key={ `address-phone` }
-						className="wc-block-components-address-card__address-section"
-					>
+					<span className="wc-block-components-address-card__address-section">
 						{ address.phone }
-					</div>
-				) : (
-					''
-				) }
+					</span>
+				) : null }
 			</address>
 			{ onEdit && (
 				<Button

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/address-card/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-address-card {
+	@include font-regular-locked;
 	border: 1px solid $universal-border-light;
-	@include font-size(regular);
-	padding: em($gap);
+	padding: $gap;
 	margin: 0;
 	border-radius: $universal-border-radius;
 	display: flex;
@@ -13,39 +13,30 @@
 	}
 
 	address {
-		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: $gap-smallest;
 		font-style: normal;
 
 		.wc-block-components-address-card__address-section {
-			display: block;
-			margin: 0 0 2px 0;
-			span {
-				display: inline-block;
-				padding: 0 4px 0 0;
-				&::after {
-					content: ", ";
-				}
-				&:last-child::after {
-					content: "";
-				}
+			&--primary {
+				font-weight: 500;
 			}
-			&:last-child {
-				margin-bottom: 0;
-			}
-			&:first-child {
-				font-weight: bold;
+
+			&--secondary {
+				color: $universal-body-low-emphasis;
 			}
 		}
 	}
 }
 .wc-block-components-address-card__edit {
+	@include font-regular-locked;
 	background-color: transparent;
 	border: 0;
 	color: inherit;
 	cursor: pointer;
 	font-family: inherit;
 	margin: 0 0 0 auto;
-	@include font-size(small);
 
 	&:hover {
 		text-decoration: underline;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -2,11 +2,16 @@
 	margin: 0;
 	max-width: 100%;
 
-	// Fix content jump for address forms when using select as first input
+	// This margin is aligned with text-input margin-top, making it positioned
+	// correctly when two are placed next to each other.
+	// Please don't change unless you plan to apply the same change
+	// in text-input/style.scss
 	.wc-blocks-components-select {
-		margin-top: $gap;
+		margin-top: $gap-small;
 	}
 
+	// No need for this margin in default country select, which sits at the top
+	// of the form
 	.wc-block-components-address-form__country {
 		.wc-blocks-components-select {
 			margin-top: 0;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -25,7 +25,7 @@
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
-			gap: 0 calc(#{$gap-smaller} * 2); // Required for spacing especially when using flex-grow
+			gap: 0 $gap-small; // Required for spacing especially when using flex-grow
 
 			.wc-block-components-text-input,
 			.wc-block-components-state-input,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/test/__snapshots__/block.tsx.snap
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/stock-filter/test/__snapshots__/block.tsx.snap
@@ -26,7 +26,6 @@ exports[`Filter by Stock block renders the stock filter block 1`] = `
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -58,7 +57,6 @@ exports[`Filter by Stock block renders the stock filter block 1`] = `
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -90,7 +88,6 @@ exports[`Filter by Stock block renders the stock filter block 1`] = `
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -138,7 +135,6 @@ exports[`Filter by Stock block renders the stock filter block with the filter bu
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -170,7 +166,6 @@ exports[`Filter by Stock block renders the stock filter block with the filter bu
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -202,7 +197,6 @@ exports[`Filter by Stock block renders the stock filter block with the filter bu
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -266,7 +260,6 @@ exports[`Filter by Stock block renders the stock filter block with the product c
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -312,7 +305,6 @@ exports[`Filter by Stock block renders the stock filter block with the product c
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
@@ -358,7 +350,6 @@ exports[`Filter by Stock block renders the stock filter block with the product c
               aria-hidden="true"
               class="wc-block-components-checkbox__mark"
               viewBox="0 0 24 20"
-              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/index.tsx
@@ -85,7 +85,6 @@ export const CheckboxControl = forwardRef<
 					<svg
 						className="wc-block-components-checkbox__mark"
 						aria-hidden="true"
-						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 24 20"
 					>
 						<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
@@ -1,6 +1,7 @@
 .wc-block-components-checkbox {
 	@include reset-color();
 	@include reset-typography();
+	line-height: 0;
 	margin-top: $gap;
 
 	// Validated checkbox is set to grid because we need to display the validation error below the checkbox, the flex

--- a/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/checkbox-control/style.scss
@@ -1,8 +1,7 @@
 .wc-block-components-checkbox {
 	@include reset-color();
 	@include reset-typography();
-	margin-top: em($gap);
-	line-height: 1;
+	margin-top: $gap;
 
 	// Validated checkbox is set to grid because we need to display the validation error below the checkbox, the flex
 	// layout doesn't allow for that without extra markup.
@@ -16,12 +15,13 @@
 	}
 
 	label {
+		@include font-regular-locked;
 		align-items: flex-start;
 		display: inline-flex;
 		position: relative;
 		cursor: pointer;
-		@include font-size(small);
 		margin-bottom: 0 !important;
+		gap: $gap-small;
 
 		input[type="checkbox"] {
 			cursor: inherit;
@@ -29,20 +29,15 @@
 	}
 
 	.wc-block-components-checkbox__input[type="checkbox"] {
-		font-size: 1em;
 		appearance: none;
 		border: 1px solid $universal-border-medium;
 		border-radius: $universal-border-radius;
 		box-sizing: border-box;
-		height: em(24px);
-		width: em(24px);
+		height: 20px;
+		width: 20px;
 		margin: 0;
-		margin-right: em($gap);
-		min-height: em(24px);
-		min-width: em(24px);
 		overflow: hidden;
 		position: static;
-		vertical-align: middle;
 		background-color: $input-background-light;
 
 		&:checked {
@@ -103,21 +98,15 @@
 	.wc-block-components-checkbox__mark {
 		fill: #000;
 		position: absolute;
-		margin-left: em(3px);
-		margin-top: em(1px);
-		width: em(18px);
-		height: em(18px);
+		margin-left: 3px;
+		margin-top: 1px;
+		width: 15px;
+		height: 15px;
 		pointer-events: none;
 
 		.has-dark-controls & {
 			fill: $input-text-dark;
 		}
-	}
-
-	> span,
-	.wc-block-components-checkbox__label {
-		vertical-align: middle;
-		line-height: em(24px);
 	}
 }
 

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -1,25 +1,28 @@
 .wc-block-components-form .wc-block-components-text-input,
 .wc-block-components-text-input {
 	position: relative;
-	margin-top: $gap;
+	margin-top: $gap-small;
 	white-space: nowrap;
+	// Resetting line-height to avoid any unnecessary space around the input
+	line-height: 0;
 
 	label {
 		@include reset-color();
 		@include reset-typography();
-		@include font-size(regular);
+		@include font-regular-locked;
 		position: absolute;
 		transform: translateY(-50%);
-		line-height: 1.5;
-		left: em($gap-smaller + 1px);
-		top: 1.562em;
+		// Not sure why, but looks better alinged when off by 1px
+		left: calc($gap-small + 1px);
+		// 1px (border) + padding of the input + half the height of the label itself
+		top: calc(1px + $gap + 10px);
 		transform-origin: top left;
 		color: $universal-body-low-emphasis;
 		transition: all 200ms ease;
 		margin: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - #{2 * $gap});
+		max-width: calc(100% - #{2 * $gap-small});
 		cursor: text;
 
 		.has-dark-controls & {
@@ -31,7 +34,9 @@
 	}
 
 	input[type="number"] {
+		appearance: textfield;
 		-moz-appearance: textfield;
+
 		&::-webkit-outer-spin-button,
 		&::-webkit-inner-spin-button {
 			appearance: none;
@@ -45,18 +50,16 @@
 	input[type="number"],
 	input[type="password"],
 	input[type="email"] {
-		@include font-size(regular);
-		padding: em($gap) em($gap-smaller);
-		line-height: em($gap);
+		@include reset-typography();
+		@include font-regular-locked;
+		padding: $gap $gap-small;
 		width: 100%;
 		border-radius: $universal-border-radius;
 		border: 1px solid $universal-border-strong;
 
-		font-family: inherit;
 		margin: 0;
 		box-sizing: border-box;
 		min-height: 0;
-		height: 3.125em;
 		background-color: $input-background-light;
 		color: $input-text-light;
 
@@ -86,13 +89,17 @@
 	&.is-active input[type="number"],
 	&.is-active input[type="password"],
 	&.is-active input[type="email"] {
-		padding: em($gap + $gap-smaller) em($gap-smaller) em($gap-smaller);
+		// Top padding = $gap-smaller + line-height of the label
+		padding: calc($gap-smaller + 16px) $gap-small $gap-smaller;
 	}
 
 	&.is-active label,
 	input:-webkit-autofill + label {
-		transform: translateY(#{$gap-smallest}) scale(0.75);
-		top: 0;
+		// Base font-size is 14px; 0.8571 * 14px = 12px (regular size font changes
+		// to small one). We use scale transform as we can animate it.
+		transform: scale(0.8571);
+		// 1px (border) + padding of the input when label + value displayed
+		top: 1px + $gap-smaller;
 	}
 
 	&.has-error input {
@@ -124,9 +131,5 @@
 		.has-dark-controls & {
 			color: color.adjust($alert-red, $lightness: 30%);
 		}
-	}
-
-	&:only-child {
-		margin-top: 1.5em;
 	}
 }

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -12,7 +12,7 @@
 		@include font-regular-locked;
 		position: absolute;
 		transform: translateY(-50%);
-		// Not sure why, but looks better alinged when off by 1px
+		// 1px (border) + padding of the input
 		left: calc($gap-small + 1px);
 		// 1px (border) + padding of the input + half the height of the label itself
 		top: calc(1px + $gap + 10px);

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -52,6 +52,14 @@
 		background-color: $input-background-light;
 		color: $input-text-light;
 
+		// We are hardcoding the height to reserve space for a wider border that
+		// we apply for focused state. Without it, when focusing the input its
+		// height will increase by 1px, causing the rest of the form to shift.
+		// height = font line-height + vertical padding + focused top/bottom border
+		// Don't worry, this calculation won't be performed at runtime, SCSS
+		// is transforming it into a singular value during build time.
+		height: calc(20px + 16px * 2 + 1.5px * 2);
+
 		&:focus {
 			background-color: $input-background-light;
 			color: $input-text-light;

--- a/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/text-input/style.scss
@@ -33,17 +33,6 @@
 		}
 	}
 
-	input[type="number"] {
-		appearance: textfield;
-		-moz-appearance: textfield;
-
-		&::-webkit-outer-spin-button,
-		&::-webkit-inner-spin-button {
-			appearance: none;
-			margin: 0;
-		}
-	}
-
 	input[type="tel"],
 	input[type="url"],
 	input[type="text"],
@@ -82,6 +71,17 @@
 		}
 	}
 
+	input[type="number"] {
+		appearance: textfield;
+		-moz-appearance: textfield;
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			appearance: none;
+			margin: 0;
+		}
+	}
+
 	input:-webkit-autofill,
 	&.is-active input[type="tel"],
 	&.is-active input[type="url"],
@@ -100,6 +100,30 @@
 		transform: scale(0.8571);
 		// 1px (border) + padding of the input when label + value displayed
 		top: 1px + $gap-smaller;
+	}
+
+	// For phones we're increasing the font-size of the input to 16px to avoid
+	// mobile Safari auto-zooming on the input (16px is the minimum font-size
+	// required to disable this behavior).
+	@include breakpoint("<480px") {
+		label {
+			@include font-for-mobile-inputs-locked;
+		}
+
+		&.is-active label,
+		input:-webkit-autofill + label {
+			// Base font-size is 16px; 0.75 * 16px = 12px
+			transform: scale(0.75);
+		}
+
+		input[type="tel"],
+		input[type="url"],
+		input[type="text"],
+		input[type="number"],
+		input[type="password"],
+		input[type="email"] {
+			@include font-for-mobile-inputs-locked;
+		}
 	}
 
 	&.has-error input {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request

Closes https://github.com/woocommerce/woocommerce/issues/59737

Continuation of work tracked in https://github.com/woocommerce/woocommerce/pull/59787 ("long" lived branch synced with trunk)
Intro post: pfHfG4-1iC-p2
Designs: fpl1YUEIW7suBFO09qymA2-fi-1212_50897

Covers shipping and billing blocks; they include a bunch of components used throughout checkout:
- `TextInput` (powers all of our form fields)
- `Checkbox`
- `Select` (powers country selector)

### Screenshots or screen recordings

Used the Twenty Twenty Four theme for the screenshots. Notice that in all cases the "After" screenshot has a lower height. 

#### Address card

| Before | After |
|--------|-------|
| <img width="747" height="254" alt="Screenshot 2025-07-23 at 13 25 08" src="https://github.com/user-attachments/assets/8e971431-5063-4da2-9848-91df9bd9dc9d" /> | <img width="756" height="216" alt="Screenshot 2025-07-23 at 13 23 21" src="https://github.com/user-attachments/assets/724ce761-9a32-435a-b924-f273d20d826e" /> |

#### Shipping/billing section

| Before | After |
|--------|-------|
| <img width="746" height="504" alt="Screenshot 2025-07-23 at 13 25 31" src="https://github.com/user-attachments/assets/6689d5d4-1509-4532-b968-bf8581441e97" /> | <img width="744" height="488" alt="Screenshot 2025-07-23 at 13 23 44" src="https://github.com/user-attachments/assets/a66bc389-c210-4675-bff1-e8bcdbbd6923" /> |

#### All expanded

| Before | After |
|--------|-------|
| <img width="749" height="1046" alt="Screenshot 2025-07-23 at 13 25 48" src="https://github.com/user-attachments/assets/817ba53a-fe18-42a6-946c-8b453a335067" /> | <img width="744" height="1009" alt="Screenshot 2025-07-23 at 13 24 02" src="https://github.com/user-attachments/assets/698f1910-cbf7-45a7-91c2-2ab558f54c19" /> |

#### Mobile

Font size is increased on mobile to 16px to accommodate for mobile Safari auto-zooming on inputs with font size smaller than 16px.

| Before | After |
|--------|-------|
| <img width="391" height="704" alt="Screenshot 2025-07-23 at 13 26 43" src="https://github.com/user-attachments/assets/68fa3cf1-752c-433a-9c47-83ac444eac72" /> | <img width="392" height="688" alt="Screenshot 2025-07-23 at 13 27 11" src="https://github.com/user-attachments/assets/1e477916-8938-40c5-bf29-7c71a8838986" /> |

### How to test the changes in this Pull Request:

1. Add some products to your cart
2. Go to checkout
3. Verify whether it matches the expectation described in this PR (you can cross-check with Figma too), try covering all possible states for these blocks:
    - test with address card (provide address and then refresh the page to see card instead of full form)
    - test with different shipping/billing address (to have two forms and cards) 
    - test with additional address field (apartment, etc.)
5. Verify that the animation for the label input (when you focus on the input it transitions above the editable area) works correctly (it's positioned absolutely, so changes to sizing require new positioning)
6. If you can, test on the mobile Safari browser (real device or emulator), we're looking for verification that you don't observe browser zooming on inputs when you focus them

> [!NOTE]
> If you want to quikcly spot which components were adjusted within this PR, you can go to global styles of the site and vastly increase the general size of the text in typography settings (Global Styles -> Typography -> Text -> Size -> XXL). Texts that will stay small after the change will be the one modified here, the rest is coming in follow-up PRs.

### Testing that has already taken place:

The above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 

Targeting a different branch than `trunk`. The final PR will include changelog.

</details>
