### PR TITLE
Fix shipping zone rate price not using currency config

### DIFF
--- a/plugins/woocommerce/changelog/59802-fix-58822-flat-rate-shipping-cost-input-locale-format
+++ b/plugins/woocommerce/changelog/59802-fix-58822-flat-rate-shipping-cost-input-locale-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix flat rate shipping cost being saved with wrong decimal separator causing incorrect shipping price.
+

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4325,7 +4325,7 @@ table.wc_shipping {
 	}
 
 	.wc-shipping-method-add-class-costs {
-		margin-top: -24px;
+		margin-top: -16px;
 		text-decoration: none;
 		color: #3858E9;
 		font-size: 12px;
@@ -4453,6 +4453,10 @@ table.wc_shipping {
 					&.wc-shipping-currency-position-right_space {
 						padding-left: 12px;
 					}
+					&.wc-shipping-invalid-price {
+						border: 2px solid var( --wc-red, #a00);
+					}
+
 				}
 			}
 		}
@@ -4484,6 +4488,12 @@ table.wc_shipping {
 		font-weight: 400;
 		line-height: 16px;
 		color: #757575;
+		&.wc-shipping-invalid-price-message {
+			color: var( --wc-red, #a00);
+			display: block;
+			margin-top: 6px;
+			margin-bottom: -24px
+		}
 	}
 
 	.wc-backbone-modal-back-inactive {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -720,15 +720,19 @@
 					}
 				},
 				isValidFormattedNumber: function(value, config) {
-					const { decimalSeparator, thousandSeparator } = config;
+					if ( ! value || typeof value !== 'string' || ! config ) {
+						return false;
+					}
 
-					const escapedThousand = thousandSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-					const escapedDecimal = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+					var decimalSeparator = config.decimalSeparator || '.';
+					var thousandSeparator = config.thousandSeparator || ',';
+					var escapedThousand = thousandSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+					var escapedDecimal = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 					// Accept either:
-					// - digits with optional thousands separator (1.234.567,89)
-					// - OR plain digits without any separators (1234567,89)
-					const regex = new RegExp(
+					// - digits with optional thousands separator (1[ts]234[ts]567[ds]89)
+					// - OR plain digits without any separators (1234567[ds]89)
+					var regex = new RegExp(
 						'^(' +
 						'\\d{1,3}(?:' + escapedThousand + '\\d{3})+' + // with thousand separator
 						'|' +

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -690,7 +690,7 @@
 								if ( ! isValidFormattedNumber( value, config ) ) {
 									$(this).addClass( 'wc-shipping-invalid-price' );
 									$('<span class="wc-shipping-zone-method-fields-help-text wc-shipping-invalid-price-message">'
-										+ shippingZoneMethodsLocalizeScript.strings.invalid_price_format
+										+ shippingZoneMethodsLocalizeScript.strings.invalid_number_format
 										+ '</span>').insertAfter( this );
 									modal.find( '#btn-ok' ).attr( 'disabled', 'disabled' );
 									modal.find( '.wc-shipping-method-add-class-costs').hide();

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -463,7 +463,7 @@
 					});
 				},
 				/**
-				 * The settings HTML is controlled and built by the settings api, so in order to refactor the 
+				 * The settings HTML is controlled and built by the settings api, so in order to refactor the
 				 * markup, it needs to be manipulated here.
 				 */
 				reformatSettingsHTML: function( html ) {
@@ -506,7 +506,7 @@
 
 					priceInputs.each( ( i ) => {
 						const priceInput = $( priceInputs[ i ] );
-						const value = priceInput.attr( 'value' );
+						const value = parseFloat( priceInput.attr( 'value' ) );
 						const formattedValue = window.wc.currency.localiseMonetaryValue( config, value );
 						priceInput.attr( 'value', formattedValue );
 					} );
@@ -569,8 +569,8 @@
 					// Wrap the html content in a div
 					const htmlContent = $( '<div>' + html + '</div>' );
 
-					// `<table class="form-table" />` elements added by the Settings API need to be removed. 
-					// Modern browsers won't interpret other table elements like `td` not in a `table`, so 
+					// `<table class="form-table" />` elements added by the Settings API need to be removed.
+					// Modern browsers won't interpret other table elements like `td` not in a `table`, so
 					// Removing the `table` is sufficient.
 					const innerTables = htmlContent.find( 'table.form-table' );
 					innerTables.each( ( i ) => {
@@ -608,13 +608,13 @@
 
 								// Avoid triggering a rerender here because we don't want to show the method
 								// in the table in case merchant doesn't finish flow.
-								
+
 								shippingMethodView.model.set( 'methods', response.data.methods );
 
 								// Close original modal
 								closeModal();
 							}
-							var instance_id = response.data.instance_id, 
+							var instance_id = response.data.instance_id,
 							    method      = response.data.methods[ instance_id ];
 
 							shippingMethodView.unblock();
@@ -642,7 +642,7 @@
 								shippingMethodView.model.trigger( 'change:methods' );
 								shippingMethodView.model.trigger( 'saved:methods' );
 							}
-		
+
 							$( document.body ).trigger( 'init_tooltips' );
 						}, 'json' );
 					}
@@ -650,8 +650,8 @@
 				// Free Shipping has hidden field elements depending on data values.
 				possiblyHideFreeShippingRequirements: function( data ) {
 					if ( Object.keys( data ).includes( 'woocommerce_free_shipping_requires' ) ) {
-						const shouldHideRequirements = data.woocommerce_free_shipping_requires === null || 
-							data.woocommerce_free_shipping_requires === '' || 
+						const shouldHideRequirements = data.woocommerce_free_shipping_requires === null ||
+							data.woocommerce_free_shipping_requires === '' ||
 							data.woocommerce_free_shipping_requires === 'coupon';
 
 						const select = $( '#woocommerce_free_shipping_requires' );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -678,6 +678,25 @@
 						event.data.view.possiblyAddShippingClassLink( event );
 						if ( window.wc.wcSettings.CURRENCY && window.wc.currency.localiseMonetaryValue ) {
 							const config = window.wc.wcSettings.CURRENCY;
+							const isValidFormattedNumber = event.data.view.isValidFormattedNumber;
+							$('.wc-shipping-modal-price').on( 'input', function() {
+								// When the user types, we validate the value.
+								const value = $(this).val();
+								$(this).removeClass( 'wc-shipping-invalid-price' );
+								$(this).siblings( 'span.wc-shipping-invalid-price-message' ).remove();
+								const modal = $( this ).parents( '.wc-backbone-modal-main' );
+								modal.find( '#btn-ok' ).removeAttr( 'disabled' );
+								modal.find( '.wc-shipping-method-add-class-costs').show();
+								if ( ! isValidFormattedNumber( value, config ) ) {
+									$(this).addClass( 'wc-shipping-invalid-price' );
+									$('<span class="wc-shipping-zone-method-fields-help-text wc-shipping-invalid-price-message">'
+										+ shippingZoneMethodsLocalizeScript.strings.invalid_price_format
+										+ '</span>').insertAfter( this );
+									modal.find( '#btn-ok' ).attr( 'disabled', 'disabled' );
+									modal.find( '.wc-shipping-method-add-class-costs').hide();
+								}
+							});
+
 							$('.wc-shipping-modal-price').on('blur', function() {
 								const value = $(this).val();
 								const formattedValue = window.wc.currency.localiseMonetaryValue( config, value );
@@ -699,6 +718,26 @@
 						const link = article.find( '.wc-shipping-method-add-class-costs' );
 						link.css( 'display', 'block' );
 					}
+				},
+				isValidFormattedNumber: function(value, config) {
+					const { decimalSeparator, thousandSeparator } = config;
+
+					const escapedThousand = thousandSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+					const escapedDecimal = decimalSeparator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+					// Accept either:
+					// - digits with optional thousands separator (1.234.567,89)
+					// - OR plain digits without any separators (1234567,89)
+					const regex = new RegExp(
+						'^(' +
+						'\\d{1,3}(?:' + escapedThousand + '\\d{3})+' + // with thousand separator
+						'|' +
+						'\\d+' + // or just plain digits
+						')' +
+						'(' + escapedDecimal + '\\d+)?$' // optional decimal part
+					);
+
+					return regex.test(value.trim());
 				},
 				validateFormArguments: function( event, target, data ) {
 					if ( target === 'wc-modal-add-shipping-method' ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -341,6 +341,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				'no'                                  => __( 'No', 'woocommerce' ),
 				'default_zone_name'                   => __( 'Zone', 'woocommerce' ),
 				'delete_shipping_method_confirmation' => __( 'Are you sure you want to delete this shipping method?', 'woocommerce' ),
+				'invalid_price_format'               => __( 'Please enter a valid price.', 'woocommerce' ),
 			),
 		);
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -341,7 +341,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				'no'                                  => __( 'No', 'woocommerce' ),
 				'default_zone_name'                   => __( 'Zone', 'woocommerce' ),
 				'delete_shipping_method_confirmation' => __( 'Are you sure you want to delete this shipping method?', 'woocommerce' ),
-				'invalid_price_format'               => __( 'Please enter a valid price.', 'woocommerce' ),
+				'invalid_price_format'                => __( 'Please enter a valid price.', 'woocommerce' ),
 			),
 		);
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -341,7 +341,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				'no'                                  => __( 'No', 'woocommerce' ),
 				'default_zone_name'                   => __( 'Zone', 'woocommerce' ),
 				'delete_shipping_method_confirmation' => __( 'Are you sure you want to delete this shipping method?', 'woocommerce' ),
-				'invalid_price_format'                => __( 'Please enter a valid price.', 'woocommerce' ),
+				'invalid_number_format'               => __( 'Please enter a valid number.', 'woocommerce' ),
 			),
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a simple input validation to shipping zone flat rate price that needs to match the store's currency formatting to be saved properly to the database, which will ensure that the shipping rate shown to the customers are always correct, and customers are not overcharged because of price formatting mistakes.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #58822 WOOPLUG-4629

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Before the fix:**
1. Go to WooCommerce > Settings, change the currency formatting to have _dot_ as the thousands separator, and _comma_ as the decimal separator. Save the settings.
2. Go to WooCommerce > Settings > Shipping > Shipping Zones.
3. Click the "Add shipping method" button, select "Flat rate". Click "Continue".
4. On the form, enter "234.54" as the flat rate cost, and save. 
5. Re-open the settings of the newly added shipping method, and see that the cost is saved as "23454,00", which is wrong.
6. Change it to "234,54", and save.
7. Re-open the settings again, and see that the cost is "234,54", which is correct. 
 
> The bug is caused because of the price can not be converted to float correctly with the wrong decimal separator.

**After the fix:**
1. Checkout this branch
2. Build the assets with `pnpm run watch:build`
3. Do the above test again, on step 4, see that you are not allowed to save "234.54" as the cost. When you change it to "234,54", see that you can save it.
4. With an invalid value, check that you see an error message, telling you that the price is invalid. And the Save button is disabled.
5. With a valid value, check that no error message is shown, and the save button is enabled.

Repeat the test with another decimal and thousand separator combination.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix flat rate shipping cost being saved with wrong decimal separator causing incorrect shipping price. 
</details>
