### PR TITLE
Bump fulfillment hook and template versions to 10.1.0

### DIFF
--- a/plugins/woocommerce/changelog/59205-fix-59200-replace-base64-icons-with-png
+++ b/plugins/woocommerce/changelog/59205-fix-59200-replace-base64-icons-with-png
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-Comment: Replace base64 images with PNG files for shipping provider logos.
-

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -698,7 +698,7 @@ class WC_Emails {
 					/**
 					 * Allows developers to translate the fulfillment meta key for display in emails.
 					 *
-					 * @since 9.9.0
+					 * @since 10.1.0
 					 */
 					$meta_key_translation = apply_filters( 'woocommerce_fulfillment_translate_meta_key', $field->key );
 					if ( $plain_text ) {

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -700,7 +700,7 @@ class WC_Emails {
 					 *
 					 * @since 9.9.0
 					 */
-					$meta_key_translation = apply_filters( 'wc_fulfillment_translate_meta_key', $field->key );
+					$meta_key_translation = apply_filters( 'woocommerce_fulfillment_translate_meta_key', $field->key );
 					if ( $plain_text ) {
 						echo esc_attr( $meta_key_translation ) . ': ' . esc_attr( $field->value ) . PHP_EOL;
 					} else {

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-created.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Created', false ) ) :
 		 *
 		 * @param WC_Order $order The order object.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
 		private function maybe_init_fulfillment_for_preview( $order ) {
 			/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-deleted.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Deleted', false ) ) :
 		 *
 		 * @param WC_Order $order The order object.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
 		private function maybe_init_fulfillment_for_preview( $order ) {
 			/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-fulfillment-updated.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'WC_Email_Customer_Fulfillment_Updated', false ) ) :
 		 *
 		 * @param WC_Order $order The order object.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
 		private function maybe_init_fulfillment_for_preview( $order ) {
 			/**

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3726,7 +3726,7 @@ if ( ! function_exists( 'wc_get_email_fulfillment_items' ) ) {
 			/**
 			 * Filter to modify the arguments for the email fulfillment items.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 *
 			 * @param array $args The arguments for the email fulfillment items.
 			 */
@@ -3750,13 +3750,13 @@ if ( ! function_exists( 'wc_get_email_fulfillment_items' ) ) {
 		/**
 		 * Filter to modify the email fulfillment items table HTML.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param string   $html The HTML output of the fulfillment items table.
 		 * @param WC_Order $order The order object.
 		 * @param Fulfillment $fulfillment The fulfillment object.
 		 */
-		return apply_filters( 'wc_get_email_fulfillment_items_table', ob_get_clean(), $order, $fulfillment );
+		return apply_filters( 'woocommerce_get_email_fulfillment_items_table', ob_get_clean(), $order, $fulfillment );
 	}
 }
 

--- a/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Fulfillments/FulfillmentsDataStore.php
@@ -54,9 +54,9 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		/**
 		 * Filter to modify the fulfillment data before it is created.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$data = apply_filters( 'wc_fulfillment_before_create', $data );
+		$data = apply_filters( 'woocommerce_fulfillment_before_create', $data );
 
 		$is_fulfill_action = $data->get_is_fulfilled();
 		// If the fulfillment is fulfilled, set the fulfilled date.
@@ -66,10 +66,10 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 			/**
 			 * Filter to modify the fulfillment data before it is fulfilled.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
 			$data = apply_filters(
-				'wc_fulfillment_before_fulfill',
+				'woocommerce_fulfillment_before_fulfill',
 				$data
 			);
 		}
@@ -111,24 +111,24 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		$data->apply_changes();
 		$data->set_object_read( true );
 
-		if ( ! doing_action( 'wc_fulfillment_after_create' ) ) {
+		if ( ! doing_action( 'woocommerce_fulfillment_after_create' ) ) {
 			/**
 			* Action to perform after a fulfillment is created.
 			*
 			* @param Fulfillment $data The fulfillment object that was created.
 			*
-			* @since 9.9.0
+			* @since 10.1.0
 			*/
-			do_action( 'wc_fulfillment_after_create', $data );
+			do_action( 'woocommerce_fulfillment_after_create', $data );
 		}
 
-		if ( $is_fulfill_action && ! doing_action( 'wc_fulfillment_after_fulfill' ) ) {
+		if ( $is_fulfill_action && ! doing_action( 'woocommerce_fulfillment_after_fulfill' ) ) {
 			/**
 			 * Action to perform after a fulfillment is fulfilled.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
-			do_action( 'wc_fulfillment_after_fulfill', $data );
+			do_action( 'woocommerce_fulfillment_after_fulfill', $data );
 		}
 	}
 
@@ -192,9 +192,9 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		 *
 		 * @param Fulfillment $data The fulfillment object that is being updated.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$data = apply_filters( 'wc_fulfillment_before_update', $data );
+		$data = apply_filters( 'woocommerce_fulfillment_before_update', $data );
 
 		// If the fulfillment is fulfilled, set the fulfilled date.
 		$is_fulfill_action = false;
@@ -207,10 +207,10 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 			 *
 			 * @param Fulfillment $data The fulfillment object that is being fulfilled.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
 			$data = apply_filters(
-				'wc_fulfillment_before_fulfill',
+				'woocommerce_fulfillment_before_fulfill',
 				$data
 			);
 		}
@@ -251,26 +251,26 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 
 		$data->set_object_read( true );
 
-		if ( ! doing_action( 'wc_fulfillment_after_update' ) ) {
+		if ( ! doing_action( 'woocommerce_fulfillment_after_update' ) ) {
 			/**
 			 * Action to perform after a fulfillment is updated.
 			 *
 			 * @param Fulfillment $data The fulfillment object that was updated.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
-			do_action( 'wc_fulfillment_after_update', $data );
+			do_action( 'woocommerce_fulfillment_after_update', $data );
 		}
 
-		if ( $is_fulfill_action && ! doing_action( 'wc_fulfillment_after_fulfill' ) ) {
+		if ( $is_fulfill_action && ! doing_action( 'woocommerce_fulfillment_after_fulfill' ) ) {
 			/**
 			 * Action to perform after a fulfillment is fulfilled.
 			 *
 			 * @param Fulfillment $data The fulfillment object that was fulfilled.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
-			do_action( 'wc_fulfillment_after_fulfill', $data );
+			do_action( 'woocommerce_fulfillment_after_fulfill', $data );
 		}
 	}
 
@@ -293,9 +293,9 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		/**
 		 * Filter to modify the fulfillment data before it is updated.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$data = apply_filters( 'wc_fulfillment_before_delete', $data );
+		$data = apply_filters( 'woocommerce_fulfillment_before_delete', $data );
 
 		// Soft Delete the fulfillment from the database.
 		global $wpdb;
@@ -322,13 +322,13 @@ class FulfillmentsDataStore extends \WC_Data_Store_WP implements \WC_Object_Data
 		$data->apply_changes();
 		$data->set_object_read( true );
 
-		if ( ! doing_action( 'wc_fulfillment_after_delete', $data ) ) {
+		if ( ! doing_action( 'woocommerce_fulfillment_after_delete', $data ) ) {
 			/**
 			 * Action to perform after a fulfillment is deleted.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
-			do_action( 'wc_fulfillment_after_delete', $data );
+			do_action( 'woocommerce_fulfillment_after_delete', $data );
 		}
 
 		// Set the fulfillment object to a fresh state.

--- a/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WC Order Fulfillment Class
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 class Fulfillment extends \WC_Data {
 	/**

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentUtils.php
@@ -164,14 +164,14 @@ class FulfillmentUtils {
 		/**
 		 * This filter allows plugins to modify the fulfillment status of an order.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param string $status The default fulfillment status.
 		 * @param WC_Order $order The order object.
 		 * @param array $fulfillments An array of fulfillments for the order.
 		 */
 		return apply_filters(
-			'wc_fulfillment_calculate_order_fulfillment_status',
+			'woocommerce_fulfillment_calculate_order_fulfillment_status',
 			$status,
 			$order,
 			$fulfillments
@@ -258,14 +258,14 @@ class FulfillmentUtils {
 		/**
 		 * This filter allows plugins to modify the fulfillment status text for an order for their custom fulfillment statuses.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param string $fulfillment_status_text The default fulfillment status text.
 		 * @param string $fulfillment_status The fulfillment status of the order.
 		 * @param WC_Order $order The order object.
 		 */
 		return apply_filters(
-			'wc_fulfillment_order_fulfillment_status_text',
+			'woocommerce_fulfillment_order_fulfillment_status_text',
 			$fulfillment_status_text,
 			$fulfillment_status,
 			$order
@@ -307,7 +307,7 @@ class FulfillmentUtils {
 	 *
 	 * This method provides the order fulfillment statuses that can be used
 	 * in the WooCommerce Fulfillments system. It can be filtered using the
-	 * `wc_fulfillment_order_fulfillment_statuses` filter.
+	 * `woocommerce_fulfillment_order_fulfillment_statuses` filter.
 	 *
 	 * @return array An associative array of order fulfillment statuses.
 	 */
@@ -317,12 +317,12 @@ class FulfillmentUtils {
 		 * It can be used to add, remove, or change the order fulfillment statuses available in the
 		 * WooCommerce Fulfillments system.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param array $order_fulfillment_statuses The default list of order fulfillment statuses.
 		 */
 		return apply_filters(
-			'wc_fulfillment_order_fulfillment_statuses',
+			'woocommerce_fulfillment_order_fulfillment_statuses',
 			self::get_default_order_fulfillment_statuses()
 		);
 	}
@@ -332,7 +332,7 @@ class FulfillmentUtils {
 	 *
 	 * This method provides the fulfillment statuses that can be used
 	 * in the WooCommerce Fulfillments system. It can be filtered using the
-	 * `wc_fulfillment_fulfillment_statuses` filter.
+	 * `woocommerce_fulfillment_fulfillment_statuses` filter.
 	 *
 	 * @return array An associative array of fulfillment statuses.
 	 */
@@ -342,12 +342,12 @@ class FulfillmentUtils {
 		 * It can be used to add, remove, or change the fulfillment statuses available in the
 		 * WooCommerce Fulfillments system.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param array $fulfillment_statuses The default list of fulfillment statuses.
 		 */
 		return apply_filters(
-			'wc_fulfillment_fulfillment_statuses',
+			'woocommerce_fulfillment_fulfillment_statuses',
 			self::get_default_fulfillment_statuses()
 		);
 	}
@@ -356,7 +356,7 @@ class FulfillmentUtils {
 	 * Get the shipping providers.
 	 *
 	 * This method retrieves the shipping providers registered in the WooCommerce Fulfillments system.
-	 * It can be filtered using the `wc_fulfillment_shipping_providers` filter.
+	 * It can be filtered using the `woocommerce_fulfillment_shipping_providers` filter.
 	 *
 	 * @return array An associative array of shipping providers with their details.
 	 */
@@ -366,12 +366,12 @@ class FulfillmentUtils {
 		 * It can be used to add, remove, or change the shipping providers available in the
 		 * WooCommerce Fulfillments system.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param array $shipping_providers The default list of shipping providers.
 		 */
 		return apply_filters(
-			'wc_fulfillment_shipping_providers',
+			'woocommerce_fulfillment_shipping_providers',
 			array()
 		);
 	}
@@ -421,7 +421,7 @@ class FulfillmentUtils {
 	 *
 	 * This method provides the default order fulfillment statuses that can be used
 	 * in the WooCommerce Fulfillments system. It can be filtered using the
-	 * `wc_fulfillment_order_fulfillment_statuses` filter.
+	 * `woocommerce_fulfillment_order_fulfillment_statuses` filter.
 	 *
 	 * @return array An associative array of default order fulfillment statuses.
 	 */
@@ -455,7 +455,7 @@ class FulfillmentUtils {
 	 *
 	 * This method provides the default fulfillment statuses that can be used
 	 * in the WooCommerce Fulfillments system. It can be filtered using the
-	 * `wc_fulfillment_fulfillment_statuses` filter.
+	 * `woocommerce_fulfillment_fulfillment_statuses` filter.
 	 *
 	 * @return array An associative array of default fulfillment statuses.
 	 */

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -17,7 +17,7 @@ use WC_Order_Refund;
  *
  * This class is responsible for adding hooks related to fulfillments in WooCommerce.
  *
- * @since 9.9.0
+ * @since 10.1.0
  * @package WooCommerce\Internal\Fulfillments
  */
 class FulfillmentsManager {
@@ -25,9 +25,9 @@ class FulfillmentsManager {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		add_filter( 'wc_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
-		add_filter( 'wc_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
-		add_filter( 'wc_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
+		add_filter( 'woocommerce_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
+		add_filter( 'woocommerce_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
+		add_filter( 'woocommerce_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
 
 		$this->init_fulfillment_status_hooks();
 		$this->init_refund_hooks();
@@ -41,9 +41,9 @@ class FulfillmentsManager {
 	 */
 	private function init_fulfillment_status_hooks() {
 		// Update order fulfillment status when a fulfillment is created, updated, or deleted.
-		add_action( 'wc_fulfillment_after_create', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
-		add_action( 'wc_fulfillment_after_update', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
-		add_action( 'wc_fulfillment_after_delete', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
+		add_action( 'woocommerce_fulfillment_after_create', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
+		add_action( 'woocommerce_fulfillment_after_update', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
+		add_action( 'woocommerce_fulfillment_after_delete', array( $this, 'update_order_fulfillment_status_on_fulfillment_update' ), 10, 1 );
 	}
 
 	/**
@@ -69,10 +69,10 @@ class FulfillmentsManager {
 		 * This filter allows us to translate fulfillment meta keys
 		 * to make them more user-friendly in the admin interface and emails.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
 		$meta_key_translations = apply_filters(
-			'wc_fulfillment_meta_key_translations',
+			'woocommerce_fulfillment_meta_key_translations',
 			array(
 				'fulfillment_status' => __( 'Fulfillment Status', 'woocommerce' ),
 				'shipment_tracking'  => __( 'Shipment Tracking', 'woocommerce' ),
@@ -85,7 +85,7 @@ class FulfillmentsManager {
 	/**
 	 * Get initial shipping providers.
 	 *
-	 * This method provides the initial shipping providers that feeds the `wc_fulfillment_shipping_providers` filter,
+	 * This method provides the initial shipping providers that feeds the `woocommerce_fulfillment_shipping_providers` filter,
 	 * which is used to populate the list of available shipping providers on the fulfillment UI.
 	 *
 	 * @param array $shipping_providers The current list of shipping providers.

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -410,11 +410,6 @@ class FulfillmentsRenderer {
 	 */
 	protected function load_fulfillments_js_settings() {
 		$fulfillment_settings = array(
-			/**
-			 * Filter to modify the shipping providers.
-			 *
-			 * @since 9.9.0
-			 */
 			'providers'                  => FulfillmentUtils::get_shipping_providers_object(),
 			'currency_symbols'           => get_woocommerce_currency_symbols(),
 			'fulfillment_statuses'       => FulfillmentUtils::get_fulfillment_statuses(),
@@ -449,8 +444,6 @@ class FulfillmentsRenderer {
 
 	/**
 	 * Render the fulfillment filters in the legacy orders table.
-	 *
-	 * @deprecated 9.9.0 Use render_fulfillment_filters() instead.
 	 */
 	public function render_fulfillment_filters_legacy() {
 		global $typenow;

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
@@ -111,14 +111,14 @@ class FulfillmentsSettings {
 		/**
 		 * Filter to get the list of the item, or variant ID's that should be auto-fulfilled.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 *
 		 * @param array $auto_fulfill_items List of product or variant ID's to auto-fulfill.
 		 * @param \WC_Order $order The order object.
 		 *
 		 * @return array Filtered list of product or variant ID's to auto-fulfill
 		 */
-		$auto_fulfill_product_ids = apply_filters( 'wc_fulfillments_auto_fulfill_products', array(), $order );
+		$auto_fulfill_product_ids = apply_filters( 'woocommerce_fulfillments_auto_fulfill_products', array(), $order );
 		$auto_fulfill_items       = array();
 
 		foreach ( $order->get_items() as $item ) {

--- a/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/OrderFulfillmentsRestController.php
@@ -263,7 +263,7 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 				/**
 				 * Trigger the fulfillment created notification on creating a fulfilled fulfillment.
 				 *
-				 * @since 9.9.0
+				 * @since 10.1.0
 				 */
 				do_action( 'woocommerce_fulfillment_created_notification', $order_id, $fulfillment, wc_get_order( $order_id ) );
 			}
@@ -365,14 +365,14 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 					/**
 					 * Trigger the fulfillment created notification on fulfilling a fulfillment.
 					 *
-					 * @since 9.9.0
+					 * @since 10.1.0
 					 */
 					do_action( 'woocommerce_fulfillment_created_notification', $order_id, $fulfillment, wc_get_order( $order_id ) );
 				} elseif ( $next_state ) {
 					/**
 					 * Trigger the fulfillment updated notification on updating a fulfillment.
 					 *
-					 * @since 9.9.0
+					 * @since 10.1.0
 					 */
 					do_action( 'woocommerce_fulfillment_updated_notification', $order_id, $fulfillment, wc_get_order( $order_id ) );
 				}
@@ -432,7 +432,7 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 			/**
 			 * Trigger the fulfillment deleted notification.
 			 *
-			 * @since 9.9.0
+			 * @since 10.1.0
 			 */
 			do_action( 'woocommerce_fulfillment_deleted_notification', $order_id, $fulfillment, wc_get_order( $order_id ) );
 		}
@@ -605,10 +605,10 @@ class OrderFulfillmentsRestController extends RestApiControllerBase {
 		/**
 		 * Parse the tracking number with additional parameters.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
 		$tracking_number_parse_result = apply_filters(
-			'wc_fulfillment_parse_tracking_number',
+			'woocommerce_fulfillment_parse_tracking_number',
 			$tracking_number,
 			WC()->countries->get_base_country(),
 			$order->get_shipping_country(),

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -37,7 +37,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 /**
  * Hook for the woocommerce_email_fulfillment_details.
  *
- * @since 9.9.0
+ * @since 10.1.0
  * @param WC_Order $order The order object.
  * @param Fulfillment $fulfillment The fulfillment object.
  * @param bool $sent_to_admin Whether the email is sent to admin.
@@ -56,7 +56,7 @@ do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_
  * @param bool $sent_to_admin Whether the email is sent to admin.
  * @param bool $plain_text Whether the email is plain text.
  * @param WC_Email $email The email object.
- * @since 9.9.0
+ * @since 10.1.0
  *
  * @hooked WC_Emails::order_meta() Shows fulfillment meta data.
  */

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -37,7 +37,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 /**
  * Hook for the woocommerce_email_fulfillment_details.
  *
- * @since 9.9.0
+ * @since 10.1.0
  * @param WC_Order $order The order object.
  * @param Fulfillment $fulfillment The fulfillment object.
  * @param bool $sent_to_admin Whether the email is sent to admin.
@@ -56,7 +56,7 @@ do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_
  * @param bool $sent_to_admin Whether the email is sent to admin.
  * @param bool $plain_text Whether the email is plain text.
  * @param WC_Email $email The email object.
- * @since 9.9.0
+ * @since 10.1.0
  *
  * @hooked WC_Emails::order_meta() Shows fulfillment meta data.
  */

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -38,7 +38,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 /**
  * Hook for the woocommerce_email_fulfillment_details.
  *
- * @since 9.9.0
+ * @since 10.1.0
  * @param WC_Order $order The order object.
  * @param Fulfillment $fulfillment The fulfillment object.
  * @param bool $sent_to_admin Whether the email is sent to admin.
@@ -57,7 +57,7 @@ do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_
  * @param bool $sent_to_admin Whether the email is sent to admin.
  * @param bool $plain_text Whether the email is plain text.
  * @param WC_Email $email The email object.
- * @since 9.9.0
+ * @since 10.1.0
  *
  * @hooked WC_Emails::order_meta() Shows fulfillment meta data.
  */

--- a/plugins/woocommerce/templates/emails/plain/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,7 +30,7 @@ echo esc_html__( 'Woo! Some items you purchased are being fulfilled. You can use
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 
@@ -41,7 +41,7 @@ echo "\n----------------------------------------\n\n";
  *
  * @hooked WC_Emails::fulfillment_meta() Shows order meta data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 

--- a/plugins/woocommerce/templates/emails/plain/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,7 +30,7 @@ echo esc_html__( 'We wanted to let you know that one of the previously fulfilled
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 
@@ -41,7 +41,7 @@ echo "\n----------------------------------------\n\n";
  *
  * @hooked WC_Emails::fulfillment_meta() Shows order meta data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 

--- a/plugins/woocommerce/templates/emails/plain/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 9.9.0
+ * @version 10.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -32,7 +32,7 @@ echo esc_html__( 'Here’s the latest info we have:', 'woocommerce' ) . "\n\n";
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_details', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 
@@ -43,7 +43,7 @@ echo "\n----------------------------------------\n\n";
  *
  * @hooked WC_Emails::fulfillment_meta() Shows order meta data.
  *
- * @since 9.9.0
+ * @since 10.1.0
  */
 do_action( 'woocommerce_email_fulfillment_meta', $order, $fulfillment, $sent_to_admin, $plain_text, $email );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -80,7 +80,7 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 		);
 
 		add_filter(
-			'wc_fulfillment_meta_key_translations',
+			'woocommerce_fulfillment_meta_key_translations',
 			function ( $translations ) {
 				$translations['test_meta_key'] = __( 'Test meta key', 'woocommerce' );
 				return $translations;

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -74,7 +74,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 	public function test_fulfillment_before_create_hook_is_called() {
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_create',
+			'woocommerce_fulfillment_before_create',
 			function ( $fulfillment ) use ( &$hook_called ) {
 				$hook_called = true;
 				return $fulfillment;
@@ -94,7 +94,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$hook_called = false;
 
 		add_filter(
-			'wc_fulfillment_before_create',
+			'woocommerce_fulfillment_before_create',
 			function () use ( &$hook_called ) {
 				$hook_called = true;
 				throw new \Exception( 'Fulfillment creation prevented by hook.' );
@@ -119,7 +119,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$hook_called = false;
 
 		add_action(
-			'wc_fulfillment_after_create',
+			'woocommerce_fulfillment_after_create',
 			function ( $fulfillment ) use ( &$hook_called, &$received_fulfillment ) {
 				$received_fulfillment = $fulfillment;
 				$hook_called          = true;
@@ -159,7 +159,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_update',
+			'woocommerce_fulfillment_before_update',
 			function ( $fulfillment ) use ( &$hook_called ) {
 				$hook_called = true;
 				return $fulfillment;
@@ -187,7 +187,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_update',
+			'woocommerce_fulfillment_before_update',
 			function () use ( &$hook_called ) {
 				$hook_called = true;
 				throw new \Exception( 'Fulfillment update prevented by hook.' );
@@ -217,7 +217,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_action(
-			'wc_fulfillment_after_update',
+			'woocommerce_fulfillment_after_update',
 			function ( $fulfillment ) use ( &$hook_called, &$received_fulfillment ) {
 				$received_fulfillment = $fulfillment;
 				$hook_called          = true;
@@ -271,7 +271,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_fulfill',
+			'woocommerce_fulfillment_before_fulfill',
 			function ( $fulfillment ) use ( &$hook_called ) {
 				$hook_called = true;
 
@@ -291,7 +291,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$db_fulfillment = new Fulfillment( $fulfillment->get_id() );
 		$this->assertFalse( $db_fulfillment->get_is_fulfilled() );
-		remove_all_filters( 'wc_fulfillment_before_fulfill' );
+		remove_all_filters( 'woocommerce_fulfillment_before_fulfill' );
 	}
 
 	/**
@@ -311,7 +311,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_fulfill',
+			'woocommerce_fulfillment_before_fulfill',
 			function ( $fulfillment ) use ( &$hook_called ) {
 				$hook_called = true;
 
@@ -334,7 +334,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$db_fulfillment = new Fulfillment( $fulfillment->get_id() );
 		$this->assertTrue( $db_fulfillment->get_is_fulfilled() );
-		remove_all_filters( 'wc_fulfillment_before_fulfill' );
+		remove_all_filters( 'woocommerce_fulfillment_before_fulfill' );
 	}
 
 	/**
@@ -354,7 +354,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_fulfill',
+			'woocommerce_fulfillment_before_fulfill',
 			function () use ( &$hook_called ) {
 				$hook_called = true;
 				throw new \Exception( 'Fulfillment fulfill prevented by hook.' );
@@ -386,7 +386,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 			$this->expectExceptionMessage( 'Fulfillment not found.' );
 			new Fulfillment( $fulfillment->get_id() );
 		}
-		remove_all_filters( 'wc_fulfillment_before_fulfill' );
+		remove_all_filters( 'woocommerce_fulfillment_before_fulfill' );
 	}
 
 	/**
@@ -406,7 +406,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_action(
-			'wc_fulfillment_after_fulfill',
+			'woocommerce_fulfillment_after_fulfill',
 			function ( $fulfillment ) use ( &$hook_called, &$received_fulfillment ) {
 				$received_fulfillment = $fulfillment;
 				$hook_called          = true;
@@ -438,7 +438,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_key_2' ), $fulfillment->get_meta( 'test_meta_key_2' ) );
 		$this->assertEquals( $received_fulfillment->get_meta( 'test_meta_update' ), $fulfillment->get_meta( 'test_meta_update' ) );
 		$this->assertEquals( $received_fulfillment->get_items(), $fulfillment->get_items() );
-		remove_all_actions( 'wc_fulfillment_after_fulfill' );
+		remove_all_actions( 'woocommerce_fulfillment_after_fulfill' );
 	}
 
 	/**
@@ -453,7 +453,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_delete',
+			'woocommerce_fulfillment_before_delete',
 			function ( $fulfillment ) use ( &$hook_called ) {
 				$hook_called = true;
 				return $fulfillment;
@@ -480,7 +480,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillment_before_delete',
+			'woocommerce_fulfillment_before_delete',
 			function () use ( &$hook_called ) {
 				$hook_called = true;
 				throw new \Exception( 'Fulfillment delete prevented by hook.' );
@@ -509,7 +509,7 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 
 		$hook_called = false;
 		add_action(
-			'wc_fulfillment_after_delete',
+			'woocommerce_fulfillment_after_delete',
 			function ( $fulfillment ) use ( &$hook_called, &$received_fulfillment ) {
 				$received_fulfillment = $fulfillment;
 				$hook_called          = true;

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -626,14 +626,14 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$after_delete_called  = false;
 
 		add_action(
-			'wc_fulfillment_before_delete',
+			'woocommerce_fulfillment_before_delete',
 			function () use ( &$before_delete_called ) {
 				$before_delete_called = true;
 			}
 		);
 
 		add_action(
-			'wc_fulfillment_after_delete',
+			'woocommerce_fulfillment_after_delete',
 			function () use ( &$after_delete_called ) {
 				$after_delete_called = true;
 			}

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
@@ -30,7 +30,7 @@ class FulfillmentUtilsTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_order_fulfillment_statuses_extension() {
 		add_filter(
-			'wc_fulfillment_order_fulfillment_statuses',
+			'woocommerce_fulfillment_order_fulfillment_statuses',
 			function ( $statuses ) {
 				$statuses['custom_status'] = __( 'Custom Status', 'woocommerce' );
 				return $statuses;
@@ -53,7 +53,7 @@ class FulfillmentUtilsTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_get_fulfillment_statuses() {
 		add_filter(
-			'wc_fulfillment_fulfillment_statuses',
+			'woocommerce_fulfillment_fulfillment_statuses',
 			function ( $statuses ) {
 				$statuses['custom_status'] = array(
 					'label'            => __( 'Custom Status', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
@@ -48,7 +48,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test hooks.
 	 */
 	public function test_hooks() {
-		$this->assertNotFalse( has_filter( 'wc_fulfillment_translate_meta_key', array( $this->manager, 'translate_fulfillment_meta_key' ) ) );
+		$this->assertNotFalse( has_filter( 'woocommerce_fulfillment_translate_meta_key', array( $this->manager, 'translate_fulfillment_meta_key' ) ) );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	public function test_extend_translate_fulfillment_meta_key() {
 		// Extend the translations.
 		add_filter(
-			'wc_fulfillment_meta_key_translations',
+			'woocommerce_fulfillment_meta_key_translations',
 			function ( $translations ) {
 				$translations['custom_meta_key'] = __( 'Custom Meta Key', 'woocommerce' );
 				return $translations;
@@ -89,7 +89,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 
 		// Add a filter to modify the translations.
 		add_filter(
-			'wc_fulfillment_meta_key_translations',
+			'woocommerce_fulfillment_meta_key_translations',
 			function ( $translations ) {
 				$translations['custom_meta_key'] = __( 'Custom Meta Key', 'woocommerce' );
 				return $translations;
@@ -99,9 +99,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		/**
 		 * Filter to translate fulfillment meta keys.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$translated_key = apply_filters( 'wc_fulfillment_translate_meta_key', 'custom_meta_key' );
+		$translated_key = apply_filters( 'woocommerce_fulfillment_translate_meta_key', 'custom_meta_key' );
 		$this->assertEquals( __( 'Custom Meta Key', 'woocommerce' ), $translated_key );
 	}
 
@@ -112,9 +112,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		/**
 		 * Filter to get initial shipping providers
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$shipping_providers = apply_filters( 'wc_fulfillment_shipping_providers', array() );
+		$shipping_providers = apply_filters( 'woocommerce_fulfillment_shipping_providers', array() );
 		// Check if the shipping providers are loaded correctly.
 		$this->assertIsArray( $shipping_providers );
 		$this->assertNotEmpty( $shipping_providers );
@@ -126,7 +126,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	public function test_extend_initial_shipping_providers() {
 		// Extend the shipping providers.
 		add_filter(
-			'wc_fulfillment_shipping_providers',
+			'woocommerce_fulfillment_shipping_providers',
 			function ( $providers ) {
 				$providers['custom_provider'] = array(
 					'label' => __( 'Custom Provider', 'woocommerce' ),
@@ -140,9 +140,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		/**
 		 * Filter to get initial shipping providers.
 		 *
-		 * @since 9.9.0
+		 * @since 10.1.0
 		 */
-		$shipping_providers = apply_filters( 'wc_fulfillment_shipping_providers', array() );
+		$shipping_providers = apply_filters( 'woocommerce_fulfillment_shipping_providers', array() );
 
 		// Check if the custom provider is included.
 		$this->assertArrayHasKey( 'custom_provider', $shipping_providers );
@@ -155,9 +155,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 * Test that the fulfillment status hooks are initialized correctly.
 	 */
 	public function test_init_fulfillment_status_hooks() {
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_create', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_update', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
-		$this->assertNotFalse( has_action( 'wc_fulfillment_after_delete', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'woocommerce_fulfillment_after_create', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'woocommerce_fulfillment_after_update', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
+		$this->assertNotFalse( has_action( 'woocommerce_fulfillment_after_delete', array( $this->manager, 'update_order_fulfillment_status_on_fulfillment_update' ) ) );
 	}
 
 	/**
@@ -185,19 +185,19 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		$this->assertTrue( did_action( 'wc_fulfillment_after_create' ) > 0 );
+		$this->assertTrue( did_action( 'woocommerce_fulfillment_after_create' ) > 0 );
 		$order = wc_get_order( $order->get_id() );
 		$this->assertEquals( 'unfulfilled', $order->get_meta( '_fulfillment_status', true ) );
 
 		$fulfillments[0]->set_status( 'fulfilled' );
 		$fulfillments[0]->save();
 
-		$this->assertTrue( did_action( 'wc_fulfillment_after_update' ) > 0 );
+		$this->assertTrue( did_action( 'woocommerce_fulfillment_after_update' ) > 0 );
 		$order = wc_get_order( $order->get_id() );
 		$this->assertEquals( 'partially_fulfilled', $order->get_meta( '_fulfillment_status' ) );
 
 		$fulfillments[0]->delete();
-		$this->assertTrue( did_action( 'wc_fulfillment_after_delete' ) > 0 );
+		$this->assertTrue( did_action( 'woocommerce_fulfillment_after_delete' ) > 0 );
 		$order = wc_get_order( $order->get_id() );
 		$this->assertEquals( '', $order->get_meta( '_fulfillment_status' ) );
 	}
@@ -217,7 +217,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		$mock_provider = $this->getMockBuilder( ShippingProviderMock::class )->onlyMethods( array( 'try_parse_tracking_number' ) )->getMock();
 		$container->replace( ShippingProviderMock::class, $mock_provider );
 		add_filter(
-			'wc_fulfillment_shipping_providers',
+			'woocommerce_fulfillment_shipping_providers',
 			function ( $providers ) {
 				$providers = array(
 					'custom_provider' => ShippingProviderMock::class,
@@ -256,7 +256,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		$mock_provider = $this->getMockBuilder( ShippingProviderMock::class )->onlyMethods( array( 'try_parse_tracking_number' ) )->getMock();
 		$container->replace( ShippingProviderMock::class, $mock_provider );
 		add_filter(
-			'wc_fulfillment_shipping_providers',
+			'woocommerce_fulfillment_shipping_providers',
 			function ( $providers ) {
 				$providers = array(
 					'custom_provider' => ShippingProviderMock::class,
@@ -281,7 +281,7 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 		$tracking_number = '1234567890';
 
 		add_filter(
-			'wc_fulfillment_shipping_providers',
+			'woocommerce_fulfillment_shipping_providers',
 			function ( $providers ) {
 				$providers = array();
 				return $providers;

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsSettingsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsSettingsTest.php
@@ -89,7 +89,7 @@ class FulfillmentsSettingsTest extends WC_Unit_Test_Case {
 	public function test_auto_fulfill_items_on_processing_bails_out_if_order_has_no_items() {
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillments_auto_fulfill_products',
+			'woocommerce_fulfillments_auto_fulfill_products',
 			function ( $products ) use ( &$hook_called ) {
 				$hook_called = true;
 				return $products;
@@ -146,7 +146,7 @@ class FulfillmentsSettingsTest extends WC_Unit_Test_Case {
 	) {
 		$hook_called = false;
 		add_filter(
-			'wc_fulfillments_auto_fulfill_products',
+			'woocommerce_fulfillments_auto_fulfill_products',
 			function ( $products ) use ( &$hook_called, $auto_fulfill_products ) {
 				$hook_called = true;
 				$products    = array_merge( $products, $auto_fulfill_products );

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/Helpers/ShippingProviderMock.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/Helpers/ShippingProviderMock.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Internal\Fulfillments\Providers\AbstractShippingProvi
  *
  * This class is a mock implementation of the AbstractShippingProvider for testing purposes.
  *
- * @since 9.9.0
+ * @since 10.1.0
  * @package WooCommerce\Tests\Internal\Fulfillments
  */
 class ShippingProviderMock extends AbstractShippingProvider {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR renames hooks added in fulfillments with the `wc_fulfillment` prefix to have the standard form of `woocommerce_fulfillment` prefix, and bumps the version number on the `@since 9.9.0` tagged filters to `10.1.0`.

Closes #59456 WOOPLUG-4911 .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The code changes:

- should only contain `wc_fulfillment -> woocommerce_fulfillment` and `9.9.0 -> 10.0.1` changes, 
- should make sense, 
- didn't miss one instance, and 
- the automated tests should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR is a part of a feature branch, which will have it's own changelog.
</details>
