### PR TITLE
Remove unused private method from WC_Product_Variable

### DIFF
--- a/plugins/woocommerce/changelog/remove-variable-product-dead-code
+++ b/plugins/woocommerce/changelog/remove-variable-product-dead-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove unused private method from WC_Product_Variable
+
+

--- a/plugins/woocommerce/includes/class-wc-product-variable.php
+++ b/plugins/woocommerce/includes/class-wc-product-variable.php
@@ -382,35 +382,6 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Check if a given variation is currently available.
-	 *
-	 * @param WC_Product_Variation $variation Variation to check.
-	 *
-	 * @return bool True if the variation is available, false otherwise.
-	 */
-	private function variation_is_available( WC_Product_Variation $variation ) {
-		// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked.
-		if ( ! $variation || ! $variation->exists() || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
-			return false;
-		}
-
-		/**
-		 * Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
-		 *
-		 * @since 2.6.8
-		 *
-		 * @param  bool                  $hide        Whether to hide invisible variations. Default true.
-		 * @param  int                   $product_id  The ID of the variation.
-		 * @param  WC_Product_Variation  $variation   The variation object.
-		 */
-		if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Returns an array of data for a variation. Used in the add to cart form.
 	 *
 	 * @since  2.4.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes some dead code from `WC_Product_Variable`: the `variation_is_available()` method was private but apparently not used anywhere.

### How to test the changes in this Pull Request:

1. Search for `variation_is_available` in the codebase and make sure this method wasn't used anywhere.