### PR TITLE
Add i18n support to NOX and NOX in LYS step labels

### DIFF
--- a/plugins/woocommerce/changelog/fix-I18N-264-nox-steps-labels-localization
+++ b/plugins/woocommerce/changelog/fix-I18N-264-nox-steps-labels-localization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add i18n support to NOX and NOX in LYS step labels.

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
@@ -87,7 +87,7 @@ const InstallWooPaymentsStep = ( {
 			<div className="launch-your-store-payments-content__step--install-woopayments-logo">
 				<img
 					src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-					alt="Woo Logo"
+					alt={ __( 'Woo Logo', 'woocommerce' ) }
 				/>
 			</div>
 			<h1 className="launch-your-store-payments-content__step--install-woopayments-title">

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
@@ -4,7 +4,7 @@
 import { useCallback } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import React, { useEffect, useState } from '@wordpress/element';
 import { pluginsStore, paymentSettingsStore } from '@woocommerce/data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -87,7 +87,10 @@ const InstallWooPaymentsStep = ( {
 			<div className="launch-your-store-payments-content__step--install-woopayments-logo">
 				<img
 					src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-					alt={ __( 'Woo Logo', 'woocommerce' ) }
+					alt={
+						/* translators: %s: plugin name */
+						sprintf( __( '%s Logo', 'woocommerce' ), 'WooCommerce' )
+					}
 				/>
 			</div>
 			<h1 className="launch-your-store-payments-content__step--install-woopayments-title">

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/payments-content.tsx
@@ -4,7 +4,7 @@
 import { useCallback } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React, { useEffect, useState } from '@wordpress/element';
 import { pluginsStore, paymentSettingsStore } from '@woocommerce/data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -87,10 +87,8 @@ const InstallWooPaymentsStep = ( {
 			<div className="launch-your-store-payments-content__step--install-woopayments-logo">
 				<img
 					src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-					alt={
-						/* translators: %s: plugin name */
-						sprintf( __( '%s Logo', 'woocommerce' ), 'WooCommerce' )
-					}
+					alt=""
+					role="presentation"
 				/>
 			</div>
 			<h1 className="launch-your-store-payments-content__step--install-woopayments-title">

--- a/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/site-preview.tsx
+++ b/plugins/woocommerce/client/admin/client/launch-your-store/hub/main-content/pages/site-preview.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { useState, useRef, useEffect } from '@wordpress/element';
 import { Spinner } from '@woocommerce/components';
 import { useResizeObserver } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -88,7 +89,7 @@ export const SitePreviewPage = ( props: MainContentComponentProps ) => {
 							ref={ iframeRef }
 							className="launch-store-site__preview-site-iframe"
 							src={ siteUrl }
-							title="Preview"
+							title={ __( 'Preview', 'woocommerce' ) }
 							onLoad={ () => setIsLoading( false ) }
 						/>
 					</ResizableFrame>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
@@ -128,7 +128,8 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 						<div className="woocommerce-woopayments-modal__content__item-flex">
 							<img
 								src={ WC_ASSET_URL + 'images/icons/store.svg' }
-								alt={ __( 'Store icon', 'woocommerce' ) }
+								alt=""
+								role="presentation"
 							/>
 							<div className="woocommerce-woopayments-modal__content__item-flex__description">
 								<h3>
@@ -151,7 +152,8 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 									src={
 										WC_ASSET_URL + 'images/icons/dollar.svg'
 									}
-									alt={ __( 'Dollar icon', 'woocommerce' ) }
+									alt=""
+									role="presentation"
 								/>
 								<div className="woocommerce-woopayments-modal__content__item-flex__description">
 									<h3>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
@@ -128,7 +128,7 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 						<div className="woocommerce-woopayments-modal__content__item-flex">
 							<img
 								src={ WC_ASSET_URL + 'images/icons/store.svg' }
-								alt="store icon"
+								alt={ __( 'Store icon', 'woocommerce' ) }
 							/>
 							<div className="woocommerce-woopayments-modal__content__item-flex__description">
 								<h3>
@@ -151,7 +151,7 @@ export const WooPaymentsPostSandboxAccountSetupModal = ( {
 									src={
 										WC_ASSET_URL + 'images/icons/dollar.svg'
 									}
-									alt="dollar icon"
+									alt={ __( 'Dollar icon', 'woocommerce' ) }
 								/>
 								<div className="woocommerce-woopayments-modal__content__item-flex__description">
 									<h3>

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -19,7 +19,7 @@ import {
 	useLocation,
 } from 'react-router-dom';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -398,7 +398,11 @@ export const SettingsPaymentsWooPaymentsWrapper = () => {
 			<Suspense
 				fallback={
 					<div>
-						{ __( 'Loading WooPayments settings…', 'woocommerce' ) }
+						{ sprintf(
+							/* translators: %s: WooPayments */
+							__( 'Loading %s settings…', 'woocommerce' ),
+							'WooPayments'
+						) }
 					</div>
 				}
 			>

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -395,7 +395,13 @@ export const SettingsPaymentsWooPaymentsWrapper = () => {
 				title={ __( 'Settings', 'woocommerce' ) }
 				context={ 'wc_settings_payments__woopayments' }
 			/>
-			<Suspense fallback={ <div>{ __( 'Loading WooPayments settings...', 'woocommerce' ) }</div> }>
+			<Suspense
+				fallback={
+					<div>
+						{ __( 'Loading WooPayments settings…', 'woocommerce' ) }
+					</div>
+				}
+			>
 				<SettingsPaymentsWooPaymentsChunk />
 			</Suspense>
 		</>

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -395,7 +395,7 @@ export const SettingsPaymentsWooPaymentsWrapper = () => {
 				title={ __( 'Settings', 'woocommerce' ) }
 				context={ 'wc_settings_payments__woopayments' }
 			/>
-			<Suspense fallback={ <div>Loading WooPayments settings...</div> }>
+			<Suspense fallback={ <div>{ __( 'Loading WooPayments settings...', 'woocommerce' ) }</div> }>
 				<SettingsPaymentsWooPaymentsChunk />
 			</Suspense>
 		</>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
@@ -3,7 +3,7 @@
  */
 import { Button, Icon } from '@wordpress/components';
 import { close } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,7 +25,10 @@ export default function WooPaymentsStepHeader( {
 		<div className="settings-payments-onboarding-modal__header">
 			<img
 				src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-				alt={ __( 'Woo Logo', 'woocommerce' ) }
+				alt={
+					/* translators: %s: plugin name */
+					sprintf( __( '%s Logo', 'woocommerce' ), 'WooCommerce' )
+				}
 				className="settings-payments-onboarding-modal__header--logo"
 			/>
 			<Button

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
@@ -3,7 +3,6 @@
  */
 import { Button, Icon } from '@wordpress/components';
 import { close } from '@wordpress/icons';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,10 +24,8 @@ export default function WooPaymentsStepHeader( {
 		<div className="settings-payments-onboarding-modal__header">
 			<img
 				src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-				alt={
-					/* translators: %s: plugin name */
-					sprintf( __( '%s Logo', 'woocommerce' ), 'WooCommerce' )
-				}
+				alt=""
+				role="presentation"
 				className="settings-payments-onboarding-modal__header--logo"
 			/>
 			<Button

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/components/header/index.tsx
@@ -3,6 +3,7 @@
  */
 import { Button, Icon } from '@wordpress/components';
 import { close } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ export default function WooPaymentsStepHeader( {
 		<div className="settings-payments-onboarding-modal__header">
 			<img
 				src={ `${ WC_ASSET_URL }images/woo-logo.svg` }
-				alt="Woo Logo"
+				alt={ __( 'Woo Logo', 'woocommerce' ) }
 				className="settings-payments-onboarding-modal__header--logo"
 			/>
 			<Button

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,14 +19,14 @@ export const steps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'payment_methods',
 		order: 1,
 		type: 'backend',
-		label: 'Choose your payment methods',
+		label: __( 'Choose your payment methods', 'woocommerce' ),
 		content: <PaymentMethodsSelection />,
 	},
 	{
 		id: 'wpcom_connection',
 		order: 2,
 		type: 'backend',
-		label: 'Connect with WordPress.com',
+		label: __( 'Connect with WordPress.com', 'woocommerce' ),
 		content: <WordPressComStep />,
 		dependencies: [ 'payment_methods' ],
 	},
@@ -33,7 +34,7 @@ export const steps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'test_account',
 		order: 3,
 		type: 'backend',
-		label: 'Ready to test payments',
+		label: __( 'Ready to test payments', 'woocommerce' ),
 		dependencies: [ 'wpcom_connection' ],
 		content: <TestAccountStep />,
 	},
@@ -41,7 +42,7 @@ export const steps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'business_verification',
 		order: 4,
 		type: 'backend',
-		label: 'Activate Payments',
+		label: __( 'Activate Payments', 'woocommerce' ),
 		dependencies: [ 'test_account' ],
 		content: <BusinessVerificationStep />,
 	},
@@ -49,7 +50,7 @@ export const steps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'finish',
 		order: 5,
 		type: 'frontend',
-		label: 'Submit for verification',
+		label: __( 'Submit for verification', 'woocommerce' ),
 		dependencies: [ 'business_verification' ],
 		content: <FinishStep />,
 	},
@@ -60,14 +61,14 @@ export const LYSPaymentsSteps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'payment_methods',
 		order: 1,
 		type: 'backend',
-		label: 'Choose your payment methods',
+		label: __( 'Choose your payment methods', 'woocommerce' ),
 		content: <PaymentMethodsSelection />,
 	},
 	{
 		id: 'wpcom_connection',
 		order: 2,
 		type: 'backend',
-		label: 'Connect with WordPress.com',
+		label: __( 'Connect with WordPress.com', 'woocommerce' ),
 		content: <WordPressComStep />,
 		dependencies: [ 'payment_methods' ],
 	},
@@ -75,7 +76,7 @@ export const LYSPaymentsSteps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'business_verification',
 		order: 3,
 		type: 'backend',
-		label: 'Activate Payments',
+		label: __( 'Activate Payments', 'woocommerce' ),
 		dependencies: [ 'wpcom_connection' ],
 		content: <BusinessVerificationStep />,
 	},

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,7 +26,11 @@ export const steps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'wpcom_connection',
 		order: 2,
 		type: 'backend',
-		label: __( 'Connect with WordPress.com', 'woocommerce' ),
+		label: sprintf(
+			/* translators: %s: WordPress.com */
+			__( 'Connect with %s', 'woocommerce' ),
+			'WordPress.com'
+		),
 		content: <WordPressComStep />,
 		dependencies: [ 'payment_methods' ],
 	},
@@ -68,7 +72,11 @@ export const LYSPaymentsSteps: WooPaymentsProviderOnboardingStep[] = [
 		id: 'wpcom_connection',
 		order: 2,
 		type: 'backend',
-		label: __( 'Connect with WordPress.com', 'woocommerce' ),
+		label: sprintf(
+			/* translators: %s: WordPress.com */
+			__( 'Connect with %s', 'woocommerce' ),
+			'WordPress.com'
+		),
 		content: <WordPressComStep />,
 		dependencies: [ 'payment_methods' ],
 	},

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -511,7 +511,10 @@ const TestAccountStep = () => {
 											WC_ASSET_URL +
 											'images/icons/store.svg'
 										}
-										alt={ __( 'Store icon', 'woocommerce' ) }
+										alt={ __(
+											'Store icon',
+											'woocommerce'
+										) }
 									/>
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>
@@ -568,7 +571,10 @@ const TestAccountStep = () => {
 											WC_ASSET_URL +
 											'images/icons/dollar.svg'
 										}
-										alt={ __( 'Dollar icon', 'woocommerce' ) }
+										alt={ __(
+											'Dollar icon',
+											'woocommerce'
+										) }
 									/>
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -43,7 +43,7 @@ const TestDriveLoader: React.FunctionComponent< {
 			<Loader.Illustration>
 				<img
 					src={ `${ WC_ASSET_URL }images/onboarding/test-account-setup.svg` }
-					alt="setup"
+					alt={ __( 'Setup', 'woocommerce' ) }
 					style={ { maxWidth: '223px' } }
 				/>
 			</Loader.Illustration>
@@ -511,7 +511,7 @@ const TestAccountStep = () => {
 											WC_ASSET_URL +
 											'images/icons/store.svg'
 										}
-										alt="store icon"
+										alt={ __( 'Store icon', 'woocommerce' ) }
 									/>
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>
@@ -568,7 +568,7 @@ const TestAccountStep = () => {
 											WC_ASSET_URL +
 											'images/icons/dollar.svg'
 										}
-										alt="dollar icon"
+										alt={ __( 'Dollar icon', 'woocommerce' ) }
 									/>
 									<div className="woocommerce-woopayments-modal__content__item-flex__description">
 										<h3>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR ensures that all labels used in the NOX and NOX in LYS steps are properly localized using WordPress internationalization functions. Previously, these labels were hardcoded and not available for translation, which affected multilingual sites and user experience for non-English speakers.

Closes I18N-264

### How to test the changes in this Pull Request:
- Ensure the code changes are making sense.
- Perform a smoke test of the NOX onboarding flow. Confirm there are no errors during the process.
- Perform a smoke test of the NOX in LYS onboarding flow. Confirm there are no errors during the process.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
