### PR TITLE
Various enhancements to release workflows

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Source branch to use. Defaults to the branch the workflow is run from.'
+        description: 'Release branch to use. Defaults to the branch the workflow is run from.'
         required: false
         default: ''
       skip_verify:
@@ -17,7 +17,7 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: 'Source branch to use. Defaults to the branch the workflow is run from.'
+        description: 'Release branch to use. Defaults to the branch the workflow is run from.'
         type: string
         required: false
         default: ''
@@ -168,7 +168,8 @@ jobs:
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-4vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: [ verify-prs, verify-release-versions ]
     outputs:
-      artifact-url: ${{ steps.output-artifact-url.outputs.artifact_url }}
+      artifact-url: ${{ steps.fetch-build-details.outputs.artifact-url }}
+      commit-hash: ${{ steps.fetch-build-details.outputs.commit-hash }}
     permissions:
       contents: read
     steps:
@@ -207,11 +208,15 @@ jobs:
           path: zipfile
           retention-days: 1
 
-      - name: Output artifact URL
-        id: output-artifact-url
+      - name: Fetch build details
+        id: fetch-build-details
         run: |
           ARTIFACT_URL=${{ steps.artifact-upload.outputs.artifact-url }}
-          echo "artifact_url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
+          echo "artifact-url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
+
+          # Fetch commit hash for this build.
+          commit_hash=$(git rev-parse "${{ inputs.branch || github.ref }}")
+          echo "commit-hash=$commit_hash" >> $GITHUB_OUTPUT
 
   create-release:
     name: Create GitHub release
@@ -252,7 +257,7 @@ jobs:
             './woocommerce.zip' \
             --title '${{ steps.get_version.outputs.version }}' \
             --notes '' \
-            --target '${{ inputs.branch || github.ref }}' \
+            --target '${{ needs.build.outputs.commit-hash }}' \
             --latest=false \
             --draft \
             $FLAGS

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -36,6 +36,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-build-zip-file-${{ inputs.branch }}-${{ ( inputs.create_github_release == true && 'with-release' ) || github.run_id }}
+
 jobs:
   verify-prs:
     name: 'Verify if any PR is left open by author:app/github-actions'

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch.'
+        description: 'Release branch'
         type: string
         required: true
         default: ''
-      bump_type:
+      bump-type:
         description: 'Type of version bump to perform'
         required: true
         type: choice
@@ -16,6 +16,16 @@ on:
           - stable
           - rc
           - dev
+  workflow_call:
+    inputs:
+      branch:
+        description: Release branch
+        type: string
+        required: true
+      bump-type:
+        description: Type of version bump to perform
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -43,8 +53,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = context.payload.inputs.branch;
-            const bumpType = context.payload.inputs.bump_type;
+            const branch = `${{ inputs.branch }}`;
+            const bumpType = `${{ inputs.bump-type }}`;
             const currentVersion = '${{ steps.get-current-version.outputs.version }}';
 
             const m = currentVersion.match( /(?<base>\d+\.\d+)\.(?<patch>\d+)(-rc\.(?<rc>\d+))?/ );
@@ -141,5 +151,4 @@ jobs:
             --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
             --base ${{ inputs.branch }} \
-            --head ${branch_name} \
-            --reviewer "${{ github.actor }}"
+            --head ${branch_name}

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -152,3 +152,24 @@ jobs:
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
             --base ${{ inputs.branch }} \
             --head ${branch_name}
+
+      - name: Ensure milestone for dev version exists
+        if: ${{ inputs.bump-type == 'dev' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const milestone = '${{ steps.compute-new-version.outputs.nextStable }}';
+
+            try {
+              await github.rest.issues.createMilestone({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: milestone,
+              });
+            } catch ( e ) {
+              if ( e.response.data.errors?.some( (err) => 'already_exists' === err.code ) ) {
+                console.log( `Milestone ${ milestone } already exists.` );
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -113,7 +113,7 @@ jobs:
           sed -i -E "s/Version: [0-9]+\.[0-9]+\.[0-9]+.*$/Version: $NEXT_VERSION/" woocommerce.php
 
           # Update changelog in readme.txt.
-          sed -i -E "s/^= [0-9]+\.[0-9]+\.[0-9]+ [0-9]{4}-XX-XX =/= $NEXT_STABLE $(date +%Y)-XX-XX =/" readme.txt
+          sed -i -E "s/^= [0-9]+\.[0-9]+\.[0-9]+ (.*) =/= $NEXT_STABLE \1 =/" readme.txt
 
           # Update composer.json and package.json.
           for filename in {composer,package}.json; do

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -3,19 +3,19 @@ name: 'Release: Bump version number'
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Release branch.'
+        type: string
+        required: true
+        default: ''
       bump_type:
         description: 'Type of version bump to perform'
         required: true
         type: choice
         options:
           - stable
-          - dev
           - rc
-      branch:
-        description: 'Source branch to use.'
-        type: string
-        required: true
-        default: ''
+          - dev
 
 permissions:
   contents: write

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -30,7 +30,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-
+  issues: write
 concurrency:
   group: release-bump-version-${{ inputs.branch }}
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -31,6 +31,9 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-bump-version-${{ inputs.branch }}
+
 jobs:
   bump-version:
     name: Bump WooCommerce Version

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: release-code-freeze

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
@@ -116,9 +117,6 @@ jobs:
     name: Perform code freeze
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: prepare-for-code-freeze
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       # Repo preparation to be able to use the monorepo-utils for the version bumps.
       - name: Checkout trunk

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-code-freeze
+
 env:
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -160,11 +160,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm utils code-freeze version-bump ${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-rc.1 -o ${{ github.repository_owner }} -n ${{ github.event.repository.name}} -b ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
-      - name: Bump versions in trunk for next dev cycle
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pnpm utils code-freeze version-bump ${{ needs.prepare-for-code-freeze.outputs.nextTrunkVersion }}-dev -o ${{ github.repository_owner }} -n ${{ github.event.repository.name}} -b trunk
+
+  bump-version-in-trunk:
+    name: Bump version in trunk for next development cycle
+    uses: ./.github/workflows/release-bump-version.yml
+    needs: [run-code-freeze]
+    secrets: inherit
+    with:
+      branch: trunk
+      bump-type: dev
 
   build-zip:
     name: 'Build WooCommerce Release Zip'

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -87,79 +87,62 @@ jobs:
               core.setFailed('There are PRs by the github-actions bot that are still open. Please merge or close before proceeding.');
               process.exit(1);
             }
+      - uses: actions/checkout@v4
+        with:
+          ref: trunk
+          sparse-checkout: |
+            /plugins/woocommerce/woocommerce.php
+          sparse-checkout-cone-mode: false
+      - name: Fetch version from trunk
+        id: fetch-trunk-version
+        run: |
+          header_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
+          echo "Trunk version is '$header_version'."
+          echo "trunk-version=$header_version" >> $GITHUB_OUTPUT
       - name: Compute next release and dev cycle versions
         id: calculate-versions
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
-            const bumpMinorVersion = (v) => {
-              const [major, minor, patch] = v.split('.').map(Number);
-              return minor >= 9 ? `${major + 1}.0.0` : `${major}.${minor + 1}.0`
-            };
+            const trunkVersion = `${{ steps.fetch-trunk-version.outputs.trunk-version }}`;
 
-            const currentRelease = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
+            const m = trunkVersion.match( /^(\d+\.\d+)\.\d+(-dev)?$/ );
+            if ( ! m ) {
+                core.setFailed( `Trunk version number is incorrect: ${ trunkVersion }` );
+                return;
+            }
 
-            const currentVersion = currentRelease.data.tag_name.replace(/[^0-9.]+/, '');
-            const nextReleaseVersion = bumpMinorVersion(currentVersion);
-            const nextReleaseBranch = `release/${nextReleaseVersion.slice(0, -2)}`;
-            const nextPrepReleaseBranch = `prep/${nextReleaseBranch}-for-next-dev-cycle-${nextReleaseVersion.slice(0, -2)}`;
-            const nextTrunkVersion = bumpMinorVersion(nextReleaseVersion);
+            const trunkMainVersion = m[1];
+            const nextReleaseVersion = trunkVersion.replace( '-dev', '' );
+            const nextReleaseBranch = `release/${ nextReleaseVersion.slice( 0, -2 ) }`;
+            const nextPrepReleaseBranch = `prep/${ nextReleaseBranch }-for-next-dev-cycle-${ nextReleaseVersion.slice( 0, -2 ) }`;
+            const nextTrunkVersion = `${ ( Number( trunkMainVersion ) + 0.1 ).toFixed( 1 ) }.0-dev`;
 
-            core.setOutput('nextReleaseVersion', nextReleaseVersion);
-            core.setOutput('nextReleaseBranch', nextReleaseBranch);
-            core.setOutput('nextPrepReleaseBranch', nextPrepReleaseBranch);
-            core.setOutput('nextTrunkVersion', nextTrunkVersion);
+            core.setOutput( 'nextReleaseVersion', nextReleaseVersion );
+            core.setOutput( 'nextReleaseBranch', nextReleaseBranch );
+            core.setOutput( 'nextPrepReleaseBranch', nextPrepReleaseBranch );
+            core.setOutput( 'nextTrunkVersion', nextTrunkVersion );
 
   run-code-freeze:
     name: Perform code freeze
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     needs: prepare-for-code-freeze
     steps:
-      # Repo preparation to be able to use the monorepo-utils for the version bumps.
       - name: Checkout trunk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: trunk
-      - name: Setup PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-            node-version-file: .nvmrc
-            cache: pnpm
-
-      - name: Install prerequisites
-        run: |
-            pnpm install --filter monorepo-utils --ignore-scripts
-            # ignore scripts speeds up setup significantly, but we still need to build monorepo utils
-            pnpm build
-        working-directory: tools/monorepo-utils
-
-      # Actual code freeze steps.
       - name: Push frozen branch to the repo
         run: |
           # Last opportunity to bail if branch already exists.
           if [[ -n $(git ls-remote --heads origin ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}) ]]; then
-            echo "::error::Release branch already exists."
+            echo "::error::Release branch '${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}' already exists."
             exit 1
           fi
 
           git checkout trunk
           git checkout -b ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
           git push origin ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
-      - name: Create next dev cycle milestone
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pnpm utils code-freeze milestone -o ${{ github.repository_owner }} -n ${{ github.event.repository.name}} -m ${{ needs.prepare-for-code-freeze.outputs.nextTrunkVersion }}
-      - name: Bump versions in frozen release branch for rc.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pnpm utils code-freeze version-bump ${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-rc.1 -o ${{ github.repository_owner }} -n ${{ github.event.repository.name}} -b ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
 
   bump-version-in-trunk:
     name: Bump version in trunk for next development cycle
@@ -171,7 +154,7 @@ jobs:
       bump-type: dev
 
   build-zip:
-    name: 'Build WooCommerce Release Zip'
+    name: Build WooCommerce release ZIP
     uses: ./.github/workflows/release-build-zip-file.yml
     needs: [prepare-for-code-freeze, run-code-freeze]
     with:

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -177,43 +177,10 @@ jobs:
       create_github_release: false
       branch: ${{ needs.prepare-for-code-freeze.outputs.nextPrepReleaseBranch }}
 
-  modify-zip-version:
-    name: 'Update version to Dev'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: [build-zip, prepare-for-code-freeze]
-    env:
-      DEV_VERSION: ${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev
-    outputs:
-      artifact_url: ${{ steps.upload-modified-zip.outputs.artifact-url }}
-    steps:
-      - name: Download original zip artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: woocommerce
-          path: ./download
-
-      - name: Modify version in woocommerce.php
-        run: |
-          sed -i "s/\* Version:.*/\* Version: $DEV_VERSION/" ./download/woocommerce/woocommerce.php
-
-      - name: Create new zip file
-        run: |
-          cd ./download/woocommerce
-          ZIPFILE_NAME="woocommerce-$DEV_VERSION"
-          zip -r "../../$ZIPFILE_NAME.zip" .
-          echo "ZIPFILE_NAME=$ZIPFILE_NAME" >> $GITHUB_ENV
-
-      - name: Upload modified zip as artifact
-        id: upload-modified-zip
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ZIPFILE_NAME }}
-          path: ${{ env.ZIPFILE_NAME }}.zip
-
   notify-slack:
     name: Notify Slack
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: [modify-zip-version, prepare-for-code-freeze]
+    needs: [build-zip, prepare-for-code-freeze]
     steps:
       - name: Notify Slack on success
         uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
@@ -223,25 +190,25 @@ jobs:
           slack-text: |
             :ice_cube: Code Freeze completed for `${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}` :checking:
             If you need a fix or change to be included in this release, please request a backport following the <https://developer.woocommerce.com/docs/contribution/releases/backporting|Backporting Guide>.
-            <${{ needs.modify-zip-version.outputs.artifact_url }}|Download zip>
+            <${{ needs.build-zip.outputs.artifact_url }}|Download zip>
           slack-optional-unfurl_links: false
           slack-optional-unfurl_media: false
 
   trigger-webhook:
     name: Trigger Release Webhook
     runs-on: ubuntu-latest
-    needs: [modify-zip-version, prepare-for-code-freeze]
+    needs: [build-zip, prepare-for-code-freeze]
     steps:
       - name: Trigger Code Freeze Webhook
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const crypto = require('crypto');
-            
+
             const payload = {
               action: 'feature-freeze',
               version: '${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}',
-              build_zip: '${{ needs.modify-zip-version.outputs.artifact_url }}',
+              build_zip: '${{ needs.build-zip.outputs.artifact_url }}',
               post_status: process.env.ENVIRONMENT === 'production' ? 'publish' : 'draft'
             };
 
@@ -252,7 +219,7 @@ jobs:
             const hmac = crypto.createHmac('sha256', process.env.WPCOM_WEBHOOK_SECRET);
             hmac.update(requestBody);
             const signature = hmac.digest('hex');
-            
+
             try {
               const response = await fetch(process.env.WPCOM_RELEASE_WEBHOOK_URL, {
                 method: 'POST',
@@ -262,7 +229,7 @@ jobs:
                 },
                 body: requestBody
               });
-              
+
               if (!response.ok) {
                 if (response.status === 409) {
                   console.log('Webhook request failed: Duplicate post detected (409)');
@@ -281,4 +248,3 @@ jobs:
           WPCOM_RELEASE_WEBHOOK_URL: ${{ secrets.WPCOM_RELEASE_WEBHOOK_URL }}
           ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
 
-    

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -72,8 +72,6 @@ jobs:
     outputs:
       nextReleaseBranch: ${{ steps.calculate-versions.outputs.nextReleaseBranch }}
       nextReleaseVersion: ${{ steps.calculate-versions.outputs.nextReleaseVersion }}
-      nextPrepReleaseBranch: ${{ steps.calculate-versions.outputs.nextPrepReleaseBranch }}
-      nextTrunkVersion: ${{ steps.calculate-versions.outputs.nextTrunkVersion }}
     steps:
       - name: Verify no PRs open by the github-actions bot are open
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
@@ -115,12 +113,10 @@ jobs:
             const trunkMainVersion = m[1];
             const nextReleaseVersion = trunkVersion.replace( '-dev', '' );
             const nextReleaseBranch = `release/${ nextReleaseVersion.slice( 0, -2 ) }`;
-            const nextPrepReleaseBranch = `prep/${ nextReleaseBranch }-for-next-dev-cycle-${ nextReleaseVersion.slice( 0, -2 ) }`;
             const nextTrunkVersion = `${ ( Number( trunkMainVersion ) + 0.1 ).toFixed( 1 ) }.0-dev`;
 
             core.setOutput( 'nextReleaseVersion', nextReleaseVersion );
             core.setOutput( 'nextReleaseBranch', nextReleaseBranch );
-            core.setOutput( 'nextPrepReleaseBranch', nextPrepReleaseBranch );
             core.setOutput( 'nextTrunkVersion', nextTrunkVersion );
 
   run-code-freeze:
@@ -160,7 +156,7 @@ jobs:
     with:
       skip_verify: true
       create_github_release: false
-      branch: ${{ needs.prepare-for-code-freeze.outputs.nextPrepReleaseBranch }}
+      branch: ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
 
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: release-compile-changelog-${{ inputs.version }}
+
 env:
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'

--- a/.github/workflows/release-update-stable-tag.yml
+++ b/.github/workflows/release-update-stable-tag.yml
@@ -21,6 +21,9 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-wporg-svn
+
 jobs:
   validate-release:
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -6,6 +6,11 @@ on:
         description: 'Release tag to upload (can be a draft release).'
         required: true
         default: ''
+      confirm-update:
+        description: 'I confirm that I want to upload a release to WordPress.org.'
+        type: boolean
+        required: true
+        default: false
 
 permissions: {}
 
@@ -20,6 +25,12 @@ jobs:
       release_asset: ${{ steps.fetch-release.outputs.release_asset }}
       overwrite_trunk: ${{ steps.check-asset.outputs.overwrite_trunk }}
     steps:
+      - name: Check confirmation
+        run: |
+          if [ "${{ github.event.inputs.confirm-update }}" != "true" ]; then
+            echo "::error::You must check the confirmation checkbox to proceed."
+            exit 1
+          fi
       - name: Fetch release
         id: fetch-release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1

--- a/.github/workflows/release-upload-to-wporg.yml
+++ b/.github/workflows/release-upload-to-wporg.yml
@@ -14,6 +14,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-wporg-svn
+
 jobs:
   get-and-validate-release-asset:
     name: Get intended release details

--- a/docs/contribution/releases/building-and-publishing.md
+++ b/docs/contribution/releases/building-and-publishing.md
@@ -20,13 +20,15 @@ sidebar_label: Building and Publishing
 
 ## Building WooCommerce
 
-1. **Run the [“Release: Compile changelog” workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-compile-changelog.yml).**
-   - Run from trunk and enter the major version number.
+1. **Run the ["Release: Bump version number" workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-bump-version.yml).**
+   - Run from `trunk`.
+   - Choose the type of version you're releasing (`rc` or `stable`).
+   - Enter as _Release branch_ the branch you are about to release from (e.g. `release/10.0`).
+   - Review and merge the PR created.
+2. **Run the [“Release: Compile changelog” workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-compile-changelog.yml).**
+   - Run from `trunk` and enter the major version number and the intended release date.
    - Review and merge the two PRs created (one for trunk, one for the release branch).
    - Ensure the changelog date is correct.
-2. **(Skip for `-rc.1`) Run the version-bump workflow.**
-   - Update the WooCommerce version in relevant files on the release branch.
-   - Review and merge the PR after CI passes.
 3. **Build the release ZIP file.**
    - Run the [“Release: Build ZIP file” workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml) from the release branch.
    - Set "Create a draft GitHub release" to `true`.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a few enhancements to release workflows. In particular:

- When creating a GitHub release draft at the same time as building a ZIP with the [`Release: Build ZIP file`](https://github.com/woocommerce/woocommerce/blob/enhancement/release-workflow-fixes/.github/workflows/release-build-zip-file.yml), the release will target the specific commit instead of the branch. This is useful when prior drafts are only published at a later time (and when the underlying release branch could've been modified).
- Changes to the [code freeze workflow](https://github.com/woocommerce/woocommerce/blob/enhancement/release-workflow-fixes/.github/workflows/release-code-freeze.yml):
   - The new "frozen" branch doesn't get its version automatically bumped to `-rc.1`, which allows us to update [the build instructions](https://github.com/woocommerce/woocommerce/commit/648d81b5e04de8c7611be20b56f9e115c5514342) so that `-rc.1` is no longer a special case.
   - Release bumps are now performed via the [`Release: Bump version number` workflow](https://github.com/woocommerce/woocommerce/blob/enhancement/release-workflow-fixes/.github/workflows/release-bump-version.yml), reusing code and entirely dropping the dependency on the local code-freeze tools.
- Concurrency groups were added to most workflows to prevent concurrent undesired runs. For example, to prevent multiple workflows from bumping the version in the same branch or having workflows interact with wporg's SVN simultaneously.
- Other fixes and minor enhancements.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repository, including at least `trunk` and `release/10.1` branches.
2. In your forked repo, go to **Settings > Secrets and variables > Actions** and create or update the following repository secrets: 
   - `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
   - `WOO_RELEASE_SLACK_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
   - `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
   - `ENVIRONMENT` set to any string.
   - `WPCOM_WEBHOOK_SECRET` set to any string.
   - `WPCOM_RELEASE_WEBHOOK_URL ` set to `https://httpbin.io/status/200` (good for testing purposes).
3. **Test updated code freeze:**
   1. Go to **Actions > Release: Enforce Code Freeze**, run the workflow and wait until it completes.
   1. Confirm that:
      - A PR bumping the version in `trunk` from `10.2.0-dev` to `10.3.0-dev` has been created.
      - Branch `release/10.2` with the current contents of `trunk` has been created.
      - Milestone `10.3.0` is now listed on **Issues > Milestones**.
      - The `test-woo-core-release-notifications` channel in Slack has received a notification about the code freeze including a link to a ZIP.
4. **Test concurrency protection:**
   1. Ensure that you can't simultaneously run the `Release: Bump version number` or `Release: Compile changelog` workflows using the same input.
      While one of the workflows is running, the other will **not** be started, showing a clock next to its name:
      <img width="465" height="76" alt="Screenshot 2025-07-23 at 19 25 26" src="https://github.com/user-attachments/assets/9da8b5c5-f08f-48a2-a026-1126438804ff" />
   1. Ensure that you can't simultaneously run two `Release: Update stable tag` and/or `Release: Upload release to WordPress.org` workflows regardless of inputs.
5. **Test that draft releases now point to commit in branch:**
   - Run the `Release: Build ZIP file` workflow, using `release/10.1` as input branch, skipping checks and enabling the creation of a draft release. Wait until the workflow finishes.
   - Go to **Code > Releases** and confirm that there's a release with tag `10.1.0-rc.1`.
   - Click the release to edit it.
   - Confirm that the **Target** is not `release/10.1` but a specific commit hash, which should match the _last_ commit in `release/10.1` at the time of building the ZIP.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
