### PR TITLE
Add missing initial stock indicator to variable products in the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-initial-stock
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-initial-stock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add missing initial stock indicator to variable products in the Add to Cart + Options block
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -47,7 +47,7 @@ const ALLOWED_ATTR = [
 ];
 
 export type Context = {
-	productElementKey: 'price_html' | 'availability_html';
+	productElementKey: 'price_html' | 'availability';
 };
 
 const productElementStore = store(

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -49,11 +49,11 @@ export type Store = {
 		products?: {
 			[ productId: number ]: {
 				price_html?: string;
-				availability_html?: string;
+				availability?: string;
 				variations?: {
 					[ variationId: number ]: {
 						price_html?: string;
-						availability_html: string;
+						availability: string;
 					};
 				};
 			};

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
@@ -35,8 +35,9 @@ wp post meta update $beanie_product_id _crosssell_ids "$cap_product_id"
 tshirt_with_logo_product_id=$(wp post list --post_type=product --field=ID --name="T-Shirt with Logo" --format=ids)
 wp wc product update $tshirt_with_logo_product_id --in_stock=false --user=1
 
-# Set a variation out of stock
+# Set a variable product as having 100 in stock and one of its variations as out of stock
 hoodie_product_variation_id=$(wp post list --post_type=product_variation --field=ID --name="Hoodie - Blue, No" --format=ids)
+wp wc product update $hoodie_product_id --stock_quantity=100 --user=1
 wp wc product_variation update $hoodie_product_id $hoodie_product_variation_id --in_stock=false --user=1
 
 # Make a product visible only with password.

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
@@ -37,8 +37,8 @@ wp wc product update $tshirt_with_logo_product_id --in_stock=false --user=1
 
 # Set a variable product as having 100 in stock and one of its variations as out of stock
 hoodie_product_variation_id=$(wp post list --post_type=product_variation --field=ID --name="Hoodie - Blue, No" --format=ids)
-wp wc product update $hoodie_product_id --stock_quantity=100 --user=1
-wp wc product_variation update $hoodie_product_id $hoodie_product_variation_id --in_stock=false --user=1
+wp wc product update $hoodie_product_id --manage_stock=true --stock_quantity=100 --user=1
+wp wc product_variation update $hoodie_product_id $hoodie_product_variation_id --manage_stock=true --in_stock=false --user=1
 
 # Make a product visible only with password.
 sunglasses_product_id=$(wp post list --post_type=product --field=ID --name="Sunglasses" --format=ids)

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -135,7 +135,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await test.step( 'updates stock indicator and product price when attributes are selected', async () => {
 			await expect( productPrice ).toHaveText( /\$42.00 – \$45.00.*/ );
-			await expect( page.getByText( 'Out of stock' ) ).toBeHidden();
+			await expect( page.getByText( '100 in stock' ) ).toBeVisible();
 
 			await colorBlueOption.click();
 			await logoNoOption.click();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -127,14 +127,12 @@ class ProductStockIndicator extends AbstractBlock {
 		$watch_attribute    = '';
 
 		if ( $is_interactive && 'out-of-stock' !== $availability['class'] ) {
-			$variations_data           = $product_to_render->get_available_variations();
+			$variations                = $product_to_render->get_available_variations( 'objects' );
 			$formatted_variations_data = array();
-			foreach ( $variations_data as $variation ) {
-				if ( ! isset( $variation['variation_id'] ) || ! isset( $variation['availability_html'] ) ) {
-					continue;
-				}
-				$formatted_variations_data[ $variation['variation_id'] ] = array(
-					'availability_html' => $variation['availability_html'],
+			foreach ( $variations as $variation ) {
+				$variation_availability                            = $variation->get_availability();
+				$formatted_variations_data[ $variation->get_id() ] = array(
+					'availability' => $variation_availability['availability'],
 				);
 			}
 
@@ -143,8 +141,8 @@ class ProductStockIndicator extends AbstractBlock {
 				array(
 					'products' => array(
 						$product_to_render->get_id() => array(
-							'availability_html' => wc_get_stock_html( $product_to_render ),
-							'variations'        => $formatted_variations_data,
+							'availability' => $availability['availability'],
+							'variations'   => $formatted_variations_data,
 						),
 					),
 				)
@@ -153,7 +151,7 @@ class ProductStockIndicator extends AbstractBlock {
 			wp_enqueue_script_module( 'woocommerce/product-elements' );
 			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
 			$context                                   = array(
-				'productElementKey' => 'availability_html',
+				'productElementKey' => 'availability',
 			);
 			$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
 			$watch_attribute                           = 'data-wp-watch="callbacks.updateValue"';

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -143,7 +143,7 @@ class ProductStockIndicator extends AbstractBlock {
 				array(
 					'products' => array(
 						$product_to_render->get_id() => array(
-							'availability_html' => '',
+							'availability_html' => wc_get_stock_html( $product_to_render ),
 							'variations'        => $formatted_variations_data,
 						),
 					),

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -20,7 +20,7 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
 			<div class="wp-block-group">
 				<!-- wp:woocommerce/product-price {"textAlign":"right","isDescendentOfSingleProductTemplate":true,"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontWeight":400,"fontStyle":"normal"}}} /-->
-				<!-- wp:woocommerce/product-stock-indicator /--></div>
+				<!-- wp:woocommerce/product-stock-indicator {"fontSize":"small"} /--></div>
 			<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,4 +1,4 @@
-<!-- wp:woocommerce/product-stock-indicator /-->
+<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 <!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /--></div>

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -23,7 +23,7 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-variation-selector -->
 
-<!-- wp:woocommerce/product-stock-indicator /-->
+<!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes some issues related to the management of dynamic stock status in variable products:

* We weren't setting the initial product stock status. That was an issue when the stock status was tracked at the product level, instead of the variation level.
* We were using `availability_html`, but it turns out the Stock Indicator block doesn't use the HTML, but the simple string. So there was a mismatched that caused styles to change when selecting a variation.
* Now that we don't have the wrapping HTML, I added wrapping margin directly in the template.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59706.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Create a variable product with these settings: (1) at product level, set it to track stock and have a specific number of items in stock and (2) set one specific variation to be out of stock.

<img width="1520" height="830" alt="imatge" src="https://github.com/user-attachments/assets/77f72638-1337-4ee5-93e6-7fc4dce3d3bd" />

<img width="1520" height="830" alt="imatge" src="https://github.com/user-attachments/assets/636689ee-12b9-4b73-a76f-c5e5f043886f" />

4. Go to the frontend of that product.
5. Verify "X in stock" is visible in the Stock Indicator.
6. Select the out of stock variation.
7. Verify "X in stock" is replaced with "Out of stock".

https://github.com/user-attachments/assets/3c6fd538-0af3-40d4-a19a-83caac37e2aa

8. Verify margins look correct all the time.
9. Check out of stock simple products and grouped products containing out of stock children to verify styles look good too.