### PR TITLE
Improve 'can add custom product attributes' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-53449-flaky-test
+++ b/plugins/woocommerce/changelog/fix-53449-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'can add custom product attributes' flaky test
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/product/create-product-attributes.spec.js
@@ -175,6 +175,15 @@ test( 'can add custom product attributes', async ( { page, product } ) => {
 		).toBeVisible();
 	} );
 
+	// There is the chance we might click on the 'Attributes' tab too early. To
+	// prevent that, we wait until the 'Variations' tab is hidden, which means
+	// the tabs have been updated.
+	await expect(
+		page
+			.locator( '.attribute_tab' )
+			.getByRole( 'link', { name: 'Variations' } )
+	).toBeHidden();
+
 	await goToAttributesTab( page );
 
 	for ( let j = 0; j < productAttributes.length; j++ ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/53449.

I think the test was flaky because we were clicking on the _Attributes_ button before it was interactive. This PR waits for the tabs to update before clicking on it.

### How to test the changes in this Pull Request:

1. Make sure the 'can add custom product attributes' test passes and is not flaky.