### PR TITLE
Introduce a new filter that allows to skip WC_Install::init

### DIFF
--- a/plugins/woocommerce/changelog/add-filter-to-prevent-install-init
+++ b/plugins/woocommerce/changelog/add-filter-to-prevent-install-init
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduce a new filter that allows to skip WC_Install::init

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -321,7 +321,12 @@ class WC_Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
-		if ( ! empty( $GLOBALS['wc_uninstalling_plugin'] ) ) {
+		// On very large stores, running WC_Install::init during page loads may cause significant performance overhead.
+		// Setting this filter to true will skip the automatic initialization,
+		// but you must run `wp wc update` manually after any WooCommerce upgrade to ensure database updates are applied.
+		$skip_install_init = apply_filters( 'woocommerce_skip_install_init', false );
+
+		if ( ! empty( $GLOBALS['wc_uninstalling_plugin'] ) || $skip_install_init ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On WCCOM, and possibly other very large stores, running `WC_Install::init` during page loads may cause significant performance overhead.

The changes here introduce a filter that allows to skip that, at the cost of performing `wp wc update` manually after any WooCommerce upgrade to ensure database updates are applied.

Partially closes WCCOM-1578.

### How to test the changes in this Pull Request:

```
bor0:~/dev/www/wp-content/mu-plugins$ wp eval "var_dump( has_action( 'init', array( 'WC_Install', 'check_version' ) ) );"
int(5)
bor0:~/dev/www/wp-content/mu-plugins$ echo "<?php add_filter( 'woocommerce_skip_install_init', '__return_true' );" > test-plugin.php
bor0:~/dev/www/wp-content/mu-plugins$ wp eval "var_dump( has_action( 'init', array( 'WC_Install', 'check_version' ) ) );"
bool(false)
```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
