### PR TITLE
Fix the content block is crashing in email editor with Gutenberg 21.2.0

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-5086-email-editor-is-crashing-with-gutenberg-2120
+++ b/packages/js/email-editor/changelog/wooplug-5086-email-editor-is-crashing-with-gutenberg-2120
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix crash of the post content block in the email editor

--- a/packages/js/email-editor/src/blocks/core/post-content.tsx
+++ b/packages/js/email-editor/src/blocks/core/post-content.tsx
@@ -23,22 +23,14 @@ function Placeholder( { layoutClassNames } ) {
 
 // Curried function to add a custom placeholder to the post content block, or just use the original Edit component.
 function PostContentEdit( OriginalEditComponent ) {
-	return function Edit( {
-		context,
-		__unstableLayoutClassNames: layoutClassNames,
-	} ) {
-		const { postId: contextPostId, postType: contextPostType } = context;
+	return function Edit( params ) {
+		const { postId: contextPostId, postType: contextPostType } =
+			params.context;
+		const { __unstableLayoutClassNames: layoutClassNames } = params;
 		const hasContent = contextPostId && contextPostType;
 
 		if ( hasContent ) {
-			return (
-				<OriginalEditComponent
-					{ ...{
-						context,
-						__unstableLayoutClassNames: layoutClassNames,
-					} }
-				/>
-			);
+			return <OriginalEditComponent { ...params } />;
 		}
 
 		return <Placeholder layoutClassNames={ layoutClassNames } />;


### PR DESCRIPTION

### Changes proposed in this Pull Request:

We wrapped the post content's block edit component, but we were not passing all the parameters. The component was [recently updated](https://github.com/WordPress/gutenberg/pull/70698) and expects to get more parameters and throws an error during destructuring the params With this change, we always pass all the params.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5086,  #59789 .

### Screenshots or screen recordings:

<img width="779" height="256" alt="Screenshot 2025-07-18 at 17 23 46" src="https://github.com/user-attachments/assets/8d85a247-b9b3-4888-b916-f4182a4c769b" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install Gutenberg 21.2.0
2. Go to WooCommerce > Settings > Advanced > Features and activate the block email editor
3. Go to WooCommerce > Settings > Advanced and open email
4. Confirm that you can see no error

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
