### PR TITLE
Add "Filter" suffix to all product filter block titles and variations

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4921-add-filter-suffix-to-all-filter-blocks-and-variations-name
+++ b/plugins/woocommerce/changelog/wooplug-4921-add-filter-suffix-to-all-filter-blocks-and-variations-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add "Filter" suffix to all product filter block titles and variations

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-active",
-	"title": "Active",
+	"title": "Active Filters",
 	"description": "Display the currently active filters.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-attribute",
-	"title": "Attribute",
+	"title": "Attribute Filter",
 	"description": "Enable customers to filter the product grid by selecting one or more attributes, such as color.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/index.tsx
@@ -33,7 +33,11 @@ registerBlockType( metadata, {
 	variations: ATTRIBUTES.map( ( attribute, index ) => {
 		return {
 			name: `product-filter-attribute-${ attribute.attribute_name }`,
-			title: `${ attribute.attribute_label }`,
+			title: sprintf(
+				// translators: %s is the attribute label.
+				__( '%s Filter', 'woocommerce' ),
+				attribute.attribute_label
+			),
 			description: sprintf(
 				// translators: %s is the attribute label.
 				__(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-price",
-	"title": "Price",
+	"title": "Price Filter",
 	"description": "Let shoppers filter products by choosing a price range.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/product-filter-rating",
-	"title": "Rating",
+	"title": "Rating Filter",
 	"description": "Enable customers to filter the product collection by rating.",
 	"category": "woocommerce",
 	"keywords": [],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/product-filter-status",
-	"title": "Status",
+	"title": "Status Filter",
 	"description": "Let shoppers filter products by choosing stock status.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],


### PR DESCRIPTION
### Submission Review Guidelines

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR adds a "Filter" suffix to all product filter block titles, making them more descriptive and immediately recognizable as filter-related blocks.

**Changes Made:**

- Updated Active Filters block title from "Active" to "Active Filters"
- Added "Filter" suffix to: Price, Rating, Status.
- Updated all dynamically generated attribute filter variations to include "Filter" suffix.

**Why This Change:**
The previous generic titles were not descriptive enough in the block inserter interface. Users had to rely on descriptions to understand these were filter-related blocks. The new naming convention provides immediate clarity about the block's purpose.

Closes WOOPLUG-4921.
Closes https://github.com/woocommerce/woocommerce/issues/59474.

### Screenshots or screen recordings

| Before                                                                              | After                                                                                                         |
| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| <img width="1538" height="851" alt="image" src="https://github.com/user-attachments/assets/5822fdd1-1cac-45b9-bda0-e62ca08a14bc" /> | <img width="1538" height="851" alt="image" src="https://github.com/user-attachments/assets/99607112-c803-4255-83b7-4d3d30526c57" /> |

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Appearance > Editor in your WordPress admin
2. Open the Product Catalog template
3. Add a Product Filters block using the block inserter (+)
4. Verify that all product filter blocks now display with the "Filter" suffix:
    - "Active Filters" (previously "Active")
    - "Price Filter" (previously "Price")
    - "Rating Filter" (previously "Rating")
    - "Status Filter" (previously "Status")
5. For attribute filters, verify that variations show with proper naming like "Color Filter", "Size Filter", etc.
