### PR TITLE
Fix syntax errors in additional checkout field docs

### DIFF
--- a/docs/block-development/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -498,7 +498,7 @@ The below example shows how to apply custom validation to the `namespace/gov-id`
 
 ```php
 add_action(
-'woocommerce_validate_additional_field',
+	'woocommerce_validate_additional_field',
 	function ( WP_Error $errors, $field_key, $field_value ) {
 		if ( 'namespace/gov-id' === $field_key ) {
 			$match = preg_match( '/[A-Z0-9]{5}/', $field_value );
@@ -1145,7 +1145,7 @@ add_action(
 						$errors->add( 'invalid_gov_id', 'Please ensure your government ID matches the correct format.' );
 					}
 				}
-				return $error;
+				return $errors;
 			},
 			10,
 			3

--- a/docs/block-development/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -954,7 +954,7 @@ In this example, we ensure that VAT is made up of a country code and 8-12 number
 ```php
 'validation' => [
 	"type" => "string",
-	"pattern" => "^[A-Z]{2}[0-9]{8,12}$"
+	"pattern" => "^[A-Z]{2}[0-9]{8,12}$",
 	"errorMessage" => "Please enter a valid VAT code with 2 letters for country code and 8-12 numbers."
 ]
 ```
@@ -966,9 +966,9 @@ Validation can also be against other fields, for example, an alternative email f
 	"type" => "string",
 	"format" => "email",
 	"not" => [
-		"const" => ["$data", "0/customer/billing_address/email"]
-	]
-	"errorMessage" => "Please enter a valid VAT code with 2 letters for country code and 8-12 numbers."
+		"const" => [ '$data' => "/customer/billing_address/email" ]
+	],
+	"errorMessage" => "Please enter a valid alternative email."
 ]
 ```
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a couple of syntax errors in 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5026


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Read the changes, try the example snippets I've changed in a real situation, e.g. using this snippet:

```php
add_action(
	'init',
	function () {
	    woocommerce_register_additional_checkout_field(
	        array(
	            'id' => 'test-plugin/vat-number',
	            'label' => 'VAT Number',
	            'location' => 'address',
	            'type' => 'text',
				'validation' => [
					"type" => "string",
					"format" => "email",
					"not" => [
						"const" => [ '$data' => "/customer/billing_address/email" ]
					],
					"errorMessage" => "Please enter a valid alternative email."
				]
	        )
	    );
	}
);
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
