### PR TITLE
Fix fatal error on wrong data input in WC_Customer

### DIFF
--- a/plugins/woocommerce/changelog/fix-fatal-error-on-wrong-data-input
+++ b/plugins/woocommerce/changelog/fix-fatal-error-on-wrong-data-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error on wrong data format sent to WC_Customer

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -850,7 +850,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $value Email.
 	 */
 	public function set_email( $value ) {
-		if ( $value && ( ! is_string( $value ) || ! is_email( $value ) ) ) {
+		if ( $value && ! is_email( (string) $value ) ) {
 			$this->error( 'customer_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
 		}
 		$this->set_prop( 'email', sanitize_email( $value ) );
@@ -1100,7 +1100,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $value Billing email.
 	 */
 	public function set_billing_email( $value ) {
-		if ( $value && ( ! is_string( $value ) || ! is_email( $value ) ) ) {
+		if ( $value && ! is_email( (string) $value ) ) {
 			$this->error( 'customer_invalid_billing_email', __( 'Invalid billing email address', 'woocommerce' ) );
 		}
 		$this->set_address_prop( 'email', 'billing', sanitize_email( $value ) );

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -850,7 +850,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $value Email.
 	 */
 	public function set_email( $value ) {
-		if ( $value && ! is_email( $value ) ) {
+		if ( $value && ( ! is_string( $value ) || ! is_email( $value ) ) ) {
 			$this->error( 'customer_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
 		}
 		$this->set_prop( 'email', sanitize_email( $value ) );
@@ -1100,7 +1100,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $value Billing email.
 	 */
 	public function set_billing_email( $value ) {
-		if ( $value && ! is_email( $value ) ) {
+		if ( $value && ( ! is_string( $value ) || ! is_email( $value ) ) ) {
 			$this->error( 'customer_invalid_billing_email', __( 'Invalid billing email address', 'woocommerce' ) );
 		}
 		$this->set_address_prop( 'email', 'billing', sanitize_email( $value ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In WCCOM, we regularly get bots that send wrong data input, sometimes causing a fatal error. This PR addresses that.

Partially closes WCCOM-1578.

### How to test the changes in this Pull Request:

All good when the input is string:

```
wp> $input = 'asdf'
=> string(4) "asdf"
wp> is_string( $input ) && is_email( $input )
=> bool(false)
wp> is_email( $input )
=> bool(false)
```

But, when the input is an array:

```
wp> $input = array()
=> array(0) {
}
wp> is_string( $input ) && is_email( $input )
=> bool(false)
wp> is_email( $input )
PHP Fatal error:  Uncaught TypeError: strlen(): Argument #1 ($string) must be of type string, array given in /opt/homebrew/var/www/wp-includes/formatting.php:3539
```

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
