### PR TITLE
Interactivity API powered MiniCart - Fix `buttonAriaLabel` getter in PHP

### DIFF
--- a/plugins/woocommerce/changelog/59779-fix-iapi-minicart-aria-label-getter
+++ b/plugins/woocommerce/changelog/59779-fix-iapi-minicart-aria-label-getter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue in the `buttonAriaLabel` PHP getter in the `woocommerce/mini-cart` iAPI initial state.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -524,7 +524,7 @@ class MiniCart extends AbstractBlock {
 					'badgeIsVisible'     => $badge_is_visible,
 					'formattedSubtotal'  => $formatted_subtotal,
 					'drawerOverlayClass' => 'wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden',
-					'buttonAriaLabel'    => function () {
+					'buttonAriaLabel'    => function () use ( $button_aria_label_template ) {
 						$state = wp_interactivity_state();
 						return isset( $attributes['hasHiddenPrice'] ) && false !== $attributes['hasHiddenPrice']
 							? sprintf( $button_aria_label_template, $state['totalItemsInCart'] )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an issue in the `state.buttonAriaLabel` getter inside the `woocommerce/mini-cart` iAPI store.

The closure was using the variable `$button_aria_label_template`, which was outside of the function scope. This fix simply adds the variable to the scope.

(For Bug Fixes) Bug introduced in PR #59636.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit a page with the mini-cart block.
2. Ensure the following error doesn't appear at the top:
   ```
   Warning: Undefined variable $button_aria_label_template
   in /var/www/html/wp-content/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
   on line 531
   
   Notice: Function WP_Interactivity_API::evaluate was called incorrectly. Uncaught error executing a derived state callback with path "state.buttonAriaLabel" and namespace "woocommerce/mini-cart".
   Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.6.0.)
   in /var/www/html/wp-includes/functions.php
   on line 6122
   ```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix an issue in the `buttonAriaLabel` PHP getter in the `woocommerce/mini-cart` iAPI initial state.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
