### PR TITLE
Refactor filter blocks to use shared DisplayStyleSwitcher component

### DIFF
--- a/plugins/woocommerce/changelog/59900-wooplug-4769-refactor-filter-blocks-to-use-shared-component-and-utility
+++ b/plugins/woocommerce/changelog/59900-wooplug-4769-refactor-filter-blocks-to-use-shared-component-and-utility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refactor Attribute and Status filter blocks to use shared DisplayStyleSwitcher component instead of duplicate implementations.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/components/display-style-switcher/index.tsx
@@ -22,7 +22,7 @@ export const DisplayStyleSwitcher = ( {
 }: {
 	clientId: string;
 	currentStyle: string;
-	onChange: ( value: string | number | undefined ) => void;
+	onChange: ( value: string ) => void;
 	parentBlockName: string;
 } ) => {
 	const displayStyleOptions = getBlockTypes().filter( ( blockType ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/components/display-style-switcher/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/components/display-style-switcher/index.tsx
@@ -18,21 +18,28 @@ export const DisplayStyleSwitcher = ( {
 	clientId,
 	currentStyle,
 	onChange,
-	parentBlockName,
 }: {
 	clientId: string;
 	currentStyle: string;
 	onChange: ( value: string ) => void;
-	parentBlockName: string;
 } ) => {
-	const displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
-		blockType.ancestor?.includes( parentBlockName )
-	);
+	const filterBlock = select( 'core/block-editor' ).getBlock( clientId );
+	const parentBlockName = filterBlock?.name;
+
+	const displayStyleOptions = getBlockTypes().filter( ( blockType ) => {
+		if ( parentBlockName ) {
+			return blockType.ancestor?.includes( parentBlockName );
+		}
+		return [];
+	} );
 
 	const { insertBlock, replaceBlock } = useDispatch( 'core/block-editor' );
 
 	const [ displayStyleBlocksAttributes, setDisplayStyleBlocksAttributes ] =
 		useState< Record< string, unknown > >( {} );
+
+	if ( displayStyleOptions.length === 0 ) return null;
+
 	return (
 		<ToggleGroupControl
 			value={ currentStyle }
@@ -43,8 +50,6 @@ export const DisplayStyleSwitcher = ( {
 			hideLabelFromVision
 			onChange={ ( value: string | number | undefined ) => {
 				if ( ! value || typeof value !== 'string' ) return;
-				const filterBlock =
-					select( 'core/block-editor' ).getBlock( clientId );
 				if ( ! filterBlock ) return;
 				const currentStyleBlock = getInnerBlockByName(
 					filterBlock,
@@ -88,12 +93,12 @@ export const DisplayStyleSwitcher = ( {
 
 export function resetDisplayStyleBlock(
 	clientId: string,
-	defaultStyle: string,
-	parentBlockName: string
+	defaultStyle: string
 ) {
 	const filterBlock = select( 'core/block-editor' ).getBlock( clientId );
 	if ( ! filterBlock ) return;
 
+	const parentBlockName = filterBlock.name;
 	const displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
 		blockType.ancestor?.includes( parentBlockName )
 	);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
@@ -8,10 +8,8 @@ import { Block, getBlockTypes } from '@wordpress/blocks';
 import {
 	SelectControl,
 	ToggleControl,
-	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
-	// @ts-expect-error - no types.
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -24,7 +22,7 @@ import {
  * Internal dependencies
  */
 import { sortOrderOptions, sortOrders } from './constants';
-import { BlockAttributes, EditProps } from './types';
+import { EditProps, DEFAULT_SORT_ORDER, DEFAULT_QUERY_TYPE } from './types';
 import metadata from './block.json';
 import {
 	DisplayStyleSwitcher,
@@ -56,10 +54,8 @@ export const Inspector = ( {
 					label={ __( 'Display Settings', 'woocommerce' ) }
 					resetAll={ () => {
 						setAttributes( {
-							sortOrder: metadata.attributes.sortOrder
-								.default as BlockAttributes[ 'sortOrder' ],
-							queryType: metadata.attributes.queryType
-								.default as BlockAttributes[ 'queryType' ],
+							sortOrder: DEFAULT_SORT_ORDER,
+							queryType: DEFAULT_QUERY_TYPE,
 							displayStyle:
 								metadata.attributes.displayStyle.default,
 							showCounts: metadata.attributes.showCounts.default,
@@ -73,13 +69,10 @@ export const Inspector = ( {
 				>
 					<ToolsPanelItem
 						label={ __( 'Sort Order', 'woocommerce' ) }
-						hasValue={ () =>
-							sortOrder !== metadata.attributes.sortOrder.default
-						}
+						hasValue={ () => sortOrder !== DEFAULT_SORT_ORDER }
 						onDeselect={ () =>
 							setAttributes( {
-								sortOrder: metadata.attributes.sortOrder
-									.default as BlockAttributes[ 'sortOrder' ],
+								sortOrder: DEFAULT_SORT_ORDER,
 							} )
 						}
 					>
@@ -117,13 +110,10 @@ export const Inspector = ( {
 					</ToolsPanelItem>
 					<ToolsPanelItem
 						label={ __( 'Logic', 'woocommerce' ) }
-						hasValue={ () =>
-							queryType !== metadata.attributes.queryType.default
-						}
+						hasValue={ () => queryType !== DEFAULT_QUERY_TYPE }
 						onDeselect={ () =>
 							setAttributes( {
-								queryType: metadata.attributes.queryType
-									.default as BlockAttributes[ 'queryType' ],
+								queryType: DEFAULT_QUERY_TYPE,
 							} )
 						}
 					>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
@@ -2,11 +2,9 @@
  * External dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { dispatch, useSelect } from '@wordpress/data';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Block, getBlockTypes, createBlock } from '@wordpress/blocks';
-import { getInnerBlockByName } from '@woocommerce/utils';
+import { Block, getBlockTypes } from '@wordpress/blocks';
 import {
 	SelectControl,
 	ToggleControl,
@@ -28,7 +26,10 @@ import {
 import { sortOrderOptions, sortOrders } from './constants';
 import { BlockAttributes, EditProps } from './types';
 import metadata from './block.json';
-import { resetDisplayStyleBlock } from '../../components/display-style-switcher';
+import {
+	DisplayStyleSwitcher,
+	resetDisplayStyleBlock,
+} from '../../components/display-style-switcher';
 
 let displayStyleOptions: Block[] = [];
 
@@ -39,15 +40,6 @@ export const Inspector = ( {
 }: EditProps ) => {
 	const { sortOrder, queryType, displayStyle, showCounts, hideEmpty } =
 		attributes;
-	const { insertBlock, replaceBlock } = dispatch( 'core/block-editor' );
-	const filterBlock = useSelect(
-		( select ) => {
-			return select( 'core/block-editor' ).getBlock( clientId );
-		},
-		[ clientId ]
-	);
-	const [ displayStyleBlocksAttributes, setDisplayStyleBlocksAttributes ] =
-		useState< Record< string, unknown > >( {} );
 
 	if ( displayStyleOptions.length === 0 ) {
 		displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
@@ -188,55 +180,13 @@ export const Inspector = ( {
 							);
 						} }
 					>
-						<ToggleGroupControl
-							value={ displayStyle }
-							isBlock
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							onChange={ (
-								value: BlockAttributes[ 'displayStyle' ]
-							) => {
-								if ( ! filterBlock ) return;
-								const currentStyleBlock = getInnerBlockByName(
-									filterBlock,
-									displayStyle
-								);
-
-								if ( currentStyleBlock ) {
-									setDisplayStyleBlocksAttributes( {
-										...displayStyleBlocksAttributes,
-										[ displayStyle ]:
-											currentStyleBlock.attributes,
-									} );
-									replaceBlock(
-										currentStyleBlock.clientId,
-										createBlock(
-											value,
-											displayStyleBlocksAttributes[
-												value
-											] || {}
-										)
-									);
-								} else {
-									insertBlock(
-										createBlock( value ),
-										filterBlock.innerBlocks.length,
-										filterBlock.clientId,
-										false
-									);
-								}
-								setAttributes( { displayStyle: value } );
-							} }
-							style={ { width: '100%' } }
-						>
-							{ displayStyleOptions.map( ( blockType ) => (
-								<ToggleGroupControlOption
-									key={ blockType.name }
-									label={ blockType.title }
-									value={ blockType.name }
-								/>
-							) ) }
-						</ToggleGroupControl>
+						<DisplayStyleSwitcher
+							clientId={ clientId }
+							currentStyle={ displayStyle }
+							onChange={ ( value ) =>
+								setAttributes( { displayStyle: value } )
+							}
+						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
 						label={ __( 'Product counts', 'woocommerce' ) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/inspector.tsx
@@ -56,8 +56,10 @@ export const Inspector = ( {
 					label={ __( 'Display Settings', 'woocommerce' ) }
 					resetAll={ () => {
 						setAttributes( {
-							sortOrder: metadata.attributes.sortOrder.default,
-							queryType: metadata.attributes.queryType.default,
+							sortOrder: metadata.attributes.sortOrder
+								.default as BlockAttributes[ 'sortOrder' ],
+							queryType: metadata.attributes.queryType
+								.default as BlockAttributes[ 'queryType' ],
 							displayStyle:
 								metadata.attributes.displayStyle.default,
 							showCounts: metadata.attributes.showCounts.default,
@@ -76,8 +78,8 @@ export const Inspector = ( {
 						}
 						onDeselect={ () =>
 							setAttributes( {
-								sortOrder:
-									metadata.attributes.sortOrder.default,
+								sortOrder: metadata.attributes.sortOrder
+									.default as BlockAttributes[ 'sortOrder' ],
 							} )
 						}
 					>
@@ -120,8 +122,8 @@ export const Inspector = ( {
 						}
 						onDeselect={ () =>
 							setAttributes( {
-								queryType:
-									metadata.attributes.queryType.default,
+								queryType: metadata.attributes.queryType
+									.default as BlockAttributes[ 'queryType' ],
 							} )
 						}
 					>
@@ -129,9 +131,11 @@ export const Inspector = ( {
 							label={ __( 'Logic', 'woocommerce' ) }
 							isBlock
 							value={ queryType }
-							onChange={ (
-								value: BlockAttributes[ 'queryType' ]
-							) => setAttributes( { queryType: value } ) }
+							onChange={ ( value ) => {
+								if ( value === 'and' || value === 'or' ) {
+									setAttributes( { queryType: value } );
+								}
+							} }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							style={ { width: '100%' } }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/attribute-filter/types.ts
@@ -8,6 +8,7 @@ import type { AttributeCount } from '@woocommerce/types';
  * Internal dependencies
  */
 import { sortOrders } from './constants';
+import metadata from './block.json';
 
 export type BlockAttributes = {
 	attributeId: number;
@@ -19,6 +20,11 @@ export type BlockAttributes = {
 	sortOrder: keyof typeof sortOrders;
 	hideEmpty: boolean;
 };
+
+export const DEFAULT_SORT_ORDER = metadata.attributes.sortOrder
+	.default as BlockAttributes[ 'sortOrder' ];
+export const DEFAULT_QUERY_TYPE = metadata.attributes.queryType
+	.default as BlockAttributes[ 'queryType' ];
 
 export interface EditProps extends BlockEditProps< BlockAttributes > {
 	debouncedSpeak: ( label: string ) => void;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
@@ -3,13 +3,23 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { EditProps } from './types';
-import { DisplayStyleSwitcher } from '../../components/display-style-switcher';
+import {
+	DisplayStyleSwitcher,
+	resetDisplayStyleBlock,
+} from '../../components/display-style-switcher';
+import metadata from './block.json';
 
 export const Inspector = ( {
 	attributes,
@@ -19,9 +29,39 @@ export const Inspector = ( {
 	const { displayStyle, showCounts, hideEmpty } = attributes;
 
 	return (
-		<>
-			<InspectorControls group="settings">
-				<PanelBody title={ __( 'Display', 'woocommerce' ) }>
+		<InspectorControls>
+			<ToolsPanel
+				label={ __( 'Display Settings', 'woocommerce' ) }
+				resetAll={ () => {
+					setAttributes( {
+						displayStyle: metadata.attributes.displayStyle.default,
+						showCounts: metadata.attributes.showCounts.default,
+						hideEmpty: metadata.attributes.hideEmpty.default,
+					} );
+					resetDisplayStyleBlock(
+						clientId,
+						metadata.attributes.displayStyle.default
+					);
+				} }
+			>
+				<ToolsPanelItem
+					label={ __( 'Display Style', 'woocommerce' ) }
+					hasValue={ () =>
+						displayStyle !==
+						'woocommerce/product-filter-checkbox-list'
+					}
+					isShownByDefault={ true }
+					onDeselect={ () => {
+						setAttributes( {
+							displayStyle:
+								metadata.attributes.displayStyle.default,
+						} );
+						resetDisplayStyleBlock(
+							clientId,
+							metadata.attributes.displayStyle.default
+						);
+					} }
+				>
 					<DisplayStyleSwitcher
 						clientId={ clientId }
 						currentStyle={ displayStyle }
@@ -29,24 +69,43 @@ export const Inspector = ( {
 							setAttributes( { displayStyle: value } )
 						}
 					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					label={ __( 'Product counts', 'woocommerce' ) }
+					hasValue={ () => showCounts }
+					onDeselect={ () =>
+						setAttributes( {
+							showCounts: metadata.attributes.showCounts.default,
+						} )
+					}
+					isShownByDefault={ true }
+				>
 					<ToggleControl
 						label={ __( 'Product counts', 'woocommerce' ) }
 						checked={ showCounts }
-						onChange={ ( value ) =>
+						onChange={ ( value: boolean ) =>
 							setAttributes( { showCounts: value } )
 						}
-						__nextHasNoMarginBottom
 					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					label={ __( 'Empty filter options', 'woocommerce' ) }
+					hasValue={ () => ! hideEmpty }
+					onDeselect={ () =>
+						setAttributes( {
+							hideEmpty: metadata.attributes.hideEmpty.default,
+						} )
+					}
+				>
 					<ToggleControl
 						label={ __( 'Empty filter options', 'woocommerce' ) }
 						checked={ ! hideEmpty }
-						onChange={ ( value ) =>
+						onChange={ ( value: boolean ) =>
 							setAttributes( { hideEmpty: ! value } )
 						}
-						__nextHasNoMarginBottom
 					/>
-				</PanelBody>
-			</InspectorControls>
-		</>
+				</ToolsPanelItem>
+			</ToolsPanel>
+		</InspectorControls>
 	);
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
@@ -3,27 +3,14 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Block, createBlock, getBlockTypes } from '@wordpress/blocks';
-import { useState } from '@wordpress/element';
-import { dispatch, useSelect } from '@wordpress/data';
-import { getInnerBlockByName } from '@woocommerce/utils';
-import {
-	PanelBody,
-	ToggleControl,
-	// @ts-expect-error - no types.
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	// @ts-expect-error - no types.
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { BlockAttributes, EditProps } from './types';
-
-let displayStyleOptions: Block[] = [];
+import { EditProps } from './types';
+import { DisplayStyleSwitcher } from '../../components/display-style-switcher';
+import metadata from './block.json';
 
 export const Inspector = ( {
 	attributes,
@@ -32,75 +19,18 @@ export const Inspector = ( {
 }: EditProps ) => {
 	const { displayStyle, showCounts, hideEmpty } = attributes;
 
-	if ( displayStyleOptions.length === 0 ) {
-		displayStyleOptions = getBlockTypes().filter( ( blockType ) =>
-			blockType.ancestor?.includes( 'woocommerce/product-filter-status' )
-		);
-	}
-
-	const { insertBlock, replaceBlock } = dispatch( 'core/block-editor' );
-	const filterBlock = useSelect(
-		( select ) => {
-			return select( 'core/block-editor' ).getBlock( clientId );
-		},
-		[ clientId ]
-	);
-
-	const [ displayStyleBlocksAttributes, setDisplayStyleBlocksAttributes ] =
-		useState< Record< string, unknown > >( {} );
-
 	return (
 		<>
 			<InspectorControls group="settings">
 				<PanelBody title={ __( 'Display', 'woocommerce' ) }>
-					<ToggleGroupControl
-						value={ displayStyle }
-						isBlock
-						onChange={ (
-							value: BlockAttributes[ 'displayStyle' ]
-						) => {
-							if ( ! filterBlock ) return;
-							const currentStyleBlock = getInnerBlockByName(
-								filterBlock,
-								displayStyle
-							);
-
-							if ( currentStyleBlock ) {
-								setDisplayStyleBlocksAttributes( {
-									...displayStyleBlocksAttributes,
-									[ displayStyle ]:
-										currentStyleBlock.attributes,
-								} );
-								replaceBlock(
-									currentStyleBlock.clientId,
-									createBlock(
-										value,
-										displayStyleBlocksAttributes[ value ] ||
-											{}
-									)
-								);
-							} else {
-								insertBlock(
-									createBlock( value ),
-									filterBlock.innerBlocks.length,
-									filterBlock.clientId,
-									false
-								);
-							}
-							setAttributes( { displayStyle: value } );
-						} }
-						style={ { width: '100%' } }
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-					>
-						{ displayStyleOptions.map( ( blockType ) => (
-							<ToggleGroupControlOption
-								key={ blockType.name }
-								label={ blockType.title }
-								value={ blockType.name }
-							/>
-						) ) }
-					</ToggleGroupControl>
+					<DisplayStyleSwitcher
+						clientId={ clientId }
+						currentStyle={ displayStyle }
+						onChange={ ( value ) =>
+							setAttributes( { displayStyle: value } )
+						}
+						parentBlockName={ metadata.name }
+					/>
 					<ToggleControl
 						label={ __( 'Product counts', 'woocommerce' ) }
 						checked={ showCounts }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/status-filter/inspector.tsx
@@ -10,7 +10,6 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
  */
 import { EditProps } from './types';
 import { DisplayStyleSwitcher } from '../../components/display-style-switcher';
-import metadata from './block.json';
 
 export const Inspector = ( {
 	attributes,
@@ -29,7 +28,6 @@ export const Inspector = ( {
 						onChange={ ( value ) =>
 							setAttributes( { displayStyle: value } )
 						}
-						parentBlockName={ metadata.name }
 					/>
 					<ToggleControl
 						label={ __( 'Product counts', 'woocommerce' ) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -110,8 +110,8 @@ export const TaxonomyFilterInspectorControls = ( {
 					<DisplayStyleSwitcher
 						clientId={ clientId }
 						currentStyle={ displayStyle }
-						onChange={ ( value: string | number | undefined ) =>
-							setAttributes( { displayStyle: value as string } )
+						onChange={ ( value ) =>
+							setAttributes( { displayStyle: value } )
 						}
 						parentBlockName={ metadata.name }
 					/>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/inspector.tsx
@@ -42,8 +42,7 @@ export const TaxonomyFilterInspectorControls = ( {
 					} );
 					resetDisplayStyleBlock(
 						clientId,
-						metadata.attributes.displayStyle.default,
-						metadata.name
+						metadata.attributes.displayStyle.default
 					);
 				} }
 			>
@@ -102,8 +101,7 @@ export const TaxonomyFilterInspectorControls = ( {
 						} );
 						resetDisplayStyleBlock(
 							clientId,
-							metadata.attributes.displayStyle.default,
-							metadata.name
+							metadata.attributes.displayStyle.default
 						);
 					} }
 				>
@@ -113,7 +111,6 @@ export const TaxonomyFilterInspectorControls = ( {
 						onChange={ ( value ) =>
 							setAttributes( { displayStyle: value } )
 						}
-						parentBlockName={ metadata.name }
 					/>
 				</ToolsPanelItem>
 				<ToolsPanelItem


### PR DESCRIPTION
### Submission Review Guidelines

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR refactors the Attribute and Status filter blocks to use the shared `DisplayStyleSwitcher` component. I took this chance to refactor the inspector setting of the status filter block to use `ToolsPanelItem`. I also improved the type handling of updated block. 

Closes WOOPLUG-4769

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template.
2. Test Status Filter Block:

    - In the block settings panel, verify that the "Display" section contains display style options
    - Switch between different display styles (List/Chips) and verify the block updates correctly
    - Confirm the display style switching behavior works as expected

3. Repeat step 2 for Attribute Filter Block.

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch
- [ ] Minor
- [ ] Major

#### Type

- [ ] Fix - Fixes an existing bug
- [ ] Add - Adds functionality
- [ ] Update - Update existing functionality
- [x] Dev - Development related task
- [ ] Tweak - A minor adjustment to the codebase
- [ ] Performance - Address performance issues
- [ ] Enhancement - Improvement to existing functionality

#### Message

Refactor Attribute and Status filter blocks to use shared DisplayStyleSwitcher component instead of duplicate implementations.

</details>