### PR TITLE
Load fulfillments classes in init action hook

### DIFF
--- a/plugins/woocommerce/changelog/59869-fix-fulfillments-load-text-domain-warning
+++ b/plugins/woocommerce/changelog/59869-fix-fulfillments-load-text-domain-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
+

--- a/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
@@ -17,7 +17,6 @@ use WC_Meta_Data;
 
 defined( 'ABSPATH' ) || exit;
 
-
 /**
  * WC Order Fulfillment Class
  *

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
@@ -32,7 +32,6 @@ class FulfillmentsController {
 		add_action( 'init', array( $this, 'initialize_fulfillments' ), 10, 0 );
 	}
 
-
 	/**
 	 * Initialize the fulfillments controller.
 	 */

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsController.php
@@ -12,20 +12,6 @@ use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
  */
 class FulfillmentsController {
 	/**
-	 * Database utility instance.
-	 *
-	 * @var DatabaseUtil
-	 */
-	private DatabaseUtil $database_util;
-
-	/**
-	 * FeaturesController instance.
-	 *
-	 * @var FeaturesController
-	 */
-	private FeaturesController $features_controller;
-
-	/**
 	 * Provides the list of classes that this controller provides.
 	 *
 	 * @var string[]
@@ -38,22 +24,24 @@ class FulfillmentsController {
 	);
 
 	/**
-	 * FulfillmentsController constructor.
-	 */
-	public function __construct() {
-		$container                 = wc_get_container();
-		$this->database_util       = $container->get( DatabaseUtil::class );
-		$this->features_controller = $container->get( FeaturesController::class );
-	}
-
-	/**
 	 * Initialize the controller.
 	 *
 	 * @return void
 	 */
 	public function register() {
+		add_action( 'init', array( $this, 'initialize_fulfillments' ), 10, 0 );
+	}
+
+
+	/**
+	 * Initialize the fulfillments controller.
+	 */
+	public function initialize_fulfillments() {
+		$container           = wc_get_container();
+		$features_controller = $container->get( FeaturesController::class );
+
 		// If fulfillments feature is not enabled, do not add the DB tables, and don't register the controller.
-		if ( ! $this->features_controller->feature_is_enabled( 'fulfillments' ) ) {
+		if ( ! $features_controller->feature_is_enabled( 'fulfillments' ) ) {
 			return;
 		}
 
@@ -61,7 +49,6 @@ class FulfillmentsController {
 		$this->maybe_create_db_tables();
 
 		// Register the classes that this controller provides.
-		$container = wc_get_container();
 		foreach ( $this->provides as $class ) {
 			$class = $container->get( $class );
 			if ( method_exists( $class, 'register' ) ) {
@@ -91,8 +78,11 @@ class FulfillmentsController {
 		// Bulk delete order fulfillment status meta from legacy and HPOS order tables.
 		$this->bulk_delete_order_fulfillment_status_meta();
 
-		$collate          = '';
-		$max_index_length = $this->database_util->get_max_index_length();
+		$collate       = '';
+		$container     = wc_get_container();
+		$database_util = $container->get( DatabaseUtil::class );
+
+		$max_index_length = $database_util->get_max_index_length();
 		if ( $wpdb->has_cap( 'collation' ) ) {
 			$collate = $wpdb->get_charset_collate();
 		}
@@ -120,7 +110,7 @@ class FulfillmentsController {
 			KEY fulfillment_id (fulfillment_id)
 		) $collate;";
 
-		$this->database_util->dbdelta( $schema );
+		$database_util->dbdelta( $schema );
 
 		// Update the option to indicate that the tables have been created.
 		update_option( 'woocommerce_fulfillments_db_tables_created', true );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -22,9 +22,9 @@ use WC_Order_Refund;
  */
 class FulfillmentsManager {
 	/**
-	 * Class constructor.
+	 * This method registers the hooks related to fulfillments.
 	 */
-	public function __construct() {
+	public function register() {
 		add_filter( 'woocommerce_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'woocommerce_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'woocommerce_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -166,7 +166,6 @@ class FulfillmentsManager {
 		$this->update_fulfillment_status( $order, $fulfillments );
 	}
 
-
 	/**
 	 * Update fulfillments after a refund is created.
 	 *

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -26,9 +26,9 @@ class FulfillmentsRenderer {
 	private array $fulfillments_cache = array();
 
 	/**
-	 * CLass constructor.
+	 * Registers the hooks related to fulfillments.
 	 */
-	public function __construct() {
+	public function register() {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// Hook into column definitions and add the new fulfillment columns.
 			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_fulfillment_columns' ) );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
@@ -13,9 +13,9 @@ use WC_Order;
 class FulfillmentsSettings {
 
 	/**
-	 * Constructor.
+	 * Registers the hooks related to fulfillments settings.
 	 */
-	public function __construct() {
+	public function register() {
 		add_filter( 'admin_init', array( $this, 'init_settings_auto_fulfill' ) );
 		add_action( 'woocommerce_order_status_processing', array( $this, 'auto_fulfill_items_on_processing' ), 10, 2 );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'auto_fulfill_items_on_completed' ), 10, 2 );

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -69,7 +69,10 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 	public function test_fulfillment_meta() {
 		// Ensure the FulfillmentsController is registered, which is necessary for the translation of meta keys.
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$container  = wc_get_container();
+		$controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		$order       = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$fulfillment = FulfillmentsHelper::create_fulfillment(

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -7,8 +7,6 @@
 
 declare( strict_types=1 );
 
-use ReflectionClass;
-
 /**
  * Unit tests for the WC_Tax class get_shipping_tax_rates method and related functionality.
  * Covers edge case bug from https://github.com/woocommerce/woocommerce/issues/58757
@@ -410,7 +408,7 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 
 		// Use reflection to test private method.
-		$reflection = new ReflectionClass( 'WC_Tax' );
+		$reflection = new \ReflectionClass( 'WC_Tax' );
 		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
 		$method->setAccessible( true );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -408,7 +408,7 @@ class WC_Tax_Test extends WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 
 		// Use reflection to test private method.
-		$reflection = new \ReflectionClass( 'WC_Tax' );
+		$reflection = new ReflectionClass( 'WC_Tax' );
 		$method     = $reflection->getMethod( 'get_shipping_tax_class_from_cart_items' );
 		$method->setAccessible( true );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -32,7 +32,9 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Internal\Fulfillments\Fulfillment;
 use WC_Meta_Data;
 
 /**
- * Tests for the WC_Order_Fulfillment_Data_Store_Test  class.
+ * Tests for the WC_Order_Fulfillment_Data_Store_Test class.
  *
  * @package WooCommerce\Tests\Order_Fulfillment
  */
@@ -19,7 +19,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 *
 	 * @var FulfillmentsDataStore
 	 */
-	private static FulfillmentsDataStore $order_fulfillment_data_store;
+	private FulfillmentsDataStore $data_store;
 
 	/**
 	 * Runs before all the tests of the class.
@@ -27,8 +27,9 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
-		self::$order_fulfillment_data_store = new FulfillmentsDataStore();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -37,6 +38,24 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public static function tearDownAfterClass(): void {
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
 		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+	}
+
+	/**
+	 * Tear down the test case.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+		// Clean up the fulfillment meta table.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_fulfillment_meta" );
+		// Clean up the fulfillment table.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_fulfillments" );
 	}
 
 	/**
@@ -60,7 +79,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 		$this->assertFulfillmentRecordInDB( $fulfillment );
 		$this->assertFulfillmentMetaInDB( $fulfillment );
 	}
@@ -85,7 +104,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid entity type.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -108,7 +127,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid entity ID.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -124,7 +143,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The fulfillment should contain at least one item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -140,7 +159,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The fulfillment should contain at least one item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -167,7 +186,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -190,14 +209,14 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$this->assertNotNull( $fulfillment->get_id() );
 
 		$new_fulfillment = new Fulfillment();
 		$new_fulfillment->set_id( $fulfillment->get_id() );
 
-		self::$order_fulfillment_data_store->read( $new_fulfillment );
+		$this->data_store->read( $new_fulfillment );
 
 		$this->assertFulfillmentRecordInDB( $new_fulfillment );
 		$this->assertFulfillmentMetaInDB( $new_fulfillment );
@@ -224,7 +243,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment->set_entity_id( '456' );
 		$fulfillment->set_items(
@@ -240,7 +259,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		self::$order_fulfillment_data_store->update( $fulfillment );
+		$this->data_store->update( $fulfillment );
 
 		$this->assertFulfillmentRecordInDB( $fulfillment );
 		$this->assertFulfillmentMetaInDB( $fulfillment );
@@ -267,7 +286,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$this->assertNotNull( $fulfillment->get_id() );
 		$this->assertNull( $fulfillment->get_date_deleted() );
@@ -278,7 +297,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		// Cache the ID before deletion.
 		$fulfillment_id = $fulfillment->get_id();
 
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 		// The fulfillment should be reset to it's initial state.
 		$this->assertEquals( 0, $fulfillment->get_id() );
 		$this->assertEquals( null, $fulfillment->get_entity_type() );
@@ -315,7 +334,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotEquals( 0, $fulfillment->get_id() );
 
-		$result = self::$order_fulfillment_data_store->read_meta( $fulfillment );
+		$result = $this->data_store->read_meta( $fulfillment );
 
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
@@ -356,7 +375,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $items, $meta[0]->value );
 		$this->assertNotNull( $meta[0]->id );
 
-		self::$order_fulfillment_data_store->delete_meta( $fulfillment, $meta[0] ); // phpcs:ignore
+		$this->data_store->delete_meta( $fulfillment, $meta[0] ); // phpcs:ignore
 
 		global $wpdb;
 		$db_metadata = $wpdb->get_results(
@@ -392,7 +411,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotEquals( 0, $fulfillment->get_id() );
 
-		self::$order_fulfillment_data_store->add_meta(
+		$this->data_store->add_meta(
 			$fulfillment,
 			new WC_Meta_Data(
 				array(
@@ -461,7 +480,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertCount( 1, $new_metadata );
 		$this->assertEquals( '_items', $new_metadata[0]->key );
 
-		$result = self::$order_fulfillment_data_store->update_meta( $fulfillment, $new_metadata[0] );
+		$result = $this->data_store->update_meta( $fulfillment, $new_metadata[0] );
 
 		$this->assertEquals( 1, $result );
 	}
@@ -471,7 +490,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_read_fulfillments() {
 		$this->prepare_db_for_test();
-		$fulfillments = self::$order_fulfillment_data_store->read_fulfillments( 'order-fulfillment', '123' );
+		$fulfillments = $this->data_store->read_fulfillments( 'order-fulfillment', '123' );
 		$this->assertCount( 2, $fulfillments );
 		$this->assertEquals( '123', $fulfillments[0]->get_entity_id() );
 		$this->assertEquals( 'order-fulfillment', $fulfillments[0]->get_entity_type() );
@@ -514,20 +533,20 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// Create a new fulfillment object and try to read the deleted one.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
 
 		// Should be able to read deleted fulfillment by ID.
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		$this->assertEquals( $fulfillment_id, $deleted_fulfillment->get_id() );
 		$this->assertEquals( 'order-fulfillment', $deleted_fulfillment->get_entity_type() );
@@ -551,25 +570,25 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// Create a new fulfillment object and read the deleted one.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		// Try to update the deleted fulfillment - should not affect any rows.
 		$deleted_fulfillment->set_entity_id( '456' );
 		$deleted_fulfillment->set_status( 'fulfilled' );
 
 		// Update should not throw an error but should not affect any rows.
-		self::$order_fulfillment_data_store->update( $deleted_fulfillment );
+		$this->data_store->update( $deleted_fulfillment );
 
 		// Verify the database record was not updated.
 		global $wpdb;
@@ -602,13 +621,13 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment the first time.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// At this point, the fulfillment object should be reset.
 		$this->assertEquals( 0, $fulfillment->get_id() );
@@ -616,7 +635,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		// Read the deleted fulfillment back.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		$first_deletion_time = $deleted_fulfillment->get_date_deleted();
 		$this->assertNotNull( $first_deletion_time );
@@ -640,7 +659,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		// Try to delete the already deleted fulfillment - should return early.
-		self::$order_fulfillment_data_store->delete( $deleted_fulfillment );
+		$this->data_store->delete( $deleted_fulfillment );
 
 		// Verify hooks were not called.
 		$this->assertFalse( $before_delete_called );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -344,7 +344,6 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $fulfillment->get_id(), $result[0]->fulfillment_id );
 	}
 
-
 	/**
 	 * Tests the delete_meta method of the order fulfillment data store.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
@@ -17,7 +17,9 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
@@ -14,7 +14,9 @@ class FulfillmentUtilsTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
@@ -25,7 +25,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -41,7 +43,8 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->manager = new FulfillmentsManager();
+		$this->manager = wc_get_container()->get( FulfillmentsManager::class );
+		$this->manager->register();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
@@ -35,9 +35,10 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		$container               = wc_get_container();
-		$fulfillments_controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
-		$fulfillments_controller->register();
+		$container  = wc_get_container();
+		$controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -54,7 +55,8 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
-		$this->manager    = new FulfillmentsManager();
+		$this->manager    = wc_get_container()->get( FulfillmentsManager::class );
+		$this->manager->register();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
@@ -637,7 +637,6 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( 5, $quantities_by_item[ $item_id_2 ] ); // 10 - 8 = 2 pending, 2 reduced from pending, 3 reduced from fulfillment, 5.
 	}
 
-
 	/**
 	 * Test fulfillment modifications with multiple refunds.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererHooksTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererHooksTest.php
@@ -1,0 +1,130 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsRenderer;
+
+/**
+ * Tests for FulfillmentsRenderer hooks.
+ */
+class FulfillmentsRendererHooksTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * FulfillmentsRenderer instance.
+	 *
+	 * @var FulfillmentsRenderer
+	 */
+	private FulfillmentsRenderer $renderer;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public static function tearDownAfterClass(): void {
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->renderer = wc_get_container()->get( FulfillmentsRenderer::class );
+	}
+
+	/**
+	 * Test hooks.
+	 */
+	public function test_hooks() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( true );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->assertNotFalse( has_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this->renderer, 'add_fulfillment_columns' ) ) );
+		$this->assertNotFalse( has_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this->renderer, 'render_fulfillment_column_row_data' ) ) );
+		$this->assertNotFalse( has_action( 'admin_footer', array( $this->renderer, 'render_fulfillment_drawer_slot' ) ) );
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $this->renderer, 'load_components' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $this->renderer, 'init_admin_hooks' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test hooks when HPOS isn't enabled.
+	 */
+	public function test_hooks_legacy() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( false );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->assertNotFalse( has_filter( 'manage_edit-shop_order_columns', array( $this->renderer, 'add_fulfillment_columns' ) ) );
+		$this->assertNotFalse( has_action( 'manage_shop_order_posts_custom_column', array( $this->renderer, 'render_fulfillment_column_row_data_legacy' ) ) );
+		$this->assertNotFalse( has_action( 'admin_footer', array( $this->renderer, 'render_fulfillment_drawer_slot' ) ) );
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $this->renderer, 'load_components' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $this->renderer, 'init_admin_hooks' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test that the admin_init hooks are registered.
+	 */
+	public function test_admin_init_hooks() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( true );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->renderer->init_admin_hooks();
+		$this->assertNotFalse( has_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this->renderer, 'define_fulfillment_bulk_actions' ) ) );
+		$this->assertNotFalse( has_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $this->renderer, 'handle_fulfillment_bulk_actions' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test that the admin_init hooks are registered when HPOS isn't enabled.
+	 */
+	public function test_admin_init_hooks_legacy() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( false );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->renderer->init_admin_hooks();
+		$this->assertNotFalse( has_filter( 'bulk_actions-edit-shop_order', array( $this->renderer, 'define_fulfillment_bulk_actions' ) ) );
+		$this->assertNotFalse( has_filter( 'handle_bulk_actions-edit-shop_order', array( $this->renderer, 'handle_fulfillment_bulk_actions' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
@@ -53,7 +53,9 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		parent::setupBeforeClass();
 
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		self::$created_user_id = wp_create_user( 'test_user', 'password', 'nonadmin@example.com' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
 
-use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsManager;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 use Automattic\WooCommerce\Internal\Fulfillments\Providers as ShippingProviders;
 
@@ -16,7 +15,10 @@ class ShippingProvidersTest extends \WP_UnitTestCase {
 	 * Test that the shipping providers configuration returns the correct classes.
 	 */
 	public function test_shipping_providers_configuration(): void {
-		new FulfillmentsManager(); // Ensure the FulfillmentsManager is initialized to load the shipping providers.
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		$shipping_providers = FulfillmentUtils::get_shipping_providers();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/TrackingNumbersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/TrackingNumbersTest.php
@@ -21,7 +21,11 @@ class TrackingNumbersTest extends WP_UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->combinator = new FulfillmentsManager();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
+		$this->combinator = wc_get_container()->get( FulfillmentsManager::class );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves the class initializations of the fulfillments feature to the init action hook, and fixes the tests. (Also fixes one warning surfacing on the test runs, not related with this problem.)

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59870 WOOPLUG-5128

(For Bug Fixes) Bug introduced in PR #57353 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Before this PR, when you go to any page, you'll get a warning on your error log file saying that load text domain was called early. After applying these changes, you should see the warning is gone.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
</details>
