### PR TITLE
Fix the Mini-Cart badge being transparent in some themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-59902-mini-cart-badge-transparent-in-some-themes
+++ b/plugins/woocommerce/changelog/fix-59902-mini-cart-badge-transparent-in-some-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Mini-Cart badge being transparent in some themes

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/edit.tsx
@@ -97,10 +97,11 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 	) as string;
 
 	// Apply Mini Cart quantity badge styles based on Site Editor's background and text colors.
+	// We need to set `span` in the selector so it has more specificity than the CSS.
 	useThemeColors(
 		'mini-cart-badge',
 		( { editorBackgroundColor, editorColor } ) => `
-			:where(.wc-block-mini-cart__badge) {
+			span:where(.wc-block-mini-cart__badge) {
 				color: ${ editorBackgroundColor };
 				background-color: ${ editorColor };
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -60,10 +60,11 @@ const Edit = ( {
 	} );
 
 	// Apply the Mini-Cart Contents block base styles based on Site Editor's background and text colors.
+	// We need to set `div` in the selector so it has more specificity than the CSS.
 	useThemeColors(
 		'mini-cart-contents',
 		( { editorBackgroundColor, editorColor } ) => `
-				:where(.wp-block-woocommerce-mini-cart-contents) {
+				div:where(.wp-block-woocommerce-mini-cart-contents) {
 					background-color: ${ editorBackgroundColor };
 					color: ${ editorColor };
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/utils/set-styles.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/utils/set-styles.ts
@@ -38,12 +38,13 @@ function setStyles() {
 
 	// We use :where here to reduce specificity so customized colors and theme
 	// CSS take priority.
+	// We need to set `div` and `span` in the selector so it has more specificity than the CSS.
 	style.appendChild(
 		document.createTextNode(
-			`:where(.wp-block-woocommerce-mini-cart-contents) {
+			`div:where(.wp-block-woocommerce-mini-cart-contents) {
 				background-color: ${ backgroundColor };
 			}
-			:where(.wc-block-mini-cart__badge) {
+			span:where(.wc-block-mini-cart__badge) {
 				background-color: ${ badgeBackgroundColor };
 				color: ${ badgeTextColor };
 			}`


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59902.

This PR increases the specificity of the CSS selectors added from the JS side that make the Mini-Cart badge and Mini-Cart drawer background to follow the same styles as the theme.

### How to test the changes in this Pull Request:

1. Switch your theme to Storefront.
2. From Appearance > Customizer, change the site background to a color different from white.
3. From Appearance > Widgets, add the Mini-Cart block to the sidebar.
4. In the frontend, verify the quantity badge is visible when there are product to cart.
5. Open the Mini-Cart drawer.
6. Verify the drawer has the same background as the page.

Before | After
--- | ---
<img width="950" height="1207" alt="imatge" src="https://github.com/user-attachments/assets/0316e759-c1f6-4532-b0d0-d84eb157749d" /> | <img width="950" height="1207" alt="imatge" src="https://github.com/user-attachments/assets/70ef6419-7528-42f3-90c5-326eed83b9b1" />

7. Optionally, also try setting the background color to something dark and text color to something light, and verify the Mini-Cart drawer looks correct:

Before | After
--- | ---
<img width="950" height="1207" alt="imatge" src="https://github.com/user-attachments/assets/776122b5-0a69-4c1f-9df4-bcb909259f4a" /> | <img width="950" height="1207" alt="imatge" src="https://github.com/user-attachments/assets/0ba8a32f-698c-44ab-bb3c-6f3a7cd2c85c" />