### PR TITLE
Improve 'allows adding grouped products to cart' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-59725-flaky-test
+++ b/plugins/woocommerce/changelog/fix-59725-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'allows adding grouped products to cart' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -181,13 +181,16 @@ test.describe( 'Add to Cart + Options Block', () => {
 		const addToCartButton = page.getByText( 'Add to cart' ).first();
 
 		await test.step( 'displays an error when attempting to add grouped products with zero quantity', async () => {
-			await addToCartButton.click();
-
-			await expect(
-				page.getByText(
-					'Please select some products to add to the cart.'
-				)
-			).toBeVisible();
+			// There is the chance the button might be clicked before the iAPI
+			// stores have been loaded.
+			await expect( async () => {
+				await addToCartButton.click();
+				await expect(
+					page.getByText(
+						'Please select some products to add to the cart.'
+					)
+				).toBeVisible();
+			} ).toPass();
 		} );
 
 		await test.step( 'successfully adds to cart when child products are selected', async () => {
@@ -195,6 +198,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 				'Increase quantity of Beanie'
 			);
 			await increaseQuantityButton.click();
+
 			await increaseQuantityButton.click();
 
 			await addToCartButton.click();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -198,7 +198,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 				'Increase quantity of Beanie'
 			);
 			await increaseQuantityButton.click();
-
 			await increaseQuantityButton.click();
 
 			await addToCartButton.click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59725.

I'm not 100% sure to understand why the test was flaky, I suspect the iAPI stores weren't loaded in time when the button was being clicked. Hopefully this PR will fix it.

### How to test the changes in this Pull Request:

1. Make sure the 'allows adding grouped products to cart' test passes and is not flaky.
