### PR TITLE
iAPI-powered Mini-Cart block should show a maximum of 15 words for the product description

### DIFF
--- a/plugins/woocommerce/changelog/59763-wooplug-4963-iapi-powered-mini-cart-block-should-show-a-maximum-of-15
+++ b/plugins/woocommerce/changelog/59763-wooplug-4963-iapi-powered-mini-cart-block-should-show-a-maximum-of-15
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix iAPI-powered Mini-Cart block to limit product descriptions to 15 words maximum, matching the behavior of the current Mini-Cart block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -77,6 +77,15 @@ type CartItemContext = {
 	cartItem: CartItem;
 };
 
+const trimWords = ( html: string, maxWords = 15 ): string => {
+	const stripped = html.replace( /<[^>]+>/g, '' );
+	const words = stripped.trim().split( /\s+/ );
+	if ( words.length <= maxWords ) {
+		return stripped;
+	}
+	return words.slice( 0, maxWords ).join( ' ' ) + '…';
+};
+
 const { state: woocommerceState, actions } = store< WooCommerce >(
 	'woocommerce',
 	{},
@@ -665,8 +674,9 @@ const { state: cartItemState } = store(
 
 					// A workaround for the lack of dangerous set HTML directive in interactivity API
 					if ( innerEl ) {
-						innerEl.innerHTML =
-							cartItemState.cartItem.short_description;
+						innerEl.innerHTML = trimWords(
+							cartItemState.cartItem.short_description
+						);
 					}
 				}
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -664,7 +664,6 @@ const { state: cartItemState } = store(
 
 		callbacks: {
 			itemShortDescription() {
-				debugger;
 				const el = getElement();
 
 				if ( el.ref ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -78,10 +78,9 @@ type CartItemContext = {
 };
 
 const trimWords = ( html: string, maxWords = 15 ): string => {
-	const stripped = html.replace( /<[^>]+>/g, '' );
-	const words = stripped.trim().split( /\s+/ );
+	const words = html.trim().split( /\s+/ );
 	if ( words.length <= maxWords ) {
-		return stripped;
+		return html;
 	}
 	return words.slice( 0, maxWords ).join( ' ' ) + '…';
 };
@@ -665,6 +664,7 @@ const { state: cartItemState } = store(
 
 		callbacks: {
 			itemShortDescription() {
+				debugger;
 				const el = getElement();
 
 				if ( el.ref ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a bug in the experimental iAPI-powered Mini-Cart block where product descriptions were displaying the full text instead of being limited to 15 words like the current Mini-Cart block.

**How:**
- Added a `trimWords` utility function that strips HTML tags and limits text to a maximum of 15 words
- Applied the utility to the `short_description` field in the Mini-Cart item display

The fix ensures that long product descriptions in the Mini-Cart are truncated with an ellipsis (`…`) when they exceed 15 words, preventing layout issues and maintaining a clean, consistent appearance.

Closes #59556.

### Screenshots or screen recordings:

<!-- Screenshots showing before/after would be helpful to demonstrate the fix -->

| Before | After |
| ------ | ----- |
|<img width="528" height="654" alt="Screenshot 2025-07-18 at 09 16 08" src="https://github.com/user-attachments/assets/a5b9990e-edf5-4ab9-a2a1-b1879aba8833" />  | <img width="528" height="399" alt="Screenshot 2025-07-18 at 09 16 26" src="https://github.com/user-attachments/assets/4ff8ba9c-7ea3-448d-be22-07dc846e4168" /> |

### How to test the changes in this Pull Request:

1. Enable the experimental iAPI-powered Mini-Cart block
2. Create or edit a product to have a short description with more than 15 words
3. Add the product to the cart
4. Open the Mini-Cart block
5. Verify that the product description is truncated to 15 words with an ellipsis (`…`)
6. Test with products that have exactly 15 words or fewer to ensure they display in full without ellipsis

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Fix iAPI-powered Mini-Cart block to limit product descriptions to 15 words maximum, matching the behavior of the current Mini-Cart block.

</details>