### PR TITLE
Product Template: added blockgap support

### DIFF
--- a/plugins/woocommerce/changelog/add-blockgap-product-template
+++ b/plugins/woocommerce/changelog/add-blockgap-product-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add block gap support to product template block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/block.json
@@ -52,6 +52,11 @@
 			"allowInheriting": false,
 			"allowSizingOnChildren": false,
 			"allowVerticalAlignment": false
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
 		}
 	},
 	"editorStyle": "file:../woocommerce/product-template-editor.css",

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -373,7 +373,12 @@ const ProductTemplateEdit = (
 		customClassName = shrinkColumns ? dynamicGrid : staticGrid;
 	}
 
-	const blockProps = useBlockProps( {
+	const blockGapStyle = ( props.attributes as any )?.style?.spacing?.blockGap;
+	const gapValue = blockGapStyle?.startsWith('var:preset|spacing|') 
+		? `var(--wp--preset--spacing--${blockGapStyle.split('|')[2]})`
+		: blockGapStyle;
+
+	const baseBlockProps = useBlockProps( {
 		className: clsx(
 			__unstableLayoutClassNames,
 			'wc-block-product-template',
@@ -381,6 +386,14 @@ const ProductTemplateEdit = (
 			{ [ `is-product-collection-layout-${ layoutType }` ]: layoutType }
 		),
 	} );
+
+	const blockProps = {
+		...baseBlockProps,
+		style: {
+			...baseBlockProps.style,
+			...( hasLayoutFlex && gapValue ? { gap: gapValue } : {} ),
+		},
+	};
 
 	if ( ! products ) {
 		return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/edit.tsx
@@ -391,7 +391,10 @@ const ProductTemplateEdit = (
 		...baseBlockProps,
 		style: {
 			...baseBlockProps.style,
-			...( hasLayoutFlex && gapValue ? { gap: gapValue } : {} ),
+			...( hasLayoutFlex && gapValue ? { 
+				gap: gapValue,
+				'--wc-product-template-gap': gapValue // Add CSS custom property for width calculations
+			} : {} ),
 		},
 	};
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
@@ -25,7 +25,7 @@ $min-product-width: 150px;
 		flex-direction: row;
 		display: flex;
 		flex-wrap: wrap;
-		gap: 1.25em;
+		gap: var(--wc-product-template-gap, 1.25em);
 
 		> li {
 			margin: 0;
@@ -37,7 +37,8 @@ $min-product-width: 150px;
 		@include break-small {
 			@for $i from 2 through 6 {
 				&.is-flex-container.columns-#{ $i } > li {
-					width: calc((100% / #{$i}) - 1.25em + (1.25em / #{$i}));
+					// Use CSS custom property with fallback for dynamic width calculation
+					width: calc((100% / #{$i}) - var(--wc-product-template-gap, 1.25em) + (var(--wc-product-template-gap, 1.25em) / #{$i}));
 				}
 			}
 		}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-template/style.scss
@@ -45,7 +45,12 @@ $min-product-width: 150px;
 
 	&__responsive {
 		display: grid;
-		grid-gap: $grid-gap;
+		gap: $grid-gap; // Use modern 'gap' instead of 'grid-gap'
+    
+		// Fallback for older browsers if needed
+		@supports not (gap: 1em) {
+			grid-gap: $grid-gap;
+		}
 
 		@for $i from 2 through 6 {
 			$gap-count: calc(#{$i} - 1);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\ProductCollection\Utils as ProductCollectionUtils;
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use WP_Block;
 
 /**
@@ -78,13 +79,24 @@ class ProductTemplate extends AbstractBlock {
 
 		$classnames .= ' wc-block-product-template';
 
-		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
-				'class'              => trim( $classnames ),
-				'data-wp-on--scroll' => 'actions.watchScroll',
-				'data-wp-init'       => 'callbacks.initResizeObserver',
-			)
+		// Build base attributes that are common to all layouts
+		$wrapper_attributes_array = array(
+			'class'              => trim( $classnames ),
+			'data-wp-on--scroll' => 'actions.watchScroll',
+			'data-wp-init'       => 'callbacks.initResizeObserver',
 		);
+
+		// Apply blockGap styles manually for flow layout
+		if ( isset( $block->context['displayLayout']['type'] ) && 'flow' === $block->context['displayLayout']['type'] ) {
+			$block_gap_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'block_gap' ] );
+
+			// Apply blockGap styles if they exist
+			if ( ! empty( $block_gap_styles['styles'] ) ) {
+				$wrapper_attributes_array['style'] = $block_gap_styles['styles'];
+			}
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes( $wrapper_attributes_array );
 
 		$content = '';
 		while ( $query->have_posts() ) {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
@@ -97,7 +97,6 @@ class ProductTemplate extends AbstractBlock {
 		}
 
 		$wrapper_attributes = get_block_wrapper_attributes( $wrapper_attributes_array );
-
 		$content = '';
 		while ( $query->have_posts() ) {
 			$query->the_post();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductTemplate.php
@@ -96,6 +96,20 @@ class ProductTemplate extends AbstractBlock {
 			}
 		}
 
+		// Apply blockGap styles for flex layout to enable dynamic width calculations
+		if ( isset( $block->context['displayLayout']['type'] ) && 'flex' === $block->context['displayLayout']['type'] ) {
+			$block_gap_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'block_gap' ] );
+
+			// Apply blockGap styles if they exist
+			if ( ! empty( $block_gap_styles['styles'] ) ) {
+				$wrapper_attributes_array['style'] = $block_gap_styles['styles'];
+			}
+
+			// Add CSS custom property for width calculations
+			$gap_value = StyleAttributesUtils::get_spacing_value( $attributes['style']['spacing']['blockGap'] ?? '1.25em' );
+			$wrapper_attributes_array['style'] = ( $wrapper_attributes_array['style'] ?? '' ) . ' --wc-product-template-gap: ' . $gap_value . ';';
+		}
+
 		$wrapper_attributes = get_block_wrapper_attributes( $wrapper_attributes_array );
 		$content = '';
 		while ( $query->have_posts() ) {

--- a/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/StyleAttributesUtils.php
@@ -600,6 +600,26 @@ class StyleAttributesUtils {
 	}
 
 	/**
+	 * Get class and style for block gap from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return array
+	 */
+	public static function get_block_gap_class_and_style( $attributes ) {
+		$block_gap = $attributes['style']['spacing']['blockGap'] ?? null;
+
+		if ( ! $block_gap ) {
+			return self::EMPTY_STYLE;
+		}
+
+		return array(
+			'class' => null,
+			'style' => sprintf( 'gap: %s;', self::get_spacing_value( $block_gap ) ),
+		);
+	}
+
+	/**
 	 * Get class and style for shadow from attributes.
 	 *
 	 * @param array $attributes Block attributes.
@@ -761,6 +781,7 @@ class StyleAttributesUtils {
 			'border_radius'    => self::get_border_radius_class_and_style( $attributes ),
 			'border_width'     => self::get_border_width_class_and_style( $attributes ),
 			'border_style'     => self::get_border_style_class_and_style( $attributes ),
+			'block_gap'        => self::get_block_gap_class_and_style( $attributes ),
 			'font_family'      => self::get_font_family_class_and_style( $attributes ),
 			'font_size'        => self::get_font_size_class_and_style( $attributes ),
 			'font_style'       => self::get_font_style_class_and_style( $attributes ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #43307 

This adds support for blockgap on the Product Template. I didn't change the way we do the layout since that seemed like a very complex endeavor. This PR leverages the core implementation applied to the way Woo does the layout for this block. We can revisit when we have a clear path to change the way we do layouts but this should bring value to users that want to control the spacing between products as of today.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Stack

<img width="1469" height="1017" alt="Screenshot 2025-08-08 at 11 55 04" src="https://github.com/user-attachments/assets/86fa69fa-e051-4ad6-9d75-e8543addb6f4" />

Grid

<img width="1489" height="863" alt="Screenshot 2025-08-08 at 11 54 20" src="https://github.com/user-attachments/assets/a937035a-5b19-4bd2-93cd-d08ac8692fee" />

Carousel

<img width="1471" height="892" alt="Screenshot 2025-08-08 at 11 55 22" src="https://github.com/user-attachments/assets/2fce9d03-0a8b-48fa-9ae3-9ee1c2865659" />




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Insert a product collection
2. For each of the modes (stack, grid, carousel) click on the product template block inside the product collection and alter the block gap value
3. You should see the effect in all cases both in the site editor and the frontend

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
