### PR TITLE
Product Variations: Move post_excerpt updates from view time to write time

### DIFF
--- a/plugins/woocommerce/changelog/move-attr-sync-to-write-time
+++ b/plugins/woocommerce/changelog/move-attr-sync-to-write-time
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Product Variations: Move post_excerpt updates from view time to write time

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -768,8 +768,9 @@ class WC_Post_Data {
 				}
 			);
 		} else {
-			$new_slug     = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
+			$new_slug     = ! empty( $attribute['attribute_name'] ) ? $attribute['attribute_name'] : $old_slug;
 			$new_taxonomy = 'pa_' . $new_slug;
+
 			if ( function_exists( 'as_schedule_single_action' ) ) {
 				as_schedule_single_action(
 					time() + 1,

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -65,6 +65,19 @@ class WC_Post_Data {
 		add_action( 'added_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 		add_action( 'deleted_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 		add_action( 'updated_order_item_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
+
+		// Attributes.
+		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
+		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
+		// Terms
+		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
+		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 5 );
+		// Parent Product Updates Attributes.
+		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
+
+		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
+		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
+		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
 	}
 
 	/**
@@ -621,6 +634,345 @@ class WC_Post_Data {
 			self::delete_product_query_transients();
 		}
 	}
+
+	/**
+	 * Regenerates attribute summaries for a list of variations.
+	 *
+	 * @since 10.2.0
+	 * @param array $variation_ids Array of variation IDs.
+	 */
+	public static function regenerate_variation_summaries( $variation_ids ) {
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$variation_ids = array_unique( array_filter( $variation_ids ) );
+
+		foreach ( $variation_ids as $variation_id ) {
+			self::regenerate_variation_attribute_summary( $variation_id );
+		}
+	}
+
+	/**
+	 * Regenerates the attribute summary for a single variation.
+	 *
+	 * @since 10.2.0
+	 * @param int $variation_id Variation ID.
+	 */
+	public static function regenerate_variation_attribute_summary( $variation_id ) {
+		global $wpdb;
+
+		$product = wc_get_product( $variation_id );
+		if ( ! $product || ! $product->is_type( 'variation' ) ) {
+			return;
+		}
+
+		$data_store = WC_Data_Store::load( 'product-variation' );
+		if ( $data_store->has_callable( 'get_attribute_summary' ) ) {
+			$new_summary = $data_store->get_attribute_summary( $product );
+			$current_excerpt = get_post_field( 'post_excerpt', $variation_id );
+			if ( $new_summary === $current_excerpt ) {
+				return;
+			}
+			$wpdb->update(
+				$wpdb->posts,
+				array( 'post_excerpt' => $new_summary ),
+				array( 'ID' => $variation_id )
+			);
+			clean_post_cache( $variation_id );
+			/**
+			* Fires after the attribute summary of a product variation has been updated.
+			*
+			* @since 10.2.0
+			* @param int $variation_id The ID of the product variation.
+			*/
+			do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
+		}
+	}
+
+	/**
+	 * Gets the threshold for synchronous regeneration of variation summaries.
+	 *
+	 * @since 10.2.0
+	 * @return int
+	 */
+	public static function get_regen_threshold() {
+		/**
+		 * Filters the threshold for synchronous regeneration of variation attribute summaries.
+		 * If the number of variations affected by an update is below this threshold, the summaries
+		 * are regenerated synchronously. Otherwise, the regeneration is scheduled asynchronously.
+		 *
+		 * @since 10.2.0
+		 * @param int $threshold The default threshold value (50).
+		 * @return int The filtered threshold value.
+		 */
+		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
+	}
+
+	/**
+	 * Handles deletion of a global attribute by triggering variation summary updates.
+	 *
+	 * @since 10.2.0
+	 * @param int    $attribute_id Attribute ID.
+	 * @param string $attribute    Attribute name.
+	 * @param string $old_slug     Old attribute slug.
+	 */
+	public static function handle_global_attribute_deleted( $attribute_id, $attribute, $old_slug ) {
+		// We can reuse the update function to trigger variation summary rebuilds.
+		// However, the handle_global_attribute_deleted includes the "pa_" prefix in $old_slug, and
+		// the handle_global_attribute_updated does not. Remove it to keep compatibility.
+		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
+			$old_slug = substr( $old_slug, 3 );
+		}
+		self::handle_global_attribute_updated( $attribute_id, $attribute, $old_slug );
+	}
+
+	/**
+	 * Handles updates to a global attribute by triggering variation summary regeneration.
+	 *
+	 * @since 10.2.0
+	 * @param int    $attribute_id Attribute ID.
+	 * @param string $attribute    Attribute name.
+	 * @param string $old_slug     Old attribute slug.
+	 */
+	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
+		$taxonomy = 'pa_' . $old_slug;
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		$variation_ids = get_posts(
+			array(
+				'post_type'   => 'product_variation',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => 'attribute_' . $taxonomy,
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+
+		$threshold = self::get_regen_threshold();
+		$count     = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			// Update variation summaries that used this product attribute, but
+			// wait until shutdown. This will allow WooC to carry out post_meta migrations
+			// if the slug of the attribute changed.
+			add_action(
+				'shutdown',
+				function() use ( $variation_ids ) {
+					self::regenerate_variation_summaries( $variation_ids );
+				}
+			);
+		} else {
+			$new_slug     = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
+			$new_taxonomy = 'pa_' . $new_slug;
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_attribute_variation_summaries',
+					array( $new_taxonomy ),
+					'woocommerce'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Regenerates variation summaries for all variations using a specific attribute taxonomy.
+	 *
+	 * @since 10.2.0
+	 * @param string $taxonomy Attribute taxonomy.
+	 */
+	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		$variation_ids = get_posts(
+			array(
+				'post_type'   => 'product_variation',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => 'attribute_' . $taxonomy,
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		self::regenerate_variation_summaries( $variation_ids );
+	}
+
+	/**
+	 * Handles regeneration of variation summaries when a variable product's attributes are updated.
+	 *
+	 * @since 10.2.0
+	 * @param WC_Product $product The variable product whose attributes were updated.
+	 * @param bool       $force Whether the update was forced.
+	 */
+	public static function on_product_attributes_updated( $product, $force ) {
+		if ( $product->is_type( 'variable' ) ) {
+			$variation_ids = $product->get_children();
+			$threshold     = self::get_regen_threshold();
+			$count         = count( $variation_ids );
+
+			if ( $count <= $threshold ) {
+				self::regenerate_variation_summaries( $variation_ids );
+			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_product_variation_summaries',
+					array( $product->get_id() ),
+					'woocommerce'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Regenerates variation summaries for all variations of a variable product.
+	 *
+	 * @since 10.2.0
+	 * @param int $product_id Variable product ID.
+	 */
+	public static function regenerate_product_variation_summaries( $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product || ! $product->is_type( 'variable' ) ) {
+			return;
+		}
+
+		$variation_ids = $product->get_children();
+		self::regenerate_variation_summaries( $variation_ids );
+	}
+
+	/**
+	 * Hook called after a term is updated to handle updates for product variations.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public static function handle_attribute_term_updated( $term_id, $tt_id, $taxonomy ) {
+		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
+			return;
+		}
+
+		$new_term = get_term( $term_id, $taxonomy );
+		if ( is_wp_error( $new_term ) || ! $new_term ) {
+			return;
+		}
+
+		$meta_key = 'attribute_' . $taxonomy;
+		global $wpdb;
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id
+				FROM $wpdb->postmeta pm
+				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = 'product_variation'",
+				$meta_key,
+				$new_term->slug
+			)
+		);
+
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$threshold = self::get_regen_threshold();
+		$count     = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			self::regenerate_variation_summaries( $variation_ids );
+		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time() + 1,
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $new_term->slug ),
+				'woocommerce'
+			);
+		}
+	}
+
+	/**
+	 * Hook called after a term is updated to handle updates for product variations.
+	 *
+	 * @param int     $term_id  Term ID.
+	 * @param int     $tt_id    Term taxonomy ID.
+	 * @param string  $taxonomy Taxonomy slug.
+	 * @param WP_Term $deleted_term Copy of the already-deleted term.
+	 * @param array   $object_ids List of term object IDs.
+	 */
+	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
+			return;
+		}
+
+		$meta_key = 'attribute_' . $taxonomy;
+		global $wpdb;
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id
+				FROM $wpdb->postmeta pm
+				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = 'product_variation'",
+				$meta_key,
+				$deleted_term->slug
+			)
+		);
+
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$threshold = self::get_regen_threshold();
+		$count     = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			self::regenerate_variation_summaries( $variation_ids );
+		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time() + 1,
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $deleted_term->slug ),
+				'woocommerce'
+			);
+		}
+	}
+
+	/**
+	 * Regenerates variation summaries for all variations using a specific term.
+	 *
+	 * @since 10.2.0
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param string $term_slug Term slug.
+	 */
+	public static function regenerate_term_variation_summaries( $taxonomy, $term_slug ) {
+		global $wpdb;
+
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id FROM {$wpdb->postmeta} pm
+				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = %s",
+				'attribute_' . $taxonomy,
+				$term_slug,
+				'product_variation'
+			)
+		);
+
+		self::regenerate_variation_summaries( $variation_ids );
+	}
+
 }
 
 WC_Post_Data::init();

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -786,6 +786,11 @@ class WC_Post_Data {
 				if ( ! $when ) {
 					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
 				}
+			} else {
+				wc_get_logger()->warning(
+					'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Attribute ID: ' . $attribute_id,
+					array( 'source' => 'woocommerce-variations' )
+				);
 			}
 		}
 	}
@@ -838,6 +843,11 @@ class WC_Post_Data {
 				if ( ! $when ) {
 					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
 				}
+			} else {
+				wc_get_logger()->warning(
+					'Action Scheduler unavailable for product variation summary regeneration. Product ID: ' . $product->get_id(),
+					array( 'source' => 'woocommerce-variations' )
+				);
 			}
 		}
 	}
@@ -908,6 +918,11 @@ class WC_Post_Data {
 			if ( ! $when ) {
 				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
 			}
+		} else {
+			wc_get_logger()->warning(
+				'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id,
+				array( 'source' => 'woocommerce-variations' )
+			);
 		}
 	}
 
@@ -957,6 +972,11 @@ class WC_Post_Data {
 			if ( ! $when ) {
 				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
 			}
+		} else {
+			wc_get_logger()->warning(
+				'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id,
+				array( 'source' => 'woocommerce-variations' )
+			);
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -712,7 +712,7 @@ class WC_Post_Data {
 		 * @param int $threshold The default threshold value (50).
 		 * @return int The filtered threshold value.
 		 */
-		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
+		return absint( apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -732,6 +732,7 @@ class WC_Post_Data {
 		}
 		$taxonomy  = 'pa_' . $old_slug;
 		$threshold = self::get_variation_summaries_sync_threshold();
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		$args      = array(
 			'post_type'      => 'product_variation',
 			'post_status'    => 'any',
@@ -744,6 +745,7 @@ class WC_Post_Data {
 				),
 			),
 		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 		$variation_ids = get_posts( $args );
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -732,29 +732,39 @@ class WC_Post_Data {
 		}
 		$taxonomy = 'pa_' . $old_slug;
 
-		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		$variation_ids = get_posts(
-			array(
-				'post_type'   => 'product_variation',
-				'numberposts' => -1,
-				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
-						'key'     => 'attribute_' . $taxonomy,
-						'compare' => 'EXISTS',
-					),
-				),
+		global $wpdb;
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID)
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+				WHERE p.post_type = 'product_variation'
+				AND pm.meta_key = %s",
+				'attribute_' . $taxonomy
 			)
 		);
-		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 		$threshold = self::get_variation_summaries_sync_threshold();
-		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
 			// Update variation summaries that used this product attribute, but
 			// wait until shutdown. This will allow WooC to carry out post_meta migrations
 			// if the slug of the attribute changed.
+			// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			$variation_ids = get_posts(
+				array(
+					'post_type'   => 'product_variation',
+					'numberposts' => -1,
+					'fields'      => 'ids',
+					'meta_query'  => array(
+						array(
+							'key'     => 'attribute_' . $taxonomy,
+							'compare' => 'EXISTS',
+						),
+					),
+				)
+			);
+			// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			add_action(
 				'shutdown',
 				function () use ( $variation_ids ) {

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -818,15 +818,15 @@ class WC_Post_Data {
 		if ( $product->is_type( 'variable' ) ) {
 			global $wpdb;
 			$count = (int) $wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT COUNT(ID)
-						FROM {$wpdb->posts}
-						WHERE post_parent = %d
-						AND post_type = %s",
-						$product->get_id(),
-						'product_variation'
-					)
-				);
+				$wpdb->prepare(
+					"SELECT COUNT(ID)
+					FROM {$wpdb->posts}
+					WHERE post_parent = %d
+					AND post_type = %s",
+					$product->get_id(),
+					'product_variation'
+				)
+			);
 
 			$threshold = self::get_variation_summaries_sync_threshold();
 
@@ -891,7 +891,7 @@ class WC_Post_Data {
 			)
 		);
 
-		if ( $count === 0 ) {
+		if ( 0 === $count ) {
 			return;
 		}
 
@@ -948,7 +948,7 @@ class WC_Post_Data {
 			)
 		);
 
-		if ( $count === 0 ) {
+		if ( 0 === $count ) {
 			return;
 		}
 
@@ -985,11 +985,11 @@ class WC_Post_Data {
 	 * given arguments is already scheduled to avoid duplicate jobs. If the Action Scheduler
 	 * is not available, a warning is logged instead.
 	 *
-	 * @param string   $action_name     The name/identifier of the scheduled action (hook name).
-	 * @param array    $args            Arguments to pass to the scheduled action callback.
-	 * @param string   $warning_message Message to log when the Action Scheduler is unavailable.
-	 * @param string   $group           Optional. The Action Scheduler group to associate with
-	 *                                  the scheduled action. Default 'woocommerce'.
+	 * @param string $action_name     The name/identifier of the scheduled action (hook name).
+	 * @param array  $args            Arguments to pass to the scheduled action callback.
+	 * @param string $warning_message Message to log when the Action Scheduler is unavailable.
+	 * @param string $group           Optional. The Action Scheduler group to associate with
+	 *                                the scheduled action. Default 'woocommerce'.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -857,9 +857,9 @@ class WC_Post_Data {
 
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
-		$variation_ids = $wpdb->get_col(
+		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT pm.post_id
+				"SELECT COUNT(DISTINCT pm.post_id)
 				FROM $wpdb->postmeta pm
 				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
 				WHERE pm.meta_key = %s
@@ -870,14 +870,25 @@ class WC_Post_Data {
 			)
 		);
 
-		if ( empty( $variation_ids ) ) {
+		if ( $count === 0 ) {
 			return;
 		}
 
 		$threshold = self::get_variation_summaries_sync_threshold();
-		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
+			$variation_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT pm.post_id
+					FROM $wpdb->postmeta pm
+					INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+					WHERE pm.meta_key = %s
+					AND pm.meta_value = %s
+					AND p.post_type = 'product_variation'",
+					$meta_key,
+					$new_term->slug
+				)
+			);
 			self::regenerate_variation_summaries( $variation_ids );
 		} else {
 			self::schedule_variation_summary_regeneration(
@@ -903,9 +914,9 @@ class WC_Post_Data {
 
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
-		$variation_ids = $wpdb->get_col(
+		$count = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT pm.post_id
+				"SELECT COUNT(DISTINCT pm.post_id)
 				FROM $wpdb->postmeta pm
 				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
 				WHERE pm.meta_key = %s
@@ -916,14 +927,25 @@ class WC_Post_Data {
 			)
 		);
 
-		if ( empty( $variation_ids ) ) {
+		if ( $count === 0 ) {
 			return;
 		}
 
 		$threshold = self::get_variation_summaries_sync_threshold();
-		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
+			$variation_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT pm.post_id
+					FROM $wpdb->postmeta pm
+					INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+					WHERE pm.meta_key = %s
+					AND pm.meta_value = %s
+					AND p.post_type = 'product_variation'",
+					$meta_key,
+					$deleted_term->slug
+				)
+			);
 			self::regenerate_variation_summaries( $variation_ids );
 		} else {
 			self::schedule_variation_summary_regeneration(

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -69,7 +69,7 @@ class WC_Post_Data {
 		// Product Variations - Attributes.
 		// Priority 50 to make sure this runs after WooCommerce attribute migrations.
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
-		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
+		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_updated' ), 10, 3 );
 		// Product Variations - Terms.
 		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
 		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 4 );
@@ -716,24 +716,6 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Handles deletion of a global attribute by triggering variation summary updates.
-	 *
-	 * @since 10.2.0
-	 * @param int    $attribute_id Attribute ID.
-	 * @param string $attribute    Attribute name.
-	 * @param string $old_slug     Old attribute slug.
-	 */
-	public static function handle_global_attribute_deleted( $attribute_id, $attribute, $old_slug ) {
-		// We can reuse the update function to trigger variation summary rebuilds.
-		// However, the handle_global_attribute_deleted includes the "pa_" prefix in $old_slug, and
-		// the handle_global_attribute_updated does not. Remove it to keep compatibility.
-		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
-			$old_slug = substr( $old_slug, 3 );
-		}
-		self::handle_global_attribute_updated( $attribute_id, $attribute, $old_slug );
-	}
-
-	/**
 	 * Handles updates to a global attribute by triggering variation summary regeneration.
 	 *
 	 * @since 10.2.0
@@ -742,6 +724,12 @@ class WC_Post_Data {
 	 * @param string $old_slug     Old attribute slug.
 	 */
 	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
+		// We use this trigger for both updates and deletions of global attributes.
+		// They pass different parameters to $old_slug - deleted attributes include the "pa_" prefix, while updated attributes do not.
+		// Remove it if existing for consistency.
+		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
+			$old_slug = substr( $old_slug, 3 );
+		}
 		$taxonomy = 'pa_' . $old_slug;
 
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -889,7 +889,7 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Hook called after a term is updated to handle updates for product variations.
+	 * Hook called after a term is deleted to handle updates for product variations.
 	 *
 	 * @param int     $term_id  Term ID.
 	 * @param int     $tt_id    Term taxonomy ID.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -778,12 +778,14 @@ class WC_Post_Data {
 			$new_taxonomy = 'pa_' . $new_slug;
 
 			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_attribute_variation_summaries',
-					array( $new_taxonomy ),
-					'woocommerce'
-				);
+				$name = 'wc_regenerate_attribute_variation_summaries';
+				$args = array( $new_taxonomy );
+
+				// Prevent duplicate scheduling of the action.
+				$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
+				if ( ! $when ) {
+					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
+				}
 			}
 		}
 	}
@@ -828,12 +830,14 @@ class WC_Post_Data {
 			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
 			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_product_variation_summaries',
-					array( $product->get_id() ),
-					'woocommerce'
-				);
+				$name = 'wc_regenerate_product_variation_summaries';
+				$args = array( $product->get_id() );
+
+				// Prevent duplicate scheduling of the action.
+				$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
+				if ( ! $when ) {
+					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
+				}
 			}
 		}
 	}
@@ -896,12 +900,14 @@ class WC_Post_Data {
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
 		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time() + 1,
-				'wc_regenerate_term_variation_summaries',
-				array( $taxonomy, $new_term->slug ),
-				'woocommerce'
-			);
+			$name = 'wc_regenerate_term_variation_summaries';
+			$args = array( $taxonomy, $new_term->slug );
+
+			// Prevent duplicate scheduling of the action.
+			$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
+			if ( ! $when ) {
+				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
+			}
 		}
 	}
 
@@ -943,12 +949,14 @@ class WC_Post_Data {
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
 		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time() + 1,
-				'wc_regenerate_term_variation_summaries',
-				array( $taxonomy, $deleted_term->slug ),
-				'woocommerce'
-			);
+			$name = 'wc_regenerate_term_variation_summaries';
+			$args = array( $taxonomy, $deleted_term->slug );
+
+			// Prevent duplicate scheduling of the action.
+			$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
+			if ( ! $when ) {
+				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -923,38 +923,29 @@ class WC_Post_Data {
 
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
-		$count = (int) $wpdb->get_var(
+		$threshold = self::get_variation_summaries_sync_threshold();
+		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT pm.post_id)
+				"SELECT DISTINCT pm.post_id
 				FROM $wpdb->postmeta pm
 				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
 				WHERE pm.meta_key = %s
 				AND pm.meta_value = %s
-				AND p.post_type = 'product_variation'",
+				AND p.post_type = 'product_variation'
+				LIMIT %d
+				",
 				$meta_key,
-				$deleted_term->slug
+				$deleted_term->slug,
+				$threshold + 1
 			)
 		);
 
-		if ( 0 === $count ) {
+		if ( empty( $variation_ids ) ) {
 			return;
 		}
 
-		$threshold = self::get_variation_summaries_sync_threshold();
-
-		if ( $count <= $threshold ) {
-			$variation_ids = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT pm.post_id
-					FROM $wpdb->postmeta pm
-					INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
-					WHERE pm.meta_key = %s
-					AND pm.meta_value = %s
-					AND p.post_type = 'product_variation'",
-					$meta_key,
-					$deleted_term->slug
-				)
-			);
+		if ( count( $variation_ids ) <= $threshold ) {
+			// If the number of variations is below the threshold, regenerate summaries synchronously.
 			self::regenerate_variation_summaries( $variation_ids );
 		} else {
 			self::schedule_variation_summary_regeneration(

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -733,38 +733,28 @@ class WC_Post_Data {
 		$taxonomy = 'pa_' . $old_slug;
 
 		global $wpdb;
-		$count = (int) $wpdb->get_var(
+		$threshold = self::get_variation_summaries_sync_threshold();
+		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT p.ID)
+				"SELECT DISTINCT p.ID
 				FROM {$wpdb->posts} p
 				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
 				WHERE p.post_type = 'product_variation'
-				AND pm.meta_key = %s",
-				'attribute_' . $taxonomy
+				AND pm.meta_key = %s
+				LIMIT %d",
+				'attribute_' . $taxonomy,
+				$threshold + 1
 			)
 		);
 
-		$threshold = self::get_variation_summaries_sync_threshold();
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
 
-		if ( $count <= $threshold ) {
+		if ( count( $variation_ids ) <= $threshold ) {
 			// Update variation summaries that used this product attribute, but
 			// wait until shutdown. This will allow WooC to carry out post_meta migrations
 			// if the slug of the attribute changed.
-			// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			$variation_ids = get_posts(
-				array(
-					'post_type'   => 'product_variation',
-					'numberposts' => -1,
-					'fields'      => 'ids',
-					'meta_query'  => array(
-						array(
-							'key'     => 'attribute_' . $taxonomy,
-							'compare' => 'EXISTS',
-						),
-					),
-				)
-			);
-			// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			add_action(
 				'shutdown',
 				function () use ( $variation_ids ) {

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -642,7 +642,7 @@ class WC_Post_Data {
 	 * @since 10.2.0
 	 * @param array $variation_ids Array of variation IDs.
 	 */
-	public static function regenerate_variation_summaries( $variation_ids ) {
+	private static function regenerate_variation_summaries( $variation_ids ) {
 		if ( empty( $variation_ids ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -702,7 +702,7 @@ class WC_Post_Data {
 	 * @since 10.2.0
 	 * @return int
 	 */
-	public static function get_regen_threshold() {
+	public static function get_variation_summaries_sync_threshold() {
 		/**
 		 * Filters the threshold for synchronous regeneration of variation attribute summaries.
 		 * If the number of variations affected by an update is below this threshold, the summaries
@@ -760,7 +760,7 @@ class WC_Post_Data {
 		);
 		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
-		$threshold = self::get_regen_threshold();
+		$threshold = self::get_variation_summaries_sync_threshold();
 		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
@@ -829,7 +829,7 @@ class WC_Post_Data {
 	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
 			$variation_ids = $product->get_children();
-			$threshold     = self::get_regen_threshold();
+			$threshold     = self::get_variation_summaries_sync_threshold();
 			$count         = count( $variation_ids );
 
 			if ( $count <= $threshold ) {
@@ -904,7 +904,7 @@ class WC_Post_Data {
 			return;
 		}
 
-		$threshold = self::get_regen_threshold();
+		$threshold = self::get_variation_summaries_sync_threshold();
 		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
@@ -958,7 +958,7 @@ class WC_Post_Data {
 			return;
 		}
 
-		$threshold = self::get_regen_threshold();
+		$threshold = self::get_variation_summaries_sync_threshold();
 		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -733,7 +733,7 @@ class WC_Post_Data {
 		$taxonomy = 'pa_' . $old_slug;
 
 		global $wpdb;
-		$threshold = self::get_variation_summaries_sync_threshold();
+		$threshold     = self::get_variation_summaries_sync_threshold();
 		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT p.ID
@@ -807,7 +807,7 @@ class WC_Post_Data {
 	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
 			global $wpdb;
-			$threshold = self::get_variation_summaries_sync_threshold();
+			$threshold     = self::get_variation_summaries_sync_threshold();
 			$variation_ids = $wpdb->get_col(
 				$wpdb->prepare(
 					"SELECT DISTINCT ID
@@ -876,7 +876,7 @@ class WC_Post_Data {
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
 
-		$threshold = self::get_variation_summaries_sync_threshold();
+		$threshold     = self::get_variation_summaries_sync_threshold();
 		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT pm.post_id

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -816,11 +816,22 @@ class WC_Post_Data {
 	 */
 	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
-			$variation_ids = $product->get_children();
-			$threshold     = self::get_variation_summaries_sync_threshold();
-			$count         = count( $variation_ids );
+			global $wpdb;
+			$count = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT COUNT(ID)
+						FROM {$wpdb->posts}
+						WHERE post_parent = %d
+						AND post_type = %s",
+						$product->get_id(),
+						'product_variation'
+					)
+				);
+
+			$threshold = self::get_variation_summaries_sync_threshold();
 
 			if ( $count <= $threshold ) {
+				$variation_ids = $product->get_children();
 				self::regenerate_variation_summaries( $variation_ids );
 			} else {
 				self::schedule_variation_summary_regeneration(

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -817,20 +817,27 @@ class WC_Post_Data {
 	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
 			global $wpdb;
-			$count = (int) $wpdb->get_var(
+			$threshold = self::get_variation_summaries_sync_threshold();
+			$variation_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT COUNT(ID)
+					"SELECT DISTINCT ID
 					FROM {$wpdb->posts}
 					WHERE post_parent = %d
-					AND post_type = %s",
+					AND post_type = %s
+					LIMIT %d
+					",
 					$product->get_id(),
-					'product_variation'
+					'product_variation',
+					$threshold + 1
 				)
 			);
 
-			$threshold = self::get_variation_summaries_sync_threshold();
+			if ( empty( $variation_ids ) ) {
+				return;
+			}
 
-			if ( $count <= $threshold ) {
+			if ( count( $variation_ids ) <= $threshold ) {
+				// If the number of variations is below the threshold, regenerate summaries synchronously.
 				$variation_ids = $product->get_children();
 				self::regenerate_variation_summaries( $variation_ids );
 			} else {

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -67,6 +67,7 @@ class WC_Post_Data {
 		add_action( 'updated_order_item_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 
 		// Product Variations - Attributes.
+		// Priority 50 to make sure this runs after WooCommerce attribute migrations.
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
 		// Product Variations - Terms.
@@ -674,6 +675,11 @@ class WC_Post_Data {
 			if ( $new_summary === $current_excerpt ) {
 				return;
 			}
+
+			/**
+			* Update directly via $wpdb for performance: Avoid firing save_post hooks, loading full post objects,
+			* and creating revisions. This is safe here as we're only updating post_excerpt.
+			*/
 			$wpdb->update(
 				$wpdb->posts,
 				array( 'post_excerpt' => $new_summary ),

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -730,22 +730,22 @@ class WC_Post_Data {
 		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
 			$old_slug = substr( $old_slug, 3 );
 		}
-		$taxonomy = 'pa_' . $old_slug;
-
-		global $wpdb;
-		$threshold     = self::get_variation_summaries_sync_threshold();
-		$variation_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT DISTINCT p.ID
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-				WHERE p.post_type = 'product_variation'
-				AND pm.meta_key = %s
-				LIMIT %d",
-				'attribute_' . $taxonomy,
-				$threshold + 1
-			)
+		$taxonomy  = 'pa_' . $old_slug;
+		$threshold = self::get_variation_summaries_sync_threshold();
+		$args      = array(
+			'post_type'      => 'product_variation',
+			'post_status'    => 'any',
+			'posts_per_page' => $threshold + 1,
+			'fields'         => 'ids',
+			'meta_query'     => array(
+				array(
+					'key'     => 'attribute_' . $taxonomy,
+					'compare' => 'EXISTS',
+				),
+			),
 		);
+
+		$variation_ids = get_posts( $args );
 
 		if ( empty( $variation_ids ) ) {
 			return;

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -66,7 +66,7 @@ class WC_Post_Data {
 		add_action( 'deleted_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 		add_action( 'updated_order_item_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 
-		// Prouduct Variations - Attributes.
+		// Product Variations - Attributes.
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
 		// Product Variations - Terms.
@@ -646,7 +646,7 @@ class WC_Post_Data {
 			return;
 		}
 
-		$variation_ids = array_unique( array_filter( $variation_ids ) );
+		$variation_ids = array_unique( array_filter( array_map( 'intval', $variation_ids ) ) );
 
 		foreach ( $variation_ids as $variation_id ) {
 			self::regenerate_variation_attribute_summary( $variation_id );

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -765,21 +765,11 @@ class WC_Post_Data {
 			$new_slug     = ! empty( $attribute['attribute_name'] ) ? $attribute['attribute_name'] : $old_slug;
 			$new_taxonomy = 'pa_' . $new_slug;
 
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				$name = 'wc_regenerate_attribute_variation_summaries';
-				$args = array( $new_taxonomy );
-
-				// Prevent duplicate scheduling of the action.
-				$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
-				if ( ! $when ) {
-					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
-				}
-			} else {
-				wc_get_logger()->warning(
-					'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Attribute ID: ' . $attribute_id,
-					array( 'source' => 'woocommerce-variations' )
-				);
-			}
+			self::schedule_variation_summary_regeneration(
+				'wc_regenerate_attribute_variation_summaries',
+				array( $new_taxonomy ),
+				'Taxonomy: ' . $taxonomy . ', Attribute ID: ' . $attribute_id
+			);
 		}
 	}
 
@@ -822,19 +812,11 @@ class WC_Post_Data {
 
 			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
-			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-				$name = 'wc_regenerate_product_variation_summaries';
-				$args = array( $product->get_id() );
-
-				// Prevent duplicate scheduling of the action.
-				$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
-				if ( ! $when ) {
-					as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
-				}
 			} else {
-				wc_get_logger()->warning(
-					'Action Scheduler unavailable for product variation summary regeneration. Product ID: ' . $product->get_id(),
-					array( 'source' => 'woocommerce-variations' )
+				self::schedule_variation_summary_regeneration(
+					'wc_regenerate_product_variation_summaries',
+					array( $product->get_id() ),
+					'Product ID: ' . $product->get_id()
 				);
 			}
 		}
@@ -897,19 +879,11 @@ class WC_Post_Data {
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			$name = 'wc_regenerate_term_variation_summaries';
-			$args = array( $taxonomy, $new_term->slug );
-
-			// Prevent duplicate scheduling of the action.
-			$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
-			if ( ! $when ) {
-				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
-			}
 		} else {
-			wc_get_logger()->warning(
-				'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id,
-				array( 'source' => 'woocommerce-variations' )
+			self::schedule_variation_summary_regeneration(
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $new_term->slug ),
+				'Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id
 			);
 		}
 	}
@@ -951,18 +925,41 @@ class WC_Post_Data {
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			$name = 'wc_regenerate_term_variation_summaries';
-			$args = array( $taxonomy, $deleted_term->slug );
+		} else {
+			self::schedule_variation_summary_regeneration(
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $deleted_term->slug ),
+				'Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id
+			);
+		}
+	}
 
+	/**
+	 * Schedule an asynchronous action to regenerate product variation summaries.
+	 *
+	 * This method uses the WooCommerce Action Scheduler to queue a single regeneration action
+	 * for product variation summaries. It first checks whether an identical action with the
+	 * given arguments is already scheduled to avoid duplicate jobs. If the Action Scheduler
+	 * is not available, a warning is logged instead.
+	 *
+	 * @param string   $action_name     The name/identifier of the scheduled action (hook name).
+	 * @param array    $args            Arguments to pass to the scheduled action callback.
+	 * @param string   $warning_message Message to log when the Action Scheduler is unavailable.
+	 * @param string   $group           Optional. The Action Scheduler group to associate with
+	 *                                  the scheduled action. Default 'woocommerce'.
+	 *
+	 * @return void
+	 */
+	private static function schedule_variation_summary_regeneration( $action_name, $args, $warning_message, $group = 'woocommerce' ) {
+		if ( function_exists( 'as_schedule_single_action' ) ) {
 			// Prevent duplicate scheduling of the action.
-			$when = as_next_scheduled_action( $name, $args, 'woocommerce' );
+			$when = as_next_scheduled_action( $action_name, $args, $group );
 			if ( ! $when ) {
-				as_schedule_single_action( time() + 1, $name, $args, 'woocommerce' );
+				as_schedule_single_action( time() + 1, $action_name, $args, $group );
 			}
 		} else {
 			wc_get_logger()->warning(
-				'Action Scheduler unavailable for product variation summary regeneration. Taxonomy: ' . $taxonomy . ', Term ID: ' . $term_id,
+				'Action Scheduler unavailable for product variation summary regeneration. ' . $warning_message,
 				array( 'source' => 'woocommerce-variations' )
 			);
 		}

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -66,15 +66,15 @@ class WC_Post_Data {
 		add_action( 'deleted_post_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 		add_action( 'updated_order_item_meta', array( __CLASS__, 'flush_object_meta_cache' ), 10, 4 );
 
-		// Attributes.
+		// Prouduct Variations - Attributes.
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
-		// Terms
+		// Product Variations - Terms.
 		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
-		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 5 );
-		// Parent Product Updates Attributes.
-		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
-
+		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 4 );
+		// Product Variations - Parent Product Updates Attributes.
+		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 1 );
+		// Product Variations - Action Scheduler.
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
@@ -669,7 +669,7 @@ class WC_Post_Data {
 
 		$data_store = WC_Data_Store::load( 'product-variation' );
 		if ( $data_store->has_callable( 'get_attribute_summary' ) ) {
-			$new_summary = $data_store->get_attribute_summary( $product );
+			$new_summary     = $data_store->get_attribute_summary( $product );
 			$current_excerpt = get_post_field( 'post_excerpt', $variation_id );
 			if ( $new_summary === $current_excerpt ) {
 				return;
@@ -763,7 +763,7 @@ class WC_Post_Data {
 			// if the slug of the attribute changed.
 			add_action(
 				'shutdown',
-				function() use ( $variation_ids ) {
+				function () use ( $variation_ids ) {
 					self::regenerate_variation_summaries( $variation_ids );
 				}
 			);
@@ -812,9 +812,8 @@ class WC_Post_Data {
 	 *
 	 * @since 10.2.0
 	 * @param WC_Product $product The variable product whose attributes were updated.
-	 * @param bool       $force Whether the update was forced.
 	 */
-	public static function on_product_attributes_updated( $product, $force ) {
+	public static function on_product_attributes_updated( $product ) {
 		if ( $product->is_type( 'variable' ) ) {
 			$variation_ids = $product->get_children();
 			$threshold     = self::get_regen_threshold();
@@ -907,9 +906,8 @@ class WC_Post_Data {
 	 * @param int     $tt_id    Term taxonomy ID.
 	 * @param string  $taxonomy Taxonomy slug.
 	 * @param WP_Term $deleted_term Copy of the already-deleted term.
-	 * @param array   $object_ids List of term object IDs.
 	 */
-	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term ) {
 		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
 			return;
 		}
@@ -973,7 +971,6 @@ class WC_Post_Data {
 
 		self::regenerate_variation_summaries( $variation_ids );
 	}
-
 }
 
 WC_Post_Data::init();

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -733,7 +733,7 @@ class WC_Post_Data {
 		$taxonomy  = 'pa_' . $old_slug;
 		$threshold = self::get_variation_summaries_sync_threshold();
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		$args      = array(
+		$args = array(
 			'post_type'      => 'product_variation',
 			'post_status'    => 'any',
 			'posts_per_page' => $threshold + 1,

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -878,38 +878,29 @@ class WC_Post_Data {
 
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
-		$count = (int) $wpdb->get_var(
+
+		$threshold = self::get_variation_summaries_sync_threshold();
+		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT pm.post_id)
+				"SELECT DISTINCT pm.post_id
 				FROM $wpdb->postmeta pm
 				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
 				WHERE pm.meta_key = %s
 				AND pm.meta_value = %s
-				AND p.post_type = 'product_variation'",
+				AND p.post_type = 'product_variation'
+				LIMIT %d
+				",
 				$meta_key,
-				$new_term->slug
+				$new_term->slug,
+				$threshold + 1
 			)
 		);
-
-		if ( 0 === $count ) {
+		if ( empty( $variation_ids ) ) {
 			return;
 		}
 
-		$threshold = self::get_variation_summaries_sync_threshold();
-
-		if ( $count <= $threshold ) {
-			$variation_ids = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT pm.post_id
-					FROM $wpdb->postmeta pm
-					INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
-					WHERE pm.meta_key = %s
-					AND pm.meta_value = %s
-					AND p.post_type = 'product_variation'",
-					$meta_key,
-					$new_term->slug
-				)
-			);
+		if ( count( $variation_ids ) <= $threshold ) {
+			// If the number of variations is below the threshold, regenerate summaries synchronously.
 			self::regenerate_variation_summaries( $variation_ids );
 		} else {
 			self::schedule_variation_summary_regeneration(

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -923,7 +923,7 @@ class WC_Post_Data {
 
 		$meta_key = 'attribute_' . $taxonomy;
 		global $wpdb;
-		$threshold = self::get_variation_summaries_sync_threshold();
+		$threshold     = self::get_variation_summaries_sync_threshold();
 		$variation_ids = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT pm.post_id

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1021,13 +1021,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			// Note, we use wp_slash to add extra level of escaping. See https://codex.wordpress.org/Function_Reference/update_post_meta#Workaround.
 			$this->update_or_delete_post_meta( $product, '_product_attributes', wp_slash( $meta_values ) );
 
-			// Regenerate variation summaries if this is a variable product and attributes changed.
-			if ( $product->is_type( 'variable' ) ) {
-				$variation_ids = $product->get_children();
-				if ( ! empty( $variation_ids ) && is_array( $variation_ids ) ) {
-					WC_Product_Variation_Data_Store_CPT::regenerate_variation_summaries( $variation_ids );
-				}
-			}
+			do_action( 'woocommerce_product_attributes_updated', $product, $force );
 		}
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1020,6 +1020,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 			// Note, we use wp_slash to add extra level of escaping. See https://codex.wordpress.org/Function_Reference/update_post_meta#Workaround.
 			$this->update_or_delete_post_meta( $product, '_product_attributes', wp_slash( $meta_values ) );
+
+			// Regenerate variation summaries if this is a variable product and attributes changed.
+			if ( $product->is_type( 'variable' ) ) {
+				$variation_ids = $product->get_children();
+				if ( ! empty( $variation_ids ) && is_array( $variation_ids ) ) {
+					WC_Product_Variation_Data_Store_CPT::regenerate_variation_summaries( $variation_ids );
+				}
+			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1021,6 +1021,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			// Note, we use wp_slash to add extra level of escaping. See https://codex.wordpress.org/Function_Reference/update_post_meta#Workaround.
 			$this->update_or_delete_post_meta( $product, '_product_attributes', wp_slash( $meta_values ) );
 
+			/**
+			 * Fires after WooCommerce product attributes have been updated.
+			 *
+			 * @since 10.2.0
+			 * @param WC_Product $product The product object whose attributes were updated.
+			 * @param bool $force Indicates if the update was forced.
+			 */
 			do_action( 'woocommerce_product_attributes_updated', $product, $force );
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -751,6 +751,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
 		$taxonomy = 'pa_' . $old_slug;
 
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		$variation_ids = get_posts(
 			array(
 				'post_type'   => 'product_variation',
@@ -764,9 +765,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				),
 			)
 		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 		$threshold = self::get_regen_threshold();
-		$count = count( $variation_ids );
+		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
 			// Update variation summaries that used this product attribute, but
@@ -778,7 +780,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				}
 			);
 		} else {
-			$new_slug = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
+			$new_slug     = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
 			$new_taxonomy = 'pa_' . $new_slug;
 			if ( function_exists( 'as_schedule_single_action' ) ) {
 				as_schedule_single_action(
@@ -798,6 +800,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 * @param string $taxonomy Attribute taxonomy.
 	 */
 	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		$variation_ids = get_posts(
 			array(
 				'post_type'   => 'product_variation',
@@ -811,6 +814,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				),
 			)
 		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 		self::regenerate_variation_summaries( $variation_ids );
 	}
@@ -826,8 +830,8 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	public static function on_product_attributes_updated( $product, $force ) {
 		if ( $product->is_type( 'variable' ) ) {
 			$variation_ids = $product->get_children();
-			$threshold = self::get_regen_threshold();
-			$count = count( $variation_ids );
+			$threshold     = self::get_regen_threshold();
+			$count         = count( $variation_ids );
 
 			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
@@ -897,7 +901,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		$threshold = self::get_regen_threshold();
-		$count = count( $variation_ids );
+		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
@@ -947,7 +951,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		$threshold = self::get_regen_threshold();
-		$count = count( $variation_ids );
+		$count     = count( $variation_ids );
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -42,6 +42,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		// Terms
 		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
 
+		// Action Scheduler
+		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
+
 		$hooks_added = true;
 	}
 
@@ -714,12 +717,15 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		// Update variation summaries that used this product attribute, but
 		// wait until shutdown. This will allow WooC to carry out post_meta migrations
 		// if the slug of the attribute changed.
-		llp('rebuild ' . json_encode($variation_ids));
 		register_shutdown_function(
 			function () use ( $variation_ids ) {
 				self::regenerate_variation_summaries( $variation_ids );
 			}
 		);
+	}
+
+	public static function get_regen_threshold() {
+		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
 	}
 
 	/**
@@ -732,11 +738,34 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	public static function on_product_attributes_updated( $product, $force ) {
 		if ( $product->is_type( 'variable' ) ) {
 			$variation_ids = $product->get_children();
-			if ( ! empty( $variation_ids ) && is_array( $variation_ids ) ) {
+			$threshold = self::get_regen_threshold();
+			$count = count( $variation_ids );
+
+			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
+			} else {
+				if ( function_exists( 'as_schedule_single_action' ) ) {
+					as_schedule_single_action(
+						time(),
+						'wc_regenerate_product_variation_summaries',
+						array( $product->get_id() ),
+						'woocommerce'
+					);
+				}
 			}
 		}
 	}
+
+	public static function regenerate_product_variation_summaries( $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product || ! $product->is_type( 'variable' ) ) {
+			return;
+		}
+
+		$variation_ids = $product->get_children();
+		self::regenerate_variation_summaries( $variation_ids );
+	}
+
 
 	/**
 	 * Hook called after a term is updated to handle updates for product variations.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -44,6 +44,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		// Action Scheduler
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
+		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
 
 		$hooks_added = true;
 	}
@@ -746,7 +747,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			} else {
 				if ( function_exists( 'as_schedule_single_action' ) ) {
 					as_schedule_single_action(
-						time(),
+						time() + 1,
 						'wc_regenerate_product_variation_summaries',
 						array( $product->get_id() ),
 						'woocommerce'
@@ -801,9 +802,44 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			)
 		);
 
-		if ( ! empty( $variation_ids ) ) {
-			self::regenerate_variation_summaries( $variation_ids );
+		if ( empty( $variation_ids ) ) {
+			return;
 		}
+
+		$threshold = self::get_regen_threshold();
+		$count = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			self::regenerate_variation_summaries( $variation_ids );
+		} else {
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_term_variation_summaries',
+					array( $taxonomy, $new_term->slug ),
+					'woocommerce'
+				);
+			}
+		}
+	}
+
+	public static function regenerate_term_variation_summaries( $taxonomy, $term_slug ) {
+		global $wpdb;
+
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id FROM {$wpdb->postmeta} pm
+				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = %s",
+				'attribute_' . $taxonomy,
+				$term_slug,
+				'product_variation'
+			)
+		);
+
+		self::regenerate_variation_summaries( $variation_ids );
 	}
 }
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -647,6 +647,18 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
 
+	public static function regenerate_variation_summaries( $variation_ids ) {
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$variation_ids = array_unique( array_filter( $variation_ids ) );
+
+		foreach ( $variation_ids as $variation_id ) {
+			self::regenerate_variation_attribute_summary( $variation_id );
+		}
+	}
+
 	public static function regenerate_variation_attribute_summary( $variation_id ) {
 		global $wpdb;
 
@@ -672,21 +684,8 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
 	}
 
-	public static function regenerate_variation_summaries( $variation_ids ) {
-		if ( empty( $variation_ids ) ) {
-			return;
-		}
-
-		$variation_ids = array_unique( array_filter( $variation_ids ) );
-
-		$limit = apply_filters( 'wc_variation_summary_regen_limit', 0, $variation_ids );
-		if ( $limit > 0 ) {
-			$variation_ids = array_slice( $variation_ids, 0, $limit );
-		}
-
-		foreach ( $variation_ids as $variation_id ) {
-			self::regenerate_variation_attribute_summary( $variation_id );
-		}
+	public static function get_regen_threshold() {
+		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
 	}
 
 	public static function on_delete_product_attribute( $attribute_id, $attribute, $old_slug ) {
@@ -742,9 +741,24 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
-	public static function get_regen_threshold() {
-		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
+	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
+		$variation_ids = get_posts(
+			array(
+				'post_type'   => 'product_variation',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => 'attribute_' . $taxonomy,
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		self::regenerate_variation_summaries( $variation_ids );
 	}
+
 
 	/**
 	 * Handles regeneration of variation summaries when a variable product's attributes are updated.
@@ -781,24 +795,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		$variation_ids = $product->get_children();
-		self::regenerate_variation_summaries( $variation_ids );
-	}
-
-	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
-		$variation_ids = get_posts(
-			array(
-				'post_type'   => 'product_variation',
-				'numberposts' => -1,
-				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
-						'key'     => 'attribute_' . $taxonomy,
-						'compare' => 'EXISTS',
-					),
-				),
-			)
-		);
-
 		self::regenerate_variation_summaries( $variation_ids );
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -20,37 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version  3.0.0
  */
 class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store_Interface {
-
-	/**
-	 * Static init to add hooks once per request.
-	 *
-	 * @since 10.2.0
-	 */
-	public static function init_hooks() {
-		static $hooks_added = false;
-		if ( $hooks_added ) {
-			return;
-		}
-
-		// Parent Product Updates Attributes.
-		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
-
-		// Attributes.
-		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
-		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
-
-		// Terms.
-		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
-		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 5 );
-
-		// Action Scheduler.
-		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
-		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
-		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
-
-		$hooks_added = true;
-	}
-
 	/**
 	 * Callback to remove unwanted meta data.
 	 *
@@ -155,7 +124,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_name( $new_title );
 		}
 
-		$attribute_summary = self::generate_attribute_summary( $product );
+		$attribute_summary = $this->generate_attribute_summary( $product );
 		$product->set_attribute_summary( $attribute_summary );
 
 		// The post parent is not a valid variable product so we should prevent this.
@@ -236,7 +205,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		// This ensures it's up-to-date not just for direct attribute changes (e.g., via $changes['attributes']),
 		// but also for indirect desyncs, like when a global term (e.g., 'Blue' -> 'Blue2') is updated elsewhere.
 		// We ideally handle those at the source (e.g., global term update hooks), but this provides a fallback.
-		$new_attribute_summary = self::generate_attribute_summary( $product );
+		$new_attribute_summary = $this->generate_attribute_summary( $product );
 		// Compare the fresh attribute summary with the stored summary and update if out of sync.
 		if ( $new_attribute_summary !== $product->get_attribute_summary() ) {
 			$product->set_attribute_summary( $new_attribute_summary );
@@ -359,8 +328,18 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 *
 	 * @return string
 	 */
-	protected static function generate_attribute_summary( $product ) {
+	protected function generate_attribute_summary( $product ) {
 		return wc_get_formatted_variation( $product, true, true );
+	}
+
+	/**
+	* Get attribute summary for a product.
+	*
+	* @param WC_Product $product The product object.
+	* @return string The generated attribute summary.
+	*/
+	public function get_attribute_summary( $product ) {
+		return $this->generate_attribute_summary( $product );
 	}
 
 	/**
@@ -648,349 +627,5 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
 
-	/**
-	 * Regenerates attribute summaries for a list of variations.
-	 *
-	 * @since 10.2.0
-	 * @param array $variation_ids Array of variation IDs.
-	 */
-	public static function regenerate_variation_summaries( $variation_ids ) {
-		if ( empty( $variation_ids ) ) {
-			return;
-		}
 
-		$variation_ids = array_unique( array_filter( $variation_ids ) );
-
-		foreach ( $variation_ids as $variation_id ) {
-			self::regenerate_variation_attribute_summary( $variation_id );
-		}
-	}
-
-	/**
-	 * Regenerates the attribute summary for a single variation.
-	 *
-	 * @since 10.2.0
-	 * @param int $variation_id Variation ID.
-	 */
-	public static function regenerate_variation_attribute_summary( $variation_id ) {
-		global $wpdb;
-
-		$product = wc_get_product( $variation_id );
-		if ( ! $product || ! $product->is_type( 'variation' ) ) {
-			return;
-		}
-
-		$new_summary = self::generate_attribute_summary( $product );
-
-		$current_excerpt = get_post_field( 'post_excerpt', $variation_id );
-		if ( $new_summary === $current_excerpt ) {
-			return;
-		}
-
-		$wpdb->update(
-			$wpdb->posts,
-			array( 'post_excerpt' => $new_summary ),
-			array( 'ID' => $variation_id )
-		);
-
-		clean_post_cache( $variation_id );
-		/**
-		 * Fires after the attribute summary of a product variation has been updated.
-		 *
-		 * @since 10.2.0
-		 * @param int $variation_id The ID of the product variation.
-		 */
-		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
-	}
-
-	/**
-	 * Gets the threshold for synchronous regeneration of variation summaries.
-	 *
-	 * @since 10.2.0
-	 * @return int
-	 */
-	public static function get_regen_threshold() {
-		/**
-		 * Filters the threshold for synchronous regeneration of variation attribute summaries.
-		 * If the number of variations affected by an update is below this threshold, the summaries
-		 * are regenerated synchronously. Otherwise, the regeneration is scheduled asynchronously.
-		 *
-		 * @since 10.2.0
-		 * @param int $threshold The default threshold value (50).
-		 * @return int The filtered threshold value.
-		 */
-		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
-	}
-
-	/**
-	 * Handles deletion of a global attribute by triggering variation summary updates.
-	 *
-	 * @since 10.2.0
-	 * @param int    $attribute_id Attribute ID.
-	 * @param string $attribute    Attribute name.
-	 * @param string $old_slug     Old attribute slug.
-	 */
-	public static function handle_global_attribute_deleted( $attribute_id, $attribute, $old_slug ) {
-		// We can reuse the update function to trigger variation summary rebuilds.
-		// However, the handle_global_attribute_deleted includes the "pa_" prefix in $old_slug, and
-		// the handle_global_attribute_updated does not. Remove it to keep compatibility.
-		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
-			$old_slug = substr( $old_slug, 3 );
-		}
-		self::handle_global_attribute_updated( $attribute_id, $attribute, $old_slug );
-	}
-
-	/**
-	 * Handles updates to a global attribute by triggering variation summary regeneration.
-	 *
-	 * @since 10.2.0
-	 * @param int    $attribute_id Attribute ID.
-	 * @param string $attribute    Attribute name.
-	 * @param string $old_slug     Old attribute slug.
-	 */
-	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
-		$taxonomy = 'pa_' . $old_slug;
-
-		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		$variation_ids = get_posts(
-			array(
-				'post_type'   => 'product_variation',
-				'numberposts' => -1,
-				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
-						'key'     => 'attribute_' . $taxonomy,
-						'compare' => 'EXISTS',
-					),
-				),
-			)
-		);
-		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-
-		$threshold = self::get_regen_threshold();
-		$count     = count( $variation_ids );
-
-		if ( $count <= $threshold ) {
-			// Update variation summaries that used this product attribute, but
-			// wait until shutdown. This will allow WooC to carry out post_meta migrations
-			// if the slug of the attribute changed.
-			add_action(
-				'shutdown',
-				function() use ( $variation_ids ) {
-					self::regenerate_variation_summaries( $variation_ids );
-				}
-			);
-		} else {
-			$new_slug     = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
-			$new_taxonomy = 'pa_' . $new_slug;
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_attribute_variation_summaries',
-					array( $new_taxonomy ),
-					'woocommerce'
-				);
-			}
-		}
-	}
-
-	/**
-	 * Regenerates variation summaries for all variations using a specific attribute taxonomy.
-	 *
-	 * @since 10.2.0
-	 * @param string $taxonomy Attribute taxonomy.
-	 */
-	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
-		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		$variation_ids = get_posts(
-			array(
-				'post_type'   => 'product_variation',
-				'numberposts' => -1,
-				'fields'      => 'ids',
-				'meta_query'  => array(
-					array(
-						'key'     => 'attribute_' . $taxonomy,
-						'compare' => 'EXISTS',
-					),
-				),
-			)
-		);
-		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-
-		self::regenerate_variation_summaries( $variation_ids );
-	}
-
-
-	/**
-	 * Handles regeneration of variation summaries when a variable product's attributes are updated.
-	 *
-	 * @since 10.2.0
-	 * @param WC_Product $product The variable product whose attributes were updated.
-	 * @param bool       $force Whether the update was forced.
-	 */
-	public static function on_product_attributes_updated( $product, $force ) {
-		if ( $product->is_type( 'variable' ) ) {
-			$variation_ids = $product->get_children();
-			$threshold     = self::get_regen_threshold();
-			$count         = count( $variation_ids );
-
-			if ( $count <= $threshold ) {
-				self::regenerate_variation_summaries( $variation_ids );
-			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_product_variation_summaries',
-					array( $product->get_id() ),
-					'woocommerce'
-				);
-			}
-		}
-	}
-
-	/**
-	 * Regenerates variation summaries for all variations of a variable product.
-	 *
-	 * @since 10.2.0
-	 * @param int $product_id Variable product ID.
-	 */
-	public static function regenerate_product_variation_summaries( $product_id ) {
-		$product = wc_get_product( $product_id );
-		if ( ! $product || ! $product->is_type( 'variable' ) ) {
-			return;
-		}
-
-		$variation_ids = $product->get_children();
-		self::regenerate_variation_summaries( $variation_ids );
-	}
-
-	/**
-	 * Hook called after a term is updated to handle updates for product variations.
-	 *
-	 * @param int    $term_id  Term ID.
-	 * @param int    $tt_id    Term taxonomy ID.
-	 * @param string $taxonomy Taxonomy slug.
-	 */
-	public static function handle_attribute_term_updated( $term_id, $tt_id, $taxonomy ) {
-		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
-			return;
-		}
-
-		$new_term = get_term( $term_id, $taxonomy );
-		if ( is_wp_error( $new_term ) || ! $new_term ) {
-			return;
-		}
-
-		$meta_key = 'attribute_' . $taxonomy;
-
-		global $wpdb;
-
-		$variation_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT pm.post_id
-				FROM $wpdb->postmeta pm
-				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
-				WHERE pm.meta_key = %s
-				AND pm.meta_value = %s
-				AND p.post_type = 'product_variation'",
-				$meta_key,
-				$new_term->slug
-			)
-		);
-
-		if ( empty( $variation_ids ) ) {
-			return;
-		}
-
-		$threshold = self::get_regen_threshold();
-		$count     = count( $variation_ids );
-
-		if ( $count <= $threshold ) {
-			self::regenerate_variation_summaries( $variation_ids );
-		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time() + 1,
-				'wc_regenerate_term_variation_summaries',
-				array( $taxonomy, $new_term->slug ),
-				'woocommerce'
-			);
-		}
-	}
-
-	/**
-	 * Hook called after a term is updated to handle updates for product variations.
-	 *
-	 * @param int     $term_id  Term ID.
-	 * @param int     $tt_id    Term taxonomy ID.
-	 * @param string  $taxonomy Taxonomy slug.
-	 * @param WP_Term $deleted_term Copy of the already-deleted term.
-	 * @param array   $object_ids List of term object IDs.
-	 */
-	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
-		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
-			return;
-		}
-
-		$meta_key = 'attribute_' . $taxonomy;
-
-		global $wpdb;
-
-		$variation_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT pm.post_id
-				FROM $wpdb->postmeta pm
-				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
-				WHERE pm.meta_key = %s
-				AND pm.meta_value = %s
-				AND p.post_type = 'product_variation'",
-				$meta_key,
-				$deleted_term->slug
-			)
-		);
-
-		if ( empty( $variation_ids ) ) {
-			return;
-		}
-
-		$threshold = self::get_regen_threshold();
-		$count     = count( $variation_ids );
-
-		if ( $count <= $threshold ) {
-			self::regenerate_variation_summaries( $variation_ids );
-		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-			as_schedule_single_action(
-				time() + 1,
-				'wc_regenerate_term_variation_summaries',
-				array( $taxonomy, $deleted_term->slug ),
-				'woocommerce'
-			);
-		}
-	}
-
-	/**
-	 * Regenerates variation summaries for all variations using a specific term.
-	 *
-	 * @since 10.2.0
-	 * @param string $taxonomy Taxonomy slug.
-	 * @param string $term_slug Term slug.
-	 */
-	public static function regenerate_term_variation_summaries( $taxonomy, $term_slug ) {
-		global $wpdb;
-
-		$variation_ids = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT pm.post_id FROM {$wpdb->postmeta} pm
-				INNER JOIN {$wpdb->posts} p ON pm.post_id = p.ID
-				WHERE pm.meta_key = %s
-				AND pm.meta_value = %s
-				AND p.post_type = %s",
-				'attribute_' . $taxonomy,
-				$term_slug,
-				'product_variation'
-			)
-		);
-
-		self::regenerate_variation_summaries( $variation_ids );
-	}
 }
-
-add_action( 'woocommerce_loaded', array( 'WC_Product_Variation_Data_Store_CPT', 'init_hooks' ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -104,7 +104,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		 * This is meant to also cover the case when global attribute name or value is updated, then the attribute summary is updated
 		 * for respective products when they're read.
 		 */
-		$new_attribute_summary = $this->generate_attribute_summary( $product );
+		$new_attribute_summary = self::generate_attribute_summary( $product );
 
 		if ( $new_attribute_summary !== $post_object->post_excerpt ) {
 			$product->set_attribute_summary( $new_attribute_summary );
@@ -137,7 +137,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_name( $new_title );
 		}
 
-		$attribute_summary = $this->generate_attribute_summary( $product );
+		$attribute_summary = self::generate_attribute_summary( $product );
 		$product->set_attribute_summary( $attribute_summary );
 
 		// The post parent is not a valid variable product so we should prevent this.
@@ -215,7 +215,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$changes = $product->get_changes();
 
 		if ( array_intersect( array( 'attributes' ), array_keys( $changes ) ) ) {
-			$product->set_attribute_summary( $this->generate_attribute_summary( $product ) );
+			$product->set_attribute_summary( self::generate_attribute_summary( $product ) );
 		}
 
 		// Only update the post when the post data changes.
@@ -329,7 +329,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 *
 	 * @return string
 	 */
-	protected function generate_attribute_summary( $product ) {
+	protected static function generate_attribute_summary( $product ) {
 		return wc_get_formatted_variation( $product, true, true );
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -44,6 +44,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		// Action Scheduler
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
+		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
 
 		$hooks_added = true;
@@ -715,14 +716,30 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			)
 		);
 
-		// Update variation summaries that used this product attribute, but
-		// wait until shutdown. This will allow WooC to carry out post_meta migrations
-		// if the slug of the attribute changed.
-		register_shutdown_function(
-			function () use ( $variation_ids ) {
-				self::regenerate_variation_summaries( $variation_ids );
+		$threshold = self::get_regen_threshold();
+		$count = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			// Update variation summaries that used this product attribute, but
+			// wait until shutdown. This will allow WooC to carry out post_meta migrations
+			// if the slug of the attribute changed.
+			register_shutdown_function(
+				function () use ( $variation_ids ) {
+					self::regenerate_variation_summaries( $variation_ids );
+				}
+			);
+		} else {
+			$new_slug = ! empty( $attribute['slug'] ) ? $attribute['slug'] : $old_slug;
+			$new_taxonomy = 'pa_' . $new_slug;
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_attribute_variation_summaries',
+					array( $new_taxonomy ),
+					'woocommerce'
+				);
 			}
-		);
+		}
 	}
 
 	public static function get_regen_threshold() {
@@ -767,6 +784,23 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		self::regenerate_variation_summaries( $variation_ids );
 	}
 
+	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
+		$variation_ids = get_posts(
+			array(
+				'post_type'   => 'product_variation',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => 'attribute_' . $taxonomy,
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		self::regenerate_variation_summaries( $variation_ids );
+	}
 
 	/**
 	 * Hook called after a term is updated to handle updates for product variations.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -333,11 +333,11 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	}
 
 	/**
-	* Get attribute summary for a product.
-	*
-	* @param WC_Product $product The product object.
-	* @return string The generated attribute summary.
-	*/
+	 * Get attribute summary for a product.
+	 *
+	 * @param WC_Product $product The product object.
+	 * @return string The generated attribute summary.
+	 */
 	public function get_attribute_summary( $product ) {
 		return $this->generate_attribute_summary( $product );
 	}
@@ -626,6 +626,4 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		);
 		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
-
-
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -694,6 +694,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		);
 
 		clean_post_cache( $variation_id );
+		/**
+		 * Fires after the attribute summary of a product variation has been updated.
+		 *
+		 * @since 10.2.0
+		 * @param int $variation_id The ID of the product variation.
+		 **/
 		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
 	}
 
@@ -704,6 +710,15 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 * @return int
 	 */
 	public static function get_regen_threshold() {
+		/**
+		 * Filters the threshold for synchronous regeneration of variation attribute summaries.
+		 * If the number of variations affected by an update is below this threshold, the summaries
+		 * are regenerated synchronously. Otherwise, the regeneration is scheduled asynchronously.
+		 *
+		 * @since 10.2.0
+		 * @param int $threshold The default threshold value (50).
+		 * @return int The filtered threshold value.
+		 */
 		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -35,8 +35,8 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		// not needed - update?
 		/* add_action( 'woocommerce_save_product_variation', array( __CLASS__, 'on_save_product_variation' ), 20, 1 ); */
 
-		/* add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 ); */
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
+		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
 
 		add_action( 'woocommerce_attribute_add', array( __CLASS__, 'on_add_product_attribute' ), 10, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
@@ -727,6 +727,45 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				self::regenerate_variation_summaries( $variation_ids );
 			}
 		);
+	}
+
+	/**
+	* Hook called after a term is updated to handle updates for product variations.
+	*
+	* @param int    $term_id  Term ID.
+	* @param int    $tt_id    Term taxonomy ID.
+	* @param string $taxonomy Taxonomy slug.
+	*/
+	public static function on_edit_product_term( $term_id, $tt_id, $taxonomy ) {
+		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
+			return;
+		}
+
+		$new_term = get_term( $term_id, $taxonomy );
+		if ( is_wp_error( $new_term ) || ! $new_term ) {
+			return;
+		}
+
+		$meta_key = 'attribute_' . $taxonomy;
+
+		global $wpdb;
+
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id
+				FROM $wpdb->postmeta pm
+				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = 'product_variation'",
+				$meta_key,
+				$new_term->slug
+			)
+		);
+
+		if ( ! empty( $variation_ids ) ) {
+			self::regenerate_variation_summaries( $variation_ids );
+		}
 	}
 }
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -719,6 +719,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			)
 		);
 
+		// Update variation summaries that used this product attribute, but
+		// wait until shutdown. This will allow WooC to carry out post_meta migrations
+		// if the slug of the attribute changed.
 		register_shutdown_function(
 			function () use ( $variation_ids ) {
 				self::regenerate_variation_summaries( $variation_ids );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -699,7 +699,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		 *
 		 * @since 10.2.0
 		 * @param int $variation_id The ID of the product variation.
-		 **/
+		 */
 		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
 	}
 
@@ -821,7 +821,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 *
 	 * @since 10.2.0
 	 * @param WC_Product $product The variable product whose attributes were updated.
-	 * @param bool $force Whether the update was forced.
+	 * @param bool       $force Whether the update was forced.
 	 */
 	public static function on_product_attributes_updated( $product, $force ) {
 		if ( $product->is_type( 'variable' ) ) {
@@ -903,26 +903,24 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} else {
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_term_variation_summaries',
-					array( $taxonomy, $new_term->slug ),
-					'woocommerce'
-				);
-			}
+		} else if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time() + 1,
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $new_term->slug ),
+				'woocommerce'
+			);
 		}
 	}
 
 	/**
 	 * Hook called after a term is updated to handle updates for product variations.
 	 *
-	 * @param int    $term_id  Term ID.
-	 * @param int    $tt_id    Term taxonomy ID.
-	 * @param string $taxonomy Taxonomy slug.
+	 * @param int     $term_id  Term ID.
+	 * @param int     $tt_id    Term taxonomy ID.
+	 * @param string  $taxonomy Taxonomy slug.
 	 * @param WP_Term $deleted_term Copy of the already-deleted term.
-	 * @param array  $object_ids List of term object IDs.
+	 * @param array   $object_ids List of term object IDs.
 	 */
 	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
 		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
@@ -955,15 +953,13 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} else {
-			if ( function_exists( 'as_schedule_single_action' ) ) {
-				as_schedule_single_action(
-					time() + 1,
-					'wc_regenerate_term_variation_summaries',
-					array( $taxonomy, $deleted_term->slug ),
-					'woocommerce'
-				);
-			}
+		} else if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action(
+				time() + 1,
+				'wc_regenerate_term_variation_summaries',
+				array( $taxonomy, $deleted_term->slug ),
+				'woocommerce'
+			);
 		}
 	}
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -831,8 +831,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
-			} else {
-				if ( function_exists( 'as_schedule_single_action' ) ) {
+			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
 					as_schedule_single_action(
 						time() + 1,
 						'wc_regenerate_product_variation_summaries',
@@ -903,7 +902,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} else if ( function_exists( 'as_schedule_single_action' ) ) {
+		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
 			as_schedule_single_action(
 				time() + 1,
 				'wc_regenerate_term_variation_summaries',
@@ -953,7 +952,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		if ( $count <= $threshold ) {
 			self::regenerate_variation_summaries( $variation_ids );
-		} else if ( function_exists( 'as_schedule_single_action' ) ) {
+		} elseif ( function_exists( 'as_schedule_single_action' ) ) {
 			as_schedule_single_action(
 				time() + 1,
 				'wc_regenerate_term_variation_summaries',

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -774,8 +774,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			// Update variation summaries that used this product attribute, but
 			// wait until shutdown. This will allow WooC to carry out post_meta migrations
 			// if the slug of the attribute changed.
-			register_shutdown_function(
-				function () use ( $variation_ids ) {
+			add_action(
+				'shutdown',
+				function() use ( $variation_ids ) {
 					self::regenerate_variation_summaries( $variation_ids );
 				}
 			);

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -39,7 +39,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
 		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 
-		add_action( 'woocommerce_attribute_add', array( __CLASS__, 'on_add_product_attribute' ), 10, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
 
 		$hooks_added = true;
@@ -684,11 +683,14 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
-	public static function on_add_product_attribute( $attribute_id, $attribute, $old_slug ) {
-		/* llp('add'); */
-	}
 	public static function on_delete_product_attribute( $attribute_id, $attribute, $old_slug ) {
-		/* llp('delete'); */
+		// We can reuse the update function to trigger variation summary rebuilds.
+		// However, the on_delete_product_attribute includes the "pa_" prefix in $old_slug, and
+		// the on_update_product_attribute does not. Remove it to keep compatibility.
+		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
+			$old_slug = substr( $old_slug, 3 );
+		}
+		self::on_update_product_attribute( $attribute_id, $attribute, $old_slug );
 	}
 
 	public static function on_update_product_attribute( $attribute_id, $attribute, $old_slug ) {
@@ -711,6 +713,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		// Update variation summaries that used this product attribute, but
 		// wait until shutdown. This will allow WooC to carry out post_meta migrations
 		// if the slug of the attribute changed.
+		llp('rebuild ' . json_encode($variation_ids));
 		register_shutdown_function(
 			function () use ( $variation_ids ) {
 				self::regenerate_variation_summaries( $variation_ids );
@@ -719,12 +722,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	}
 
 	/**
-	* Handles regeneration of variation summaries when a variable product's attributes are updated.
-	*
-	* @since 10.2.0
-	* @param WC_Product $product The variable product whose attributes were updated.
-	* @param bool $force Whether the update was forced.
-	*/
+	 * Handles regeneration of variation summaries when a variable product's attributes are updated.
+	 *
+	 * @since 10.2.0
+	 * @param WC_Product $product The variable product whose attributes were updated.
+	 * @param bool $force Whether the update was forced.
+	 */
 	public static function on_product_attributes_updated( $product, $force ) {
 		if ( $product->is_type( 'variable' ) ) {
 			$variation_ids = $product->get_children();

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -22,10 +22,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store_Interface {
 
 	/**
-	* Static init to add hooks once per request.
-	*
-	* @since 10.2.0
-	*/
+	 * Static init to add hooks once per request.
+	 *
+	 * @since 10.2.0
+	 */
 	public static function init_hooks() {
 		static $hooks_added = false;
 		if ( $hooks_added ) {
@@ -121,18 +121,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_name( $new_title );
 			$updates = array_merge( $updates, array( 'post_title' => $new_title ) );
 		}
-
-		/**
-		 * If the attribute summary is not in sync, update here. Used when searching for variations by attribute values.
-		 * This is meant to also cover the case when global attribute name or value is updated, then the attribute summary is updated
-		 * for respective products when they're read.
-		 */
-		/* $new_attribute_summary = self::generate_attribute_summary( $product ); */
-		/**/
-		/* if ( $new_attribute_summary !== $post_object->post_excerpt ) { */
-		/* 	$product->set_attribute_summary( $new_attribute_summary ); */
-		/* 	$updates = array_merge( $updates, array( 'post_excerpt' => $new_attribute_summary ) ); */
-		/* } */
 
 		if ( ! empty( $updates ) ) {
 			$GLOBALS['wpdb']->update( $GLOBALS['wpdb']->posts, $updates, array( 'ID' => $product->get_id() ) );
@@ -730,12 +718,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	}
 
 	/**
-	* Hook called after a term is updated to handle updates for product variations.
-	*
-	* @param int    $term_id  Term ID.
-	* @param int    $tt_id    Term taxonomy ID.
-	* @param string $taxonomy Taxonomy slug.
-	*/
+	 * Hook called after a term is updated to handle updates for product variations.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
 	public static function on_edit_product_term( $term_id, $tt_id, $taxonomy ) {
 		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
 			return;

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -237,8 +237,20 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$changes = $product->get_changes();
 
-		if ( array_intersect( array( 'attributes' ), array_keys( $changes ) ) ) {
-			$product->set_attribute_summary( self::generate_attribute_summary( $product ) );
+		// Always recompute and sync the attribute summary as a safety net.
+		// This ensures it's up-to-date not just for direct attribute changes (e.g., via $changes['attributes']),
+		// but also for indirect desyncs, like when a global term (e.g., 'Blue' -> 'Blue2') is updated elsewhere.
+		// We ideally handle those at the source (e.g., global term update hooks), but this provides a fallback.
+		$new_attribute_summary = self::generate_attribute_summary( $product );
+		// Compare the fresh attribute summary with the stored summary and update if out of sync.
+		if ( $new_attribute_summary !== $product->get_attribute_summary() ) {
+			$product->set_attribute_summary( $new_attribute_summary );
+
+			// If attributes weren't explicitly changed in this update, flag it to ensure the product is saved.
+			// This acts as a "just-in-case" trigger for indirect desyncs.
+			if ( ! isset( $changes['attributes'] ) ) {
+				$changes['attributes'] = true;
+			}
 		}
 
 		// Only update the post when the post data changes.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -37,6 +37,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
 		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
+		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 
 		add_action( 'woocommerce_attribute_add', array( __CLASS__, 'on_add_product_attribute' ), 10, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
@@ -715,6 +716,22 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				self::regenerate_variation_summaries( $variation_ids );
 			}
 		);
+	}
+
+	/**
+	* Handles regeneration of variation summaries when a variable product's attributes are updated.
+	*
+	* @since 10.2.0
+	* @param WC_Product $product The variable product whose attributes were updated.
+	* @param bool $force Whether the update was forced.
+	*/
+	public static function on_product_attributes_updated( $product, $force ) {
+		if ( $product->is_type( 'variable' ) ) {
+			$variation_ids = $product->get_children();
+			if ( ! empty( $variation_ids ) && is_array( $variation_ids ) ) {
+				self::regenerate_variation_summaries( $variation_ids );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -647,6 +647,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
 
+	/**
+	 * Regenerates attribute summaries for a list of variations.
+	 *
+	 * @since 10.2.0
+	 * @param array $variation_ids Array of variation IDs.
+	 */
 	public static function regenerate_variation_summaries( $variation_ids ) {
 		if ( empty( $variation_ids ) ) {
 			return;
@@ -659,6 +665,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
+	/**
+	 * Regenerates the attribute summary for a single variation.
+	 *
+	 * @since 10.2.0
+	 * @param int $variation_id Variation ID.
+	 */
 	public static function regenerate_variation_attribute_summary( $variation_id ) {
 		global $wpdb;
 
@@ -684,10 +696,24 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
 	}
 
+	/**
+	 * Gets the threshold for synchronous regeneration of variation summaries.
+	 *
+	 * @since 10.2.0
+	 * @return int
+	 */
 	public static function get_regen_threshold() {
 		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
 	}
 
+	/**
+	 * Handles deletion of a global attribute by triggering variation summary updates.
+	 *
+	 * @since 10.2.0
+	 * @param int    $attribute_id Attribute ID.
+	 * @param string $attribute    Attribute name.
+	 * @param string $old_slug     Old attribute slug.
+	 */
 	public static function handle_global_attribute_deleted( $attribute_id, $attribute, $old_slug ) {
 		// We can reuse the update function to trigger variation summary rebuilds.
 		// However, the handle_global_attribute_deleted includes the "pa_" prefix in $old_slug, and
@@ -698,6 +724,14 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		self::handle_global_attribute_updated( $attribute_id, $attribute, $old_slug );
 	}
 
+	/**
+	 * Handles updates to a global attribute by triggering variation summary regeneration.
+	 *
+	 * @since 10.2.0
+	 * @param int    $attribute_id Attribute ID.
+	 * @param string $attribute    Attribute name.
+	 * @param string $old_slug     Old attribute slug.
+	 */
 	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
 		$taxonomy = 'pa_' . $old_slug;
 
@@ -741,6 +775,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
+	/**
+	 * Regenerates variation summaries for all variations using a specific attribute taxonomy.
+	 *
+	 * @since 10.2.0
+	 * @param string $taxonomy Attribute taxonomy.
+	 */
 	public static function regenerate_attribute_variation_summaries( $taxonomy ) {
 		$variation_ids = get_posts(
 			array(
@@ -788,6 +828,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
+	/**
+	 * Regenerates variation summaries for all variations of a variable product.
+	 *
+	 * @since 10.2.0
+	 * @param int $product_id Variable product ID.
+	 */
 	public static function regenerate_product_variation_summaries( $product_id ) {
 		$product = wc_get_product( $product_id );
 		if ( ! $product || ! $product->is_type( 'variable' ) ) {
@@ -853,6 +899,13 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 	}
 
+	/**
+	 * Regenerates variation summaries for all variations using a specific term.
+	 *
+	 * @since 10.2.0
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param string $term_slug Term slug.
+	 */
 	public static function regenerate_term_variation_summaries( $taxonomy, $term_slug ) {
 		global $wpdb;
 

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -666,7 +666,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
 	}
 
-	protected static function regenerate_variation_summaries( $variation_ids ) {
+	public static function regenerate_variation_summaries( $variation_ids ) {
 		if ( empty( $variation_ids ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -22,6 +22,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store_Interface {
 
 	/**
+	* Static init to add hooks once per request.
+	*
+	* @since 10.2.0
+	*/
+	public static function init_hooks() {
+		static $hooks_added = false;
+		if ( $hooks_added ) {
+			return;
+		}
+
+		// not needed - update?
+		/* add_action( 'woocommerce_save_product_variation', array( __CLASS__, 'on_save_product_variation' ), 20, 1 ); */
+
+		/* add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 ); */
+		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
+
+		add_action( 'woocommerce_attribute_add', array( __CLASS__, 'on_add_product_attribute' ), 10, 3 );
+		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
+
+		$hooks_added = true;
+	}
+
+	/**
 	 * Callback to remove unwanted meta data.
 	 *
 	 * @param object $meta Meta object.
@@ -104,12 +127,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		 * This is meant to also cover the case when global attribute name or value is updated, then the attribute summary is updated
 		 * for respective products when they're read.
 		 */
-		$new_attribute_summary = self::generate_attribute_summary( $product );
-
-		if ( $new_attribute_summary !== $post_object->post_excerpt ) {
-			$product->set_attribute_summary( $new_attribute_summary );
-			$updates = array_merge( $updates, array( 'post_excerpt' => $new_attribute_summary ) );
-		}
+		/* $new_attribute_summary = self::generate_attribute_summary( $product ); */
+		/**/
+		/* if ( $new_attribute_summary !== $post_object->post_excerpt ) { */
+		/* 	$product->set_attribute_summary( $new_attribute_summary ); */
+		/* 	$updates = array_merge( $updates, array( 'post_excerpt' => $new_attribute_summary ) ); */
+		/* } */
 
 		if ( ! empty( $updates ) ) {
 			$GLOBALS['wpdb']->update( $GLOBALS['wpdb']->posts, $updates, array( 'ID' => $product->get_id() ) );
@@ -617,4 +640,79 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		);
 		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
+
+	public static function regenerate_variation_attribute_summary( $variation_id ) {
+		global $wpdb;
+
+		$product = wc_get_product( $variation_id );
+		if ( ! $product || ! $product->is_type( 'variation' ) ) {
+			return;
+		}
+
+		$new_summary = self::generate_attribute_summary( $product );
+
+		$current_excerpt = get_post_field( 'post_excerpt', $variation_id );
+		if ( $new_summary === $current_excerpt ) {
+			return;
+		}
+
+		$wpdb->update(
+			$wpdb->posts,
+			array( 'post_excerpt' => $new_summary ),
+			array( 'ID' => $variation_id )
+		);
+
+		clean_post_cache( $variation_id );
+		do_action( 'woocommerce_updated_product_attribute_summary', $variation_id );
+	}
+
+	protected static function regenerate_variation_summaries( $variation_ids ) {
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$variation_ids = array_unique( array_filter( $variation_ids ) );
+
+		$limit = apply_filters( 'wc_variation_summary_regen_limit', 0, $variation_ids );
+		if ( $limit > 0 ) {
+			$variation_ids = array_slice( $variation_ids, 0, $limit );
+		}
+
+		foreach ( $variation_ids as $variation_id ) {
+			self::regenerate_variation_attribute_summary( $variation_id );
+		}
+	}
+
+	public static function on_add_product_attribute( $attribute_id, $attribute, $old_slug ) {
+		llp('add');
+	}
+	public static function on_delete_product_attribute( $attribute_id, $attribute, $old_slug ) {
+		llp('delete');
+	}
+
+	public static function on_update_product_attribute( $attribute_id, $attribute, $old_slug ) {
+		$taxonomy = 'pa_' . $old_slug;
+
+		$variation_ids = get_posts(
+			array(
+				'post_type'   => 'product_variation',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'key'     => 'attribute_' . $taxonomy,
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		register_shutdown_function(
+			function () use ( $variation_ids ) {
+				self::regenerate_variation_summaries( $variation_ids );
+			}
+		);
+	}
 }
+
+add_action( 'woocommerce_loaded', array( 'WC_Product_Variation_Data_Store_CPT', 'init_hooks' ) );

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -832,13 +832,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			if ( $count <= $threshold ) {
 				self::regenerate_variation_summaries( $variation_ids );
 			} elseif ( function_exists( 'as_schedule_single_action' ) ) {
-					as_schedule_single_action(
-						time() + 1,
-						'wc_regenerate_product_variation_summaries',
-						array( $product->get_id() ),
-						'woocommerce'
-					);
-				}
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_product_variation_summaries',
+					array( $product->get_id() ),
+					'woocommerce'
+				);
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -684,10 +684,10 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	}
 
 	public static function on_add_product_attribute( $attribute_id, $attribute, $old_slug ) {
-		llp('add');
+		/* llp('add'); */
 	}
 	public static function on_delete_product_attribute( $attribute_id, $attribute, $old_slug ) {
-		llp('delete');
+		/* llp('delete'); */
 	}
 
 	public static function on_update_product_attribute( $attribute_id, $attribute, $old_slug ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -32,14 +32,15 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			return;
 		}
 
-		// not needed - update?
-		/* add_action( 'woocommerce_save_product_variation', array( __CLASS__, 'on_save_product_variation' ), 20, 1 ); */
-
-		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
-		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
+		// Parent Product Updates Attributes
 		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 
+		// Attributes
+		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
+
+		// Terms
+		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
 
 		$hooks_added = true;
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -36,11 +36,11 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 
 		// Attributes
-		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'on_update_product_attribute' ), 50, 3 );
-		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'on_delete_product_attribute' ), 10, 3 );
+		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
+		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
 
 		// Terms
-		add_action( 'edited_term', array( __CLASS__, 'on_edit_product_term' ), 10, 3 );
+		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
 
 		// Action Scheduler
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
@@ -688,17 +688,17 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		return apply_filters( 'woocommerce_regenerate_variation_summaries_sync_threshold', 50 );
 	}
 
-	public static function on_delete_product_attribute( $attribute_id, $attribute, $old_slug ) {
+	public static function handle_global_attribute_deleted( $attribute_id, $attribute, $old_slug ) {
 		// We can reuse the update function to trigger variation summary rebuilds.
-		// However, the on_delete_product_attribute includes the "pa_" prefix in $old_slug, and
-		// the on_update_product_attribute does not. Remove it to keep compatibility.
+		// However, the handle_global_attribute_deleted includes the "pa_" prefix in $old_slug, and
+		// the handle_global_attribute_updated does not. Remove it to keep compatibility.
 		if ( strpos( $old_slug, 'pa_' ) === 0 ) {
 			$old_slug = substr( $old_slug, 3 );
 		}
-		self::on_update_product_attribute( $attribute_id, $attribute, $old_slug );
+		self::handle_global_attribute_updated( $attribute_id, $attribute, $old_slug );
 	}
 
-	public static function on_update_product_attribute( $attribute_id, $attribute, $old_slug ) {
+	public static function handle_global_attribute_updated( $attribute_id, $attribute, $old_slug ) {
 		$taxonomy = 'pa_' . $old_slug;
 
 		$variation_ids = get_posts(
@@ -805,7 +805,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 * @param int    $tt_id    Term taxonomy ID.
 	 * @param string $taxonomy Taxonomy slug.
 	 */
-	public static function on_edit_product_term( $term_id, $tt_id, $taxonomy ) {
+	public static function handle_attribute_term_updated( $term_id, $tt_id, $taxonomy ) {
 		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -32,17 +32,18 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			return;
 		}
 
-		// Parent Product Updates Attributes
+		// Parent Product Updates Attributes.
 		add_action( 'woocommerce_product_attributes_updated', array( __CLASS__, 'on_product_attributes_updated' ), 10, 2 );
 
-		// Attributes
+		// Attributes.
 		add_action( 'woocommerce_attribute_updated', array( __CLASS__, 'handle_global_attribute_updated' ), 50, 3 );
 		add_action( 'woocommerce_attribute_deleted', array( __CLASS__, 'handle_global_attribute_deleted' ), 10, 3 );
 
-		// Terms
+		// Terms.
 		add_action( 'edited_term', array( __CLASS__, 'handle_attribute_term_updated' ), 10, 3 );
+		add_action( 'delete_term', array( __CLASS__, 'handle_attribute_term_deleted' ), 10, 5 );
 
-		// Action Scheduler
+		// Action Scheduler.
 		add_action( 'wc_regenerate_product_variation_summaries', array( __CLASS__, 'regenerate_product_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_attribute_variation_summaries', array( __CLASS__, 'regenerate_attribute_variation_summaries' ), 10, 1 );
 		add_action( 'wc_regenerate_term_variation_summaries', array( __CLASS__, 'regenerate_term_variation_summaries' ), 10, 2 );
@@ -893,6 +894,58 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 					time() + 1,
 					'wc_regenerate_term_variation_summaries',
 					array( $taxonomy, $new_term->slug ),
+					'woocommerce'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Hook called after a term is updated to handle updates for product variations.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param WP_Term $deleted_term Copy of the already-deleted term.
+	 * @param array  $object_ids List of term object IDs.
+	 */
+	public static function handle_attribute_term_deleted( $term_id, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+		if ( strpos( $taxonomy, 'pa_' ) !== 0 ) {
+			return;
+		}
+
+		$meta_key = 'attribute_' . $taxonomy;
+
+		global $wpdb;
+
+		$variation_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT pm.post_id
+				FROM $wpdb->postmeta pm
+				INNER JOIN $wpdb->posts p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				AND pm.meta_value = %s
+				AND p.post_type = 'product_variation'",
+				$meta_key,
+				$deleted_term->slug
+			)
+		);
+
+		if ( empty( $variation_ids ) ) {
+			return;
+		}
+
+		$threshold = self::get_regen_threshold();
+		$count = count( $variation_ids );
+
+		if ( $count <= $threshold ) {
+			self::regenerate_variation_summaries( $variation_ids );
+		} else {
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				as_schedule_single_action(
+					time() + 1,
+					'wc_regenerate_term_variation_summaries',
+					array( $taxonomy, $deleted_term->slug ),
 					'woocommerce'
 				);
 			}

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -616,7 +616,7 @@ function wc_create_attribute( $args ) {
 			}
 			global $wp_taxonomies;
 			if ( isset( $wp_taxonomies[ $old_taxonomy_name ] ) && ! isset( $wp_taxonomies[ $new_taxonomy_name ] ) ) {
-				$wp_taxonomies[ $new_taxonomy_name ] = $wp_taxonomies[ $old_taxonomy_name ];
+				$wp_taxonomies[ $new_taxonomy_name ] = $wp_taxonomies[ $old_taxonomy_name ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -608,7 +608,8 @@ function wc_create_attribute( $args ) {
 				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_slug ) ) // WPCS: slow query ok.
 			);
 
-			// Update global vars to reflect migration.
+			// Update global vars to reflect migration. This ensures any functions dealing with terms later in this request
+			// use the correct info.
 			global $wc_product_attributes;
 			if ( isset( $wc_product_attributes[ $old_taxonomy_name ] ) && ! isset( $wc_product_attributes[ $new_taxonomy_name ] ) ) {
 				$wc_product_attributes[ $new_taxonomy_name ] = $wc_product_attributes[ $old_taxonomy_name ];

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -607,6 +607,16 @@ function wc_create_attribute( $args ) {
 				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $data['attribute_name'] ) ), // WPCS: slow query ok.
 				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_slug ) ) // WPCS: slow query ok.
 			);
+
+			// Update global vars to reflect migration.
+			global $wc_product_attributes;
+			if ( isset( $wc_product_attributes[ $old_taxonomy_name ] ) && ! isset( $wc_product_attributes[ $new_taxonomy_name ] ) ) {
+				$wc_product_attributes[ $new_taxonomy_name ] = $wc_product_attributes[ $old_taxonomy_name ];
+			}
+			global $wp_taxonomies;
+			if ( isset( $wp_taxonomies[ $old_taxonomy_name ] ) && ! isset( $wp_taxonomies[ $new_taxonomy_name ] ) ) {
+				$wp_taxonomies[ $new_taxonomy_name ] = $wp_taxonomies[ $old_taxonomy_name ];
+			}
 		}
 	}
 


### PR DESCRIPTION
### Problem

_tldr: recalculation of post_excerpt field on every view of a variation product_

Product Variations are entries in the `wp_posts` table that have two fields of _derived data_, `post_title` and `post_excerpt`. Examples:
```
                   ID: 32024
           post_title: Gorgeous Steel Hat - large, Purple
         post_excerpt: CustomWidth: large, Color: Purple
          post_status: publish
            post_name: gorgeous-steel-hat-purple
```
As other parts of the DB change, the `post_title` and `post_excerpt` are recomputed to reflect them. They are not the source of truth for any of these values.

Note that the values are recalculated and updated if necessary **at view time**. If 10,000 customers view the large purple hat page, on each view, the site calculates the `"CustomWidth: large, Color: Purple"` and `"Gorgeous Steel Hat - large, Purple"` values to see the DB needs to be updated.

Because of the way OO is used, calling `is_on_sale()`, which calls `get_variation_prices()`, which creates objects for all Product Variations, can end up re-calculating all of these "attribute summaries" that go in the post_excerpt, even though we aren't concerned with them.

Here is a flamegraph showing `generate_attribute_summary()` (highlighted) run for a large number of products, multiple times, as I browse a product page:

<img width="2548" height="708" alt="screenshot_2025-07-17_at_11 25 35___am" src="https://github.com/user-attachments/assets/e4809389-a4a6-4957-9277-9f0447e45735" />

The goal of this PR is to move the attribute summary updates to write time instead of view time. If I change the product attributes, or change any of the associated term names, then we should be able to update the associated product variations once, then. This will stop us from having to re-check each one on product read.

### Timings

By measuring and aggregating the [title sync on read](https://github.com/woocommerce/woocommerce/blob/0e996a7ba449ee44282dd46174556cfa0cd270ed/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L95-L100) and [attr sync on read blocks](https://github.com/woocommerce/woocommerce/blob/0e996a7ba449ee44282dd46174556cfa0cd270ed/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L107-L112), I'm able to get an idea of the scale of the problem.

This was done on my M4 MacbookPro with 2100 products and 4601 product variations, as created by smooth generator. Everything is local and there is a Redis memcache. Woo commit is trunk as of 2025-07-22. 

Browsing to random listing pages, I see the attr sync take 1ms-43ms in aggregate for page view. I used microtime() timings via my [timescope](https://github.com/mreishus/wp-misc/blob/master/timescope.php) plugin, which aggregates in `ac_start()`/`ac_stop()`.

(M4 MBP)

```
 [2            7f0fd] http://localhost:8081/product-category/industrial-home/page/2/
 [2            7f0fd] AC Debug Summary for: /product-category/industrial-home/page/2/
 Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
 ----------------------------------------------------------------------------------------------------
 title sync                               |       69 |       5.37 |       0.08 |       0.04 |       0.03 |       0.58
 attr sync                                |       69 |       9.01 |       0.13 |       0.15 |       0.06 |       0.25
 ----------------------------------------------------------------------------------------------------
 [3            c9eec] http://localhost:8081/product-category/industrial-home/page/3/
 [3            c9eec] AC Debug Summary for: /product-category/industrial-home/page/3/
 Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
 ----------------------------------------------------------------------------------------------------
 title sync                               |      141 |       2.73 |       0.02 |       0.00 |       0.00 |       0.25
 attr sync                                |      141 |      36.33 |       0.26 |       0.28 |       0.15 |       0.59
 ----------------------------------------------------------------------------------------------------
 [2            86d90] http://localhost:8081/product-category/grocery/page/2/
 [2            86d90] AC Debug Summary for: /product-category/grocery/page/2/
 Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
 ----------------------------------------------------------------------------------------------------
 title sync                               |        4 |       0.33 |       0.08 |       0.07 |       0.03 |       0.16
 attr sync                                |        4 |       0.69 |       0.17 |       0.16 |       0.15 |       0.23
 ----------------------------------------------------------------------------------------------------
 [3            3dfa8] http://localhost:8081/product-category/grocery/page/3/
 [3            3dfa8] AC Debug Summary for: /product-category/grocery/page/3/
 Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
 ----------------------------------------------------------------------------------------------------
 title sync                               |      207 |       1.36 |       0.01 |       0.00 |       0.00 |       0.14
 attr sync                                |      207 |      43.38 |       0.21 |       0.21 |       0.10 |       0.56
 ----------------------------------------------------------------------------------------------------
 [4            51b5e] http://localhost:8081/product-category/grocery/page/4/
 [4            51b5e] AC Debug Summary for: /product-category/grocery/page/4/
 Label                                    |    Count | Total (ms) |   Avg (ms) | Median (ms) |   Min (ms) |   Max (ms)
 ----------------------------------------------------------------------------------------------------
 title sync                               |      105 |       1.14 |       0.01 |       0.00 |       0.00 |       0.24
 attr sync                                |      105 |      26.04 |       0.25 |       0.28 |       0.03 |       0.63
 ----------------------------------------------------------------------------------------------------
```

### Changes proposed in this Pull Request:

### Types of Attributes

Note there are two types of product Attributes. Global and per-product:

<img width="1066" height="834" alt="Screenshot 2025-07-23 at 9 51 45 AM" src="https://github.com/user-attachments/assets/2ced96af-a64c-4cf1-b555-9f0de1f66833" />

For changes we make, we want to make sure we are covering both types of attributes.

### Methods of Change

Here I am listing all the ways to make changes that may need to be reflected in the post_excerpt:

#### Base Product Edits

None needed - an example `post_excerpt` is `Color: Purple, CustomWidth: large2` and doesn't change with any basic changes on the base product.

#### Variation Edits

- Adding a new Product Variation
  - ✅  Already handled by `create()` before PR
- Product Variation Update [changing an attribute dropdown like Blue -> Red]
  - ✅ Already covered by `update()` before PR
- Product Variation Update [Changing a non-attribute value, like price or SKU in the variations tab]
  - ✅ Covered by `update()` as a "just in case" sync added in this PR

#### System Wide Attributes

- Edit system wide Attribute, name only
  - http://localhost:8081/wp-admin/edit.php?post_type=product&page=product_attributes&edit=4
  - ✅ Done by `on_update_product_attribute()` in this PR
  - Took 1.3 seconds to update ~950 attributes on my M4 (one query per)
- Edit system wide attribute, slug or slug and name
  - ✅ Done by `on_update_product_attribute()` in this PR
- Edit term belonging to system wide attribute, Name only
  - For example, the system wide attribute "Color" might have a term called "blue" in the "pa_color" taxonomy
  - ✅ Done by `on_edit_product_term()` in this PR
- Edit term belonging to system wide attribute, Slug or Slug+Name
  - For example, the system wide attribute "Color" might have a term called "blue" in the "pa_color" taxonomy
  - ✅ Done by `on_edit_product_term()` in this PR
- Delete System Wide Attribute
  - ❌ Not fully working. An update is queued, but `Color3: Purple, CustomWidth: large2, Inventore: Ad` is updated to `Color3: Purple, CustomWidth: large2, inventore: ad`. I can't seem to figure this one out.
  - I've even tried using `woocommerce_before_attribute_delete` to collect the ids, then running `$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'attribute_' . sanitize_title( $taxonomy ) ), );` to delete the meta rows, then using `woocommerce_attribute_deleted` to recompute, but it's still missing.
- Delete System Wide Term
  - ✅ ❓ Attribute updates are run via the new `woocommerce_product_attributes_updated` hook in this PR.
    - But WooC does not currently update the termmeta on variations using the deleted term. (For a more detailed explanation, see the ✅ ❓ just below this one - that applies here too.)
  
#### Product Specific Attributes
- Add/remove/change values on an existing product specific attribute
  - ✅ ❓ Attribute updates are run via the new `woocommerce_product_attributes_updated` hook in this PR.
    - But WooC does not currently migrate product specific attributes on the variations.
      - Both before and after this PR, the variations will have outdated metadata on them, until an admin edits the variation in the UI.
      - For example, if a variation has "attribute_material=wood" in the meta table, and I make any relevant edits to the custom attribute (like removing the wood option or renaming it to "material2"), the variation will continue to have "attribute_material=wood", even though it's nonsensical.
      - In practice, this PR does not make anything worse than trunk. The admin will still need to edit the variation to specify the updated attribute, and when they do, the derived data will be updated.
- Rename existing product specific attribute
  - ✅ ❓ As above.
- Remove existing product specific attribute
  - ✅ ❓ As above.
- Add new existing product specific attribute
  - ✅ ❓ As above.






Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:


| Before | After |
| ------ | ----- |
|        |       |



### How to test the changes in this Pull Request:

* Have a product with variation attributes that are both per-product and system-wide
  * System wide are defined here `/wp-admin/edit.php?post_type=product&page=product_attributes`
  * Per-product are defined here `/wp-admin/post.php?post=32023&action=edit`

<img width="904" height="713" alt="Screenshot 2025-07-18 at 5 40 13 PM" src="https://github.com/user-attachments/assets/53481342-45a0-4b4d-ab2f-a5b570910bc6" />
<img width="703" height="219" alt="Screenshot 2025-07-18 at 5 41 11 PM" src="https://github.com/user-attachments/assets/f09dc55c-cc54-46c0-80d8-988584bff2a5" />

* As we edit product variations, and attributes, the post_excerpt of each variation needs to be updated to reflect those changes.
* Run this SQL to check: `select ID, post_title, post_excerpt FROM wp_posts where id in (32024, 32033, 32026, 32027);`
* You should see something like this:

```
+-------+-------------------------------------+---------------------------------------+
| ID    | post_title                          | post_excerpt                          |
+-------+-------------------------------------+---------------------------------------+
| 32024 | Gorgeous Steel Hat - large2, Purple | CustomWidth: large2, Colore55: Purple |
| 32026 | Gorgeous Steel Hat - medium, Blue   | CustomWidth: medium, Colore55: Blue   |
| 32027 | Gorgeous Steel Hat - large2, Yellow | CustomWidth: large2, Colore55: Yellow |
| 32033 | Gorgeous Steel Hat - medium, Purple | CustomWidth: medium, Colore55: Purple |
+-------+-------------------------------------+---------------------------------------+
4 rows in set (0.001 sec)

```

* The goal in testing is to find any possible edit you can make that allows the post_excerpt to be out of sync.

### Testing that has already taken place:


### Changelog entry



-   [ ] Automatically create a changelog entry from the details below.


-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance


-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type


-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
</details>
