### PR TITLE
Fix email content and template validation in email editor

### DIFF
--- a/packages/js/email-editor/changelog/fix-email-editor-validation
+++ b/packages/js/email-editor/changelog/fix-email-editor-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Email Editor: validation now correctly runs when both the email body and its template are modified, preventing silent skips of template-only edits.

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -21,7 +21,7 @@ import {
 	initDomTracking,
 } from './events';
 import { initContentValidationMiddleware } from './middleware/content-validation';
-import { useContentValidation } from './hooks/use-content-validation';
+import { useContentValidation, useRemoveSavingFailedNotices } from './hooks';
 
 function Editor() {
 	const { postId, postType, settings } = useSelect(
@@ -33,6 +33,7 @@ function Editor() {
 		[]
 	);
 	useContentValidation();
+	useRemoveSavingFailedNotices();
 
 	// Set allowed blockTypes to the editor settings.
 	settings.allowedBlockTypes = getAllowedBlockNames();

--- a/packages/js/email-editor/src/editor.tsx
+++ b/packages/js/email-editor/src/editor.tsx
@@ -20,6 +20,7 @@ import {
 	initStoreTracking,
 	initDomTracking,
 } from './events';
+import { initContentValidationMiddleware } from './middleware/content-validation';
 import { useContentValidation } from './hooks/use-content-validation';
 
 function Editor() {
@@ -60,6 +61,7 @@ export function initialize( elementId: string ) {
 	initStoreTracking();
 	initDomTracking();
 	createStore();
+	initContentValidationMiddleware();
 	initializeLayout();
 	initBlocks();
 	initHooks();

--- a/packages/js/email-editor/src/hooks/index.ts
+++ b/packages/js/email-editor/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './use-email-styles';
 export * from './use-email-css';
 export * from './use-preview-templates';
 export * from './use-editor-mode';
+export * from './use-remove-saving-failed-notices';

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useCallback, useEffect } from '@wordpress/element';
-import { useSelect, subscribe } from '@wordpress/data';
+import { useSelect, subscribe, dispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { applyFilters, addFilter, removeFilter } from '@wordpress/hooks';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -90,28 +90,17 @@ export const useContentValidation = (): ContentValidationData => {
 		hasValidationNotice,
 	] );
 
+	// Register the validation function with the store
 	useEffect( () => {
-		const filterHandler = async ( edits: Record< string, unknown > ) => {
-			const isValid = validateContent();
-			if ( ! isValid ) {
-				throw new Error();
-			}
-			return edits;
-		};
-
-		addFilter(
-			'editor.preSavePost',
-			'woocommerce/email-editor/validate-content',
-			filterHandler
-		);
+		dispatch( emailEditorStore ).setContentValidation( {
+			validateContent,
+			isInvalid: hasValidationNotice(),
+		} );
 
 		return () => {
-			removeFilter(
-				'editor.preSavePost',
-				'woocommerce/email-editor/validate-content'
-			);
+			dispatch( emailEditorStore ).setContentValidation( undefined );
 		};
-	}, [ validateContent ] );
+	}, [ validateContent, hasValidationNotice ] );
 
 	// Subscribe to updates so notices can be dismissed once resolved.
 	useEffect( () => {

--- a/packages/js/email-editor/src/hooks/use-content-validation.ts
+++ b/packages/js/email-editor/src/hooks/use-content-validation.ts
@@ -21,7 +21,6 @@ import { useValidationNotices } from './use-validation-notices';
 const EMPTY_ARRAY = [];
 
 export type ContentValidationData = {
-	isInvalid: boolean;
 	validateContent: () => boolean;
 };
 
@@ -94,13 +93,12 @@ export const useContentValidation = (): ContentValidationData => {
 	useEffect( () => {
 		dispatch( emailEditorStore ).setContentValidation( {
 			validateContent,
-			isInvalid: hasValidationNotice(),
 		} );
 
 		return () => {
 			dispatch( emailEditorStore ).setContentValidation( undefined );
 		};
-	}, [ validateContent, hasValidationNotice ] );
+	}, [ validateContent ] );
 
 	// Subscribe to updates so notices can be dismissed once resolved.
 	useEffect( () => {
@@ -115,7 +113,6 @@ export const useContentValidation = (): ContentValidationData => {
 	}, [ hasValidationNotice, validateContent ] );
 
 	return {
-		isInvalid: hasValidationNotice(),
 		validateContent,
 	};
 };

--- a/packages/js/email-editor/src/hooks/use-remove-saving-failed-notices.ts
+++ b/packages/js/email-editor/src/hooks/use-remove-saving-failed-notices.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useMemo } from '@wordpress/element';
+import { subscribe, select, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Remove error notice that could be confusing for users. This error is thrown when we reject saving in the validation middleware.
+ * For example: Saving failed. Error: Content validation failed.
+ */
+export const useRemoveSavingFailedNotices = () => {
+	// Create a regular expression that escapes special characters and matches the beginning of the string
+	const savingFailedRegex = useMemo( () => {
+		// Get the translated "Saving failed" message once
+		// eslint-disable-next-line @wordpress/i18n-text-domain -- We want to match WordPress translation here.
+		const savingFailedMessage = __( 'Saving failed.' );
+		return new RegExp(
+			'^' + savingFailedMessage.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' )
+		);
+	}, [] );
+
+	useEffect( () => {
+		const unsubscribe = subscribe( () => {
+			select( noticesStore )
+				.getNotices()
+				.forEach( ( notice ) => {
+					if (
+						typeof notice.content === 'string' &&
+						savingFailedRegex.test( notice.content )
+					) {
+						dispatch( noticesStore ).removeNotice( notice.id );
+					}
+				} );
+		} );
+
+		return () => {
+			unsubscribe(); // Clean up subscription
+		};
+	}, [ savingFailedRegex ] );
+};

--- a/packages/js/email-editor/src/middleware/content-validation.ts
+++ b/packages/js/email-editor/src/middleware/content-validation.ts
@@ -10,8 +10,8 @@ import { __ } from '@wordpress/i18n';
 import { storeName as emailEditorStore } from '../store';
 
 // Store original actions and rewritten actions
-const originalActions = {};
-const rewrittenActions = {};
+const originalActions = new WeakMap();
+const rewrittenActions = new WeakMap();
 
 // Define which stores and actions we want to intercept
 const INTERCEPTED_ACTIONS = {
@@ -84,15 +84,10 @@ export const initContentValidationMiddleware = () => {
 								}
 							}
 
-							try {
-								// If validation passes, call the original function
-								return await originalActions[ storeName ][
-									actionName
-								]( ...args );
-							} catch ( error ) {
-								// For other types of errors, just rethrow them
-								throw error;
-							}
+							// If validation passes, call the original function
+							return await originalActions[ storeName ][
+								actionName
+							]( ...args );
 						};
 
 						actions[ actionName ] =

--- a/packages/js/email-editor/src/middleware/content-validation.ts
+++ b/packages/js/email-editor/src/middleware/content-validation.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { use, subscribe, select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { storeName as emailEditorStore } from '../store';
+
+// Store original actions and rewritten actions
+const originalActions = {};
+const rewrittenActions = {};
+
+// Define which stores and actions we want to intercept
+const INTERCEPTED_ACTIONS = {
+	core: [ 'saveEditedEntityRecord', 'saveEntityRecord' ],
+};
+
+export const initContentValidationMiddleware = () => {
+	// Check if middleware is already registered to avoid duplicate registrations
+	if ( Object.keys( originalActions ).length > 0 ) {
+		return;
+	}
+
+	use( ( registry ) => ( {
+		dispatch: ( namespace ) => {
+			const storeName =
+				typeof namespace === 'object' ? namespace.name : namespace;
+
+			// Only intercept actions for stores we're interested in
+			if ( ! INTERCEPTED_ACTIONS[ storeName ] ) {
+				return registry.dispatch( storeName );
+			}
+
+			const actions = registry.dispatch( storeName );
+
+			// Initialize namespace level objects if not yet done
+			if ( ! rewrittenActions[ storeName ] ) {
+				rewrittenActions[ storeName ] = {};
+			}
+			if ( ! originalActions[ storeName ] ) {
+				originalActions[ storeName ] = {};
+			}
+
+			// Only intercept actions we're interested in
+			for ( const actionName of INTERCEPTED_ACTIONS[ storeName ] ) {
+				if ( ! originalActions[ storeName ][ actionName ] ) {
+					originalActions[ storeName ][ actionName ] =
+						actions[ actionName ];
+
+					if (
+						actionName === 'saveEditedEntityRecord' ||
+						actionName === 'saveEntityRecord'
+					) {
+						rewrittenActions[ storeName ][ actionName ] = async (
+							...args
+						) => {
+							// Get validation function from the store
+							const validation = registry
+								.select( emailEditorStore )
+								.getContentValidation();
+
+							const validateContent = validation?.validateContent;
+
+							if ( validateContent ) {
+								let isValid = false;
+								try {
+									// Validate content before saving
+									isValid = validateContent();
+								} catch ( error ) {
+									// If there's an error, we'll consider the validation failed
+									isValid = false;
+								}
+
+								if ( ! isValid ) {
+									// Return a rejected promise instead of throwing an error
+									return Promise.reject(
+										new Error(
+											'Content validation failed.'
+										)
+									);
+								}
+							}
+
+							try {
+								// If validation passes, call the original function
+								return await originalActions[ storeName ][
+									actionName
+								]( ...args );
+							} catch ( error ) {
+								// For other types of errors, just rethrow them
+								throw error;
+							}
+						};
+
+						actions[ actionName ] =
+							rewrittenActions[ storeName ][ actionName ];
+					}
+				}
+			}
+
+			return actions;
+		},
+	} ) );
+
+	// Remove error notice that could be confusing for users.
+	subscribe( () => {
+		select( 'core/notices' )
+			.getNotices()
+			.forEach( ( notice ) => {
+				if ( /^Saving failed/.test( notice.content ) ) {
+					dispatch( 'core/notices' ).removeNotice( notice.id );
+				}
+			} );
+	} );
+};

--- a/packages/js/email-editor/src/middleware/content-validation.ts
+++ b/packages/js/email-editor/src/middleware/content-validation.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { use, subscribe, select, dispatch } from '@wordpress/data';
+import { use } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -9,9 +9,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { storeName as emailEditorStore } from '../store';
 
-// Store original actions and rewritten actions
+// Store original actions
 const originalActions = new WeakMap();
-const rewrittenActions = new WeakMap();
 
 // Define which stores and actions we want to intercept
 const INTERCEPTED_ACTIONS = {
@@ -37,86 +36,63 @@ export const initContentValidationMiddleware = () => {
 			const actions = registry.dispatch( storeName );
 
 			// Initialize namespace level objects if not yet done
-			if ( ! rewrittenActions[ storeName ] ) {
-				rewrittenActions[ storeName ] = {};
-			}
 			if ( ! originalActions[ storeName ] ) {
 				originalActions[ storeName ] = {};
 			}
 
-			// Only intercept actions we're interested in
-			for ( const actionName of INTERCEPTED_ACTIONS[ storeName ] ) {
-				if ( ! originalActions[ storeName ][ actionName ] ) {
+			// Check if we need to intercept any actions for this store
+			const actionsToIntercept = INTERCEPTED_ACTIONS[ storeName ].filter(
+				( actionName ) => ! originalActions[ storeName ][ actionName ]
+			);
+
+			// Only proceed with the loop if there are actions to intercept
+			if ( actionsToIntercept.length > 0 ) {
+				// Only intercept actions we're interested in
+				for ( const actionName of actionsToIntercept ) {
 					originalActions[ storeName ][ actionName ] =
 						actions[ actionName ];
 
-					if (
-						actionName === 'saveEditedEntityRecord' ||
-						actionName === 'saveEntityRecord'
-					) {
-						rewrittenActions[ storeName ][ actionName ] = async (
-							...args
-						) => {
-							// Get validation function from the store
-							const validation = registry
-								.select( emailEditorStore )
-								.getContentValidation();
+					// Create a local rewritten action
+					actions[ actionName ] = async ( ...args ) => {
+						// Get validation function from the store
+						const validation = registry
+							.select( emailEditorStore )
+							.getContentValidation();
 
-							const validateContent = validation?.validateContent;
+						const validateContent = validation?.validateContent;
 
-							if ( validateContent ) {
-								let isValid = false;
-								try {
-									// Validate content before saving
-									isValid = validateContent();
-								} catch ( error ) {
-									// If there's an error, we'll consider the validation failed
-									isValid = false;
-								}
-
-								if ( ! isValid ) {
-									// Return a rejected promise instead of throwing an error
-									return Promise.reject(
-										new Error(
-											'Content validation failed.'
-										)
-									);
-								}
+						if ( validateContent ) {
+							let isValid;
+							try {
+								// Validate content before saving
+								isValid = validateContent();
+							} catch ( error ) {
+								// If there's an error, we'll consider the validation failed
+								isValid = false;
 							}
 
-							// If validation passes, call the original function
-							return await originalActions[ storeName ][
-								actionName
-							]( ...args );
-						};
+							if ( ! isValid ) {
+								// Return a rejected promise instead of throwing an error
+								return Promise.reject(
+									new Error(
+										__(
+											'Content validation failed.',
+											'woocommerce'
+										)
+									)
+								);
+							}
+						}
 
-						actions[ actionName ] =
-							rewrittenActions[ storeName ][ actionName ];
-					}
+						// If validation passes, call the original function
+						return await originalActions[ storeName ][ actionName ](
+							...args
+						);
+					};
 				}
 			}
 
 			return actions;
 		},
 	} ) );
-
-	// Remove error notice that could be confusing for users.
-	// Use a translated message to support all languages
-	subscribe( () => {
-		// Get the translated "Saving failed" message
-		// eslint-disable-next-line @wordpress/i18n-text-domain
-		const savingFailedMessage = __( 'Saving failed.' );
-		// Create a regular expression that escapes special characters and matches the beginning of the string
-		const savingFailedRegex = new RegExp(
-			'^' + savingFailedMessage.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' )
-		);
-
-		select( 'core/notices' )
-			.getNotices()
-			.forEach( ( notice ) => {
-				if ( savingFailedRegex.test( notice.content ) ) {
-					dispatch( 'core/notices' ).removeNotice( notice.id );
-				}
-			} );
-	} );
 };

--- a/packages/js/email-editor/src/middleware/content-validation.ts
+++ b/packages/js/email-editor/src/middleware/content-validation.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { use, subscribe, select, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -105,11 +106,20 @@ export const initContentValidationMiddleware = () => {
 	} ) );
 
 	// Remove error notice that could be confusing for users.
+	// Use a translated message to support all languages
 	subscribe( () => {
+		// Get the translated "Saving failed" message
+		// eslint-disable-next-line @wordpress/i18n-text-domain
+		const savingFailedMessage = __( 'Saving failed.' );
+		// Create a regular expression that escapes special characters and matches the beginning of the string
+		const savingFailedRegex = new RegExp(
+			'^' + savingFailedMessage.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' )
+		);
+
 		select( 'core/notices' )
 			.getNotices()
 			.forEach( ( notice ) => {
-				if ( /^Saving failed/.test( notice.content ) ) {
+				if ( savingFailedRegex.test( notice.content ) ) {
 					dispatch( 'core/notices' ).removeNotice( notice.id );
 				}
 			} );

--- a/packages/js/email-editor/src/store/actions.ts
+++ b/packages/js/email-editor/src/store/actions.ts
@@ -9,7 +9,12 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import { storeName } from './constants';
-import { SendingPreviewStatus, State, PersonalizationTag } from './types';
+import {
+	SendingPreviewStatus,
+	State,
+	PersonalizationTag,
+	ContentValidation,
+} from './types';
 import { recordEvent } from '../events';
 
 export function togglePreviewModal( isOpen: boolean ) {
@@ -102,5 +107,14 @@ export function setPersonalizationTagsList( list: PersonalizationTag[] ) {
 		state: {
 			list,
 		} as Partial< State[ 'personalizationTags' ] >,
+	} as const;
+}
+
+export function setContentValidation(
+	validation: ContentValidation | undefined
+) {
+	return {
+		type: 'SET_CONTENT_VALIDATION',
+		validation,
 	} as const;
 }

--- a/packages/js/email-editor/src/store/initial-state.ts
+++ b/packages/js/email-editor/src/store/initial-state.ts
@@ -42,5 +42,6 @@ export function getInitialState(): State {
 			list: [],
 			isFetching: false,
 		},
+		contentValidation: undefined,
 	};
 }

--- a/packages/js/email-editor/src/store/reducer.ts
+++ b/packages/js/email-editor/src/store/reducer.ts
@@ -42,6 +42,11 @@ export function reducer( state: State, action ): State {
 					...action.state,
 				},
 			};
+		case 'SET_CONTENT_VALIDATION':
+			return {
+				...state,
+				contentValidation: action.validation,
+			};
 		default:
 			return state;
 	}

--- a/packages/js/email-editor/src/store/selectors.ts
+++ b/packages/js/email-editor/src/store/selectors.ts
@@ -372,3 +372,9 @@ export function getGlobalStylesPostId( state: State ): number | null {
 export function getUrls( state: State ): State[ 'urls' ] {
 	return state.urls;
 }
+
+export function getContentValidation(
+	state: State
+): State[ 'contentValidation' ] {
+	return state.contentValidation;
+}

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -186,7 +186,6 @@ export type PersonalizationTag = {
 
 export type ContentValidation = {
 	validateContent: () => boolean;
-	isInvalid: boolean;
 };
 
 export type State = {

--- a/packages/js/email-editor/src/store/types.ts
+++ b/packages/js/email-editor/src/store/types.ts
@@ -184,6 +184,11 @@ export type PersonalizationTag = {
 	valueToInsert: string;
 };
 
+export type ContentValidation = {
+	validateContent: () => boolean;
+	isInvalid: boolean;
+};
+
 export type State = {
 	postId: number | string; // Template use strings
 	postType: string;
@@ -204,6 +209,7 @@ export type State = {
 		list: PersonalizationTag[];
 		isFetching: boolean;
 	};
+	contentValidation?: ContentValidation;
 };
 
 export type EmailTemplate = {

--- a/packages/js/email-editor/src/types/wordpress-modules.ts
+++ b/packages/js/email-editor/src/types/wordpress-modules.ts
@@ -105,7 +105,7 @@ declare module '@wordpress/notices' {
 			) => void;
 		};
 		selectors: {
-			getNotices: ( state: unknown, context?: string ) => Notice[];
+			getNotices: ( state?: unknown, context?: string ) => Notice[];
 			removeNotice: ( id: string, context?: string ) => void;
 		};
 	} >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The email editor validation did not work as expected when editing the email and template content.
The editor.preSavePost filter is not triggered when saving from the EntitiesSavedStates component.
This behavior allows validation to be skipped. For example, in the MailPoet plugin, it allows the email to be saved without an unsubscribe link. This PR introduces a new middleware layer that wraps the actions `saveEntityRecord` and `saveEditedEntityRecord` with validation.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from __WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)__
2. Open an email in the editor __WooCommerce → Settings → Emails__
3. Test email and template content validation. Creating a similar validation rule as it is in MailPoet can help to check that everything works correctly.

Rule example:
```
const contentValidationRule: EmailContentValidationRule = {
	id: 'content-email-validation',
	testContent: ( emailContent: string ) => {
		return ! emailContent.includes(
			'[mailpoet/subscription-unsubscribe-url]'
		);
	},
	message: __( 'The unsubscribe link is missing.', 'woocommerce' ),
	actions: [],
};
```
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
