### PR TITLE
Product Filters: Fixes loading skeleton styling for Checkbox List block

### DIFF
--- a/plugins/woocommerce/changelog/2025-07-23-04-47-08-190564
+++ b/plugins/woocommerce/changelog/2025-07-23-04-47-08-190564
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Filters: Fixes loading skeleton styling for Checkbox List block.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -63,15 +63,16 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 
 	const loadingState = useMemo( () => {
 		return [ ...Array( 5 ) ].map( ( x, i ) => (
-			<li
+			<div
+				className="wc-block-product-filter-checkbox-list__item"
 				key={ i }
 				style={ {
 					/* stylelint-disable */
-					width: Math.floor( Math.random() * ( 100 - 25 ) ) + '%',
+					width: Math.floor( Math.random() * 75 ) + '%',
 				} }
 			>
 				&nbsp;
-			</li>
+			</div>
 		) );
 	}, [] );
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/editor.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/editor.scss
@@ -1,11 +1,8 @@
 .wc-block-product-filter-checkbox-list.is-loading {
-	.wc-block-product-filter-checkbox-list__list {
-		padding: 0;
-
-		li {
-			@include placeholder();
-			margin: 5px 0;
-		}
+	.wc-block-product-filter-checkbox-list__item {
+		@include placeholder();
+		margin: 5px 0;
+		min-width: 25%;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines

- [ ] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [ ] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [ ] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR fixes the loading skeleton implementation for the Product Filter - Checkbox List block to prevent content jumping during the loading state.

Closes WOOPLUG-5054

### Screenshots or screen recordings

| Before | After |
| ------ | ----- |
|  <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/85a8c77b-281e-476e-a14f-d1c13ff380d2" />      |    <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/8a101980-a186-42f9-b2f9-5a04e03340d7" /> |

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Appearance → Editor → Templates → Product Catalog
2. Add a Product Filters block and insert a Checkbox List block inside it
3. Configure the Checkbox List block to filter by a product attribute or category
4. Save the template and view the product catalog page on the frontend
5. Reload the page and observe the loading skeleton - it should show placeholder items while the filter options load
