### PR TITLE
Product Details: restore legacy block setting and default layout

### DIFF
--- a/plugins/woocommerce/changelog/fix-restore-product-details-legacy-settings
+++ b/plugins/woocommerce/changelog/fix-restore-product-details-legacy-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Details: restore legacy block setting and default layout

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -14,7 +14,8 @@
 	},
 	"attributes": {
 		"align": {
-			"type": "string"
+			"type": "string",
+			"default": "wide"
 		},
 		"hideTabTitle": {
 			"type": "boolean",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -13,6 +13,9 @@
 		"align": [ "wide", "full" ]
 	},
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"hideTabTitle": {
 			"type": "boolean",
 			"default": false

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/block.json
@@ -12,6 +12,11 @@
 		},
 		"align": [ "wide", "full" ]
 	},
-	"attributes": {},
+	"attributes": {
+		"hideTabTitle": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"usesContext": [ "query", "queryId", "postId", "postType" ]
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/edit.tsx
@@ -9,8 +9,9 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 	Warning,
+	InspectorControls,
 } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -106,8 +107,14 @@ const useIsInvalidQueryLoopContext = ( clientId: string, postType: string ) => {
 	);
 };
 
-const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
+const Edit = ( {
+	clientId,
+	context,
+	attributes,
+	setAttributes,
+}: ProductDetailsEditProps ) => {
 	const blockProps = useBlockProps();
+	const { hideTabTitle } = attributes;
 
 	const { hasInnerBlocks, wasBlockJustInserted } = useSelect(
 		( select ) => {
@@ -116,7 +123,7 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 				hasInnerBlocks: blocks.length > 0,
 				wasBlockJustInserted:
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore method exists but not typed
+					// @ts-expected-error method exists but not typed
 					select( blockEditorStore ).wasBlockJustInserted( clientId ),
 			};
 		},
@@ -150,8 +157,24 @@ const Edit = ( { clientId, context }: ProductDetailsEditProps ) => {
 
 	return (
 		<div { ...blockProps }>
+			<InspectorControls key="inspector">
+				<PanelBody title={ __( 'Settings', 'woocommerce' ) }>
+					<ToggleControl
+						label={ __(
+							'Show tab title in content',
+							'woocommerce'
+						) }
+						checked={ ! hideTabTitle }
+						onChange={ () =>
+							setAttributes( {
+								hideTabTitle: ! hideTabTitle,
+							} )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<Disabled>
-				<LegacyProductDetailsPreview hideTabTitle={ true } />
+				<LegacyProductDetailsPreview hideTabTitle={ hideTabTitle } />
 			</Disabled>
 		</div>
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -11,6 +11,7 @@ import save from './save';
 import edit from './edit';
 import icon from './icon';
 import './style.scss';
+import { Attributes } from './types';
 
 const blockConfig = {
 	...metadata,
@@ -27,6 +28,15 @@ const blockConfig = {
 			},
 			save() {
 				return null;
+			},
+			migrate( attributes: Attributes ) {
+				return {
+					...attributes,
+					// In the previous version of this block, we didn't define the align attribute.
+					// Because of that, align is missing from attributes argument here.
+					// We need to add it manually as wide is the previous default value.
+					align: 'wide',
+				};
 			},
 		},
 	],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -17,6 +17,19 @@ const blockConfig = {
 	icon,
 	edit,
 	save,
+	deprecated: [
+		{
+			attributes: {
+				hideTabTitle: {
+					type: 'boolean',
+					default: false,
+				},
+			},
+			save() {
+				return null;
+			},
+		},
+	],
 };
 // @ts-expect-error blockConfig is not typed.
 registerProductBlockType( blockConfig );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/index.tsx
@@ -17,19 +17,6 @@ const blockConfig = {
 	icon,
 	edit,
 	save,
-	deprecated: [
-		{
-			attributes: {
-				hideTabTitle: {
-					type: 'boolean',
-					default: false,
-				},
-			},
-			save() {
-				return null;
-			},
-		},
-	],
 };
 // @ts-expect-error blockConfig is not typed.
 registerProductBlockType( blockConfig );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -7,7 +7,8 @@ type Context = {
 	context: { postId: string; postType: string };
 };
 
-export type ProductDetailsEditProps = BlockEditProps<
-	Record< string, never >
-> &
-	Context;
+type Attributes = {
+	hideTabTitle: boolean;
+};
+
+export type ProductDetailsEditProps = BlockEditProps< Attributes > & Context;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -7,7 +7,7 @@ type Context = {
 	context: { postId: string; postType: string };
 };
 
-type Attributes = {
+export type Attributes = {
 	hideTabTitle: boolean;
 };
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-details/types.ts
@@ -8,6 +8,7 @@ type Context = {
 };
 
 export type Attributes = {
+	align?: 'wide' | 'full';
 	hideTabTitle: boolean;
 };
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Split from https://github.com/woocommerce/woocommerce/pull/59698, which restores the legacy Product Details block settings. The other part was merged into trunk in https://github.com/woocommerce/woocommerce/pull/59691.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Same as https://github.com/woocommerce/woocommerce/pull/59698

<!-- End testing instructions -->
