### PR TITLE
Product Filters: Add hierarchical support to product taxonomy filtering

### DIFF
--- a/plugins/woocommerce/changelog/59878-wooplug-4918-support-hierarchy
+++ b/plugins/woocommerce/changelog/59878-wooplug-4918-support-hierarchy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Product Filters: Add hierarchical category support to product taxonomy filtering - when filtering by parent categories, products from child categories are now included in results.

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Automattic\WooCommerce\Internal\ProductFilters;
 
-use WC_Cache_Helper;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
-use Automattic\WooCommerce\Internal\ProductFilters\CacheController;
+use WC_Cache_Helper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -408,19 +407,13 @@ class FilterData {
 
 				$ancestor_term_taxonomy_id = $this->get_term_taxonomy_id_from_term_id( $ancestor_term_id, $taxonomy_escaped );
 
-				// Get all descendants for this ancestor (cached).
-				$cache_key   = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . 'descendants_' . $taxonomy_escaped . '_' . $ancestor_term_id;
-				$descendants = wp_cache_get( $cache_key );
+				// Get all descendants for this ancestor (WordPress handles caching internally).
+				$descendants = get_term_children( $ancestor_term_id, $taxonomy_escaped );
 
-				if ( false === $descendants ) {
-					$descendants = get_term_children( $ancestor_term_id, $taxonomy_escaped );
-
-					if ( ! is_wp_error( $descendants ) ) {
-						$descendants[] = $ancestor_term_id; // Include the ancestor term itself.
-						wp_cache_set( $cache_key, $descendants, '', HOUR_IN_SECONDS );
-					} else {
-						$descendants = array( $ancestor_term_id );
-					}
+				if ( ! is_wp_error( $descendants ) ) {
+					$descendants[] = $ancestor_term_id; // Include the ancestor term itself.
+				} else {
+					$descendants = array( $ancestor_term_id );
 				}
 
 				$hierarchy_counts[ $ancestor_term_taxonomy_id ] = $descendants;
@@ -449,8 +442,6 @@ class FilterData {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$count_result = $wpdb->get_row( $batch_count_sql, ARRAY_A );
-
-		dd( $count_result );
 
 		if ( empty( $count_result ) ) {
 			return array();

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\Internal\ProductFilters;
 
 use WC_Cache_Helper;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
+use Automattic\WooCommerce\Internal\ProductFilters\CacheController;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -323,25 +324,30 @@ class FilterData {
 		if ( $product_ids ) {
 			global $wpdb;
 
-			$taxonomies_to_count_sql = 'AND term_taxonomy.taxonomy IN ("' . esc_sql( wc_sanitize_taxonomy_name( $taxonomy_to_count ) ) . '")';
-			$taxonomy_count_sql      = "
-				SELECT COUNT( DISTINCT term_relationships.object_id ) as term_count, term_taxonomy.term_taxonomy_id as term_count_id
-				FROM {$wpdb->term_relationships} AS term_relationships
-				INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
-				WHERE term_relationships.object_id IN ( {$product_ids} )
-				{$taxonomies_to_count_sql}
-				GROUP BY term_taxonomy.term_taxonomy_id
-			";
+			$taxonomy_escaped = esc_sql( wc_sanitize_taxonomy_name( $taxonomy_to_count ) );
 
-			/**
-			 * We can't use $wpdb->prepare() here because using %s with
-			 * $wpdb->prepare() for a subquery won't work as it will escape the
-			 * SQL query.
-			 * We're using the query as is, same as Core does.
-			 */
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$results = $wpdb->get_results( $taxonomy_count_sql );
-			$results = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
+			if ( is_taxonomy_hierarchical( $taxonomy_to_count ) ) {
+				$results = $this->get_hierarchical_taxonomy_counts( $product_ids, $taxonomy_escaped );
+			} else {
+				$taxonomy_count_sql = "
+					SELECT COUNT( DISTINCT term_relationships.object_id ) as term_count, term_taxonomy.term_taxonomy_id as term_count_id
+					FROM {$wpdb->term_relationships} AS term_relationships
+					INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
+					WHERE term_relationships.object_id IN ( {$product_ids} )
+					AND term_taxonomy.taxonomy = '{$taxonomy_escaped}'
+					GROUP BY term_taxonomy.term_taxonomy_id
+				";
+
+				/**
+				 * We can't use $wpdb->prepare() here because using %s with
+				 * $wpdb->prepare() for a subquery won't work as it will escape the
+				 * SQL query.
+				 * We're using the query as is, same as Core does.
+				 */
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$base_results = $wpdb->get_results( $taxonomy_count_sql );
+				$results      = array_map( 'absint', wp_list_pluck( $base_results, 'term_count', 'term_count_id' ) );
+			}
 		}
 
 		/**
@@ -354,6 +360,134 @@ class FilterData {
 		$this->set_cache( $transient_key, $results );
 
 		return $results;
+	}
+
+	/**
+	 * Get hierarchical taxonomy counts with minimal query optimization.
+	 *
+	 * @param string $product_ids      Comma-separated list of product IDs.
+	 * @param string $taxonomy_escaped Escaped taxonomy name.
+	 * @return array Array of term_taxonomy_id => count pairs.
+	 */
+	private function get_hierarchical_taxonomy_counts( string $product_ids, string $taxonomy_escaped ) {
+		global $wpdb;
+
+		// Step 1: Get all terms that have products in the filtered set (1 query).
+		$base_terms_sql = "
+			SELECT DISTINCT tt.term_id, tt.term_taxonomy_id
+			FROM {$wpdb->term_relationships} tr
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			WHERE tr.object_id IN ( {$product_ids} )
+			AND tt.taxonomy = '{$taxonomy_escaped}'
+		";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$base_terms = $wpdb->get_results( $base_terms_sql );
+
+		if ( empty( $base_terms ) ) {
+			return array();
+		}
+
+		// Step 2: Build hierarchy relationships using cached WordPress functions.
+		$hierarchy_counts = array();
+		$processed_terms  = array();
+
+		// Process each base term and its ancestors.
+		foreach ( $base_terms as $term ) {
+			// Count for the term itself.
+			if ( ! isset( $hierarchy_counts[ $term->term_taxonomy_id ] ) ) {
+				$hierarchy_counts[ $term->term_taxonomy_id ] = array( $term->term_id );
+			}
+
+			// Get ancestors and add this term's descendants to each ancestor.
+			$ancestors = get_ancestors( $term->term_id, $taxonomy_escaped );
+			foreach ( $ancestors as $ancestor_term_id ) {
+				if ( in_array( $ancestor_term_id, $processed_terms, true ) ) {
+					continue;
+				}
+
+				$ancestor_term_taxonomy_id = $this->get_term_taxonomy_id_from_term_id( $ancestor_term_id, $taxonomy_escaped );
+
+				// Get all descendants for this ancestor (cached).
+				$cache_key   = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . 'descendants_' . $taxonomy_escaped . '_' . $ancestor_term_id;
+				$descendants = wp_cache_get( $cache_key );
+
+				if ( false === $descendants ) {
+					$descendants = get_term_children( $ancestor_term_id, $taxonomy_escaped );
+
+					if ( ! is_wp_error( $descendants ) ) {
+						$descendants[] = $ancestor_term_id; // Include the ancestor term itself.
+						wp_cache_set( $cache_key, $descendants, '', HOUR_IN_SECONDS );
+					} else {
+						$descendants = array( $ancestor_term_id );
+					}
+				}
+
+				$hierarchy_counts[ $ancestor_term_taxonomy_id ] = $descendants;
+				$processed_terms[]                              = $ancestor_term_id;
+			}
+		}
+
+		if ( empty( $hierarchy_counts ) ) {
+			return array();
+		}
+
+		// Step 3: Execute batch counting using a single query with CASE statements.
+		$count_cases = array();
+		foreach ( $hierarchy_counts as $term_taxonomy_id => $term_ids ) {
+			$term_ids_str  = implode( ',', array_map( 'absint', $term_ids ) );
+			$count_cases[] = "SUM(CASE WHEN tt.term_id IN ({$term_ids_str}) THEN 1 ELSE 0 END) as count_{$term_taxonomy_id}";
+		}
+
+		$batch_count_sql = '
+			SELECT ' . implode( ', ', $count_cases ) . "
+			FROM {$wpdb->term_relationships} tr
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			WHERE tr.object_id IN ( {$product_ids} )
+			AND tt.taxonomy = '{$taxonomy_escaped}'
+		";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$count_result = $wpdb->get_row( $batch_count_sql, ARRAY_A );
+
+		dd( $count_result );
+
+		if ( empty( $count_result ) ) {
+			return array();
+		}
+
+		// Parse results back to term_taxonomy_id => count format.
+		$final_counts = array();
+		foreach ( $hierarchy_counts as $term_taxonomy_id => $term_ids ) {
+			$count_key = "count_{$term_taxonomy_id}";
+			if ( isset( $count_result[ $count_key ] ) && $count_result[ $count_key ] > 0 ) {
+				$final_counts[ $term_taxonomy_id ] = absint( $count_result[ $count_key ] );
+			}
+		}
+
+		return $final_counts;
+	}
+
+	/**
+	 * Get term_taxonomy_id from term_id.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param string $taxonomy Taxonomy name.
+	 * @return int Term taxonomy ID.
+	 */
+	private function get_term_taxonomy_id_from_term_id( int $term_id, string $taxonomy ) {
+		global $wpdb;
+
+		$cache_key        = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . 'term_taxonomy_id_' . $term_id . '_' . $taxonomy;
+		$term_taxonomy_id = wp_cache_get( $cache_key );
+
+		if ( false === $term_taxonomy_id ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$term_taxonomy_id = $wpdb->get_var( $wpdb->prepare( "SELECT term_taxonomy_id FROM {$wpdb->term_taxonomy} WHERE term_id = %d AND taxonomy = %s", $term_id, $taxonomy ) );
+			wp_cache_set( $cache_key, $term_taxonomy_id, '', HOUR_IN_SECONDS );
+		}
+
+		return absint( $term_taxonomy_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -429,7 +429,7 @@ class FilterData {
 		$count_cases = array();
 		foreach ( $hierarchy_counts as $term_taxonomy_id => $term_ids ) {
 			$term_ids_str  = implode( ',', array_map( 'absint', $term_ids ) );
-			$count_cases[] = "SUM(CASE WHEN tt.term_id IN ({$term_ids_str}) THEN 1 ELSE 0 END) as count_{$term_taxonomy_id}";
+			$count_cases[] = "COUNT(DISTINCT CASE WHEN tt.term_id IN ({$term_ids_str}) THEN tr.object_id END) as count_{$term_taxonomy_id}";
 		}
 
 		$batch_count_sql = '

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -374,9 +374,7 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 						}
 					}
 
-					if ( ! is_wp_error( $children ) ) {
-						$expanded_term_ids = array_merge( $expanded_term_ids, $children );
-					}
+					$expanded_term_ids = array_merge( $expanded_term_ids, $children );
 				}
 
 				$term_ids = array_unique( $expanded_term_ids );

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Internal\ProductFilters;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\MainQueryClausesGenerator;
+use Automattic\WooCommerce\Internal\ProductFilters\CacheController;
 use WC_Tax;
 use WC_Cache_Helper;
 
@@ -328,13 +329,13 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		);
 
 		if ( is_wp_error( $all_terms ) ) {
-			$logger = wc_get_logger();
-			$logger->error(
-				$all_terms->get_error_message(),
-				array(
-					'taxonomies' => $chosen_taxonomies,
-				)
-			);
+			/**
+			 * No error logging needed here because:
+			 * 1. Taxonomy existence is already validated in the initial get_terms() call above
+			 * 2. get_terms() only returns WP_Error for invalid taxonomy or rare DB connection issues
+			 * 3. If the taxonomy was invalid, we would have failed earlier and never reached this code
+			 * 4. Database errors would likely affect the entire request, not just this call
+			 */
 			return $args;
 		}
 
@@ -347,6 +348,38 @@ class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
 		foreach ( $term_ids_by_taxonomy as $taxonomy => $term_ids ) {
 			if ( empty( $term_ids ) ) {
 				continue;
+			}
+
+			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+				$expanded_term_ids = $term_ids;
+
+				foreach ( $term_ids as $term_id ) {
+					$cache_key = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . 'child_terms_' . $taxonomy . '_' . $term_id;
+					$children  = wp_cache_get( $cache_key );
+
+					if ( false === $children ) {
+						$children = get_terms(
+							array(
+								'taxonomy'   => $taxonomy,
+								'child_of'   => $term_id,
+								'fields'     => 'ids',
+								'hide_empty' => false,
+							)
+						);
+
+						if ( ! is_wp_error( $children ) ) {
+							wp_cache_set( $cache_key, $children, '', HOUR_IN_SECONDS );
+						} else {
+							$children = array();
+						}
+					}
+
+					if ( ! is_wp_error( $children ) ) {
+						$expanded_term_ids = array_merge( $expanded_term_ids, $children );
+					}
+				}
+
+				$term_ids = array_unique( $expanded_term_ids );
 			}
 
 			$term_ids_list = '(' . implode( ',', array_map( 'absint', $term_ids ) ) . ')';

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataTest.php
@@ -301,6 +301,78 @@ class FilterDataTest extends AbstractProductFiltersTest {
 	}
 
 	/**
+	 * @testdox Test taxonomy count with hierarchical categories.
+	 *
+	 * Note: We create test categories here rather than using the existing ones from setUp()
+	 * because calculating expected counts for hierarchical categories would require complex
+	 * filtering logic in the callback passed to get_expected_category_counts(). The callback
+	 * would need to analyze the $product_data property to handle parent-child relationships.
+	 * For these hierarchy-specific tests, we directly create a simple parent-child
+	 * structure and assert the expected counts based on our test data.
+	 */
+	public function test_get_taxonomy_counts_with_hierarchical_categories() {
+		// Create parent category.
+		$parent_term = wp_insert_term( 'Electronics', 'product_cat' );
+		$parent_id = $parent_term['term_id'];
+
+		// Create child category.
+		$child_term = wp_insert_term( 'Phones', 'product_cat', array( 'parent' => $parent_id ) );
+		$child_id = $child_term['term_id'];
+
+		wp_set_object_terms( $this->products[0]->get_id(), array( $parent_id ), 'product_cat' );
+		wp_set_object_terms( $this->products[1]->get_id(), array( $child_id ), 'product_cat' );
+
+		$wp_query = new \WP_Query( array( 'post_type' => 'product' ) );
+		$query_vars = array_filter( $wp_query->query_vars );
+
+		$actual_taxonomy_counts = $this->sut->get_taxonomy_counts( $query_vars, 'product_cat' );
+
+		// Parent category should have count of 2, child category should have count of 1.
+		$this->assertSame( 2, $actual_taxonomy_counts[ $parent_id ] );
+		$this->assertSame( 1, $actual_taxonomy_counts[ $child_id ] );
+
+		wp_delete_term( $child_id, 'product_cat' );
+		wp_delete_term( $parent_id, 'product_cat' );
+	}
+
+	/**
+	 * @testdox Test taxonomy count with hierarchical categories and max price.
+	 *
+	 * Note: We create test categories here rather than using the existing ones from setUp()
+	 * because calculating expected counts for hierarchical categories would require complex
+	 * filtering logic in the callback passed to get_expected_category_counts(). The callback
+	 * would need to analyze the $product_data property to handle parent-child relationships.
+	 * For these hierarchy-specific tests, we directly create a simple parent-child
+	 * structure and assert the expected counts based on our test data.
+	 */
+	public function test_get_taxonomy_counts_with_hierarchical_categories_with_max_price() {
+		// Create parent category.
+		$parent_term = wp_insert_term( 'Electronics', 'product_cat' );
+		$parent_id = $parent_term['term_id'];
+
+		// Create child category.
+		$child_term = wp_insert_term( 'Phones', 'product_cat', array( 'parent' => $parent_id ) );
+		$child_id = $child_term['term_id'];
+
+		wp_set_object_terms( $this->products[0]->get_id(), array( $parent_id ), 'product_cat' );
+		wp_set_object_terms( $this->products[1]->get_id(), array( $child_id ), 'product_cat' );
+
+		$wp_query = new \WP_Query( array( 'post_type' => 'product' ) );
+		$wp_query->set( 'max_price', 15 );
+
+		$query_vars = array_filter( $wp_query->query_vars );
+
+		$actual_taxonomy_counts = $this->sut->get_taxonomy_counts( $query_vars, 'product_cat' );
+
+		// Parent category should have count of 1, child category should have count of 0.
+		$this->assertSame( 1, $actual_taxonomy_counts[ $parent_id ] );
+		$this->assertSame( 0, $actual_taxonomy_counts[ $child_id ] );
+
+		wp_delete_term( $child_id, 'product_cat' );
+		wp_delete_term( $parent_id, 'product_cat' );
+	}
+
+	/**
 	 * Get expected attribute count from product data and map them with actual term IDs.
 	 *
 	 * @param string   $attribute_name  WP_Query instance.

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/FilterDataTest.php
@@ -313,16 +313,16 @@ class FilterDataTest extends AbstractProductFiltersTest {
 	public function test_get_taxonomy_counts_with_hierarchical_categories() {
 		// Create parent category.
 		$parent_term = wp_insert_term( 'Electronics', 'product_cat' );
-		$parent_id = $parent_term['term_id'];
+		$parent_id   = $parent_term['term_id'];
 
 		// Create child category.
 		$child_term = wp_insert_term( 'Phones', 'product_cat', array( 'parent' => $parent_id ) );
-		$child_id = $child_term['term_id'];
+		$child_id   = $child_term['term_id'];
 
 		wp_set_object_terms( $this->products[0]->get_id(), array( $parent_id ), 'product_cat' );
 		wp_set_object_terms( $this->products[1]->get_id(), array( $child_id ), 'product_cat' );
 
-		$wp_query = new \WP_Query( array( 'post_type' => 'product' ) );
+		$wp_query   = new \WP_Query( array( 'post_type' => 'product' ) );
 		$query_vars = array_filter( $wp_query->query_vars );
 
 		$actual_taxonomy_counts = $this->sut->get_taxonomy_counts( $query_vars, 'product_cat' );
@@ -348,11 +348,11 @@ class FilterDataTest extends AbstractProductFiltersTest {
 	public function test_get_taxonomy_counts_with_hierarchical_categories_with_max_price() {
 		// Create parent category.
 		$parent_term = wp_insert_term( 'Electronics', 'product_cat' );
-		$parent_id = $parent_term['term_id'];
+		$parent_id   = $parent_term['term_id'];
 
 		// Create child category.
 		$child_term = wp_insert_term( 'Phones', 'product_cat', array( 'parent' => $parent_id ) );
-		$child_id = $child_term['term_id'];
+		$child_id   = $child_term['term_id'];
 
 		wp_set_object_terms( $this->products[0]->get_id(), array( $parent_id ), 'product_cat' );
 		wp_set_object_terms( $this->products[1]->get_id(), array( $child_id ), 'product_cat' );
@@ -364,9 +364,9 @@ class FilterDataTest extends AbstractProductFiltersTest {
 
 		$actual_taxonomy_counts = $this->sut->get_taxonomy_counts( $query_vars, 'product_cat' );
 
-		// Parent category should have count of 1, child category should have count of 0.
+		// Parent category should have count of 1, child category should not be in results.
 		$this->assertSame( 1, $actual_taxonomy_counts[ $parent_id ] );
-		$this->assertSame( 0, $actual_taxonomy_counts[ $child_id ] );
+		$this->assertArrayNotHasKey( $child_id, $actual_taxonomy_counts );
 
 		wp_delete_term( $child_id, 'product_cat' );
 		wp_delete_term( $parent_id, 'product_cat' );


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR adds hierarchical taxonomy support to WooCommerce product filtering, specifically enhancing how categories and other hierarchical taxonomies are handled in the ProductFilterTaxonomy block.

**Key Changes:**

-   Add hierarchical taxonomy detection in `QueryClauses.php` to automatically expand selected terms to include child terms
-   Implement hierarchical counting in `FilterData.php` that includes child term counts in parent term counts

**Why This Change:**
When users select a parent category in product filters, they expect to see products from child categories as well.

Note: The terms are not currently displayed in hierarchical order. This will be addressed in a follow-up PR.

Closes WOOPLUG-4918

### Screenshots or screen recordings

| Before | After |
| ------ | ----- |
|     <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/89a78a7a-d707-4970-9faf-d9e02bebe113" />   |    <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/4728b2ff-59ea-4cb5-bd7d-e2182df275ea" />   |

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Import sample data:**

    - Import the sample products from `plugins/woocommerce/sample-data/sample_products.csv`
    - This creates a "Clothing" parent category with child categories: "Tshirts", "Hoodies", and "Accessories"

2. **Add Product Catagories Filter block:**

    - Go to Appearance → Editor → Templates → Product Catalog
    - Add a "Product Categories Filter" block to Product Filters
    - Enable Product counts.
    - Save the template

3. **Test hierarchical filtering:**
    - Visit the shop page
    - Note the count displayed for "Clothing" category (should include all products from Tshirts, Hoodies, and Accessories)
    - Filter by "Clothing" parent category and verify all products from child categories appear
    - Add a price range filter (e.g., $15-$50) and verify the "Clothing" count updates to reflect only products within that price range across all child categories
    - Clear all filter then test filtering by individual child categories (e.g., "Tshirts") works normally

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Product Filters: Add hierarchical category support to product taxonomy filtering - when filtering by parent categories, products from child categories are now included in results.

</details>