### PR TITLE
Fix MySQL default timestamp for 5.5.5+ bwc

### DIFF
--- a/plugins/woocommerce/changelog/fix-default-timestamp-mysql-compat
+++ b/plugins/woocommerce/changelog/fix-default-timestamp-mysql-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address MySQL 5.5.5 incompatibility issue

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1604,6 +1604,13 @@ class WC_Install {
 			self::should_enable_hpos_for_new_shop();
 		$hpos_table_schema  = $hpos_enabled ? wc_get_container()->get( OrdersTableDataStore::class )->get_database_schema() : '';
 
+		$mysql_version = wc_get_server_database_version()['number'];
+		if ( version_compare( $mysql_version, '5.6', '>=' ) ) {
+			$datetime_default = "DEFAULT CURRENT_TIMESTAMP";
+		} else {
+			$datetime_default = "DEFAULT '1970-01-01 00:00:00'";
+		}
+
 		$tables = "
 CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
   session_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -1860,7 +1867,7 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 	product_id bigint(20) unsigned NOT NULL,
 	variation_id bigint(20) unsigned NOT NULL,
 	customer_id bigint(20) unsigned NULL,
-	date_created datetime DEFAULT '1970-01-01 00:00:00' NOT NULL,
+	date_created datetime $datetime_default NOT NULL,
 	product_qty int(11) NOT NULL,
 	product_net_revenue double DEFAULT 0 NOT NULL,
 	product_gross_revenue double DEFAULT 0 NOT NULL,

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1606,7 +1606,7 @@ class WC_Install {
 
 		$mysql_version = wc_get_server_database_version()['number'];
 		if ( version_compare( $mysql_version, '5.6', '>=' ) ) {
-			$datetime_default = "DEFAULT CURRENT_TIMESTAMP";
+			$datetime_default = 'DEFAULT CURRENT_TIMESTAMP';
 		} else {
 			$datetime_default = "DEFAULT '1970-01-01 00:00:00'";
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1860,7 +1860,7 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 	product_id bigint(20) unsigned NOT NULL,
 	variation_id bigint(20) unsigned NOT NULL,
 	customer_id bigint(20) unsigned NULL,
-	date_created datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	date_created datetime DEFAULT '1970-01-01 00:00:00' NOT NULL,
 	product_qty int(11) NOT NULL,
 	product_net_revenue double DEFAULT 0 NOT NULL,
 	product_gross_revenue double DEFAULT 0 NOT NULL,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We switched to using `CURRENT_TIMESTAMP` in https://github.com/woocommerce/woocommerce/pull/53940. Find details in commit 9606375da6d09d67fc2e0bccc5d6f92cf0ae6c38.

However, that caused backward compatibility issues with MySQL 5.5.5 since `DEFAULT CURRENT_TIMESTAMP` isn't supported.

Since we started indexing on `date_created`, and index creation fails on '0000-00-00 00:00:00', we use '1970-01-01 00:00:00' which seems to be another commonly used placeholder for "no data".

This makes MySQL 5.5.5+ happy, and it also makes the index happy.

Closes pcShBQ-3tn#comment-5181.

### How to test the changes in this Pull Request:

1. Install WordPress and then WooCommerce in an environment with MySQL 5.5.5.
2. Activate WooCommerce.
3. Expect no errors with DB creation.
4. `SHOW INDEX FROM wc_order_product_lookup` should show the index on `date_created`

Repeat testing instructions with a more recent MySQL version.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
