### PR TITLE
Fix displaying "Send" button when editing a new email

### DIFF
--- a/packages/js/email-editor/changelog/fix-email-editor-send-button
+++ b/packages/js/email-editor/changelog/fix-email-editor-send-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Email Editor: show “Send” button when editing a new (unsaved) email draft.

--- a/packages/js/email-editor/src/hacks/publish-save.tsx
+++ b/packages/js/email-editor/src/hacks/publish-save.tsx
@@ -40,20 +40,26 @@ function NextPublishSlot( { children }: NextButtonSlotPropType ) {
 
 export function PublishSave() {
 	const observerRef = useRef< MutationObserver | null >( null );
-	const { hasNonPostEntityChanges, isEditedPostDirty } = useSelect(
-		( select ) => ( {
-			hasNonPostEntityChanges:
-				// @ts-expect-error hasNonPostEntityChanges is not typed in @types/wordpress__editor
-				select( editorStore ).hasNonPostEntityChanges(),
-			isEditedPostDirty: select( editorStore ).isEditedPostDirty(),
-		} ),
-		[]
-	);
+	const { hasNonPostEntityChanges, isEditedPostDirty, currentPost } =
+		useSelect(
+			( select ) => ( {
+				hasNonPostEntityChanges:
+					// @ts-expect-error hasNonPostEntityChanges is not typed in @types/wordpress__editor
+					select( editorStore ).hasNonPostEntityChanges(),
+				isEditedPostDirty: select( editorStore ).isEditedPostDirty(),
+				currentPost: select( editorStore ).getCurrentPost(),
+			} ),
+			[]
+		);
+
+	// Check the post status
+	const isDraftPost = currentPost.status === 'draft';
 
 	// Display original button when there are changes to save except for draft
 	// For draft, there is an extra save button to save as draft
+	// Also display original button when the post is in draft status
 	const displayOriginalPublishButton =
-		hasNonPostEntityChanges || isEditedPostDirty;
+		( hasNonPostEntityChanges || isEditedPostDirty ) && ! isDraftPost;
 
 	const toggleElementVisible = useCallback(
 		( element: Element, visible: boolean ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Display the Send button for unsaved email drafts in third-party integrations (e.g. MailPoet), allowing immediate send without needing to save first.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1414" height="176" alt="Screenshot 2025-07-23 at 14 31 53" src="https://github.com/user-attachments/assets/2a435b7c-8211-48f7-ae3b-530daedf2224" />|<img width="1411" height="238" alt="Screenshot 2025-07-23 at 14 24 20" src="https://github.com/user-attachments/assets/3b2f3e97-ad88-40c3-8e94-9caf5aff6411" />|

Screenshots were captured as part of the MailPoet integration

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from __WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)__
2. Open an email in the editor __WooCommerce → Settings → Emails__
3. Set email editor settings `displaySendEmailButton` to true
4. Verify that the Send button works as expected

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
