### PR TITLE
WPS migration: specify user_action field for order creation

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -185,6 +185,13 @@ class WC_Gateway_Paypal_Request {
 
 		return array(
 			'intent'              => $this->get_paypal_order_intent(),
+			'payment_source'      => array(
+				'paypal' => array(
+					'experience_context' => array(
+						'user_action' => 'PAY_NOW',
+					),
+				),
+			),
 			'purchase_units'      => array(
 				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of the WPS migration project. **Merges into feature/paypal-wps-migration**

I noticed the PayPal payment approval button label is "Review Order", which seemed wrong as clicking it submits the approval for payment capture. It turns out we need to specify `user_action` as `PAY_NOW` (default is `CONTINUE`) ([Source](https://developer.paypal.com/docs/api/orders/v2/#orders_create!ct=application/json&path=payment_source/paypal/experience_context/user_action&t=request))

| Before | After |
|--------|-------|
| <img width="638" height="227" alt="Screenshot 2025-07-23 at 11 50 48 AM" src="https://github.com/user-attachments/assets/499d721f-dad0-499e-b415-343cf9621f4f" /> | <img width="638" height="227" alt="Screenshot 2025-07-23 at 11 51 12 AM" src="https://github.com/user-attachments/assets/51ce116b-99e5-4382-9d9d-963efef9e7d4" /> |

Related to PAYPAL-30 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. If you haven't yet, follow the PayPal Orders v2 basic setup.
2. As a shopper, add a product to cart and go to checkout.
3. Click "Proceed to PayPal".
4. After logging in to your PayPal account, you should see the button say "Pay" instead of "Review Order".

**Orders v2 basic setup**
1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
   ```
   wp option patch update woocommerce_paypal_settings _should_load 'yes'
   wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
   ```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
5.  Configure PayPal Standard's setting:
   - For `PayPal email`, enter your merchant sandbox account email.
   - Check `Enable PayPal sandbox`
   - Check `Enable logging` (optional, for logging)
   - For `Payment action`, select `Capture`
6. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
   ```
   wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
   wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
   ```

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This merges into a feature branch. The feature branch will take care of the changelog entry.

</details>
