### PR TITLE
Clean iAPI errors when interacting with the Add to Cart + Options form

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-clean-errors
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-clean-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clean iAPI errors when interacting with the Add to Cart + Options form again

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/store-notices.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/store-notices.ts
@@ -43,6 +43,7 @@ export type Store = {
 	actions: {
 		addNotice: ( notice: Notice ) => string;
 		removeNotice: ( noticeId: string | PointerEvent ) => void;
+		removeAllNotices: () => void;
 	};
 	callbacks: {
 		renderNoticeContent: () => void;
@@ -149,6 +150,11 @@ const { state } = store< Store >(
 				if ( index !== -1 ) {
 					notices.splice( index, 1 );
 				}
+			},
+
+			removeAllNotices: () => {
+				const { notices } = state;
+				notices.splice( 0, notices.length );
 			},
 		},
 		callbacks: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -220,6 +220,7 @@ const addToCartWithOptionsStore = store<
 		},
 		actions: {
 			setQuantity( value: number, childProductId?: number ) {
+				addToCartWithOptionsStore.actions.cleanErrorNotices();
 				const context = getContext< Context >();
 				const productId = childProductId || context.productId;
 
@@ -430,6 +431,20 @@ const addToCartWithOptionsStore = store<
 						type: productType,
 					} );
 				}
+			},
+			*cleanErrorNotices() {
+				// Todo: Use the module exports instead of `store()` once the store-notices
+				// store is public.
+				yield import( '@woocommerce/stores/store-notices' );
+				const { actions: noticeActions } = store< StoreNotices >(
+					'woocommerce/store-notices',
+					{},
+					{
+						lock: 'I acknowledge that using a private store means my plugin will inevitably break on the next store release.',
+					}
+				);
+
+				noticeActions.removeAllNotices();
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -152,6 +152,7 @@ export type AddToCartWithOptionsStore = {
 			event: HTMLElementEvent< HTMLInputElement >
 		) => void;
 		handleSubmit: ( event: FormEvent< HTMLFormElement > ) => void;
+		cleanErrorNotices: () => void;
 	};
 };
 
@@ -220,7 +221,6 @@ const addToCartWithOptionsStore = store<
 		},
 		actions: {
 			setQuantity( value: number, childProductId?: number ) {
-				addToCartWithOptionsStore.actions.cleanErrorNotices();
 				const context = getContext< Context >();
 				const productId = childProductId || context.productId;
 
@@ -340,6 +340,7 @@ const addToCartWithOptionsStore = store<
 			},
 			*handleSubmit( event: FormEvent< HTMLFormElement > ) {
 				event.preventDefault();
+				addToCartWithOptionsStore.actions.cleanErrorNotices();
 
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -140,13 +140,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await colorBlueOption.click();
 			await logoNoOption.click();
 
-			// Verify error was removed.
-			await expect(
-				page.getByText(
-					'Please select product attributes before adding to cart.'
-				)
-			).toBeHidden();
-
 			// Verify blocks updated.
 			await expect( page.getByText( 'Out of stock' ) ).toBeVisible();
 			await expect( productPrice ).toHaveText( '$45.00' );
@@ -163,6 +156,13 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await addToCartButton.click();
 
 			await expect( page.getByText( '1 in cart' ) ).toBeVisible();
+
+			// Verify error was removed.
+			await expect(
+				page.getByText(
+					'Please select product attributes before adding to cart.'
+				)
+			).toBeHidden();
 		} );
 
 		await test.step( '"X in cart" text reflects the correct amount in variations', async () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -140,6 +140,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await colorBlueOption.click();
 			await logoNoOption.click();
 
+			// Verify error was removed.
+			await expect(
+				page.getByText(
+					'Please select product attributes before adding to cart.'
+				)
+			).toBeHidden();
+
+			// Verify blocks updated.
 			await expect( page.getByText( 'Out of stock' ) ).toBeVisible();
 			await expect( productPrice ).toHaveText( '$45.00' );
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #58584.

This PR makes it so iAPI errors in the _Add to Cart + Options_ form are cleared every time the shopper interacts with the form.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. In the frontend, visit a variable product. Try to add it to the cart without selecting any attributes. Notice an error appears. Now select an attribute and verify the error disappears.
4. Now, visit a grouped product. Leaving all quantities to `0`, try adding to cart. Notice an error appears. Now change a quantity and verify the error disappears.

https://github.com/user-attachments/assets/98e2c927-062c-444d-a8d0-251d02b3b3a7
