### PR TITLE
Product Filters: properly handle special characters in filter option label

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5048-inconsistent-character-decoding-for-special-characters-in
+++ b/plugins/woocommerce/changelog/wooplug-5048-inconsistent-character-decoding-for-special-characters-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: properly handle special characters in filter option label.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -3,6 +3,11 @@
  */
 import * as iAPI from '@wordpress/interactivity';
 
+/**
+ * Internal dependencies
+ */
+import { decodeHtmlEntities } from '../../utils/html-entities';
+
 const { getContext, store, getServerContext, getConfig } = iAPI;
 
 const BLOCK_NAME = 'woocommerce/product-filters';
@@ -30,6 +35,7 @@ function selectFilter() {
 
 	context.activeFilters = newActiveFilters;
 }
+
 function unselectFilter() {
 	const { item } = getContext< ProductFiltersContext >();
 	actions.removeActiveFiltersBy(
@@ -115,6 +121,7 @@ const productFiltersStore = {
 				} )
 				.map( ( item ) => ( {
 					...item,
+					activeLabel: decodeHtmlEntities( item.activeLabel ),
 					uid: `${ item.type }/${ item.value }`,
 				} ) );
 		},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/edit.tsx
@@ -33,6 +33,7 @@ import { EXCLUDED_BLOCKS } from '../../constants';
 import { FilterOptionItem } from '../../types';
 import { InitialDisabled } from '../../components/initial-disabled';
 import { Notice } from '../../components/notice';
+import { sortFilterOptions } from '../../utils/sort-filter-options';
 
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
@@ -88,34 +89,21 @@ const Edit = ( props: EditProps ) => {
 		if ( termIdHasProducts.length === 0 && hideEmpty ) {
 			setAttributeOptions( [] );
 		} else {
+			const filteredOptions = attributeTerms
+				.filter( ( term ) => {
+					if ( hideEmpty )
+						return termIdHasProducts.includes( term.id );
+					return true;
+				} )
+				.map( ( term, index ) => ( {
+					label: term.name,
+					value: term.id.toString(),
+					selected: index === 0,
+					count: term.count,
+				} ) );
+
 			setAttributeOptions(
-				attributeTerms
-					.filter( ( term ) => {
-						if ( hideEmpty )
-							return termIdHasProducts.includes( term.id );
-						return true;
-					} )
-					.sort( ( a, b ) => {
-						switch ( sortOrder ) {
-							case 'name-asc':
-								return a.name > b.name ? 1 : -1;
-							case 'name-desc':
-								return a.name < b.name ? 1 : -1;
-							case 'count-asc':
-								return a.count > b.count ? 1 : -1;
-							case 'count-desc':
-							default:
-								return a.count < b.count ? 1 : -1;
-						}
-					} )
-					.map( ( term, index ) => ( {
-						label: term.name,
-						ariaLabel: term.name,
-						value: term.id.toString(),
-						selected: index === 0,
-						count: term.count,
-						type: `attribute/${ attributeObject?.taxonomy }`,
-					} ) )
+				sortFilterOptions( filteredOptions, sortOrder )
 			);
 		}
 
@@ -128,6 +116,7 @@ const Edit = ( props: EditProps ) => {
 		hideEmpty,
 		isTermsLoading,
 		isFilterCountsLoading,
+		attributeObject,
 	] );
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, Disabled } from '@wordpress/components';
 import { checkMark } from '@woocommerce/icons';
 import { useMemo } from '@wordpress/element';
+import { decodeHtmlEntities } from '@woocommerce/utils';
 import {
 	useBlockProps,
 	withColors,
@@ -116,7 +117,9 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 										</span>
 										<span className="wc-block-product-filter-checkbox-list__text-wrapper">
 											<span className="wc-block-product-filter-checkbox-list__text">
-												{ item.label }
+												{ decodeHtmlEntities(
+													item.label
+												) }
 											</span>
 											{ showCounts && (
 												<span className="wc-block-product-filter-checkbox-list__count">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -117,9 +117,11 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 										</span>
 										<span className="wc-block-product-filter-checkbox-list__text-wrapper">
 											<span className="wc-block-product-filter-checkbox-list__text">
-												{ decodeHtmlEntities(
-													item.label
-												) }
+												{ typeof item.label === 'string'
+													? decodeHtmlEntities(
+															item.label
+													  )
+													: item.label }
 											</span>
 											{ showCounts && (
 												<span className="wc-block-product-filter-checkbox-list__count">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import clsx from 'clsx';
+import { decodeHtmlEntities } from '@woocommerce/utils';
 import {
 	InspectorControls,
 	useBlockProps,
@@ -101,7 +102,7 @@ const Edit = ( props: EditProps ): JSX.Element => {
 							>
 								<span className="wc-block-product-filter-chips__label">
 									<span className="wc-block-product-filter-chips__text">
-										{ item.label }
+										{ decodeHtmlEntities( item.label ) }
 									</span>
 									{ showCounts && (
 										<span className="wc-block-product-filter-chips__count">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/chips/edit.tsx
@@ -102,7 +102,9 @@ const Edit = ( props: EditProps ): JSX.Element => {
 							>
 								<span className="wc-block-product-filter-chips__label">
 									<span className="wc-block-product-filter-chips__text">
-										{ decodeHtmlEntities( item.label ) }
+										{ typeof item.label === 'string'
+											? decodeHtmlEntities( item.label )
+											: item.label }
 									</span>
 									{ showCounts && (
 										<span className="wc-block-product-filter-chips__count">

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import {
 	useBlockProps,
@@ -121,6 +121,11 @@ const RatingFilterEdit = ( props: BlockEditProps< Attributes > ) => {
 					.filter( ( { rating } ) => rating >= minimumRating )
 					.map( ( { rating, count }, index ) => ( {
 						label: <RatingStars key={ rating } stars={ rating } />,
+						ariaLabel: sprintf(
+							/* translators: %d: rating value. Example: Rated 4 out of 5. */
+							__( 'Rated %d out of 5', 'woocommerce' ),
+							rating
+						),
 						value: rating?.toString(),
 						selected: index === 0,
 						count,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/preview.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/preview.tsx
@@ -1,31 +1,42 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
+import { FilterOptionItem } from '../../types';
 import RatingStars from './components/rating-stars';
 
-export const previewOptions = [
+export const previewOptions: FilterOptionItem[] = [
 	{
 		label: <RatingStars stars={ 5 } />,
+		ariaLabel: __( 'Rated 5 out of 5', 'woocommerce' ),
 		value: '5',
 		count: 35,
 	},
 	{
 		label: <RatingStars stars={ 4 } />,
+		ariaLabel: __( 'Rated 4 out of 5', 'woocommerce' ),
 		value: '4',
 		count: 20,
 	},
 	{
 		label: <RatingStars stars={ 3 } />,
+		ariaLabel: __( 'Rated 3 out of 5', 'woocommerce' ),
 		value: '3',
 		count: 3,
 	},
 	{
 		label: <RatingStars stars={ 2 } />,
+		ariaLabel: __( 'Rated 2 out of 5', 'woocommerce' ),
 		value: '2',
 		count: 6,
 	},
 	{
 		label: <RatingStars stars={ 1 } />,
+		ariaLabel: __( 'Rated 1 out of 5', 'woocommerce' ),
 		value: '1',
 		count: 1,
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { BlockEditProps } from '@wordpress/blocks';
+import type { ReactNode } from 'react';
 
 export type BlockAttributes = {
 	productId?: string;
@@ -10,8 +11,16 @@ export type BlockAttributes = {
 
 export type EditProps = BlockEditProps< BlockAttributes >;
 
-export type FilterOptionItem = {
-	label: string;
+export type FilterOptionItem = (
+	| {
+			label: string;
+			ariaLabel?: string;
+	  }
+	| {
+			label: ReactNode;
+			ariaLabel: string;
+	  }
+ ) & {
 	value: string;
 	selected?: boolean;
 	count: number;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/utils/sort-filter-options.ts
@@ -4,6 +4,22 @@
 import type { FilterOptionItem } from '../types';
 
 /**
+ * Gets the sortable text from a filter option item.
+ * For string labels, returns the label directly.
+ * For ReactNode labels, returns the ariaLabel.
+ *
+ * @param item - Filter option item
+ * @return Sortable text string
+ */
+function getSortableText( item: FilterOptionItem ): string {
+	if ( typeof item.label === 'string' ) {
+		return item.label;
+	}
+	// When label is ReactNode, ariaLabel is guaranteed to exist by our type definition
+	return ( item as { ariaLabel: string } ).ariaLabel;
+}
+
+/**
  * Sorts filter options based on the specified sort order
  *
  * @param options   - Array of filter option items to sort
@@ -17,9 +33,13 @@ export function sortFilterOptions(
 	return options.sort( ( a, b ) => {
 		switch ( sortOrder ) {
 			case 'name-asc':
-				return a.label.localeCompare( b.label );
+				return getSortableText( a ).localeCompare(
+					getSortableText( b )
+				);
 			case 'name-desc':
-				return b.label.localeCompare( a.label );
+				return getSortableText( b ).localeCompare(
+					getSortableText( a )
+				);
 			case 'count-asc':
 				return a.count - b.count;
 			default: // count-desc


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses an issue where special characters in product filter labels were not being properly decoded, causing shoppers to see encoded HTML entities (such as &amp; instead of &) that create a poor user experience and make filter labels harder to read.

Closes WOOPLUG-5048.
Closes https://github.com/woocommerce/woocommerce/issues/59719.

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/be57618c-3542-486d-a367-05faf42e70be" /> | <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/7948d61b-e252-4561-af2b-55ee6b11bd7a" /> |
| <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/654acf9d-40e0-488b-af2c-13443f72b523" /> | <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/081f8ae0-a4e7-436a-a0d2-5561d2a90b0e" /> |


### How to test the changes in this Pull Request:

1. Create a product with special characters in its attributes (e.g., "Size & Color" or "Material & Finish")
2. Add a Product Filters block to a page
3. Configure the filter to show the attribute with special characters
4. In the editor, verify that the filter options display the decoded characters properly
5. View the page on the frontend and verify that both the filter options and active filter labels show decoded characters
6. Test with various special characters: `&`, `<`, `>`, `"`, `'`, `©`, `®`, etc.


