### PR TITLE
Fix Mini-Cart 'Open drawer' toggle issue with multiple blocks on page

### DIFF
--- a/plugins/woocommerce/changelog/fix-57686
+++ b/plugins/woocommerce/changelog/fix-57686
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed 'Open drawer when adding' option not working on first try when there are multiple mini cart blocks on a page with conflicting opwn drawer setting.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/frontend.ts
@@ -108,6 +108,16 @@ window.addEventListener( 'load', () => {
 		}
 	);
 
+	// Check if any Mini-Cart block has 'open_drawer' behavior enabled.
+	const shouldOpenDrawerOnAddToCart = Array.from( miniCartBlocks ).some(
+		( block ) => {
+			if ( ! ( block instanceof HTMLElement ) ) {
+				return false;
+			}
+			return block.dataset.addToCartBehaviour === 'open_drawer';
+		}
+	);
+
 	miniCartBlocks.forEach( ( miniCartBlock, i ) => {
 		if ( ! ( miniCartBlock instanceof HTMLElement ) ) {
 			return;
@@ -180,10 +190,11 @@ window.addEventListener( 'load', () => {
 
 		miniCartButton.addEventListener( 'click', openDrawer );
 
-		const funcOnAddToCart =
-			miniCartBlock.dataset.addToCartBehaviour === 'open_drawer'
-				? openDrawerWithRefresh
-				: loadContentsWithRefresh;
+		// Open drawer if any of the mini cart block on the page
+		// has 'open_drawer' behavior enabled.
+		const funcOnAddToCart = shouldOpenDrawerOnAddToCart
+			? openDrawerWithRefresh
+			: loadContentsWithRefresh;
 
 		// There might be more than one Mini-Cart block in the page. Make sure
 		// only one opens when adding a product to the cart.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a check to see if any of the carts on the page has 'open_drawer' option enabled. Based on that it add the event listener.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #57686 

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/49fe74df-beab-42c4-9c68-bd131d69e84a

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In a block theme with the Mini-Cart block in the header, make sure it has the 'Open drawer when adding' toggle disabled.
2. Create a post or page and add the Product Collection block and the Mini-Cart block, this time with the 'Open drawer when adding' toggle enabled.
3. In the frontend, add some products to your cart.
4. Notice the Mini-Cart drawer is opened correctly.
5. Add another product to your cart.
6. Notice the Mini-Cart drawer still opens correctly.

<!-- End testing instructions -->

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
