### PR TITLE
Improve 'loads the Single Product template for a specific product' flaky test

### DIFF
--- a/plugins/woocommerce/changelog/fix-48808-flaky-test
+++ b/plugins/woocommerce/changelog/fix-48808-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'loads the Single Product template for a specific product' flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/single-product-template.block_theme.spec.ts
@@ -38,7 +38,7 @@ test.describe( 'Single Product template', () => {
 		await page
 			.getByRole( 'option', { name: testData.productName } )
 			.click();
-		await page.getByLabel( 'Fallback content' ).click();
+		await page.getByLabel( 'Close', { exact: true } ).click();
 
 		// Edit the template.
 		await editor.insertBlock( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/48808.

The flaky test was caused by some unexpected changes in the header, which made the `saveSiteEditorEntities()` not to work as there were two entities to save instead of one.

I think an easy way to fix it is that instead of starting with the fallback content, we start with an empty template. This should also speed up the test slightly.

### How to test the changes in this Pull Request:

1. Make sure the 'loads the Single Product template for a specific product' test passes and is not flaky.