### PR TITLE
Custom Email Templates in theme not being pulled in

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5090-custom-email-templates-in-theme-not-being-pulled-in
+++ b/plugins/woocommerce/changelog/wooplug-5090-custom-email-templates-in-theme-not-being-pulled-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear template cache on email template edit via admin

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1148,6 +1148,7 @@ class WC_Email extends WC_Settings_API {
 				wp_safe_redirect( $redirect );
 				exit;
 			}
+			wc_clear_template_cache();
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds Woo template cache cleanup when the user edits an email template file via the admin UI (WooCommerce > Settings > Email > Manage > View template).

This is related to https://github.com/woocommerce/woocommerce/pull/58877, which added the cache cleanup when deleting or adding the file, but [skipped](https://github.com/woocommerce/woocommerce/pull/58877#issuecomment-2983242472) cleanup on edit.

It seems that some customers edit the template via the UI so this PR adds the cache cleanup also on edit.

Closes WOOPLUG-5090 ,#59798 .

### How to test the changes in this Pull Request:

The issue is replicable on a jurrasic.ninja site

1) install WooCommerce, a payment gateway for testing, and a simple theme like Storefront.
2) under WooCommerce > Settings on the Emails tab, open the Processing Order email for editing
3) copy the template to your theme using the button at the bottom of the screen
4) make a simple edit to the template file (I changed the greeting from Hi to Hello)
5) observe that the email preview still contains the old template content

When you upload a zip from this PR, the edits should be immediately visible.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
