### PR TITLE
Fix analytics crashes with gutenberg 21.2

### DIFF
--- a/packages/js/components/changelog/wooa7s-313-analytics-crash-with-gutenberg-2120
+++ b/packages/js/components/changelog/wooa7s-313-analytics-crash-with-gutenberg-2120
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue in Analytics reports where itemsLabel can be undefined and cause an error with Gutenberg 21.2.0

--- a/packages/js/components/changelog/wooa7s-313-analytics-crash-with-gutenberg-2120
+++ b/packages/js/components/changelog/wooa7s-313-analytics-crash-with-gutenberg-2120
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix issue in Analytics reports where itemsLabel can be undefined and cause an error with Gutenberg 21.2.0
+Fix areas where undefined can be passed into sprintf and cause a fatal error with Gutenberg 21.2.0, in particular in Analytics reports.

--- a/packages/js/components/src/chart/index.js
+++ b/packages/js/components/src/chart/index.js
@@ -333,6 +333,11 @@ class Chart extends Component {
 		const legendDirection = legendPosition === 'top' ? 'row' : 'column';
 		const chartDirection = legendPosition === 'side' ? 'row' : 'column';
 
+		// TODO: This is a temporary fix to avoid the issue with the itemsLabel being undefined.
+		const totalLabel = itemsLabel
+			? sprintf( itemsLabel, orderedKeys.length )
+			: '';
+
 		const chartHeight = this.getChartHeight();
 		const legend =
 			legendPosition !== 'hidden' && isRequesting ? null : (
@@ -344,7 +349,7 @@ class Chart extends Component {
 					interactive={ interactiveLegend }
 					legendDirection={ legendDirection }
 					legendValueFormat={ tooltipValueFormat }
-					totalLabel={ sprintf( itemsLabel, orderedKeys.length ) }
+					totalLabel={ totalLabel }
 				/>
 			);
 		const margin = {

--- a/packages/js/components/src/chart/index.js
+++ b/packages/js/components/src/chart/index.js
@@ -333,7 +333,7 @@ class Chart extends Component {
 		const legendDirection = legendPosition === 'top' ? 'row' : 'column';
 		const chartDirection = legendPosition === 'side' ? 'row' : 'column';
 
-		// TODO: This is a temporary fix to avoid the issue with the itemsLabel being undefined.
+		// Items label is not defined for all the reports.
 		const totalLabel = itemsLabel
 			? sprintf( itemsLabel, orderedKeys.length )
 			: '';

--- a/packages/js/components/src/search-list-control/index.js
+++ b/packages/js/components/src/search-list-control/index.js
@@ -166,7 +166,7 @@ export const SearchListControl = ( props ) => {
 					<span className="woocommerce-search-list__not-found-text">
 						{ searchValue
 							? // eslint-disable-next-line @wordpress/valid-sprintf
-							  sprintf( messages.noResults, searchValue )
+							  sprintf( messages.noResults || '', searchValue )
 							: messages.noItems }
 					</span>
 				</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the latest GB version `sprintf` does not allow you to pass in `undefined` ( expected ), but it looks like we were doing this for some of our Analytics reports.
This change makes it so we only call `sprintf` when the items label is defined.

Closes WOOA7S-313 .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install Woo from this branch and the latest Gutenberg version ( 21.2 )
2. Go to **Analytics > Overview** and all the other report screens if no error appears.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
