### PR TITLE
Fix empty Mini-cart after login for shoppers with existing cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-empty-mini-cart-after-login
+++ b/plugins/woocommerce/changelog/fix-empty-mini-cart-after-login
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cart API request for logged-in customers with previous cart session

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
@@ -58,10 +58,10 @@ register( store );
 // Likewise, if we have a valid persistent cart, we can skip the request.
 // The only reliable way to check if the cart is empty is to check the cookies.
 window.addEventListener( 'load', () => {
-	const hasCachedCart = persistenceLayer.get();
+	const cachedCart = persistenceLayer.get();
 	// On login, if a customer had a cart session, the cached cart is equal to the default cart data, with no items.
 	// We need to check if the cached cart has items, otherwise we will wrongly skip the API request.
-	const hasItemsInCachedCart = hasCachedCart?.itemsCount > 0;
+	const hasItemsInCachedCart = cachedCart?.itemsCount > 0;
 
 	if (
 		( ! hasCartSession() || hasItemsInCachedCart ) &&

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
@@ -58,10 +58,16 @@ register( store );
 // Likewise, if we have a valid persistent cart, we can skip the request.
 // The only reliable way to check if the cart is empty is to check the cookies.
 window.addEventListener( 'load', () => {
+	const hasCachedCart = persistenceLayer.get();
+	// On login, if a customer had a cart session, the cached cart is equal to the default cart data, with no items.
+	// We need to check if the cached cart has items, otherwise we will wrongly skip the API request.
+	const hasItemsInCachedCart = hasCachedCart?.itemsCount > 0;
+
 	if (
-		( ! hasCartSession() || persistenceLayer.get() ) &&
+		( ! hasCartSession() || hasItemsInCachedCart ) &&
 		! isAddingToCart()
 	) {
+		// Prevent the API request from being made.
 		wpDispatch( store ).finishResolution( 'getCartData' );
 	}
 } );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { dispatch as wpDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	hasCartSession,
+	persistenceLayer,
+	isAddingToCart,
+} from '../persistence-layer';
+
+// Mock all dependencies before importing the module that contains the event listener
+jest.mock( '@wordpress/data' );
+jest.mock( '../persistence-layer' );
+
+const mockHasCartSession = hasCartSession as jest.MockedFunction<
+	typeof hasCartSession
+>;
+const mockIsAddingToCart = isAddingToCart as jest.MockedFunction<
+	typeof isAddingToCart
+>;
+const mockPersistenceLayerGet = persistenceLayer.get as jest.MockedFunction<
+	typeof persistenceLayer.get
+>;
+const mockWpDispatch = wpDispatch as jest.MockedFunction< typeof wpDispatch >;
+
+describe( 'Window load event handler', () => {
+	let mockFinishResolution: jest.Mock;
+	let originalAddEventListener: typeof window.addEventListener;
+	let loadHandler: EventListener;
+
+	beforeAll( () => {
+		// Capture the addEventListener calls to extract the load handler
+		originalAddEventListener = window.addEventListener;
+		window.addEventListener = jest.fn(
+			( event: string, handler: EventListenerOrEventListenerObject ) => {
+				if ( event === 'load' && typeof handler === 'function' ) {
+					loadHandler = handler;
+				}
+				return originalAddEventListener.call( window, event, handler );
+			}
+		);
+
+		// Now import the module to register the event listener
+		require( '../index' );
+	} );
+
+	beforeEach( () => {
+		mockFinishResolution = jest.fn();
+		mockWpDispatch.mockReturnValue( {
+			finishResolution: mockFinishResolution,
+		} as any );
+	} );
+
+	afterAll( () => {
+		window.addEventListener = originalAddEventListener;
+	} );
+
+	it( 'should skip API request when no cart session and not adding to cart with /?add-to-cart=', () => {
+		mockHasCartSession.mockReturnValue( false );
+		mockIsAddingToCart.mockReturnValue( false );
+		mockPersistenceLayerGet.mockReturnValue( null );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).toHaveBeenCalledWith( 'getCartData' );
+	} );
+
+	it( 'should skip API request when cached cart has items and not adding to cart with /?add-to-cart=', () => {
+		mockHasCartSession.mockReturnValue( true );
+		mockIsAddingToCart.mockReturnValue( false );
+		mockPersistenceLayerGet.mockReturnValue( { itemsCount: 2 } );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).toHaveBeenCalledWith( 'getCartData' );
+	} );
+
+	it( 'should make API request when has cart session but cached cart is empty', () => {
+		mockHasCartSession.mockReturnValue( true );
+		mockIsAddingToCart.mockReturnValue( false );
+		mockPersistenceLayerGet.mockReturnValue( { itemsCount: 0 } );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should make API request when has cart session but cached cart is null', () => {
+		mockHasCartSession.mockReturnValue( true );
+		mockIsAddingToCart.mockReturnValue( false );
+		mockPersistenceLayerGet.mockReturnValue( null );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should make API request when currently adding to cart with /?add-to-cart=', () => {
+		mockHasCartSession.mockReturnValue( false );
+		mockIsAddingToCart.mockReturnValue( true );
+		mockPersistenceLayerGet.mockReturnValue( null );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should make API request when has cart session, cached cart has items, but adding to cart with /?add-to-cart=', () => {
+		mockHasCartSession.mockReturnValue( true );
+		mockIsAddingToCart.mockReturnValue( true );
+		mockPersistenceLayerGet.mockReturnValue( { itemsCount: 2 } );
+
+		loadHandler( new Event( 'load' ) );
+
+		expect( mockFinishResolution ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
@@ -52,7 +52,7 @@ describe( 'Window load event handler', () => {
 		mockFinishResolution = jest.fn();
 		mockWpDispatch.mockReturnValue( {
 			finishResolution: mockFinishResolution,
-		} as any );
+		} as unknown as ReturnType< typeof wpDispatch > );
 	} );
 
 	afterAll( () => {

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/test/index.test.ts
@@ -16,16 +16,10 @@ import {
 jest.mock( '@wordpress/data' );
 jest.mock( '../persistence-layer' );
 
-const mockHasCartSession = hasCartSession as jest.MockedFunction<
-	typeof hasCartSession
->;
-const mockIsAddingToCart = isAddingToCart as jest.MockedFunction<
-	typeof isAddingToCart
->;
-const mockPersistenceLayerGet = persistenceLayer.get as jest.MockedFunction<
-	typeof persistenceLayer.get
->;
-const mockWpDispatch = wpDispatch as jest.MockedFunction< typeof wpDispatch >;
+const mockHasCartSession = jest.mocked( hasCartSession );
+const mockIsAddingToCart = jest.mocked( isAddingToCart );
+const mockPersistenceLayerGet = jest.mocked( persistenceLayer.get );
+const mockWpDispatch = jest.mocked( wpDispatch );
 
 describe( 'Window load event handler', () => {
 	let mockFinishResolution: jest.Mock;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This is based on `release/10.1` and will need a CFE.

This PR fixes cart API request logic to prevent unnecessary calls to the cart endpoint on page load while ensuring proper cart synchronization after user login. 

The bug was revealed after [my PR](https://github.com/woocommerce/woocommerce/pull/58782) , where I was making a [valid fix to the logic](https://github.com/woocommerce/woocommerce/pull/58782/files#r2143193550). This fix revealed another bug: after user login, if a customer had a cart session, the cached cart would be equal to the default cart data with no items (itemsCount: 0). The logic would incorrectly skip the API request based solely on the presence of cached cart data, leading to an empty mini cart display even when the server-side cart contained items.

- With this PR we check if the cached cart actually contains items `(itemsCount > 0)` rather than just checking for
  the presence of cached data. 
- It prevents unnecessary API requests when the cached cart legitimately contains items (Before https://github.com/woocommerce/woocommerce/pull/58782 the call was made on every page)

Closes https://github.com/woocommerce/woocommerce/issues/59875
(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/58782


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Log in with a shopper account and add an item to the cart
2. Notice the Mini-Cart shows the items count
3. Log out
4. Go to My account and log in 
5. Notice the Mini cart count shows 1
6. Open the Mini-cart and see your product

7. Go to `my-account/orders/` page and check the Network tab; notice no `/cart` call is being made
8. Delete the localStorage `storeApiCartData` key.
9. Go to another page (or reload page) and notice the Mini Cart shows the correct counter

10. Log out
11. Add another product to your cart
12. Log in again
13. Notice that the two carts were merged



<!-- End testing instructions -->

### Testing that has already taken place:

  - I've added comprehensive unit JS test

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>