### PR TITLE
Get `address_1` label from derived props in Checkout block

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5127-address-field-in-the-block-checkout-does-not-show-optional
+++ b/plugins/woocommerce/changelog/wooplug-5127-address-field-in-the-block-checkout-does-not-show-optional
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensure address 1 inherits the correct laberom locale
+Ensure address 1 inherits the correct label from locale

--- a/plugins/woocommerce/changelog/wooplug-5127-address-field-in-the-block-checkout-does-not-show-optional
+++ b/plugins/woocommerce/changelog/wooplug-5127-address-field-in-the-block-checkout-does-not-show-optional
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure address 1 inherits the correct laberom locale

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/address-line-fields.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/address-line-fields.tsx
@@ -34,7 +34,6 @@ const AddressLineFields = ( {
 				<ValidatedTextInput
 					{ ...address1FieldProps }
 					type={ address1.field.type }
-					label={ address1.field.label }
 					className={ `wc-block-components-address-form__address_1` }
 					value={ address1.value }
 					onChange={ ( newValue: string ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/prepare-form-fields.ts
@@ -45,6 +45,10 @@ const getSupportedCoreLocaleProps = (
 		);
 	}
 
+	if ( localeField.optionalLabel !== undefined ) {
+		fields.optionalLabel = localeField.optionalLabel;
+	}
+
 	if ( localeField.index ) {
 		if ( isNumber( localeField.index ) ) {
 			fields.index = localeField.index;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When generating the address 1 and address 2 fields, address 1 always uses the `label` prop, even if the field is optional. In this case it should use the `optionalLabel` prop. The logic in `createFieldProps` is correct, but the address_1 `ValidatedTextInput` component had the label prop, which overrode the value from `createFieldProps`.

This PR removes that prop from the address_1 `ValidatedTextInput`.

It also ensures the optionalLabel property is added to the country's locale. Previously, the optional label was never set if defined, and instead the generated one ( label + 'Optional' ) was used.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5127

(For Bug Fixes) Bug introduced in PR #55254

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="518" height="290" alt="image" src="https://github.com/user-attachments/assets/61b843fa-fe6c-4602-ae16-010f239cc241" /> |   <img width="499" height="320" alt="image" src="https://github.com/user-attachments/assets/9b72c365-efcc-4b35-a0d8-2d8fa0ca4edb" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this snippet:
```php
add_filter('woocommerce_get_country_locale', function( $locale ){
        foreach ( $locale as $country => $value ) {
			$locale[$country]['address_1'] = [
				'required' => false,
				'optionalLabel' => 'Custom optional label',
			];
	}
	return $locale;
}, 10, 1);
```
2. Go to the Checkout, ensure the address 1 label says "Custom optional label"
3. In the snippet, remove the `optionalLabel` entry and re-visit the checkout. Ensure the label says "Address (Optional)"
4. Re-add the `optionalLabel` entry above, but set `required` to true.
5. Ensure the label  'Address' shows.
6. Add the following snippet:
```php
    woocommerce_register_additional_checkout_field(
        array(
            'id' => 'test-plugin/required-changer',
            'label' => 'Required label showing (local pickup selected)',
			'optionalLabel' => 'Optional label showing (shipping selected)',
            'location' => 'contact',
            'type' => 'text',
			'required' => [
				"type" => "object",
				"properties" => [
					"cart" => [
						"properties" => [
							"prefers_collection" => [
								"const" => true
							]
						]
					]
				]
			],
        )
    );
```
7. Go to the Checkout. Change between local pickup and shipping and ensure the label of the input in the contact area changes.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
