### PR TITLE
Add experimental feature on WooCommerce Advanced Settings for new iAPI Mini Cart

### DIFF
--- a/plugins/woocommerce/changelog/59782-wooplug-5085-iapi-powered-mini-cart-add-feature-in-the-woocommerce
+++ b/plugins/woocommerce/changelog/59782-wooplug-5085-iapi-powered-mini-cart-add-feature-in-the-woocommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add an experimental feature toggle for the Interactivity API-powered Mini Cart.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -284,7 +284,7 @@ class FeaturesController {
 		$tracking_enabled                 = WC_Site_Tracking::is_tracking_enabled();
 
 		$legacy_features = array(
-			'analytics'              => array(
+			'analytics'                   => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 				'option_key'         => Analytics::TOGGLE_OPTION_NAME,
@@ -293,7 +293,7 @@ class FeaturesController {
 				'disable_ui'         => false,
 				'is_legacy'          => true,
 			),
-			'product_block_editor'   => array(
+			'product_block_editor'        => array(
 				'name'            => __( 'New product editor', 'woocommerce' ),
 				'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 				'is_experimental' => true,
@@ -314,13 +314,13 @@ class FeaturesController {
 					return $string;
 				},
 			),
-			'cart_checkout_blocks'   => array(
+			'cart_checkout_blocks'        => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 				'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 				'is_experimental' => false,
 				'disable_ui'      => true,
 			),
-			'rate_limit_checkout'    => array(
+			'rate_limit_checkout'         => array(
 				'name'               => __( 'Rate limit Checkout', 'woocommerce' ),
 				'description'        => sprintf(
 					// translators: %s is the URL to the rate limiting documentation.
@@ -332,7 +332,7 @@ class FeaturesController {
 				'enabled_by_default' => false,
 				'is_legacy'          => true,
 			),
-			'marketplace'            => array(
+			'marketplace'                 => array(
 				'name'               => __( 'Marketplace', 'woocommerce' ),
 				'description'        => __(
 					'New, faster way to find extensions and themes for your WooCommerce store',
@@ -345,7 +345,7 @@ class FeaturesController {
 			),
 			// Marked as a legacy feature to avoid compatibility checks, which aren't really relevant to this feature.
 			// https://github.com/woocommerce/woocommerce/pull/39701#discussion_r1376976959.
-			'order_attribution'      => array(
+			'order_attribution'           => array(
 				'name'               => __( 'Order Attribution', 'woocommerce' ),
 				'description'        => __(
 					'Enable this feature to track and credit channels and campaigns that contribute to orders on your site',
@@ -356,7 +356,7 @@ class FeaturesController {
 				'is_legacy'          => true,
 				'is_experimental'    => false,
 			),
-			'site_visibility_badge'  => array(
+			'site_visibility_badge'       => array(
 				'name'               => __( 'Site visibility badge', 'woocommerce' ),
 				'description'        => __(
 					'Enable the site visibility badge in the WordPress admin bar',
@@ -368,7 +368,7 @@ class FeaturesController {
 				'is_experimental'    => false,
 				'disabled'           => false,
 			),
-			'hpos_fts_indexes'       => array(
+			'hpos_fts_indexes'            => array(
 				'name'               => __( 'HPOS Full text search indexes', 'woocommerce' ),
 				'description'        => __(
 					'Create and use full text search indexes for orders. This feature only works with high-performance order storage.',
@@ -379,7 +379,7 @@ class FeaturesController {
 				'is_legacy'          => true,
 				'option_key'         => CustomOrdersTableController::HPOS_FTS_INDEX_OPTION,
 			),
-			'hpos_datastore_caching' => array(
+			'hpos_datastore_caching'      => array(
 				'name'               => __( 'HPOS Data Caching', 'woocommerce' ),
 				'description'        => __(
 					'Enable order data caching in the datastore. This feature only works with high-performance order storage.',
@@ -391,7 +391,7 @@ class FeaturesController {
 				'disable_ui'         => false,
 				'option_key'         => CustomOrdersTableController::HPOS_DATASTORE_CACHING_ENABLED_OPTION,
 			),
-			'remote_logging'         => array(
+			'remote_logging'              => array(
 				'name'               => __( 'Remote Logging', 'woocommerce' ),
 				'description'        => sprintf(
 					/* translators: %1$s: opening link tag, %2$s: closing link tag */
@@ -424,7 +424,7 @@ class FeaturesController {
 					},
 				),
 			),
-			'email_improvements'     => array(
+			'email_improvements'          => array(
 				'name'            => __( 'Email improvements', 'woocommerce' ),
 				'description'     => __(
 					'Enable modern email design for transactional emails',
@@ -443,7 +443,7 @@ class FeaturesController {
 				'is_legacy'       => true,
 				'is_experimental' => false,
 			),
-			'blueprint'              => array(
+			'blueprint'                   => array(
 				'name'               => __( 'Blueprint (beta)', 'woocommerce' ),
 				'description'        => __(
 					'Enable blueprint to import and export settings in bulk',
@@ -463,7 +463,7 @@ class FeaturesController {
 				'is_legacy'          => true,
 				'is_experimental'    => false,
 			),
-			'block_email_editor'     => array(
+			'block_email_editor'          => array(
 				'name'               => __( 'Block Email Editor (alpha)', 'woocommerce' ),
 				'description'        => __(
 					'Enable the block-based email editor for transactional emails. <a href="https://github.com/woocommerce/woocommerce/discussions/52897#discussioncomment-11630256" target="_blank">Learn more</a>',
@@ -481,7 +481,7 @@ class FeaturesController {
 				'is_legacy'          => true,
 				'enabled_by_default' => false,
 			),
-			'point_of_sale'          => array(
+			'point_of_sale'               => array(
 				'name'               => __( 'Point of Sale', 'woocommerce' ),
 				'description'        => __(
 					'Enable Point of Sale functionality in the WooCommerce mobile apps.',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -163,6 +163,29 @@ class FeaturesController {
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'set_change_feature_enable_nonce' ), 20, 1 );
 		add_action( 'admin_init', array( $this, 'change_feature_enable_from_query_params' ), 20, 0 );
 		add_action( self::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'display_email_improvements_feedback_notice' ), 10, 2 );
+		add_filter( 'woocommerce_admin_features', array( $this, 'sync_iapi_mini_cart_feature' ) );
+	}
+
+	/**
+	 * Synchronize the 'experimental-iapi-mini-cart' feature flag with the admin Features system.
+	 *
+	 * @param array $features The original list of features.
+	 * @return array The modified list of features.
+	 */
+	public function sync_iapi_mini_cart_feature( $features ) {
+		if ( $this->feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
+			if ( ! in_array( 'experimental-iapi-mini-cart', $features, true ) ) {
+				$features[] = 'experimental-iapi-mini-cart';
+			}
+		} else {
+			$features = array_filter(
+				$features,
+				function ( $feature ) {
+					return 'experimental-iapi-mini-cart' !== $feature;
+				}
+			);
+		}
+		return $features;
 	}
 
 	/**
@@ -474,6 +497,11 @@ class FeaturesController {
 				*/
 				'is_legacy'          => true,
 				'is_experimental'    => true,
+			),
+			'experimental-iapi-mini-cart' => array(
+				'name'            => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
+				'description'     => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
+				'is_experimental' => true,
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -173,7 +173,10 @@ class FeaturesController {
 	 * @return array The modified list of features.
 	 */
 	public function sync_iapi_mini_cart_feature( $features ) {
-		if ( $this->feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		$option_name = 'woocommerce_feature_experimental-iapi-mini-cart_enabled';
+		$is_enabled  = 'yes' === get_option( $option_name, 'no' );
+
+		if ( $is_enabled ) {
 			if ( ! in_array( 'experimental-iapi-mini-cart', $features, true ) ) {
 				$features[] = 'experimental-iapi-mini-cart';
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This pull request introduces a new setting under **WooCommerce > Settings > Advanced > Features** to allow store administrators to easily enable or disable the experimental Interactivity API-powered Mini Cart.

Previously, this feature could only be enabled by developers via a feature flag in code. This change exposes the setting in the UI, making it more accessible for testing and evaluation.

### Screenshots or screen recordings:

<img width="1090" height="103" alt="Screenshot 2025-07-18 at 15 01 44" src="https://github.com/user-attachments/assets/df34e216-dded-40e0-9bdf-718e6170783e" />


### How to test the changes in this Pull Request:

1.  Navigate to **WooCommerce > Settings > Advanced > Features**.
2.  Scroll down to the **Experimental features** section.
3.  Confirm you see a new option: **"Interactivity API powered Mini Cart"** with the description "Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend."
4.  Enable the checkbox for this feature and click **"Save changes"**.
5.  Go to your store's frontend and add a product to the cart.
6.  Open the mini cart. Verify that it uses the new Interactivity API version.
7.  Go back to the settings page, disable the checkbox for the feature, and save changes.
8.  Return to the frontend, refresh the page, and open the mini cart again.
9.  Verify that it now uses the classic (default) mini cart implementation.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Add - Adds functionality

#### Message

Add an experimental feature toggle for the Interactivity API-powered Mini Cart.

</details>