### PR TITLE
Fix/fulfillments constructor causing text domain warnings

### DIFF
--- a/plugins/woocommerce/changelog/59353-update-wooplug-4287-selecting-all-countries-in-shipping-zone-settings-doesnt
+++ b/plugins/woocommerce/changelog/59353-update-wooplug-4287-selecting-all-countries-in-shipping-zone-settings-doesnt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update region picker empty value and label to match its behaviour.

--- a/plugins/woocommerce/changelog/59869-fix-fulfillments-load-text-domain-warning
+++ b/plugins/woocommerce/changelog/59869-fix-fulfillments-load-text-domain-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
+

--- a/plugins/woocommerce/changelog/59880-fix-fulfillments-constructor-causing-text-domain-warnings
+++ b/plugins/woocommerce/changelog/59880-fix-fulfillments-constructor-causing-text-domain-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
-

--- a/plugins/woocommerce/changelog/59880-fix-fulfillments-constructor-causing-text-domain-warnings
+++ b/plugins/woocommerce/changelog/59880-fix-fulfillments-constructor-causing-text-domain-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
+

--- a/plugins/woocommerce/changelog/wooplug-4916-register-url-param
+++ b/plugins/woocommerce/changelog/wooplug-4916-register-url-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Filters: Add taxonomy filter support for product queries.

--- a/plugins/woocommerce/changelog/wooplug-4921-add-filter-suffix-to-all-filter-blocks-and-variations-name
+++ b/plugins/woocommerce/changelog/wooplug-4921-add-filter-suffix-to-all-filter-blocks-and-variations-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add "Filter" suffix to all product filter block titles and variations

--- a/plugins/woocommerce/changelog/wooplug-5090-custom-email-templates-in-theme-not-being-pulled-in
+++ b/plugins/woocommerce/changelog/wooplug-5090-custom-email-templates-in-theme-not-being-pulled-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear template cache on email template edit via admin

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -5,9 +5,20 @@ import { useState } from '@wordpress/element';
 import { TreeSelectControl } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
+const everywhere = '__WC_TREE_SELECT_COMPONENT_ROOT__';
+
 export const RegionPicker = ( { options, initialValues } ) => {
-	const [ selected, setSelected ] = useState( initialValues );
+	const [ selected, setSelected ] = useState(
+		initialValues.length ? initialValues : [ everywhere ]
+	);
 	const onChange = ( value ) => {
+		// Set selection to 'everywhere' when empty or when 'everywhere' is the last selected.
+		if ( value.length === 0 || value[ value.length - 1 ] === everywhere ) {
+			value = [ everywhere ];
+		} else {
+			// Remove 'everywhere' from selection when other regions are chosen.
+			value = value.filter( ( item ) => item !== everywhere );
+		}
 		document.body.dispatchEvent(
 			new CustomEvent( 'wc_region_picker_update', { detail: value } )
 		);
@@ -20,7 +31,7 @@ export const RegionPicker = ( { options, initialValues } ) => {
 			onChange={ onChange }
 			options={ options }
 			placeholder={ __( 'Start typing to filter zones', 'woocommerce' ) }
-			selectAllLabel={ __( 'Select all countries', 'woocommerce' ) }
+			selectAllLabel={ __( 'Everywhere', 'woocommerce' ) }
 			individuallySelectParent
 			maxVisibleTags={ 5 }
 		/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -76,7 +76,11 @@ const productFiltersStore = {
 				params[ key ] = value;
 			}
 
+			const config = getConfig( BLOCK_NAME );
+			const taxonomyParamsMap = config?.taxonomyParamsMap || {};
+
 			activeFilters.forEach( ( filter ) => {
+				// todo: refactor this to use params data from Automattic\WooCommerce\Internal\ProductFilters\Params.
 				const { type, value } = filter;
 
 				if ( ! value ) return;
@@ -100,6 +104,12 @@ const productFiltersStore = {
 					addParam( `filter_${ slug }`, value );
 					params[ `query_type_${ slug }` ] =
 						filter.attributeQueryType || 'or';
+				}
+
+				if ( type.includes( 'taxonomy' ) ) {
+					const [ , taxonomy ] = type.split( '/' );
+					const paramKey = taxonomyParamsMap[ taxonomy ];
+					addParam( paramKey, value );
 				}
 			} );
 			return params;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/active-filters/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-active",
-	"title": "Active",
+	"title": "Active Filters",
 	"description": "Display the currently active filters.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-attribute",
-	"title": "Attribute",
+	"title": "Attribute Filter",
 	"description": "Enable customers to filter the product grid by selecting one or more attributes, such as color.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/index.tsx
@@ -33,7 +33,11 @@ registerBlockType( metadata, {
 	variations: ATTRIBUTES.map( ( attribute, index ) => {
 		return {
 			name: `product-filter-attribute-${ attribute.attribute_name }`,
-			title: `${ attribute.attribute_label }`,
+			title: sprintf(
+				// translators: %s is the attribute label.
+				__( '%s Filter', 'woocommerce' ),
+				attribute.attribute_label
+			),
 			description: sprintf(
 				// translators: %s is the attribute label.
 				__(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/price-filter/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "woocommerce/product-filter-price",
-	"title": "Price",
+	"title": "Price Filter",
 	"description": "Let shoppers filter products by choosing a price range.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/rating-filter/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/product-filter-rating",
-	"title": "Rating",
+	"title": "Rating Filter",
 	"description": "Enable customers to filter the product collection by rating.",
 	"category": "woocommerce",
 	"keywords": [],

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/product-filter-status",
-	"title": "Status",
+	"title": "Status Filter",
 	"description": "Let shoppers filter products by choosing stock status.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/woocommerce",
 	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
 	"homepage": "https://woocommerce.com/",
-	"version": "10.1.0",
+	"version": "10.2.0",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"prefer-stable": true,

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -44,7 +44,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '10.1.0';
+	public $version = '10.2.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -1148,6 +1148,7 @@ class WC_Email extends WC_Settings_API {
 				wp_safe_redirect( $redirect );
 				exit;
 			}
+			wc_clear_template_cache();
 		}
 	}
 

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/plugin-woocommerce",
 	"private": true,
 	"title": "WooCommerce",
-	"version": "10.1.0",
+	"version": "10.2.0",
 	"homepage": "https://woocommerce.com/",
 	"repository": {
 		"type": "git",

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -169,6 +169,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-= 10.1.0 2025-XX-XX =
+= 10.2.0 2025-XX-XX =
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/changelog.txt).

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterAttribute.php
@@ -28,7 +28,6 @@ final class ProductFilterAttribute extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 		add_action( 'deleted_transient', array( $this, 'delete_default_attribute_id_transient' ) );
 		add_action( 'wp_loaded', array( $this, 'register_block_patterns' ) );
@@ -60,27 +59,7 @@ final class ProductFilterAttribute extends AbstractBlock {
 		}
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$attribute_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return strpos( $param, 'filter_' ) === 0 || strpos( $param, 'query_type_' ) === 0;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$attribute_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterPrice.php
@@ -34,7 +34,6 @@ final class ProductFilterPrice extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
@@ -86,27 +85,7 @@ final class ProductFilterPrice extends AbstractBlock {
 		return $items;
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$price_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::MIN_PRICE_QUERY_VAR === $param || self::MAX_PRICE_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$price_param_keys
-		);
-	}
 
 	/**
 	 * Render the block.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterRating.php
@@ -32,31 +32,10 @@ final class ProductFilterRating extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$rating_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::RATING_FILTER_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$rating_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterStatus.php
@@ -29,31 +29,10 @@ final class ProductFilterStatus extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'woocommerce_blocks_product_filters_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
 	}
 
-	/**
-	 * Register the query param keys.
-	 *
-	 * @param array $filter_param_keys The active filters data.
-	 * @param array $url_param_keys    The query param parsed from the URL.
-	 *
-	 * @return array Active filters param keys.
-	 */
-	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
-		$stock_param_keys = array_filter(
-			$url_param_keys,
-			function ( $param ) {
-				return self::STOCK_STATUS_QUERY_VAR === $param;
-			}
-		);
 
-		return array_merge(
-			$filter_param_keys,
-			$stock_param_keys
-		);
-	}
 
 	/**
 	 * Prepare the active filter items.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -36,19 +36,23 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array
 	 */
 	private function get_taxonomies() {
-		$taxonomies    = get_object_taxonomies( 'product', 'objects' );
+		$taxonomies    = get_taxonomies(
+			array(
+				'public'      => true,
+				'object_type' => array( 'product' ),
+			),
+			'objects'
+		);
 		$taxonomy_data = array();
 
 		foreach ( $taxonomies as $taxonomy ) {
-			if ( $taxonomy->public && 'product_shipping_class' !== $taxonomy->name ) {
-				$taxonomy_data[] = array(
-					'label'  => $taxonomy->label,
-					'name'   => $taxonomy->name,
-					'labels' => array(
-						'singular_name' => $taxonomy->labels->singular_name,
-					),
-				);
-			}
+			$taxonomy_data[] = array(
+				'label'  => $taxonomy->label,
+				'name'   => $taxonomy->name,
+				'labels' => array(
+					'singular_name' => $taxonomy->labels->singular_name,
+				),
+			);
 		}
 
 		return $taxonomy_data;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -3,6 +3,10 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection\Utils as ProductCollectionUtils;
+use Automattic\WooCommerce\Internal\ProductFilters\FilterDataProvider;
+use Automattic\WooCommerce\Internal\ProductFilters\QueryClauses;
+
 /**
  * Product Filter: Taxonomy Block.
  */
@@ -14,6 +18,18 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-filter-taxonomy';
+
+	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+	}
 
 	/**
 	 * Extra data passed through from server to client for block.
@@ -31,21 +47,256 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	}
 
 	/**
+	 * Prepare the active filter items.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 *
+	 * @param array $items  The active filter items.
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters items.
+	 */
+	public function prepare_selected_filters( $items, $params ) {
+		$container      = wc_get_container();
+		$params_handler = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+
+		// Use centralized parameter mapping to avoid hardcoding URL parameter formats.
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		$active_taxonomies = array();
+		$all_term_slugs    = array();
+
+		foreach ( $taxonomy_params as $taxonomy_slug => $param_key ) {
+			if ( ! empty( $params[ $param_key ] ) && is_string( $params[ $param_key ] ) ) {
+				$term_slugs                          = array_map( 'sanitize_title', explode( ',', $params[ $param_key ] ) );
+				$active_taxonomies[ $taxonomy_slug ] = $term_slugs;
+				$all_term_slugs                      = array_merge( $all_term_slugs, $term_slugs );
+			}
+		}
+
+		if ( empty( $active_taxonomies ) ) {
+			return $items;
+		}
+
+		// Single query for all taxonomies and terms to avoid N+1 query problem.
+		$terms = get_terms(
+			array(
+				'taxonomy'   => array_keys( $active_taxonomies ),
+				'slug'       => array_unique( $all_term_slugs ),
+				'hide_empty' => false,
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return $items;
+		}
+
+		foreach ( $terms as $term ) {
+			$taxonomy_object = get_taxonomy( $term->taxonomy );
+			if ( $taxonomy_object ) {
+				$items[] = array(
+					'type'        => 'taxonomy/' . $term->taxonomy,
+					'value'       => $term->slug,
+					'activeLabel' => $taxonomy_object->labels->singular_name . ': ' . $term->name,
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $block_attributes Block attributes.
+	 * @param string   $content          Block content.
+	 * @param WP_Block $block            Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $block_attributes, $content, $block ) {
+		// Skip rendering in admin or during AJAX requests.
+		if ( is_admin() || wp_doing_ajax() || empty( $block_attributes['taxonomy'] ) ) {
+			return '';
+		}
+
+		$taxonomy        = $block_attributes['taxonomy'];
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
+		if ( ! $taxonomy_object || ! taxonomy_exists( $taxonomy ) ) {
+			return '';
+		}
+
+		// Validate that this taxonomy is configured in the parameter map.
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		if ( ! isset( $taxonomy_params[ $taxonomy ] ) ) {
+			return '';
+		}
+
+		// Pass taxonomy parameter mapping to frontend via interactivity config.
+		wp_interactivity_config(
+			'woocommerce/product-filters',
+			array(
+				'taxonomyParamsMap' => $taxonomy_params,
+			)
+		);
+
+		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
+		$hide_empty      = $block_attributes['hideEmpty'] ?? true;
+		$orderby         = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
+		$order           = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
+
+		$args = array(
+			'taxonomy' => $taxonomy,
+			'orderby'  => $orderby,
+			'order'    => $order,
+		);
+
+		if ( $hide_empty ) {
+			$args['include'] = array_keys( $taxonomy_counts );
+		} else {
+			$args['hide_empty'] = false;
+		}
+
+		$taxonomy_terms = get_terms( $args );
+
+		if ( is_wp_error( $taxonomy_terms ) ) {
+			return '';
+		}
+
+		// Get selected terms from filter params.
+		$filter_params  = $block->context['filterParams'] ?? array();
+		$selected_terms = array();
+		$param_key      = $taxonomy_params[ $taxonomy ];
+
+		if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
+			$selected_terms = array_filter( array_map( 'sanitize_title', explode( ',', $filter_params[ $param_key ] ) ) );
+		}
+
+		$filter_context = array(
+			'showCounts' => $block_attributes['showCounts'] ?? false,
+			'items'      => array(),
+			'groupLabel' => $taxonomy_object->labels->singular_name,
+		);
+
+		if ( ! empty( $taxonomy_counts ) ) {
+			$taxonomy_options = array_map(
+				function ( $term ) use ( $taxonomy_counts, $selected_terms, $taxonomy ) {
+					$term          = (array) $term;
+					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
+
+					return array(
+						'label'    => $term['name'],
+						'value'    => $term['slug'],
+						'selected' => in_array( $term['slug'], $selected_terms, true ),
+						'count'    => $term['count'],
+						'type'     => 'taxonomy/' . $taxonomy,
+					);
+				},
+				$taxonomy_terms
+			);
+
+			$filter_context['items'] = $taxonomy_options;
+		}
+
+		$wrapper_attributes = array(
+			'data-wp-interactive' => 'woocommerce/product-filters',
+			'data-wp-key'         => wp_unique_prefixed_id( $this->get_block_type() ),
+			'data-wp-context'     => wp_json_encode(
+				array(
+					'activeLabelTemplate' => $taxonomy_object->labels->singular_name . ': {{label}}',
+					'filterType'          => 'taxonomy/' . $taxonomy,
+				),
+				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			),
+		);
+
+		if ( empty( $filter_context['items'] ) ) {
+			$wrapper_attributes['hidden'] = true;
+			$wrapper_attributes['class']  = 'wc-block-product-filter--hidden';
+		}
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			get_block_wrapper_attributes( $wrapper_attributes ),
+			array_reduce(
+				$block->parsed_block['innerBlocks'],
+				function ( $carry, $parsed_block ) use ( $filter_context ) {
+					$carry .= ( new \WP_Block( $parsed_block, array( 'filterData' => $filter_context ) ) )->render();
+					return $carry;
+				},
+				''
+			)
+		);
+	}
+
+	/**
+	 * Retrieve the taxonomy term counts for current block.
+	 *
+	 * @param WP_Block $block    Block instance.
+	 * @param string   $taxonomy Taxonomy slug.
+	 * @return array Term counts with term_id as key and count as value.
+	 */
+	private function get_taxonomy_term_counts( $block, $taxonomy ) {
+		if ( ! isset( $block->context['filterParams'] ) ) {
+			return array();
+		}
+
+		$query_vars = ProductCollectionUtils::get_query_vars( $block, 1 );
+
+		// Remove current taxonomy from query vars to avoid circular counting.
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+
+		if ( isset( $taxonomy_params[ $taxonomy ] ) ) {
+			$param_key = $taxonomy_params[ $taxonomy ];
+			unset( $query_vars[ $param_key ] );
+		}
+
+		/**
+		 * Prevent circular counting when calculating filter counts with active attribute filters.
+		 * Removes product attribute taxonomy filters to ensure accurate cross-filter counting.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/52759
+		 */
+		if ( isset( $query_vars['taxonomy'] ) && false !== strpos( $query_vars['taxonomy'], 'pa_' ) ) {
+			unset(
+				$query_vars['taxonomy'],
+				$query_vars['term']
+			);
+		}
+
+		// Remove from tax_query if present.
+		if ( ! empty( $query_vars['tax_query'] ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			$query_vars['tax_query'] = ProductCollectionUtils::remove_query_array( $query_vars['tax_query'], 'taxonomy', $taxonomy );
+		}
+
+		$counts = $container->get( FilterDataProvider::class )->with( $container->get( QueryClauses::class ) )->get_taxonomy_counts( $query_vars, $taxonomy );
+
+		return $counts;
+	}
+
+	/**
 	 * Get product taxonomies for the block.
 	 *
 	 * @return array
 	 */
 	private function get_taxonomies() {
-		$taxonomies    = get_taxonomies(
-			array(
-				'public'      => true,
-				'object_type' => array( 'product' ),
-			),
-			'objects'
-		);
-		$taxonomy_data = array();
+		$container       = wc_get_container();
+		$params_handler  = $container->get( \Automattic\WooCommerce\Internal\ProductFilters\Params::class );
+		$taxonomy_params = $params_handler->get_param( 'taxonomy' );
+		$taxonomy_data   = array();
 
-		foreach ( $taxonomies as $taxonomy ) {
+		foreach ( array_keys( $taxonomy_params ) as $taxonomy_slug ) {
+			$taxonomy = get_taxonomy( $taxonomy_slug );
+
+			if ( ! $taxonomy ) {
+				continue;
+			}
+
 			$taxonomy_data[] = array(
 				'label'  => $taxonomy->label,
 				'name'   => $taxonomy->name,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilters.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
 
 /**
  * ProductFilters class.
@@ -226,17 +227,7 @@ class ProductFilters extends AbstractBlock {
 
 		parse_str( $parsed_url['query'], $url_query_params );
 
-		/**
-		 * Filters the active filter data provided by filter blocks.
-		 *
-		 * @since 11.7.0
-		 *
-		 * @param array $filter_param_keys The active filters data
-		 * @param array $url_param_keys    The query param parsed from the URL.
-		 *
-		 * @return array Active filters params.
-		 */
-		$filter_param_keys = array_unique( apply_filters( 'woocommerce_blocks_product_filters_param_keys', array(), array_keys( $url_query_params ) ) );
+		$filter_param_keys = wc_get_container()->get( Params::class )->get_param_keys();
 
 		return array_filter(
 			$url_query_params,

--- a/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/Fulfillment.php
@@ -17,7 +17,6 @@ use WC_Meta_Data;
 
 defined( 'ABSPATH' ) || exit;
 
-
 /**
  * WC Order Fulfillment Class
  *

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsManager.php
@@ -22,9 +22,9 @@ use WC_Order_Refund;
  */
 class FulfillmentsManager {
 	/**
-	 * Class constructor.
+	 * This method registers the hooks related to fulfillments.
 	 */
-	public function __construct() {
+	public function register() {
 		add_filter( 'woocommerce_fulfillment_shipping_providers', array( $this, 'get_initial_shipping_providers' ), 10, 1 );
 		add_filter( 'woocommerce_fulfillment_translate_meta_key', array( $this, 'translate_fulfillment_meta_key' ), 10, 1 );
 		add_filter( 'woocommerce_fulfillment_parse_tracking_number', array( $this, 'try_parse_tracking_number' ), 10, 3 );
@@ -165,7 +165,6 @@ class FulfillmentsManager {
 
 		$this->update_fulfillment_status( $order, $fulfillments );
 	}
-
 
 	/**
 	 * Update fulfillments after a refund is created.

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsRenderer.php
@@ -26,9 +26,9 @@ class FulfillmentsRenderer {
 	private array $fulfillments_cache = array();
 
 	/**
-	 * CLass constructor.
+	 * Registers the hooks related to fulfillments.
 	 */
-	public function __construct() {
+	public function register() {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// Hook into column definitions and add the new fulfillment columns.
 			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_fulfillment_columns' ) );

--- a/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
+++ b/plugins/woocommerce/src/Internal/Fulfillments/FulfillmentsSettings.php
@@ -13,9 +13,9 @@ use WC_Order;
 class FulfillmentsSettings {
 
 	/**
-	 * Constructor.
+	 * Registers the hooks related to fulfillments settings.
 	 */
-	public function __construct() {
+	public function register() {
 		add_filter( 'admin_init', array( $this, 'init_settings_auto_fulfill' ) );
 		add_action( 'woocommerce_order_status_processing', array( $this, 'auto_fulfill_items_on_processing' ), 10, 2 );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'auto_fulfill_items_on_completed' ), 10, 2 );

--- a/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/CacheController.php
@@ -10,6 +10,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Hooks into WooCommerce actions to register cache invalidation.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class CacheController implements RegisterHooksInterface {
 	const CACHE_GROUP = 'filter_data';
@@ -24,8 +26,6 @@ class CacheController implements RegisterHooksInterface {
 
 	/**
 	 * Invalidate all cache under filter data group.
-	 *
-	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function clear_filter_data_cache() {
 		WC_Cache_Helper::get_transient_version( self::CACHE_GROUP, true );

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class for filter counts.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class FilterData {
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterDataProvider.php
@@ -13,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Provider class.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
 class FilterDataProvider {
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/FilterUrlParam.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\ProductFilters\Interfaces;
+
+/**
+ * Interface for filter URL parameters.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+ */
+interface FilterUrlParam {
+	/**
+	 * Get the param keys.
+	 *
+	 * @return array
+	 */
+	public function get_param_keys(): array;
+
+	/**
+	 * Get the param.
+	 *
+	 * @param string $type The type of param to get.
+	 * @return array
+	 */
+	public function get_param( string $type ): array;
+}

--- a/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Interfaces/MainQueryClausesGenerator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ClausesProviderInterface interface file.
+ * MainQueryClausesGenerator interface file.
  */
 
 declare(strict_types=1);
@@ -10,18 +10,18 @@ namespace Automattic\WooCommerce\Internal\ProductFilters\Interfaces;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * QueryClausesGenerator interface.
+ * MainQueryClausesGenerator interface.
  *
  * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
-interface QueryClausesGenerator {
+interface MainQueryClausesGenerator {
 
 	/**
-	 * Add conditional query clauses based on the filter params in query vars.
+	 * Add conditional query clauses for main query based on the filter params in query vars.
 	 *
 	 * @param array     $args     Query args.
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( array $args, \WP_Query $wp_query ): array;
+	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query ): array;
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/Params.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/Params.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Internal\ProductFilters;
+
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\FilterUrlParam;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Single source of truth for managing all filter params.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+ */
+class Params implements FilterUrlParam {
+	/**
+	 * Hold the filter params.
+	 *
+	 * @var array
+	 */
+	private static $params = array();
+
+	/**
+	 * Get the param keys.
+	 *
+	 * @return array
+	 */
+	public function get_param_keys(): array {
+		if ( empty( self::$params ) ) {
+			$this->init_params();
+		}
+
+		$keys = array();
+		foreach ( self::$params as $taxonomy => $params ) {
+			$keys = array_merge( $keys, array_values( $params ) );
+			if ( 'attribute' === $taxonomy ) {
+				$query_type_params = array_map(
+					function ( $param ) {
+						return 'query_type_' . $param;
+					},
+					array_keys( $params )
+				);
+				$keys              = array_merge( $keys, $query_type_params );
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Get the param.
+	 *
+	 * @param string $type The type of param to get.
+	 * @return array
+	 */
+	public function get_param( string $type ): array {
+		if ( empty( self::$params ) ) {
+			$this->init_params();
+		}
+
+		return self::$params[ $type ] ?? array();
+	}
+
+	/**
+	 * Initialize the params.
+	 *
+	 * @return void
+	 */
+	private function init_params(): void {
+		self::$params = array(
+			'price'     => array(
+				'min_price',
+				'max_price',
+			),
+			'rating'    => array(
+				'rating_filter',
+			),
+			'status'    => array(
+				'filter_stock_status',
+			),
+			'attribute' => $this->get_attribute_params(),
+			'taxonomy'  => $this->get_taxonomy_params(),
+		);
+	}
+
+	/**
+	 * Get the attribute params.
+	 *
+	 * @return array
+	 */
+	private function get_attribute_params(): array {
+		$params = array();
+		foreach ( wc_get_attribute_taxonomies() as $attribute ) {
+			$params[ $attribute->attribute_name ] = "filter_$attribute->attribute_name";
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Get the taxonomy params.
+	 *
+	 * @return array
+	 */
+	private function get_taxonomy_params(): array {
+		$public_product_taxonomies = get_taxonomies(
+			array(
+				'public'  => true,
+				'show_ui' => true,
+			),
+			'objects'
+		);
+
+		// We have control over built-in taxonomies, so we can use prettier names.
+		$map = array(
+			'product_cat'   => 'categories',
+			'product_tag'   => 'tags',
+			'product_brand' => 'brands',
+		);
+
+		$params = array();
+
+		foreach ( $public_product_taxonomies as $taxonomy ) {
+			if ( is_array( $taxonomy->object_type ) && in_array( 'product', $taxonomy->object_type, true ) ) {
+				$params[ $taxonomy->name ] = $map[ $taxonomy->name ] ?? "filter_$taxonomy->name";
+			}
+		}
+
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/QueryClauses.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Internal\ProductFilters;
 
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\QueryClausesGenerator;
+use Automattic\WooCommerce\Internal\ProductFilters\Interfaces\MainQueryClausesGenerator;
 use WC_Tax;
 use WC_Cache_Helper;
 
@@ -16,8 +17,27 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class for filter clauses.
+ *
+ * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
  */
-class QueryClauses implements QueryClausesGenerator {
+class QueryClauses implements QueryClausesGenerator, MainQueryClausesGenerator {
+	/**
+	 * Hold the filter params.
+	 *
+	 * @var Params
+	 */
+	private $params;
+
+	/**
+	 * Initialize the query clauses.
+	 *
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
+	 * @param Params $params The filter params.
+	 * @return void
+	 */
+	final public function init( Params $params ): void {
+		$this->params = $params;
+	}
 
 	/**
 	 * Add conditional query clauses based on the filter params in query vars.
@@ -29,7 +49,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( $args, $wp_query ) {
+	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		if ( $wp_query->get( 'filter_stock_status' ) ) {
 			$stock_statuses = trim( $wp_query->get( 'filter_stock_status' ) );
 			$stock_statuses = explode( ',', $stock_statuses );
@@ -51,6 +71,44 @@ class QueryClauses implements QueryClausesGenerator {
 			$this->get_chosen_attributes( $wp_query->query_vars )
 		);
 
+		$args = $this->add_taxonomy_clauses(
+			$args,
+			$this->get_chosen_taxonomies( $wp_query->query_vars )
+		);
+
+		return $args;
+	}
+
+	/**
+	 * Add query clauses for main query.
+	 * WooCommerce handles attribute, price, and rating filters in the main query.
+	 * This method is used to add stock status and taxonomy filters to the main query.
+	 *
+	 * @param array     $args     Query args.
+	 * @param \WP_Query $wp_query WP_Query object.
+	 * @return array
+	 */
+	public function add_query_clauses_for_main_query( array $args, \WP_Query $wp_query ): array {
+		if (
+			! $wp_query->is_main_query() ||
+			'product_query' !== $wp_query->get( 'wc_query' )
+		) {
+			return $args;
+		}
+
+		if ( $wp_query->get( 'filter_stock_status' ) ) {
+			$stock_statuses = trim( $wp_query->get( 'filter_stock_status' ) );
+			$stock_statuses = explode( ',', $stock_statuses );
+			$stock_statuses = array_filter( $stock_statuses );
+
+			$args = $this->add_stock_clauses( $args, $stock_statuses );
+		}
+
+		$args = $this->add_taxonomy_clauses(
+			$args,
+			$this->get_chosen_taxonomies( $wp_query->query_vars )
+		);
+
 		return $args;
 	}
 
@@ -61,7 +119,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * @param array $stock_statuses Stock statuses to be queried.
 	 * @return array
 	 */
-	public function add_stock_clauses( $args, $stock_statuses ) {
+	public function add_stock_clauses( array $args, array $stock_statuses ): array {
 		$stock_statuses = array_filter( $stock_statuses );
 
 		if ( empty( $stock_statuses ) ) {
@@ -91,7 +149,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * }
 	 * @return array
 	 */
-	public function add_price_clauses( $args, $price_range ) {
+	public function add_price_clauses( array $args, array $price_range ): array {
 		if ( ! isset( $price_range['min_price'] ) && ! isset( $price_range['max_price'] ) ) {
 			return $args;
 		}
@@ -139,7 +197,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 *
 	 * @return array
 	 */
-	public function add_attribute_clauses( $args, $chosen_attributes ) {
+	public function add_attribute_clauses( array $args, array $chosen_attributes ): array {
 		if ( empty( $chosen_attributes ) ) {
 			return $args;
 		}
@@ -240,12 +298,103 @@ class QueryClauses implements QueryClausesGenerator {
 	}
 
 	/**
+	 * Add query clauses for taxonomy filter (e.g., product_cat, product_tag).
+	 *
+	 * @param array $args           Query args.
+	 * @param array $chosen_taxonomies {
+	 *     Chosen taxonomies array.
+	 *
+	 *     @type array {$taxonomy: Taxonomy name} {
+	 *         @type string[] $terms Chosen terms' slug.
+	 *     }
+	 * }
+	 * @return array
+	 */
+	public function add_taxonomy_clauses( array $args, array $chosen_taxonomies ): array {
+		if ( empty( $chosen_taxonomies ) ) {
+			return $args;
+		}
+
+		global $wpdb;
+
+		$tax_queries = array();
+
+		$all_terms = get_terms(
+			array(
+				'taxonomy'   => array_keys( $chosen_taxonomies ),
+				'slug'       => array_merge( ...array_values( $chosen_taxonomies ) ),
+				'hide_empty' => false,
+			)
+		);
+
+		if ( is_wp_error( $all_terms ) ) {
+			$logger = wc_get_logger();
+			$logger->error(
+				$all_terms->get_error_message(),
+				array(
+					'taxonomies' => $chosen_taxonomies,
+				)
+			);
+			return $args;
+		}
+
+		$term_ids_by_taxonomy = array();
+
+		foreach ( $all_terms as $term ) {
+			$term_ids_by_taxonomy[ $term->taxonomy ][] = $term->term_id;
+		}
+
+		foreach ( $term_ids_by_taxonomy as $taxonomy => $term_ids ) {
+			if ( empty( $term_ids ) ) {
+				continue;
+			}
+
+			$term_ids_list = '(' . implode( ',', array_map( 'absint', $term_ids ) ) . ')';
+
+			/*
+			 * Use EXISTS subquery for taxonomy filtering for several key benefits:
+			 *
+			 * 1. Performance: EXISTS stops execution as soon as the first matching row is found,
+			 *    making it faster than JOIN approaches that need to process all matches.
+			 *
+			 * 2. No duplicate rows: Unlike JOINs, EXISTS doesn't create duplicate rows when
+			 *    a product has multiple matching terms, eliminating the need for DISTINCT.
+			 *
+			 * 3. Clean boolean logic: We only care IF a product has the terms, not HOW MANY
+			 *    or which specific ones, making EXISTS semantically correct.
+			 *
+			 * 4. Efficient combination: Multiple taxonomy filters can be combined with AND
+			 *    without complex GROUP BY logic or performance degradation.
+			 */
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+			$tax_queries[] = $wpdb->prepare(
+				"EXISTS (
+					SELECT 1 FROM {$wpdb->term_relationships} tr
+					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+					WHERE tr.object_id = {$wpdb->posts}.ID
+					AND tt.taxonomy = %s
+					AND tt.term_id IN {$term_ids_list}
+				)",
+				$taxonomy
+			);
+		}
+
+		if ( ! empty( $tax_queries ) ) {
+			$args['where'] .= ' AND (' . implode( ' AND ', $tax_queries ) . ')';
+		} else {
+			$args['where'] .= ' AND 1=0';
+		}
+
+		return $args;
+	}
+
+	/**
 	 * Join wc_product_meta_lookup to posts if not already joined.
 	 *
 	 * @param string $sql SQL join.
 	 * @return string
 	 */
-	private function append_product_sorting_table_join( $sql ) {
+	private function append_product_sorting_table_join( string $sql ): string {
 		global $wpdb;
 
 		if ( ! strstr( $sql, 'wc_product_meta_lookup' ) ) {
@@ -262,7 +411,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 *
 	 * @return boolean
 	 */
-	private function should_adjust_price_filters_for_displayed_taxes() {
+	private function should_adjust_price_filters_for_displayed_taxes(): bool {
 		$display  = get_option( 'woocommerce_tax_display_shop' );
 		$database = wc_prices_include_tax() ? 'incl' : 'excl';
 
@@ -277,7 +426,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * @param string $operator Comparison operator for column. Accepts '>=' or '<='.
 	 * @return string Constructed query.
 	 */
-	private function get_price_filter_query_for_displayed_taxes( $price_filter, $column = 'min_price', $operator = '>=' ) {
+	private function get_price_filter_query_for_displayed_taxes( float $price_filter, string $column = 'min_price', string $operator = '>=' ): string {
 		global $wpdb;
 
 		if ( ! in_array( $operator, array( '>=', '<=' ), true ) ) {
@@ -329,7 +478,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * @param string $tax_class Tax class for adjustment.
 	 * @return float
 	 */
-	private function adjust_price_filter_for_tax_class( $price_filter, $tax_class ) {
+	private function adjust_price_filter_for_tax_class( float $price_filter, string $tax_class ): float {
 		$tax_display    = get_option( 'woocommerce_tax_display_shop' );
 		$tax_rates      = WC_Tax::get_rates( $tax_class );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $tax_class );
@@ -366,7 +515,7 @@ class QueryClauses implements QueryClausesGenerator {
 	 * @param array $query_vars The WP_Query arguments.
 	 * @return array
 	 */
-	private function get_chosen_attributes( $query_vars ) {
+	private function get_chosen_attributes( array $query_vars ): array {
 		$chosen_attributes = array();
 
 		if ( empty( $query_vars ) ) {
@@ -393,11 +542,33 @@ class QueryClauses implements QueryClausesGenerator {
 	}
 
 	/**
+	 * Get an array of taxonomies and terms selected from query arguments.
+	 *
+	 * @param array $query_vars The WP_Query arguments.
+	 * @return array
+	 */
+	private function get_chosen_taxonomies( array $query_vars ): array {
+		$chosen_taxonomies = array();
+
+		if ( empty( $query_vars ) ) {
+			return $chosen_taxonomies;
+		}
+
+		foreach ( $this->params->get_param( 'taxonomy' ) as $taxonomy => $param ) {
+			if ( isset( $query_vars[ $param ] ) && ! empty( trim( $query_vars[ $param ] ) ) ) {
+				$chosen_taxonomies[ $taxonomy ] = array_filter( array_map( 'sanitize_title', explode( ',', $query_vars[ $param ] ) ) );
+			}
+		}
+
+		return $chosen_taxonomies;
+	}
+
+	/**
 	 * Get attribute lookup table name.
 	 *
 	 * @return string
 	 */
-	private function get_lookup_table_name() {
+	private function get_lookup_table_name(): string {
 		return wc_get_container()->get( LookupDataStore::class )->get_lookup_table_name();
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php
@@ -350,7 +350,7 @@ class ProductQuery implements QueryClausesGenerator {
 	 * @param \WP_Query $wp_query WP_Query object.
 	 * @return array
 	 */
-	public function add_query_clauses( array $args, \WP_Query $wp_query ) {
+	public function add_query_clauses( array $args, \WP_Query $wp_query ): array {
 		global $wpdb;
 
 		if ( $wp_query->get( 'search' ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-emails-tests.php
@@ -69,7 +69,10 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 	public function test_fulfillment_meta() {
 		// Ensure the FulfillmentsController is registered, which is necessary for the translation of meta keys.
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$container  = wc_get_container();
+		$controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		$order       = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$fulfillment = FulfillmentsHelper::create_fulfillment(

--- a/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tax-test.php
@@ -7,8 +7,6 @@
 
 declare( strict_types=1 );
 
-use ReflectionClass;
-
 /**
  * Unit tests for the WC_Tax class get_shipping_tax_rates method and related functionality.
  * Covers edge case bug from https://github.com/woocommerce/woocommerce/issues/58757

--- a/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Helpers/FixtureData.php
@@ -263,6 +263,22 @@ class FixtureData {
 	}
 
 	/**
+	 * Create a product tag and return the result.
+	 *
+	 * @param array $props Tag props.
+	 * @return array
+	 */
+	public function get_product_tag( $props ) {
+		$tag_name = $props['name'] ?? 'Test Tag';
+
+		return wp_insert_term(
+			$tag_name,
+			'product_tag',
+			$props
+		);
+	}
+
+	/**
 	 * Create a product brand and return the result.
 	 *
 	 * @param array $props Product props.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreHookTest.php
@@ -32,7 +32,9 @@ class FulfillmentsDataStoreHookTest extends WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Fulfillments/FulfillmentsDataStoreTest.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Internal\Fulfillments\Fulfillment;
 use WC_Meta_Data;
 
 /**
- * Tests for the WC_Order_Fulfillment_Data_Store_Test  class.
+ * Tests for the WC_Order_Fulfillment_Data_Store_Test class.
  *
  * @package WooCommerce\Tests\Order_Fulfillment
  */
@@ -19,7 +19,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 *
 	 * @var FulfillmentsDataStore
 	 */
-	private static FulfillmentsDataStore $order_fulfillment_data_store;
+	private FulfillmentsDataStore $data_store;
 
 	/**
 	 * Runs before all the tests of the class.
@@ -27,8 +27,9 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
-		self::$order_fulfillment_data_store = new FulfillmentsDataStore();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -37,6 +38,24 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	public static function tearDownAfterClass(): void {
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
 		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
+	}
+
+	/**
+	 * Tear down the test case.
+	 */
+	public function tearDown(): void {
+		global $wpdb;
+		// Clean up the fulfillment meta table.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_fulfillment_meta" );
+		// Clean up the fulfillment table.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_order_fulfillments" );
 	}
 
 	/**
@@ -60,7 +79,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 		$this->assertFulfillmentRecordInDB( $fulfillment );
 		$this->assertFulfillmentMetaInDB( $fulfillment );
 	}
@@ -85,7 +104,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid entity type.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -108,7 +127,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid entity ID.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -124,7 +143,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The fulfillment should contain at least one item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -140,7 +159,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'The fulfillment should contain at least one item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -167,7 +186,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->expectException( \Exception::class );
 		$this->expectExceptionMessage( 'Invalid item.' );
 
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 	}
 
 	/**
@@ -190,14 +209,14 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$this->assertNotNull( $fulfillment->get_id() );
 
 		$new_fulfillment = new Fulfillment();
 		$new_fulfillment->set_id( $fulfillment->get_id() );
 
-		self::$order_fulfillment_data_store->read( $new_fulfillment );
+		$this->data_store->read( $new_fulfillment );
 
 		$this->assertFulfillmentRecordInDB( $new_fulfillment );
 		$this->assertFulfillmentMetaInDB( $new_fulfillment );
@@ -224,7 +243,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment->set_entity_id( '456' );
 		$fulfillment->set_items(
@@ -240,7 +259,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 			)
 		);
 
-		self::$order_fulfillment_data_store->update( $fulfillment );
+		$this->data_store->update( $fulfillment );
 
 		$this->assertFulfillmentRecordInDB( $fulfillment );
 		$this->assertFulfillmentMetaInDB( $fulfillment );
@@ -267,7 +286,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$this->assertNotNull( $fulfillment->get_id() );
 		$this->assertNull( $fulfillment->get_date_deleted() );
@@ -278,7 +297,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		// Cache the ID before deletion.
 		$fulfillment_id = $fulfillment->get_id();
 
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 		// The fulfillment should be reset to it's initial state.
 		$this->assertEquals( 0, $fulfillment->get_id() );
 		$this->assertEquals( null, $fulfillment->get_entity_type() );
@@ -315,7 +334,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotEquals( 0, $fulfillment->get_id() );
 
-		$result = self::$order_fulfillment_data_store->read_meta( $fulfillment );
+		$result = $this->data_store->read_meta( $fulfillment );
 
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
@@ -324,7 +343,6 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( '_items', $result[0]->meta_key );
 		$this->assertEquals( $fulfillment->get_id(), $result[0]->fulfillment_id );
 	}
-
 
 	/**
 	 * Tests the delete_meta method of the order fulfillment data store.
@@ -356,7 +374,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $items, $meta[0]->value );
 		$this->assertNotNull( $meta[0]->id );
 
-		self::$order_fulfillment_data_store->delete_meta( $fulfillment, $meta[0] ); // phpcs:ignore
+		$this->data_store->delete_meta( $fulfillment, $meta[0] ); // phpcs:ignore
 
 		global $wpdb;
 		$db_metadata = $wpdb->get_results(
@@ -392,7 +410,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->assertNotEquals( 0, $fulfillment->get_id() );
 
-		self::$order_fulfillment_data_store->add_meta(
+		$this->data_store->add_meta(
 			$fulfillment,
 			new WC_Meta_Data(
 				array(
@@ -461,7 +479,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		$this->assertCount( 1, $new_metadata );
 		$this->assertEquals( '_items', $new_metadata[0]->key );
 
-		$result = self::$order_fulfillment_data_store->update_meta( $fulfillment, $new_metadata[0] );
+		$result = $this->data_store->update_meta( $fulfillment, $new_metadata[0] );
 
 		$this->assertEquals( 1, $result );
 	}
@@ -471,7 +489,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_read_fulfillments() {
 		$this->prepare_db_for_test();
-		$fulfillments = self::$order_fulfillment_data_store->read_fulfillments( 'order-fulfillment', '123' );
+		$fulfillments = $this->data_store->read_fulfillments( 'order-fulfillment', '123' );
 		$this->assertCount( 2, $fulfillments );
 		$this->assertEquals( '123', $fulfillments[0]->get_entity_id() );
 		$this->assertEquals( 'order-fulfillment', $fulfillments[0]->get_entity_type() );
@@ -514,20 +532,20 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// Create a new fulfillment object and try to read the deleted one.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
 
 		// Should be able to read deleted fulfillment by ID.
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		$this->assertEquals( $fulfillment_id, $deleted_fulfillment->get_id() );
 		$this->assertEquals( 'order-fulfillment', $deleted_fulfillment->get_entity_type() );
@@ -551,25 +569,25 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// Create a new fulfillment object and read the deleted one.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		// Try to update the deleted fulfillment - should not affect any rows.
 		$deleted_fulfillment->set_entity_id( '456' );
 		$deleted_fulfillment->set_status( 'fulfilled' );
 
 		// Update should not throw an error but should not affect any rows.
-		self::$order_fulfillment_data_store->update( $deleted_fulfillment );
+		$this->data_store->update( $deleted_fulfillment );
 
 		// Verify the database record was not updated.
 		global $wpdb;
@@ -602,13 +620,13 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
-		self::$order_fulfillment_data_store->create( $fulfillment );
+		$this->data_store->create( $fulfillment );
 
 		$fulfillment_id = $fulfillment->get_id();
 		$this->assertNotNull( $fulfillment_id );
 
 		// Delete the fulfillment the first time.
-		self::$order_fulfillment_data_store->delete( $fulfillment );
+		$this->data_store->delete( $fulfillment );
 
 		// At this point, the fulfillment object should be reset.
 		$this->assertEquals( 0, $fulfillment->get_id() );
@@ -616,7 +634,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		// Read the deleted fulfillment back.
 		$deleted_fulfillment = new Fulfillment();
 		$deleted_fulfillment->set_id( $fulfillment_id );
-		self::$order_fulfillment_data_store->read( $deleted_fulfillment );
+		$this->data_store->read( $deleted_fulfillment );
 
 		$first_deletion_time = $deleted_fulfillment->get_date_deleted();
 		$this->assertNotNull( $first_deletion_time );
@@ -640,7 +658,7 @@ class FulfillmentsDataStoreTest extends \WC_Unit_Test_Case {
 		);
 
 		// Try to delete the already deleted fulfillment - should return early.
-		self::$order_fulfillment_data_store->delete( $deleted_fulfillment );
+		$this->data_store->delete( $deleted_fulfillment );
 
 		// Verify hooks were not called.
 		$this->assertFalse( $before_delete_called );

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentTest.php
@@ -17,7 +17,9 @@ class FulfillmentTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentUtilsTest.php
@@ -14,7 +14,9 @@ class FulfillmentUtilsTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsManagerTest.php
@@ -25,7 +25,9 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -41,7 +43,8 @@ class FulfillmentsManagerTest extends \WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->manager = new FulfillmentsManager();
+		$this->manager = wc_get_container()->get( FulfillmentsManager::class );
+		$this->manager->register();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRefundTest.php
@@ -35,9 +35,10 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		$container               = wc_get_container();
-		$fulfillments_controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
-		$fulfillments_controller->register();
+		$container  = wc_get_container();
+		$controller = $container->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 	}
 
 	/**
@@ -54,7 +55,8 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->data_store = wc_get_container()->get( FulfillmentsDataStore::class );
-		$this->manager    = new FulfillmentsManager();
+		$this->manager    = wc_get_container()->get( FulfillmentsManager::class );
+		$this->manager->register();
 	}
 
 	/**
@@ -634,7 +636,6 @@ class FulfillmentsRefundTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( 6, $quantities_by_item[ $item_id_1 ] ); // 10 - 6 = 4 pending, 3 reduced from pending, fulfillment stays the same.
 		$this->assertEquals( 5, $quantities_by_item[ $item_id_2 ] ); // 10 - 8 = 2 pending, 2 reduced from pending, 3 reduced from fulfillment, 5.
 	}
-
 
 	/**
 	 * Test fulfillment modifications with multiple refunds.

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererHooksTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/FulfillmentsRendererHooksTest.php
@@ -1,0 +1,130 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsRenderer;
+
+/**
+ * Tests for FulfillmentsRenderer hooks.
+ */
+class FulfillmentsRendererHooksTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * FulfillmentsRenderer instance.
+	 *
+	 * @var FulfillmentsRenderer
+	 */
+	private FulfillmentsRenderer $renderer;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public static function tearDownAfterClass(): void {
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'no' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Set up the test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->renderer = wc_get_container()->get( FulfillmentsRenderer::class );
+	}
+
+	/**
+	 * Test hooks.
+	 */
+	public function test_hooks() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( true );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->assertNotFalse( has_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this->renderer, 'add_fulfillment_columns' ) ) );
+		$this->assertNotFalse( has_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this->renderer, 'render_fulfillment_column_row_data' ) ) );
+		$this->assertNotFalse( has_action( 'admin_footer', array( $this->renderer, 'render_fulfillment_drawer_slot' ) ) );
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $this->renderer, 'load_components' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $this->renderer, 'init_admin_hooks' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test hooks when HPOS isn't enabled.
+	 */
+	public function test_hooks_legacy() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( false );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->assertNotFalse( has_filter( 'manage_edit-shop_order_columns', array( $this->renderer, 'add_fulfillment_columns' ) ) );
+		$this->assertNotFalse( has_action( 'manage_shop_order_posts_custom_column', array( $this->renderer, 'render_fulfillment_column_row_data_legacy' ) ) );
+		$this->assertNotFalse( has_action( 'admin_footer', array( $this->renderer, 'render_fulfillment_drawer_slot' ) ) );
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $this->renderer, 'load_components' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( $this->renderer, 'init_admin_hooks' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test that the admin_init hooks are registered.
+	 */
+	public function test_admin_init_hooks() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( true );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->renderer->init_admin_hooks();
+		$this->assertNotFalse( has_filter( 'bulk_actions-woocommerce_page_wc-orders', array( $this->renderer, 'define_fulfillment_bulk_actions' ) ) );
+		$this->assertNotFalse( has_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( $this->renderer, 'handle_fulfillment_bulk_actions' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+
+	/**
+	 * Test that the admin_init hooks are registered when HPOS isn't enabled.
+	 */
+	public function test_admin_init_hooks_legacy() {
+		/**
+		 * @var TestingContainer $container
+		 */
+		$container = wc_get_container();
+		$cot_mock  = $this->createMock( CustomOrdersTableController::class );
+		$cot_mock->method( 'custom_orders_table_usage_is_enabled' )->willReturn( false );
+		$container->replace( CustomOrdersTableController::class, $cot_mock );
+
+		$this->renderer->register();
+
+		$this->renderer->init_admin_hooks();
+		$this->assertNotFalse( has_filter( 'bulk_actions-edit-shop_order', array( $this->renderer, 'define_fulfillment_bulk_actions' ) ) );
+		$this->assertNotFalse( has_filter( 'handle_bulk_actions-edit-shop_order', array( $this->renderer, 'handle_fulfillment_bulk_actions' ) ) );
+		$container->reset_replacement( CustomOrdersTableController::class );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/OrderFulfillmentsRestControllerTest.php
@@ -53,7 +53,9 @@ class OrderFulfillmentsRestControllerTest extends WC_REST_Unit_Test_Case {
 		parent::setupBeforeClass();
 
 		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
-		wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class )->register();
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		self::$created_user_id = wp_create_user( 'test_user', 'password', 'nonadmin@example.com' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/ShippingProvidersTest.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Fulfillments;
 
-use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsManager;
 use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
 use Automattic\WooCommerce\Internal\Fulfillments\Providers as ShippingProviders;
 
@@ -16,7 +15,10 @@ class ShippingProvidersTest extends \WP_UnitTestCase {
 	 * Test that the shipping providers configuration returns the correct classes.
 	 */
 	public function test_shipping_providers_configuration(): void {
-		new FulfillmentsManager(); // Ensure the FulfillmentsManager is initialized to load the shipping providers.
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
 
 		$shipping_providers = FulfillmentUtils::get_shipping_providers();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Fulfillments/TrackingNumbersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Fulfillments/TrackingNumbersTest.php
@@ -21,7 +21,11 @@ class TrackingNumbersTest extends WP_UnitTestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->combinator = new FulfillmentsManager();
+		update_option( 'woocommerce_feature_fulfillments_enabled', 'yes' );
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\Fulfillments\FulfillmentsController::class );
+		$controller->register();
+		$controller->initialize_fulfillments();
+		$this->combinator = wc_get_container()->get( FulfillmentsManager::class );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/AbstractProductFiltersTest.php
@@ -41,6 +41,13 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 	protected $product_categories;
 
 	/**
+	 * Product tags.
+	 *
+	 * @var array
+	 */
+	protected $product_tags;
+
+	/**
 	 * Backup options.
 	 *
 	 * @var array
@@ -93,18 +100,41 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 			'cat-3' => $this->fixture_data->get_product_category( array( 'name' => 'Cat 3' ) ),
 		);
 
+		$this->product_tags = array(
+			'tag-1' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 1',
+					'slug' => 'tag-1',
+				)
+			),
+			'tag-2' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 2',
+					'slug' => 'tag-2',
+				)
+			),
+			'tag-3' => $this->fixture_data->get_product_tag(
+				array(
+					'name' => 'Tag 3',
+					'slug' => 'tag-3',
+				)
+			),
+		);
+
 		$this->products_data = array(
 			array(
 				'name'          => 'Product 1',
 				'regular_price' => 10,
 				'stock_status'  => ProductStockStatus::ON_BACKORDER,
 				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-1']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 2',
 				'regular_price' => 20,
 				'stock_status'  => ProductStockStatus::IN_STOCK,
 				'category_ids'  => array( $this->product_categories['cat-2']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-2']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 3',
@@ -114,17 +144,20 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 					$this->product_categories['cat-2']['term_id'],
 					$this->product_categories['cat-3']['term_id'],
 				),
+				'tag_ids'       => array( $this->product_tags['tag-3']['term_id'] ),
 			),
 			array(
 				'name'          => 'Product 4',
 				'regular_price' => 40,
 				'stock_status'  => ProductStockStatus::IN_STOCK,
 				'category_ids'  => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'       => array( $this->product_tags['tag-1']['term_id'] ),
 			),
 			array(
 				'name'         => 'Product 5',
 				'stock_status' => ProductStockStatus::IN_STOCK,
 				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'      => array( $this->product_tags['tag-2']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(
@@ -150,6 +183,7 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 				'name'         => 'Product 6',
 				'stock_status' => ProductStockStatus::IN_STOCK,
 				'category_ids' => array( $this->product_categories['cat-1']['term_id'] ),
+				'tag_ids'      => array( $this->product_tags['tag-3']['term_id'] ),
 				'variations'   => array(
 					array(
 						'attributes' => array(
@@ -188,6 +222,7 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 		$this->remove_all_attributes();
 		$this->remove_all_products();
 		$this->remove_all_product_categories();
+		$this->remove_all_product_tags();
 		$this->empty_lookup_tables();
 
 		foreach ( $this->backup_options as $option => $value ) {
@@ -263,6 +298,15 @@ abstract class AbstractProductFiltersTest extends \WC_Unit_Test_Case {
 	private function remove_all_product_categories() {
 		foreach ( $this->product_categories as $term ) {
 			wp_delete_term( $term['term_id'], 'product_cat' );
+		}
+	}
+
+	/**
+	 * Remove all product tags.
+	 */
+	private function remove_all_product_tags() {
+		foreach ( $this->product_tags as $term ) {
+			wp_delete_term( $term['term_id'], 'product_tag' );
 		}
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/ParamsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/ParamsTest.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Tests\Internal\ProductFilters;
+
+use Automattic\WooCommerce\Internal\ProductFilters\Params;
+
+require_once WC_ABSPATH . '/includes/class-wc-brands.php';
+
+/**
+ * Tests for the Params class.
+ */
+class ParamsTest extends AbstractProductFiltersTest {
+	/**
+	 * The system under test.
+	 *
+	 * @var Params
+	 */
+	private $sut;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Ensure brands taxonomy is registered for testing.
+		\WC_Brands::init_taxonomy();
+
+		$container = wc_get_container();
+		$this->sut = $container->get( Params::class );
+		$this->clear_params_cache();
+	}
+
+	/**
+	 * Test that get_param_keys returns all expected parameter types.
+	 */
+	public function test_get_param_keys_returns_all_parameter_types() {
+		$param_keys = $this->sut->get_param_keys();
+
+		// Should contain price parameters.
+		$this->assertContains( 'min_price', $param_keys );
+		$this->assertContains( 'max_price', $param_keys );
+
+		// Should contain rating parameters.
+		$this->assertContains( 'rating_filter', $param_keys );
+
+		// Should contain status parameters.
+		$this->assertContains( 'filter_stock_status', $param_keys );
+
+		// Should contain taxonomy parameters with prettier names.
+		$this->assertContains( 'categories', $param_keys );
+		$this->assertContains( 'tags', $param_keys );
+		$this->assertContains( 'brands', $param_keys );
+
+		// Should contain attribute parameters created in setup.
+		$this->assertContains( 'filter_color', $param_keys );
+		$this->assertContains( 'query_type_color', $param_keys );
+	}
+
+
+	/**
+	 * Test get_param method with different parameter types.
+	 *
+	 * @dataProvider param_type_provider
+	 * @param string $type The parameter type to test.
+	 * @param array  $expected_structure The expected structure for the parameter type.
+	 */
+	public function test_get_param_with_different_types( $type, $expected_structure ) {
+		$params = $this->sut->get_param( $type );
+
+		$this->assertIsArray( $params );
+
+		if ( ! empty( $expected_structure ) ) {
+			foreach ( $expected_structure as $expected_param ) {
+				$this->assertContains( $expected_param, $params );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for parameter types.
+	 */
+	public function param_type_provider() {
+		return array(
+			'price parameters'     => array(
+				'price',
+				array( 'min_price', 'max_price' ),
+			),
+			'rating parameters'    => array(
+				'rating',
+				array( 'rating_filter' ),
+			),
+			'status parameters'    => array(
+				'status',
+				array( 'filter_stock_status' ),
+			),
+			'taxonomy parameters'  => array(
+				'taxonomy',
+				array( 'categories', 'tags', 'brands' ),
+			),
+			'attribute parameters' => array(
+				'attribute',
+				array( 'filter_color' ), // Color attribute is created in setup.
+			),
+			'non-existent type'    => array(
+				'non_existent',
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * Test taxonomy parameter mapping for built-in taxonomies.
+	 */
+	public function test_taxonomy_parameter_mapping() {
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Test built-in taxonomy mappings.
+		$this->assertContains( 'categories', $taxonomy_params );
+		$this->assertContains( 'tags', $taxonomy_params );
+		$this->assertContains( 'brands', $taxonomy_params );
+	}
+
+	/**
+	 * Test that custom taxonomies use filter_ prefix.
+	 */
+	public function test_custom_taxonomy_parameter_generation() {
+		// Register a custom taxonomy.
+		register_taxonomy(
+			'product_custom_tax',
+			'product',
+			array(
+				'label'  => 'Custom Taxonomy',
+				'public' => true,
+			)
+		);
+
+		// Clear cached params to force re-initialization.
+		$this->clear_params_cache();
+
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Should contain custom taxonomy with filter_ prefix.
+		$this->assertContains( 'filter_product_custom_tax', $taxonomy_params );
+
+		// Clean up.
+		unregister_taxonomy( 'product_custom_tax' );
+	}
+
+	/**
+	 * Test static caching behavior.
+	 */
+	public function test_static_caching_behavior() {
+		// Clear cache to start fresh.
+		$this->clear_params_cache();
+
+		// First call should initialize params.
+		$first_call = $this->sut->get_param_keys();
+
+		// Modify the cached params to test if caching is working.
+		$reflection      = new \ReflectionClass( Params::class );
+		$params_property = $reflection->getProperty( 'params' );
+		$params_property->setAccessible( true );
+		$cached_params = $params_property->getValue();
+
+		// Add a test parameter to the cached data.
+		$cached_params['test_type'] = array( 'test_param' );
+		$params_property->setValue( $cached_params );
+
+		// Second call should return the modified cached data (proving caching works).
+		$second_call = $this->sut->get_param_keys();
+
+		// If caching works, the second call should include our test parameter.
+		$this->assertContains( 'test_param', $second_call, 'Second call should return modified cached data, proving caching works' );
+
+		// Test that get_param also uses the modified cached data.
+		$test_params = $this->sut->get_param( 'test_type' );
+		$this->assertEquals( array( 'test_param' ), $test_params, 'get_param should return modified cached data' );
+	}
+
+
+	/**
+	 * Test edge cases and error handling.
+	 */
+	public function test_edge_cases_and_error_handling() {
+		// Test with empty string parameter type.
+		$empty_params = $this->sut->get_param( '' );
+		$this->assertIsArray( $empty_params );
+		$this->assertEmpty( $empty_params );
+
+		// Test with non-existent parameter type.
+		$non_existent_params = $this->sut->get_param( 'non_existent_type' );
+		$this->assertIsArray( $non_existent_params );
+		$this->assertEmpty( $non_existent_params );
+	}
+
+	/**
+	 * Test that param keys are unique.
+	 */
+	public function test_param_keys_are_unique() {
+		$param_keys  = $this->sut->get_param_keys();
+		$unique_keys = array_unique( $param_keys );
+
+		$this->assertEquals( count( $param_keys ), count( $unique_keys ), 'Parameter keys should be unique' );
+	}
+
+	/**
+	 * Test that taxonomy parameters only include public taxonomies with UI.
+	 */
+	public function test_taxonomy_parameters_only_include_public_taxonomies_with_ui() {
+		// Register a private taxonomy.
+		register_taxonomy(
+			'product_private_tax',
+			'product',
+			array(
+				'label'   => 'Private Taxonomy',
+				'public'  => false,
+				'show_ui' => true,
+			)
+		);
+
+		// Register a public taxonomy without UI.
+		register_taxonomy(
+			'product_no_ui_tax',
+			'product',
+			array(
+				'label'   => 'No UI Taxonomy',
+				'public'  => true,
+				'show_ui' => false,
+			)
+		);
+
+		// Clear cached params.
+		$this->clear_params_cache();
+
+		$taxonomy_params = $this->sut->get_param( 'taxonomy' );
+
+		// Should not contain private taxonomy.
+		$this->assertNotContains( 'filter_product_private_tax', $taxonomy_params );
+
+		// Should not contain public taxonomy without UI.
+		$this->assertNotContains( 'filter_product_no_ui_tax', $taxonomy_params );
+
+		// Clean up.
+		unregister_taxonomy( 'product_private_tax' );
+		unregister_taxonomy( 'product_no_ui_tax' );
+	}
+
+	/**
+	 * Helper method to clear params cache for testing.
+	 */
+	private function clear_params_cache() {
+		$reflection      = new \ReflectionClass( Params::class );
+		$params_property = $reflection->getProperty( 'params' );
+		$params_property->setAccessible( true );
+		$params_property->setValue( array() );
+	}
+}

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An ecommerce toolkit that helps you sell anything. Beautifully.
- * Version: 10.1.0-dev
+ * Version: 10.2.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An ecommerce toolkit that helps you sell anything. Beautifully.
- * Version: 10.1.0-rc.1
+ * Version: 10.2.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR moves the class initializations of the fulfillments feature to the init action hook, and fixes the tests. (Also fixes one warning surfacing on the test runs, not related with this problem.)

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59870 WOOPLUG-5128

(For Bug Fixes) Bug introduced in PR #57353 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Before this PR, when you go to any page, you'll get a warning on your error log file saying that load text domain was called early. After applying these changes, you should see the warning is gone.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix load text domain warnings caused by fulfillments class loading features controller before fully initialized.
</details>
