### PR TITLE
Implement Product Data Mapping for WooCommerce CLI Migrator

### DIFF
--- a/plugins/woocommerce/changelog/migrator-shopify-woo-mapper
+++ b/plugins/woocommerce/changelog/migrator-shopify-woo-mapper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Implement Product Data Mapping for WooCommerce CLI Migrator

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
@@ -58,237 +58,26 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @return array Standardized data array for WooCommerce_Product_Importer.
 	 */
 	public function map_product_data( object $shopify_product ): array {
-		$wc_data = array();
+		$is_variable = $this->is_variable_product( $shopify_product );
 
-		$is_variable                    = $this->is_variable_product( $shopify_product );
-		$wc_data['is_variable']         = $is_variable;
-		$wc_data['original_product_id'] = basename( $shopify_product->id );
+		// Map basic product fields.
+		$wc_data = $this->mapBasicProductFields( $shopify_product, $is_variable );
 
-		// Basic Product Fields.
-		$wc_data['name']             = $shopify_product->title;
-		$wc_data['slug']             = $shopify_product->handle;
-		$wc_data['description']      = $this->sanitize_product_description( $shopify_product->descriptionHtml ?? '' );
-		$wc_data['short_description'] = $shopify_product->descriptionPlainSummary ?? '';
-		$wc_data['status']           = $this->get_woo_product_status( $shopify_product );
-		$wc_data['date_created_gmt'] = $shopify_product->createdAt;
-
-		// Enhanced date handling.
-		if ( property_exists( $shopify_product, 'updatedAt' ) ) {
-			$wc_data['date_modified_gmt'] = $shopify_product->updatedAt;
+		// Map simple product data (for non-variable products).
+		if ( ! $is_variable ) {
+			$simple_data = $this->mapSimpleProductData( $shopify_product );
+			$wc_data     = array_merge( $wc_data, $simple_data );
 		}
 
-		// Catalog Visibility & Original URL.
-		$wc_data['catalog_visibility'] = 'visible';
-		$wc_data['original_url']       = null;
-		if ( property_exists( $shopify_product, 'onlineStoreUrl' ) ) {
-			if ( null === $shopify_product->onlineStoreUrl ) {
-				$wc_data['catalog_visibility'] = 'hidden';
-			} else {
-				$wc_data['original_url'] = $shopify_product->onlineStoreUrl;
-			}
-		}
+		// Map product images.
+		$wc_data['images'] = $this->mapProductImages( $shopify_product );
 
-		// Enhanced publication status.
-		$enhanced_status = $this->map_enhanced_status( $shopify_product );
-		$wc_data         = array_merge( $wc_data, $enhanced_status );
+		// Map metafields and SEO data.
+		$wc_data['metafields'] = $this->mapMetafields( $shopify_product );
 
-		// Taxonomies.
-		$wc_data['categories'] = $this->get_mapped_categories( $shopify_product );
-		$wc_data['tags']       = $this->get_mapped_tags( $shopify_product );
-
-		// Enhanced product classification.
-		$classification = $this->map_product_classification( $shopify_product );
-		$wc_data        = array_merge( $wc_data, $classification );
-
-		// Brand (Vendor).
-		$brand_name       = $shopify_product->vendor ?? null;
-		$wc_data['brand'] = $brand_name ? array(
-			'name' => $brand_name,
-			'slug' => sanitize_title( $brand_name ),
-		) : null;
-
-		// Simple Product Fields.
-		if ( ! $is_variable && ! empty( $shopify_product->variants->edges ) ) {
-			$variant_node = $shopify_product->variants->edges[0]->node;
-
-			// Price.
-			if ( $this->should_process( 'price' ) ) {
-				if ( $variant_node->compareAtPrice && $variant_node->compareAtPrice > $variant_node->price ) {
-					$wc_data['sale_price']    = $variant_node->price;
-					$wc_data['regular_price'] = $variant_node->compareAtPrice;
-				} else {
-					$wc_data['sale_price']    = null;
-					$wc_data['regular_price'] = $variant_node->price;
-				}
-			}
-
-			// SKU.
-			if ( $this->should_process( 'sku' ) ) {
-				$wc_data['sku'] = $variant_node->sku;
-			}
-
-			// Stock.
-			if ( $this->should_process( 'stock' ) ) {
-				$manage_stock              = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked;
-				$wc_data['manage_stock']   = $manage_stock;
-				$stock_quantity            = $variant_node->inventoryQuantity ?? 0;
-				$allow_oversell            = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy;
-				$wc_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
-				$wc_data['stock_quantity'] = $stock_quantity;
-			}
-
-			// Weight.
-			if ( $this->should_process( 'weight' ) ) {
-				$weight_data = null;
-				if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) &&
-					property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) &&
-					property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight )
-				) {
-					$weight_data = $variant_node->inventoryItem->measurement->weight;
-				}
-				$weight            = $weight_data ? $weight_data->value : null;
-				$weight_unit       = $weight_data ? $weight_data->unit : null;
-				$wc_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
-			}
-
-			$wc_data['original_variant_id'] = basename( $variant_node->id );
-
-		} else {
-			// Defaults for variable or product with no variants.
-			$wc_data['sku']                 = null;
-			$wc_data['regular_price']       = null;
-			$wc_data['sale_price']          = null;
-			$wc_data['stock_quantity']      = null;
-			$wc_data['manage_stock']        = false;
-			$wc_data['stock_status']        = 'instock';
-			$wc_data['weight']              = null;
-			$wc_data['original_variant_id'] = null;
-		}
-
-		// Images.
-		$wc_data['images'] = array();
-		$featured_media_id = null;
-		if ( ! empty( $shopify_product->featuredMedia ) && is_object( $shopify_product->featuredMedia ) && ! empty( $shopify_product->featuredMedia->id ) ) {
-			$featured_media_id = $shopify_product->featuredMedia->id;
-		}
-
-		if ( ! empty( $shopify_product->media->edges ) ) {
-			foreach ( $shopify_product->media->edges as $media_edge ) {
-				$media_node = $media_edge->node;
-				if ( property_exists( $media_node, 'image' ) && is_object( $media_node->image ) && ! empty( $media_node->id ) && ! empty( $media_node->image->url ) ) {
-					$wc_data['images'][] = array(
-						'original_id' => $media_node->id,
-						'url'         => $media_node->image->url,
-						'alt'         => $media_node->image->altText ?? null,
-						'is_featured' => ( $media_node->id === $featured_media_id ),
-					);
-				}
-			}
-		}
-
-		// Metafields & SEO.
-		$wc_data['metafields'] = array();
-		if ( property_exists( $shopify_product, 'metafields' ) && ! empty( $shopify_product->metafields->edges ) ) {
-			foreach ( $shopify_product->metafields->edges as $edge ) {
-				$field_node                    = $edge->node;
-				$key                           = sprintf( '%s_%s', $field_node->namespace, $field_node->key );
-				$wc_data['metafields'][ $key ] = $field_node->value;
-			}
-		}
-
-		// Enhanced SEO mapping.
-		$seo_data              = $this->map_seo_fields( $shopify_product );
-		$wc_data['metafields'] = array_merge( $wc_data['metafields'], $seo_data );
-
-		// Attributes (Variable Only).
-		$wc_data['attributes'] = array();
-		if ( $is_variable && property_exists( $shopify_product, 'options' ) && ! empty( $shopify_product->options ) ) {
-			foreach ( $shopify_product->options as $option ) {
-				$wc_data['attributes'][] = array(
-					'name'         => $option->name,
-					'options'      => $option->values,
-					'position'     => $option->position,
-					'is_visible'   => true,
-					'is_variation' => true,
-				);
-			}
-		}
-
-		// Variations (Variable Only).
-		$wc_data['variations'] = array();
-		if ( $is_variable && property_exists( $shopify_product, 'variants' ) && ! empty( $shopify_product->variants->edges ) ) {
-			foreach ( $shopify_product->variants->edges as $variant_edge ) {
-				$variant_node                  = $variant_edge->node;
-				$variation_data                = array();
-				$variation_data['original_id'] = basename( $variant_node->id );
-
-				// Price.
-				if ( $this->should_process( 'price' ) ) {
-					if ( $variant_node->compareAtPrice && (float) $variant_node->compareAtPrice > (float) $variant_node->price ) {
-						$variation_data['regular_price'] = $variant_node->compareAtPrice;
-						$variation_data['sale_price']    = $variant_node->price;
-					} else {
-						$variation_data['regular_price'] = $variant_node->price;
-						$variation_data['sale_price']    = null;
-					}
-				}
-
-				// SKU.
-				if ( $this->should_process( 'sku' ) ) {
-					$variation_data['sku'] = $variant_node->sku ?? null;
-				}
-
-				// Stock.
-				if ( $this->should_process( 'stock' ) ) {
-					$manage_stock                     = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked;
-					$variation_data['manage_stock']   = $manage_stock;
-					$stock_quantity                   = $variant_node->inventoryQuantity ?? 0;
-					$allow_oversell                   = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy;
-					$variation_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
-					$variation_data['stock_quantity'] = $stock_quantity;
-				}
-
-				// Weight.
-				if ( $this->should_process( 'weight' ) ) {
-					$weight_data = null;
-					if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) &&
-						property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) &&
-						property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight )
-					) {
-						$weight_data = $variant_node->inventoryItem->measurement->weight;
-					}
-					$weight                   = $weight_data ? $weight_data->value : null;
-					$weight_unit              = $weight_data ? $weight_data->unit : null;
-					$variation_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
-				}
-
-				// Mapped Attributes.
-				if ( $this->should_process( 'attributes' ) ) {
-					$variation_data['attributes'] = array();
-					if ( ! empty( $variant_node->selectedOptions ) ) {
-						foreach ( $variant_node->selectedOptions as $selectedOption ) {
-							$variation_data['attributes'][ $selectedOption->name ] = $selectedOption->value;
-						}
-					}
-				}
-
-				// Image Mapping.
-				if ( $this->should_process( 'images' ) ) {
-					$variation_data['image_original_id'] = null;
-					if ( ! empty( $variant_node->media->edges ) ) {
-						$variant_media_node = $variant_node->media->edges[0]->node ?? null;
-						if ( $variant_media_node && property_exists( $variant_media_node, 'image' ) && is_object( $variant_media_node->image ) && ! empty( $variant_media_node->id ) ) {
-							$variation_data['image_original_id'] = $variant_media_node->id;
-						}
-					}
-				}
-
-				// Menu Order / Position.
-				$variation_data['menu_order'] = $variant_node->position;
-
-				$wc_data['variations'][] = $variation_data;
-			}
-		}
+		// Map variable product data (attributes and variations).
+		$variable_data = $this->mapVariableProductData( $shopify_product, $is_variable );
+		$wc_data       = array_merge( $wc_data, $variable_data );
 
 		return $wc_data;
 	}
@@ -327,13 +116,13 @@ class ShopifyMapper implements PlatformMapperInterface {
 		$status_data = array();
 
 		// Publication date.
-		if ( property_exists( $shopify_product, 'publishedAt' ) && $shopify_product->publishedAt ) {
-			$status_data['date_published_gmt'] = $shopify_product->publishedAt;
+		if ( property_exists( $shopify_product, 'publishedAt' ) && $shopify_product->publishedAt ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+			$status_data['date_published_gmt'] = $shopify_product->publishedAt; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
 		}
 
 		// Available for sale flag.
 		if ( property_exists( $shopify_product, 'availableForSale' ) ) {
-			$status_data['available_for_sale'] = $shopify_product->availableForSale;
+			$status_data['available_for_sale'] = $shopify_product->availableForSale; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
 		}
 
 		return $status_data;
@@ -348,11 +137,18 @@ class ShopifyMapper implements PlatformMapperInterface {
 	private function map_product_classification( object $shopify_product ): array {
 		$classification = array();
 
-		// Product type.
-		if ( property_exists( $shopify_product, 'productType' ) && $shopify_product->productType ) {
+		// Product type - check both camelCase and snake_case for compatibility.
+		$product_type = null;
+		if ( property_exists( $shopify_product, 'productType' ) && $shopify_product->productType ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+			$product_type = $shopify_product->productType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		} elseif ( property_exists( $shopify_product, 'product_type' ) && $shopify_product->product_type ) {
+			$product_type = $shopify_product->product_type;
+		}
+
+		if ( $product_type ) {
 			$classification['product_type'] = array(
-				'name' => $shopify_product->productType,
-				'slug' => sanitize_title( $shopify_product->productType ),
+				'name' => $product_type,
+				'slug' => sanitize_title( $product_type ),
 			);
 		}
 
@@ -364,14 +160,18 @@ class ShopifyMapper implements PlatformMapperInterface {
 			);
 		}
 
-		// Gift card detection.
+		// Gift card detection - check both camelCase and snake_case for compatibility.
 		if ( property_exists( $shopify_product, 'isGiftCard' ) ) {
-			$classification['is_gift_card'] = $shopify_product->isGiftCard;
+			$classification['is_gift_card'] = $shopify_product->isGiftCard; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		} elseif ( property_exists( $shopify_product, 'is_gift_card' ) ) {
+			$classification['is_gift_card'] = $shopify_product->is_gift_card;
 		}
 
-		// Subscription product detection.
+		// Subscription product detection - check both camelCase and snake_case for compatibility.
 		if ( property_exists( $shopify_product, 'requiresSellingPlan' ) ) {
-			$classification['requires_subscription'] = $shopify_product->requiresSellingPlan;
+			$classification['requires_subscription'] = $shopify_product->requiresSellingPlan; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		} elseif ( property_exists( $shopify_product, 'requires_selling_plan' ) ) {
+			$classification['requires_subscription'] = $shopify_product->requires_selling_plan;
 		}
 
 		return $classification;
@@ -542,6 +342,292 @@ class ShopifyMapper implements PlatformMapperInterface {
 			return true;
 		}
 		return in_array( $field_key, $this->fields_to_process, true );
+	}
+
+	/**
+	 * Maps basic product fields from Shopify to WooCommerce format.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @param bool   $is_variable     Whether this is a variable product.
+	 * @return array Basic product field mappings.
+	 */
+	private function mapBasicProductFields( object $shopify_product, bool $is_variable ): array {
+		$basic_data = array();
+
+		$basic_data['is_variable']         = $is_variable;
+		$basic_data['original_product_id'] = basename( $shopify_product->id );
+
+		// Basic Product Fields.
+		$basic_data['name']              = $shopify_product->title;
+		$basic_data['slug']              = $shopify_product->handle;
+		$basic_data['description']       = $this->sanitize_product_description( $shopify_product->descriptionHtml ?? '' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$basic_data['short_description'] = $shopify_product->descriptionPlainSummary ?? ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$basic_data['status']            = $this->get_woo_product_status( $shopify_product );
+		$basic_data['date_created_gmt']  = $shopify_product->createdAt; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+
+		// Enhanced date handling.
+		if ( property_exists( $shopify_product, 'updatedAt' ) ) {
+			$basic_data['date_modified_gmt'] = $shopify_product->updatedAt; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		}
+
+		// Catalog Visibility & Original URL.
+		$basic_data['catalog_visibility'] = 'visible';
+		$basic_data['original_url']       = null;
+		if ( property_exists( $shopify_product, 'onlineStoreUrl' ) ) {
+			if ( null === $shopify_product->onlineStoreUrl ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				$basic_data['catalog_visibility'] = 'hidden';
+			} else {
+				$basic_data['original_url'] = $shopify_product->onlineStoreUrl; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+			}
+		}
+
+		// Enhanced publication status.
+		$enhanced_status = $this->map_enhanced_status( $shopify_product );
+		$basic_data      = array_merge( $basic_data, $enhanced_status );
+
+		// Taxonomies.
+		$basic_data['categories'] = $this->get_mapped_categories( $shopify_product );
+		$basic_data['tags']       = $this->get_mapped_tags( $shopify_product );
+
+		// Enhanced product classification.
+		$classification = $this->map_product_classification( $shopify_product );
+		$basic_data     = array_merge( $basic_data, $classification );
+
+		// Brand (Vendor).
+		$brand_name          = $shopify_product->vendor ?? null;
+		$basic_data['brand'] = $brand_name ? array(
+			'name' => $brand_name,
+			'slug' => sanitize_title( $brand_name ),
+		) : null;
+
+		return $basic_data;
+	}
+
+	/**
+	 * Maps simple product data (price, SKU, stock, weight) from Shopify variant.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Simple product data mappings.
+	 */
+	private function mapSimpleProductData( object $shopify_product ): array {
+		$simple_data = array();
+
+		if ( ! empty( $shopify_product->variants->edges ) ) {
+			$variant_node = $shopify_product->variants->edges[0]->node;
+
+			// Price.
+			if ( $this->should_process( 'price' ) ) {
+				if ( $variant_node->compareAtPrice && $variant_node->compareAtPrice > $variant_node->price ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					$simple_data['sale_price']    = $variant_node->price;
+					$simple_data['regular_price'] = $variant_node->compareAtPrice; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				} else {
+					$simple_data['sale_price']    = null;
+					$simple_data['regular_price'] = $variant_node->price;
+				}
+			}
+
+			// SKU.
+			if ( $this->should_process( 'sku' ) ) {
+				$simple_data['sku'] = $variant_node->sku;
+			}
+
+			// Stock.
+			if ( $this->should_process( 'stock' ) ) {
+				$manage_stock                  = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				$simple_data['manage_stock']   = $manage_stock;
+				$stock_quantity                = $variant_node->inventoryQuantity ?? 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				$allow_oversell                = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				$simple_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
+				$simple_data['stock_quantity'] = $stock_quantity;
+			}
+
+			// Weight.
+			if ( $this->should_process( 'weight' ) ) {
+				$weight_data = null;
+				if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) && // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) && // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				) {
+					$weight_data = $variant_node->inventoryItem->measurement->weight; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+				}
+				$weight                = $weight_data ? $weight_data->value : null;
+				$weight_unit           = $weight_data ? $weight_data->unit : null;
+				$simple_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
+			}
+
+			$simple_data['original_variant_id'] = basename( $variant_node->id );
+
+		} else {
+			// Defaults for variable or product with no variants.
+			$simple_data['sku']                 = null;
+			$simple_data['regular_price']       = null;
+			$simple_data['sale_price']          = null;
+			$simple_data['stock_quantity']      = null;
+			$simple_data['manage_stock']        = false;
+			$simple_data['stock_status']        = 'instock';
+			$simple_data['weight']              = null;
+			$simple_data['original_variant_id'] = null;
+		}
+
+		return $simple_data;
+	}
+
+	/**
+	 * Maps variable product data (attributes and variations) from Shopify.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @param bool   $is_variable     Whether this is a variable product.
+	 * @return array Variable product data mappings.
+	 */
+	private function mapVariableProductData( object $shopify_product, bool $is_variable ): array {
+		$variable_data = array();
+
+		// Attributes (Variable Only).
+		$variable_data['attributes'] = array();
+		if ( $is_variable && property_exists( $shopify_product, 'options' ) && ! empty( $shopify_product->options ) ) {
+			foreach ( $shopify_product->options as $option ) {
+				$variable_data['attributes'][] = array(
+					'name'         => $option->name,
+					'options'      => $option->values,
+					'position'     => $option->position,
+					'is_visible'   => true,
+					'is_variation' => true,
+				);
+			}
+		}
+
+		// Variations (Variable Only).
+		$variable_data['variations'] = array();
+		if ( $is_variable && property_exists( $shopify_product, 'variants' ) && ! empty( $shopify_product->variants->edges ) ) {
+			foreach ( $shopify_product->variants->edges as $variant_edge ) {
+				$variant_node                  = $variant_edge->node;
+				$variation_data                = array();
+				$variation_data['original_id'] = basename( $variant_node->id );
+
+				// Price.
+				if ( $this->should_process( 'price' ) ) {
+					if ( $variant_node->compareAtPrice && (float) $variant_node->compareAtPrice > (float) $variant_node->price ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+						$variation_data['regular_price'] = $variant_node->compareAtPrice; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+						$variation_data['sale_price']    = $variant_node->price;
+					} else {
+						$variation_data['regular_price'] = $variant_node->price;
+						$variation_data['sale_price']    = null;
+					}
+				}
+
+				// SKU.
+				if ( $this->should_process( 'sku' ) ) {
+					$variation_data['sku'] = $variant_node->sku ?? null;
+				}
+
+				// Stock.
+				if ( $this->should_process( 'stock' ) ) {
+					$manage_stock                     = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					$variation_data['manage_stock']   = $manage_stock;
+					$stock_quantity                   = $variant_node->inventoryQuantity ?? 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					$allow_oversell                   = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					$variation_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
+					$variation_data['stock_quantity'] = $stock_quantity;
+				}
+
+				// Weight.
+				if ( $this->should_process( 'weight' ) ) {
+					$weight_data = null;
+					if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) && // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+						property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) && // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+						property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					) {
+						$weight_data = $variant_node->inventoryItem->measurement->weight; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+					}
+					$weight                   = $weight_data ? $weight_data->value : null;
+					$weight_unit              = $weight_data ? $weight_data->unit : null;
+					$variation_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
+				}
+
+				// Mapped Attributes.
+				if ( $this->should_process( 'attributes' ) ) {
+					$variation_data['attributes'] = array();
+					if ( ! empty( $variant_node->selectedOptions ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+						foreach ( $variant_node->selectedOptions as $selectedOption ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- GraphQL uses camelCase.
+							$variation_data['attributes'][ $selectedOption->name ] = $selectedOption->value; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- GraphQL uses camelCase.
+						}
+					}
+				}
+
+				// Image Mapping.
+				if ( $this->should_process( 'images' ) ) {
+					$variation_data['image_original_id'] = null;
+					if ( ! empty( $variant_node->media->edges ) ) {
+						$variant_media_node = $variant_node->media->edges[0]->node ?? null;
+						if ( $variant_media_node && property_exists( $variant_media_node, 'image' ) && is_object( $variant_media_node->image ) && ! empty( $variant_media_node->id ) ) {
+							$variation_data['image_original_id'] = $variant_media_node->id;
+						}
+					}
+				}
+
+				// Menu Order / Position.
+				$variation_data['menu_order'] = $variant_node->position;
+
+				$variable_data['variations'][] = $variation_data;
+			}
+		}
+
+		return $variable_data;
+	}
+
+	/**
+	 * Maps product images from Shopify media data.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Product images data.
+	 */
+	private function mapProductImages( object $shopify_product ): array {
+		$images_data       = array();
+		$featured_media_id = null;
+
+		if ( ! empty( $shopify_product->featuredMedia ) && is_object( $shopify_product->featuredMedia ) && ! empty( $shopify_product->featuredMedia->id ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+			$featured_media_id = $shopify_product->featuredMedia->id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		}
+
+		if ( ! empty( $shopify_product->media->edges ) ) {
+			foreach ( $shopify_product->media->edges as $media_edge ) {
+				$media_node = $media_edge->node;
+				if ( property_exists( $media_node, 'image' ) && is_object( $media_node->image ) && ! empty( $media_node->id ) && ! empty( $media_node->image->url ) ) {
+					$images_data[] = array(
+						'original_id' => $media_node->id,
+						'url'         => $media_node->image->url,
+						'alt'         => $media_node->image->altText ?? null,
+						'is_featured' => ( $media_node->id === $featured_media_id ),
+					);
+				}
+			}
+		}
+
+		return $images_data;
+	}
+
+	/**
+	 * Maps metafields and SEO data from Shopify product.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Metafields data.
+	 */
+	private function mapMetafields( object $shopify_product ): array {
+		$metafields_data = array();
+
+		if ( property_exists( $shopify_product, 'metafields' ) && ! empty( $shopify_product->metafields->edges ) ) {
+			foreach ( $shopify_product->metafields->edges as $edge ) {
+				$field_node              = $edge->node;
+				$key                     = sprintf( '%s_%s', $field_node->namespace, $field_node->key );
+				$metafields_data[ $key ] = $field_node->value;
+			}
+		}
+
+		// Enhanced SEO mapping.
+		$seo_data        = $this->map_seo_fields( $shopify_product );
+		$metafields_data = array_merge( $metafields_data, $seo_data );
+
+		return $metafields_data;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
@@ -26,6 +26,51 @@ defined( 'ABSPATH' ) || exit;
 class ShopifyMapper implements PlatformMapperInterface {
 
 	/**
+	 * Shopify weight unit to standard unit mapping.
+	 *
+	 * @var array
+	 */
+	private const WEIGHT_UNIT_MAP = array(
+		'GRAMS'     => 'g',
+		'KILOGRAMS' => 'kg',
+		'POUNDS'    => 'lb',
+		'OUNCES'    => 'oz',
+	);
+
+	/**
+	 * Weight conversion factors between units.
+	 * Structure: [from_unit][to_unit] = factor
+	 *
+	 * @var array
+	 */
+	private const WEIGHT_CONVERSION_FACTORS = array(
+		'kg' => array(
+			'kg' => 1,
+			'g'  => 1000,
+			'lb' => 2.20462,
+			'oz' => 35.274,
+		),
+		'g'  => array(
+			'kg' => 0.001,
+			'g'  => 1,
+			'lb' => 0.00220462,
+			'oz' => 0.035274,
+		),
+		'lb' => array(
+			'kg' => 0.453592,
+			'g'  => 453.592,
+			'lb' => 1,
+			'oz' => 16,
+		),
+		'oz' => array(
+			'kg' => 0.0283495,
+			'g'  => 28.3495,
+			'lb' => 0.0625,
+			'oz' => 1,
+		),
+	);
+
+	/**
 	 * Fields to process during mapping.
 	 *
 	 * @var array
@@ -257,14 +302,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 			return null;
 		}
 
-		$unit_map = array(
-			'GRAMS'     => 'g',
-			'KILOGRAMS' => 'kg',
-			'POUNDS'    => 'lb',
-			'OUNCES'    => 'oz',
-		);
-
-		$shopify_unit_key = $unit_map[ $weight_unit ] ?? null;
+		$shopify_unit_key = self::WEIGHT_UNIT_MAP[ $weight_unit ] ?? null;
 
 		if ( ! $shopify_unit_key ) {
 			return (float) $weight;
@@ -286,39 +324,12 @@ class ShopifyMapper implements PlatformMapperInterface {
 			return is_numeric( $converted ) ? (float) $converted : null;
 		}
 
-		// Fallback manual conversion.
-		$conversion_factors = array(
-			'kg' => array(
-				'kg' => 1,
-				'g'  => 1000,
-				'lb' => 2.20462,
-				'oz' => 35.274,
-			),
-			'g'  => array(
-				'kg' => 0.001,
-				'g'  => 1,
-				'lb' => 0.00220462,
-				'oz' => 0.035274,
-			),
-			'lb' => array(
-				'kg' => 0.453592,
-				'g'  => 453.592,
-				'lb' => 1,
-				'oz' => 16,
-			),
-			'oz' => array(
-				'kg' => 0.0283495,
-				'g'  => 28.3495,
-				'lb' => 0.0625,
-				'oz' => 1,
-			),
-		);
-
-		if ( ! isset( $conversion_factors[ $shopify_unit_key ][ $store_weight_unit ] ) ) {
+		// Fallback manual conversion using class constants.
+		if ( ! isset( self::WEIGHT_CONVERSION_FACTORS[ $shopify_unit_key ][ $store_weight_unit ] ) ) {
 			return (float) $weight;
 		}
 
-		return (float) $weight * $conversion_factors[ $shopify_unit_key ][ $store_weight_unit ];
+		return (float) $weight * self::WEIGHT_CONVERSION_FACTORS[ $shopify_unit_key ][ $store_weight_unit ];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
@@ -95,7 +95,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 	public function map_product_data( object $shopify_product ): array {
 		$is_variable = $this->is_variable_product( $shopify_product );
 
-		// Map basic product fields.
 		$wc_data = $this->map_basic_product_fields( $shopify_product, $is_variable );
 
 		// Map simple product data (for non-variable products).
@@ -382,7 +381,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 			}
 		}
 
-		// Enhanced publication status.
 		$enhanced_status = $this->map_enhanced_status( $shopify_product );
 		$basic_data      = array_merge( $basic_data, $enhanced_status );
 
@@ -416,7 +414,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 		if ( ! empty( $shopify_product->variants->edges ) ) {
 			$variant_node = $shopify_product->variants->edges[0]->node;
 
-			// Price.
 			if ( $this->should_process( 'price' ) ) {
 				if ( $variant_node->compareAtPrice && $variant_node->compareAtPrice > $variant_node->price ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
 					$simple_data['sale_price']    = $variant_node->price;
@@ -427,7 +424,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 				}
 			}
 
-			// SKU.
 			if ( $this->should_process( 'sku' ) ) {
 				$simple_data['sku'] = $variant_node->sku;
 			}
@@ -505,7 +501,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 				$variation_data                = array();
 				$variation_data['original_id'] = basename( $variant_node->id );
 
-				// Price.
 				if ( $this->should_process( 'price' ) ) {
 					if ( $variant_node->compareAtPrice && (float) $variant_node->compareAtPrice > (float) $variant_node->price ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
 						$variation_data['regular_price'] = $variant_node->compareAtPrice; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
@@ -516,7 +511,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 					}
 				}
 
-				// SKU.
 				if ( $this->should_process( 'sku' ) ) {
 					$variation_data['sku'] = $variant_node->sku ?? null;
 				}

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
@@ -87,16 +87,6 @@ class ShopifyMapper implements PlatformMapperInterface {
 	}
 
 	/**
-	 * Initialize dependencies via DI container.
-	 * Required for WooCommerce DI pattern compliance.
-	 *
-	 * @internal
-	 */
-	final public function init(): void {
-		// No dependencies currently needed, but method required for DI pattern.
-	}
-
-	/**
 	 * Maps raw Shopify product data to a standardized array format.
 	 *
 	 * @param object $shopify_product The raw Shopify product node from GraphQL.
@@ -106,22 +96,22 @@ class ShopifyMapper implements PlatformMapperInterface {
 		$is_variable = $this->is_variable_product( $shopify_product );
 
 		// Map basic product fields.
-		$wc_data = $this->mapBasicProductFields( $shopify_product, $is_variable );
+		$wc_data = $this->map_basic_product_fields( $shopify_product, $is_variable );
 
 		// Map simple product data (for non-variable products).
 		if ( ! $is_variable ) {
-			$simple_data = $this->mapSimpleProductData( $shopify_product );
+			$simple_data = $this->map_simple_product_data( $shopify_product );
 			$wc_data     = array_merge( $wc_data, $simple_data );
 		}
 
 		// Map product images.
-		$wc_data['images'] = $this->mapProductImages( $shopify_product );
+		$wc_data['images'] = $this->map_product_images( $shopify_product );
 
 		// Map metafields and SEO data.
-		$wc_data['metafields'] = $this->mapMetafields( $shopify_product );
+		$wc_data['metafields'] = $this->map_metafields( $shopify_product );
 
 		// Map variable product data (attributes and variations).
-		$variable_data = $this->mapVariableProductData( $shopify_product, $is_variable );
+		$variable_data = $this->map_variable_product_data( $shopify_product, $is_variable );
 		$wc_data       = array_merge( $wc_data, $variable_data );
 
 		return $wc_data;
@@ -362,7 +352,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @param bool   $is_variable     Whether this is a variable product.
 	 * @return array Basic product field mappings.
 	 */
-	private function mapBasicProductFields( object $shopify_product, bool $is_variable ): array {
+	private function map_basic_product_fields( object $shopify_product, bool $is_variable ): array {
 		$basic_data = array();
 
 		$basic_data['is_variable']         = $is_variable;
@@ -420,7 +410,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @param object $shopify_product The Shopify product data.
 	 * @return array Simple product data mappings.
 	 */
-	private function mapSimpleProductData( object $shopify_product ): array {
+	private function map_simple_product_data( object $shopify_product ): array {
 		$simple_data = array();
 
 		if ( ! empty( $shopify_product->variants->edges ) ) {
@@ -490,7 +480,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @param bool   $is_variable     Whether this is a variable product.
 	 * @return array Variable product data mappings.
 	 */
-	private function mapVariableProductData( object $shopify_product, bool $is_variable ): array {
+	private function map_variable_product_data( object $shopify_product, bool $is_variable ): array {
 		$variable_data = array();
 
 		// Attributes (Variable Only).
@@ -592,7 +582,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @param object $shopify_product The Shopify product data.
 	 * @return array Product images data.
 	 */
-	private function mapProductImages( object $shopify_product ): array {
+	private function map_product_images( object $shopify_product ): array {
 		$images_data       = array();
 		$featured_media_id = null;
 
@@ -623,7 +613,7 @@ class ShopifyMapper implements PlatformMapperInterface {
 	 * @param object $shopify_product The Shopify product data.
 	 * @return array Metafields data.
 	 */
-	private function mapMetafields( object $shopify_product ): array {
+	private function map_metafields( object $shopify_product ): array {
 		$metafields_data = array();
 
 		if ( property_exists( $shopify_product, 'metafields' ) && ! empty( $shopify_product->metafields->edges ) ) {

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php
@@ -18,20 +18,556 @@ defined( 'ABSPATH' ) || exit;
  *
  * This class is responsible for transforming raw Shopify product data
  * into a standardized format suitable for the WooCommerce Importer.
- * Currently contains stub implementations that will be replaced with actual
- * data mapping logic in future PRs.
+ * Maps comprehensive product data including variants, images, taxonomies,
+ * and metadata from Shopify's GraphQL API response format.
+ *
+ * @internal This class is part of the CLI Migrator feature and should not be used directly.
  */
 class ShopifyMapper implements PlatformMapperInterface {
 
 	/**
+	 * Fields to process during mapping.
+	 *
+	 * @var array
+	 */
+	private $fields_to_process = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $args Optional arguments including 'fields' array for selective processing.
+	 */
+	public function __construct( array $args = array() ) {
+		$this->fields_to_process = $args['fields'] ?? $this->get_default_product_fields();
+	}
+
+	/**
+	 * Initialize dependencies via DI container.
+	 * Required for WooCommerce DI pattern compliance.
+	 *
+	 * @internal
+	 */
+	final public function init(): void {
+		// No dependencies currently needed, but method required for DI pattern.
+	}
+
+	/**
 	 * Maps raw Shopify product data to a standardized array format.
 	 *
-	 * @param object $platform_data The raw product data object from Shopify (e.g., Shopify product node).
-	 *
-	 * @return array A standardized array representing the product, understandable by the WooCommerce_Product_Importer.
+	 * @param object $shopify_product The raw Shopify product node from GraphQL.
+	 * @return array Standardized data array for WooCommerce_Product_Importer.
 	 */
-	public function map_product_data( object $platform_data ): array {
-		// Stub implementation - will be replaced with actual Shopify to WooCommerce data mapping.
-		return array();
+	public function map_product_data( object $shopify_product ): array {
+		$wc_data = array();
+
+		$is_variable                    = $this->is_variable_product( $shopify_product );
+		$wc_data['is_variable']         = $is_variable;
+		$wc_data['original_product_id'] = basename( $shopify_product->id );
+
+		// Basic Product Fields.
+		$wc_data['name']             = $shopify_product->title;
+		$wc_data['slug']             = $shopify_product->handle;
+		$wc_data['description']      = $this->sanitize_product_description( $shopify_product->descriptionHtml ?? '' );
+		$wc_data['short_description'] = $shopify_product->descriptionPlainSummary ?? '';
+		$wc_data['status']           = $this->get_woo_product_status( $shopify_product );
+		$wc_data['date_created_gmt'] = $shopify_product->createdAt;
+
+		// Enhanced date handling.
+		if ( property_exists( $shopify_product, 'updatedAt' ) ) {
+			$wc_data['date_modified_gmt'] = $shopify_product->updatedAt;
+		}
+
+		// Catalog Visibility & Original URL.
+		$wc_data['catalog_visibility'] = 'visible';
+		$wc_data['original_url']       = null;
+		if ( property_exists( $shopify_product, 'onlineStoreUrl' ) ) {
+			if ( null === $shopify_product->onlineStoreUrl ) {
+				$wc_data['catalog_visibility'] = 'hidden';
+			} else {
+				$wc_data['original_url'] = $shopify_product->onlineStoreUrl;
+			}
+		}
+
+		// Enhanced publication status.
+		$enhanced_status = $this->map_enhanced_status( $shopify_product );
+		$wc_data         = array_merge( $wc_data, $enhanced_status );
+
+		// Taxonomies.
+		$wc_data['categories'] = $this->get_mapped_categories( $shopify_product );
+		$wc_data['tags']       = $this->get_mapped_tags( $shopify_product );
+
+		// Enhanced product classification.
+		$classification = $this->map_product_classification( $shopify_product );
+		$wc_data        = array_merge( $wc_data, $classification );
+
+		// Brand (Vendor).
+		$brand_name       = $shopify_product->vendor ?? null;
+		$wc_data['brand'] = $brand_name ? array(
+			'name' => $brand_name,
+			'slug' => sanitize_title( $brand_name ),
+		) : null;
+
+		// Simple Product Fields.
+		if ( ! $is_variable && ! empty( $shopify_product->variants->edges ) ) {
+			$variant_node = $shopify_product->variants->edges[0]->node;
+
+			// Price.
+			if ( $this->should_process( 'price' ) ) {
+				if ( $variant_node->compareAtPrice && $variant_node->compareAtPrice > $variant_node->price ) {
+					$wc_data['sale_price']    = $variant_node->price;
+					$wc_data['regular_price'] = $variant_node->compareAtPrice;
+				} else {
+					$wc_data['sale_price']    = null;
+					$wc_data['regular_price'] = $variant_node->price;
+				}
+			}
+
+			// SKU.
+			if ( $this->should_process( 'sku' ) ) {
+				$wc_data['sku'] = $variant_node->sku;
+			}
+
+			// Stock.
+			if ( $this->should_process( 'stock' ) ) {
+				$manage_stock              = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked;
+				$wc_data['manage_stock']   = $manage_stock;
+				$stock_quantity            = $variant_node->inventoryQuantity ?? 0;
+				$allow_oversell            = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy;
+				$wc_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
+				$wc_data['stock_quantity'] = $stock_quantity;
+			}
+
+			// Weight.
+			if ( $this->should_process( 'weight' ) ) {
+				$weight_data = null;
+				if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) &&
+					property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) &&
+					property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight )
+				) {
+					$weight_data = $variant_node->inventoryItem->measurement->weight;
+				}
+				$weight            = $weight_data ? $weight_data->value : null;
+				$weight_unit       = $weight_data ? $weight_data->unit : null;
+				$wc_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
+			}
+
+			$wc_data['original_variant_id'] = basename( $variant_node->id );
+
+		} else {
+			// Defaults for variable or product with no variants.
+			$wc_data['sku']                 = null;
+			$wc_data['regular_price']       = null;
+			$wc_data['sale_price']          = null;
+			$wc_data['stock_quantity']      = null;
+			$wc_data['manage_stock']        = false;
+			$wc_data['stock_status']        = 'instock';
+			$wc_data['weight']              = null;
+			$wc_data['original_variant_id'] = null;
+		}
+
+		// Images.
+		$wc_data['images'] = array();
+		$featured_media_id = null;
+		if ( ! empty( $shopify_product->featuredMedia ) && is_object( $shopify_product->featuredMedia ) && ! empty( $shopify_product->featuredMedia->id ) ) {
+			$featured_media_id = $shopify_product->featuredMedia->id;
+		}
+
+		if ( ! empty( $shopify_product->media->edges ) ) {
+			foreach ( $shopify_product->media->edges as $media_edge ) {
+				$media_node = $media_edge->node;
+				if ( property_exists( $media_node, 'image' ) && is_object( $media_node->image ) && ! empty( $media_node->id ) && ! empty( $media_node->image->url ) ) {
+					$wc_data['images'][] = array(
+						'original_id' => $media_node->id,
+						'url'         => $media_node->image->url,
+						'alt'         => $media_node->image->altText ?? null,
+						'is_featured' => ( $media_node->id === $featured_media_id ),
+					);
+				}
+			}
+		}
+
+		// Metafields & SEO.
+		$wc_data['metafields'] = array();
+		if ( property_exists( $shopify_product, 'metafields' ) && ! empty( $shopify_product->metafields->edges ) ) {
+			foreach ( $shopify_product->metafields->edges as $edge ) {
+				$field_node                    = $edge->node;
+				$key                           = sprintf( '%s_%s', $field_node->namespace, $field_node->key );
+				$wc_data['metafields'][ $key ] = $field_node->value;
+			}
+		}
+
+		// Enhanced SEO mapping.
+		$seo_data              = $this->map_seo_fields( $shopify_product );
+		$wc_data['metafields'] = array_merge( $wc_data['metafields'], $seo_data );
+
+		// Attributes (Variable Only).
+		$wc_data['attributes'] = array();
+		if ( $is_variable && property_exists( $shopify_product, 'options' ) && ! empty( $shopify_product->options ) ) {
+			foreach ( $shopify_product->options as $option ) {
+				$wc_data['attributes'][] = array(
+					'name'         => $option->name,
+					'options'      => $option->values,
+					'position'     => $option->position,
+					'is_visible'   => true,
+					'is_variation' => true,
+				);
+			}
+		}
+
+		// Variations (Variable Only).
+		$wc_data['variations'] = array();
+		if ( $is_variable && property_exists( $shopify_product, 'variants' ) && ! empty( $shopify_product->variants->edges ) ) {
+			foreach ( $shopify_product->variants->edges as $variant_edge ) {
+				$variant_node                  = $variant_edge->node;
+				$variation_data                = array();
+				$variation_data['original_id'] = basename( $variant_node->id );
+
+				// Price.
+				if ( $this->should_process( 'price' ) ) {
+					if ( $variant_node->compareAtPrice && (float) $variant_node->compareAtPrice > (float) $variant_node->price ) {
+						$variation_data['regular_price'] = $variant_node->compareAtPrice;
+						$variation_data['sale_price']    = $variant_node->price;
+					} else {
+						$variation_data['regular_price'] = $variant_node->price;
+						$variation_data['sale_price']    = null;
+					}
+				}
+
+				// SKU.
+				if ( $this->should_process( 'sku' ) ) {
+					$variation_data['sku'] = $variant_node->sku ?? null;
+				}
+
+				// Stock.
+				if ( $this->should_process( 'stock' ) ) {
+					$manage_stock                     = property_exists( $variant_node, 'inventoryItem' ) && $variant_node->inventoryItem->tracked;
+					$variation_data['manage_stock']   = $manage_stock;
+					$stock_quantity                   = $variant_node->inventoryQuantity ?? 0;
+					$allow_oversell                   = $manage_stock && 'CONTINUE' === $variant_node->inventoryPolicy;
+					$variation_data['stock_status']   = ( $stock_quantity > 0 || $allow_oversell ) ? 'instock' : 'outofstock';
+					$variation_data['stock_quantity'] = $stock_quantity;
+				}
+
+				// Weight.
+				if ( $this->should_process( 'weight' ) ) {
+					$weight_data = null;
+					if ( property_exists( $variant_node, 'inventoryItem' ) && is_object( $variant_node->inventoryItem ) &&
+						property_exists( $variant_node->inventoryItem, 'measurement' ) && is_object( $variant_node->inventoryItem->measurement ) &&
+						property_exists( $variant_node->inventoryItem->measurement, 'weight' ) && is_object( $variant_node->inventoryItem->measurement->weight )
+					) {
+						$weight_data = $variant_node->inventoryItem->measurement->weight;
+					}
+					$weight                   = $weight_data ? $weight_data->value : null;
+					$weight_unit              = $weight_data ? $weight_data->unit : null;
+					$variation_data['weight'] = $this->get_converted_weight( $weight, $weight_unit );
+				}
+
+				// Mapped Attributes.
+				if ( $this->should_process( 'attributes' ) ) {
+					$variation_data['attributes'] = array();
+					if ( ! empty( $variant_node->selectedOptions ) ) {
+						foreach ( $variant_node->selectedOptions as $selectedOption ) {
+							$variation_data['attributes'][ $selectedOption->name ] = $selectedOption->value;
+						}
+					}
+				}
+
+				// Image Mapping.
+				if ( $this->should_process( 'images' ) ) {
+					$variation_data['image_original_id'] = null;
+					if ( ! empty( $variant_node->media->edges ) ) {
+						$variant_media_node = $variant_node->media->edges[0]->node ?? null;
+						if ( $variant_media_node && property_exists( $variant_media_node, 'image' ) && is_object( $variant_media_node->image ) && ! empty( $variant_media_node->id ) ) {
+							$variation_data['image_original_id'] = $variant_media_node->id;
+						}
+					}
+				}
+
+				// Menu Order / Position.
+				$variation_data['menu_order'] = $variant_node->position;
+
+				$wc_data['variations'][] = $variation_data;
+			}
+		}
+
+		return $wc_data;
+	}
+
+	/**
+	 * Checks if a product is a variable product.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return bool True if the product is a variable product, false otherwise.
+	 */
+	private function is_variable_product( object $shopify_product ): bool {
+		return isset( $shopify_product->variants->edges ) && count( $shopify_product->variants->edges ) > 1;
+	}
+
+	/**
+	 * Converts the Shopify product status into WooCommerce product status.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return string The WooCommerce product status.
+	 */
+	private function get_woo_product_status( object $shopify_product ): string {
+		$woo_product_status = 'draft';
+		if ( 'ACTIVE' === $shopify_product->status ) {
+			$woo_product_status = 'publish';
+		}
+		return $woo_product_status;
+	}
+
+	/**
+	 * Maps enhanced publication status fields from Shopify.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Enhanced status data.
+	 */
+	private function map_enhanced_status( object $shopify_product ): array {
+		$status_data = array();
+
+		// Publication date.
+		if ( property_exists( $shopify_product, 'publishedAt' ) && $shopify_product->publishedAt ) {
+			$status_data['date_published_gmt'] = $shopify_product->publishedAt;
+		}
+
+		// Available for sale flag.
+		if ( property_exists( $shopify_product, 'availableForSale' ) ) {
+			$status_data['available_for_sale'] = $shopify_product->availableForSale;
+		}
+
+		return $status_data;
+	}
+
+	/**
+	 * Maps product classification fields from Shopify.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Product classification data.
+	 */
+	private function map_product_classification( object $shopify_product ): array {
+		$classification = array();
+
+		// Product type.
+		if ( property_exists( $shopify_product, 'productType' ) && $shopify_product->productType ) {
+			$classification['product_type'] = array(
+				'name' => $shopify_product->productType,
+				'slug' => sanitize_title( $shopify_product->productType ),
+			);
+		}
+
+		// Standard category.
+		if ( property_exists( $shopify_product, 'category' ) && is_object( $shopify_product->category ) ) {
+			$classification['standard_category'] = array(
+				'name' => $shopify_product->category->name ?? '',
+				'slug' => sanitize_title( $shopify_product->category->name ?? '' ),
+			);
+		}
+
+		// Gift card detection.
+		if ( property_exists( $shopify_product, 'isGiftCard' ) ) {
+			$classification['is_gift_card'] = $shopify_product->isGiftCard;
+		}
+
+		// Subscription product detection.
+		if ( property_exists( $shopify_product, 'requiresSellingPlan' ) ) {
+			$classification['requires_subscription'] = $shopify_product->requiresSellingPlan;
+		}
+
+		return $classification;
+	}
+
+	/**
+	 * Maps SEO fields from Shopify product data.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array SEO metafields data.
+	 */
+	private function map_seo_fields( object $shopify_product ): array {
+		$seo_data = array();
+
+		if ( property_exists( $shopify_product, 'seo' ) && is_object( $shopify_product->seo ) ) {
+			if ( ! empty( $shopify_product->seo->title ) ) {
+				$seo_data['global_title_tag'] = $shopify_product->seo->title;
+			}
+			if ( ! empty( $shopify_product->seo->description ) ) {
+				$seo_data['global_description_tag'] = $shopify_product->seo->description;
+			}
+		}
+
+		return $seo_data;
+	}
+
+	/**
+	 * Gets mapped WooCommerce product categories from Shopify collections.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Mapped category data.
+	 */
+	private function get_mapped_categories( object $shopify_product ): array {
+		$categories = array();
+		if ( ! property_exists( $shopify_product, 'collections' ) || empty( $shopify_product->collections->edges ) ) {
+			return $categories;
+		}
+
+		foreach ( $shopify_product->collections->edges as $collection_edge ) {
+			$collection_node = $collection_edge->node;
+			$categories[]    = array(
+				'name' => $collection_node->title,
+				'slug' => $collection_node->handle,
+			);
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * Gets mapped WooCommerce product tags from Shopify tags.
+	 *
+	 * @param object $shopify_product The Shopify product data.
+	 * @return array Mapped tag data.
+	 */
+	private function get_mapped_tags( object $shopify_product ): array {
+		$tags = array();
+		if ( empty( $shopify_product->tags ) ) {
+			return $tags;
+		}
+
+		foreach ( $shopify_product->tags as $tag ) {
+			$trimmed_tag = trim( $tag );
+			if ( ! empty( $trimmed_tag ) ) {
+				$tags[] = array(
+					'name' => $trimmed_tag,
+					'slug' => sanitize_title( $trimmed_tag ),
+				);
+			}
+		}
+		return $tags;
+	}
+
+	/**
+	 * Converts weight based on Shopify weight unit to store's weight unit.
+	 *
+	 * @param float|null  $weight      The weight value from Shopify.
+	 * @param string|null $weight_unit The weight unit from Shopify.
+	 * @return float|null The converted weight, or null if input is invalid/zero.
+	 */
+	private function get_converted_weight( $weight, $weight_unit ): ?float {
+		if ( null === $weight || null === $weight_unit || (float) $weight <= 0 ) {
+			return null;
+		}
+
+		$unit_map = array(
+			'GRAMS'     => 'g',
+			'KILOGRAMS' => 'kg',
+			'POUNDS'    => 'lb',
+			'OUNCES'    => 'oz',
+		);
+
+		$shopify_unit_key = $unit_map[ $weight_unit ] ?? null;
+
+		if ( ! $shopify_unit_key ) {
+			return (float) $weight;
+		}
+
+		$store_weight_unit = get_option( 'woocommerce_weight_unit' );
+
+		if ( 'lbs' === $store_weight_unit ) {
+			$store_weight_unit = 'lb';
+		}
+
+		if ( $shopify_unit_key === $store_weight_unit ) {
+			return (float) $weight;
+		}
+
+		// Use wc_get_weight for conversion if possible.
+		if ( function_exists( 'wc_get_weight' ) ) {
+			$converted = wc_get_weight( (float) $weight, $store_weight_unit, $shopify_unit_key );
+			return is_numeric( $converted ) ? (float) $converted : null;
+		}
+
+		// Fallback manual conversion.
+		$conversion_factors = array(
+			'kg' => array(
+				'kg' => 1,
+				'g'  => 1000,
+				'lb' => 2.20462,
+				'oz' => 35.274,
+			),
+			'g'  => array(
+				'kg' => 0.001,
+				'g'  => 1,
+				'lb' => 0.00220462,
+				'oz' => 0.035274,
+			),
+			'lb' => array(
+				'kg' => 0.453592,
+				'g'  => 453.592,
+				'lb' => 1,
+				'oz' => 16,
+			),
+			'oz' => array(
+				'kg' => 0.0283495,
+				'g'  => 28.3495,
+				'lb' => 0.0625,
+				'oz' => 1,
+			),
+		);
+
+		if ( ! isset( $conversion_factors[ $shopify_unit_key ][ $store_weight_unit ] ) ) {
+			return (float) $weight;
+		}
+
+		return (float) $weight * $conversion_factors[ $shopify_unit_key ][ $store_weight_unit ];
+	}
+
+	/**
+	 * Basic sanitization for product description HTML.
+	 *
+	 * @param string $html Raw description HTML.
+	 * @return string Sanitized HTML.
+	 */
+	private function sanitize_product_description( string $html ): string {
+		return trim( $html );
+	}
+
+	/**
+	 * Checks if a specific field should be processed based on constructor args.
+	 *
+	 * @param string $field_key The field key.
+	 * @return bool True if the field should be processed.
+	 */
+	private function should_process( string $field_key ): bool {
+		if ( empty( $this->fields_to_process ) ) {
+			return true;
+		}
+		return in_array( $field_key, $this->fields_to_process, true );
+	}
+
+	/**
+	 * Gets the default product fields to process if not specified.
+	 *
+	 * @return array Default fields.
+	 */
+	private function get_default_product_fields(): array {
+		return array(
+			'title',
+			'slug',
+			'description',
+			'short_description',
+			'status',
+			'date_created',
+			'catalog_visibility',
+			'category',
+			'tag',
+			'price',
+			'sku',
+			'stock',
+			'weight',
+			'brand',
+			'images',
+			'seo',
+			'attributes',
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
@@ -126,10 +126,10 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_product_classification_mapping() {
 		$shopify_product                        = $this->create_simple_shopify_product();
-		$shopify_product->productType           = 'Apparel';
+		$shopify_product->product_type          = 'Apparel';
 		$shopify_product->category              = (object) array( 'name' => 'Shirts' );
-		$shopify_product->isGiftCard            = false;
-		$shopify_product->requiresSellingPlan   = true;
+		$shopify_product->is_gift_card          = false;
+		$shopify_product->requires_selling_plan = true;
 
 		$result = $this->mapper->map_product_data( $shopify_product );
 

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
@@ -30,7 +30,6 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->mapper = new ShopifyMapper();
-		$this->mapper->init();
 	}
 
 	/**
@@ -490,7 +489,6 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_selective_field_processing() {
 		$mapper_limited = new ShopifyMapper( array( 'fields' => array( 'title', 'slug', 'price' ) ) );
-		$mapper_limited->init();
 
 		$shopify_product = $this->create_simple_shopify_product();
 		$result          = $mapper_limited->map_product_data( $shopify_product );

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
@@ -95,16 +95,16 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_catalog_visibility_mapping() {
 		// Test visible product (has onlineStoreUrl).
-		$visible_product                   = $this->create_simple_shopify_product();
-		$visible_product->online_store_url = 'https://test-store.myshopify.com/products/amazing-t-shirt';
-		$result                            = $this->mapper->map_product_data( $visible_product );
+		$visible_product                 = $this->create_simple_shopify_product();
+		$visible_product->onlineStoreUrl = 'https://test-store.myshopify.com/products/amazing-t-shirt'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$result                          = $this->mapper->map_product_data( $visible_product );
 		$this->assertEquals( 'visible', $result['catalog_visibility'] );
 		$this->assertEquals( 'https://test-store.myshopify.com/products/amazing-t-shirt', $result['original_url'] );
 
 		// Test hidden product (onlineStoreUrl is null).
-		$hidden_product                   = $this->create_simple_shopify_product();
-		$hidden_product->online_store_url = null;
-		$result                           = $this->mapper->map_product_data( $hidden_product );
+		$hidden_product                 = $this->create_simple_shopify_product();
+		$hidden_product->onlineStoreUrl = null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$result                         = $this->mapper->map_product_data( $hidden_product );
 		$this->assertEquals( 'hidden', $result['catalog_visibility'] );
 		$this->assertNull( $result['original_url'] );
 	}
@@ -113,10 +113,10 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 * Test enhanced status mapping.
 	 */
 	public function test_enhanced_status_mapping() {
-		$shopify_product                     = $this->create_simple_shopify_product();
-		$shopify_product->published_at       = '2023-06-01T10:00:00Z';
-		$shopify_product->available_for_sale = true;
-		$result                              = $this->mapper->map_product_data( $shopify_product );
+		$shopify_product                   = $this->create_simple_shopify_product();
+		$shopify_product->publishedAt      = '2023-06-01T10:00:00Z'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$shopify_product->availableForSale = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$result                            = $this->mapper->map_product_data( $shopify_product );
 
 		$this->assertEquals( '2023-06-01T10:00:00Z', $result['date_published_gmt'] );
 		$this->assertTrue( $result['available_for_sale'] );
@@ -395,9 +395,9 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 * Test images mapping.
 	 */
 	public function test_images_mapping() {
-		$shopify_product                 = $this->create_simple_shopify_product();
-		$shopify_product->featured_media = (object) array( 'id' => 'gid://shopify/MediaImage/featured123' );
-		$shopify_product->media          = (object) array(
+		$shopify_product                = $this->create_simple_shopify_product();
+		$shopify_product->featuredMedia = (object) array( 'id' => 'gid://shopify/MediaImage/featured123' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- GraphQL uses camelCase.
+		$shopify_product->media         = (object) array(
 			'edges' => array(
 				(object) array(
 					'node' => (object) array(

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
@@ -30,6 +30,7 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->mapper = new ShopifyMapper();
+		$this->mapper->init();
 	}
 
 	/**
@@ -43,130 +44,597 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 * Test map_product_data method returns expected type.
 	 */
 	public function test_map_product_data_returns_array() {
-		$platform_data = (object) array( 'id' => 'test_id' );
-		$result        = $this->mapper->map_product_data( $platform_data );
+		$shopify_product = $this->create_simple_shopify_product();
+		$result          = $this->mapper->map_product_data( $shopify_product );
 
 		$this->assertIsArray( $result );
 	}
 
 	/**
-	 * Test map_product_data method returns stub value.
+	 * Test basic product field mapping for simple product.
 	 */
-	public function test_map_product_data_returns_stub_value() {
-		$platform_data = (object) array( 'id' => 'test_id' );
-		$result        = $this->mapper->map_product_data( $platform_data );
-		$this->assertEquals( array(), $result );
+	public function test_basic_product_field_mapping() {
+		$shopify_product = $this->create_simple_shopify_product();
+		$result          = $this->mapper->map_product_data( $shopify_product );
+
+		// Test basic fields.
+		$this->assertEquals( 'Amazing T-Shirt', $result['name'] );
+		$this->assertEquals( 'amazing-t-shirt', $result['slug'] );
+		$this->assertEquals( 'A really amazing t-shirt', $result['description'] );
+		$this->assertEquals( 'publish', $result['status'] );
+		$this->assertEquals( '123456789', $result['original_product_id'] );
+		$this->assertEquals( '2023-01-01T00:00:00Z', $result['date_created_gmt'] );
+		$this->assertFalse( $result['is_variable'] );
 	}
 
 	/**
-	 * Test map_product_data with various platform data objects.
+	 * Test product status mapping.
 	 */
-	public function test_map_product_data_with_different_inputs() {
-		$test_cases = array(
-			(object) array(),
-			(object) array( 'id' => 'shopify_123' ),
-			(object) array(
-				'id'     => 'shopify_456',
-				'title'  => 'Test Product',
-				'handle' => 'test-product',
+	public function test_product_status_mapping() {
+		// Test ACTIVE status.
+		$active_product         = $this->create_simple_shopify_product();
+		$active_product->status = 'ACTIVE';
+		$result                 = $this->mapper->map_product_data( $active_product );
+		$this->assertEquals( 'publish', $result['status'] );
+
+		// Test DRAFT status.
+		$draft_product         = $this->create_simple_shopify_product();
+		$draft_product->status = 'DRAFT';
+		$result                = $this->mapper->map_product_data( $draft_product );
+		$this->assertEquals( 'draft', $result['status'] );
+
+		// Test ARCHIVED status.
+		$archived_product         = $this->create_simple_shopify_product();
+		$archived_product->status = 'ARCHIVED';
+		$result                   = $this->mapper->map_product_data( $archived_product );
+		$this->assertEquals( 'draft', $result['status'] );
+	}
+
+	/**
+	 * Test catalog visibility mapping.
+	 */
+	public function test_catalog_visibility_mapping() {
+		// Test visible product (has onlineStoreUrl).
+		$visible_product                   = $this->create_simple_shopify_product();
+		$visible_product->online_store_url = 'https://test-store.myshopify.com/products/amazing-t-shirt';
+		$result                            = $this->mapper->map_product_data( $visible_product );
+		$this->assertEquals( 'visible', $result['catalog_visibility'] );
+		$this->assertEquals( 'https://test-store.myshopify.com/products/amazing-t-shirt', $result['original_url'] );
+
+		// Test hidden product (onlineStoreUrl is null).
+		$hidden_product                   = $this->create_simple_shopify_product();
+		$hidden_product->online_store_url = null;
+		$result                           = $this->mapper->map_product_data( $hidden_product );
+		$this->assertEquals( 'hidden', $result['catalog_visibility'] );
+		$this->assertNull( $result['original_url'] );
+	}
+
+	/**
+	 * Test enhanced status mapping.
+	 */
+	public function test_enhanced_status_mapping() {
+		$shopify_product                     = $this->create_simple_shopify_product();
+		$shopify_product->published_at       = '2023-06-01T10:00:00Z';
+		$shopify_product->available_for_sale = true;
+		$result                              = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertEquals( '2023-06-01T10:00:00Z', $result['date_published_gmt'] );
+		$this->assertTrue( $result['available_for_sale'] );
+	}
+
+	/**
+	 * Test product classification mapping.
+	 */
+	public function test_product_classification_mapping() {
+		$shopify_product                        = $this->create_simple_shopify_product();
+		$shopify_product->product_type          = 'Apparel';
+		$shopify_product->category              = (object) array( 'name' => 'Shirts' );
+		$shopify_product->is_gift_card          = false;
+		$shopify_product->requires_selling_plan = true;
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertEquals(
+			array(
+				'name' => 'Apparel',
+				'slug' => 'apparel',
 			),
-			(object) array(
-				'id'       => 'shopify_789',
-				'title'    => 'Complex Product',
-				'variants' => array(
-					(object) array( 'price' => '10.00' ),
-				),
-			),
+			$result['product_type']
 		);
-
-		foreach ( $test_cases as $platform_data ) {
-			$result = $this->mapper->map_product_data( $platform_data );
-
-			$this->assertIsArray( $result );
-			$this->assertEquals( array(), $result ); // Stub implementation always returns empty array.
-		}
-	}
-
-	/**
-	 * Test that method handles type declarations correctly.
-	 */
-	public function test_method_signature() {
-		$reflection = new \ReflectionClass( $this->mapper );
-		$method     = $reflection->getMethod( 'map_product_data' );
-
-		$params = $method->getParameters();
-		$this->assertEquals( 'object', (string) $params[0]->getType() );
-		$this->assertEquals( 'array', (string) $method->getReturnType() );
-	}
-
-	/**
-	 * Test that the mapper accepts various object types.
-	 */
-	public function test_accepts_different_object_types() {
-		// Test with stdClass.
-		$std_object     = new \stdClass();
-		$std_object->id = 'test';
-		$result         = $this->mapper->map_product_data( $std_object );
-		$this->assertIsArray( $result );
-
-		// Test with array cast to object.
-		$array_object = (object) array( 'title' => 'Test Product' );
-		$result       = $this->mapper->map_product_data( $array_object );
-		$this->assertIsArray( $result );
-
-		// Test with custom object.
-		$custom_object = new class() {
-			/**
-			 * Test ID property.
-			 *
-			 * @var string
-			 */
-			public $id = 'custom_123';
-
-			/**
-			 * Test name property.
-			 *
-			 * @var string
-			 */
-			public $name = 'Custom Product';
-		};
-		$result        = $this->mapper->map_product_data( $custom_object );
-		$this->assertIsArray( $result );
-	}
-
-	/**
-	 * Test that the mapper is ready for future enhancement.
-	 */
-	public function test_stub_implementation_ready_for_enhancement() {
-		// This test documents that this is a stub implementation.
-		// Future PRs should replace this method with actual Shopify to WooCommerce data mapping.
-
-		$shopify_product = (object) array(
-			'id'          => 'gid://shopify/Product/123456789',
-			'title'       => 'Amazing T-Shirt',
-			'handle'      => 'amazing-t-shirt',
-			'description' => 'A really amazing t-shirt',
-			'productType' => 'Apparel',
-			'vendor'      => 'Cool Brand',
-			'variants'    => array(
-				(object) array(
-					'id'                => 'gid://shopify/ProductVariant/987654321',
-					'price'             => '25.00',
-					'sku'               => 'AMAZ-TSHIRT-M',
-					'inventoryQuantity' => 100,
-				),
+		$this->assertEquals(
+			array(
+				'name' => 'Shirts',
+				'slug' => 'shirts',
 			),
-			'images'      => array(
-				(object) array(
-					'url'     => 'https://example.com/image.jpg',
-					'altText' => 'Amazing T-Shirt',
+			$result['standard_category']
+		);
+		$this->assertFalse( $result['is_gift_card'] );
+		$this->assertTrue( $result['requires_subscription'] );
+	}
+
+	/**
+	 * Test simple product pricing mapping.
+	 */
+	public function test_simple_product_pricing() {
+		$shopify_product = $this->create_simple_shopify_product();
+		$result          = $this->mapper->map_product_data( $shopify_product );
+
+		// Test regular pricing (no sale).
+		$this->assertEquals( '25.00', $result['regular_price'] );
+		$this->assertNull( $result['sale_price'] );
+
+		// Test sale pricing.
+		$sale_product = $this->create_simple_shopify_product();
+		$sale_product->variants->edges[0]->node->compareAtPrice = '35.00';
+		$sale_result = $this->mapper->map_product_data( $sale_product );
+
+		$this->assertEquals( '35.00', $sale_result['regular_price'] );
+		$this->assertEquals( '25.00', $sale_result['sale_price'] );
+	}
+
+	/**
+	 * Test simple product inventory mapping.
+	 */
+	public function test_simple_product_inventory() {
+		$shopify_product = $this->create_simple_shopify_product();
+
+		// Add inventory tracking.
+		$shopify_product->variants->edges[0]->node->inventoryItem     = (object) array( 'tracked' => true );
+		$shopify_product->variants->edges[0]->node->inventoryQuantity = 50;
+		$shopify_product->variants->edges[0]->node->inventoryPolicy   = 'DENY';
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertTrue( $result['manage_stock'] );
+		$this->assertEquals( 50, $result['stock_quantity'] );
+		$this->assertEquals( 'instock', $result['stock_status'] );
+
+		// Test out of stock.
+		$shopify_product->variants->edges[0]->node->inventoryQuantity = 0;
+		$result = $this->mapper->map_product_data( $shopify_product );
+		$this->assertEquals( 'outofstock', $result['stock_status'] );
+
+		// Test oversell allowed.
+		$shopify_product->variants->edges[0]->node->inventoryPolicy = 'CONTINUE';
+		$result = $this->mapper->map_product_data( $shopify_product );
+		$this->assertEquals( 'instock', $result['stock_status'] ); // Should be in stock even with 0 qty.
+	}
+
+	/**
+	 * Test weight conversion.
+	 */
+	public function test_weight_conversion() {
+		$shopify_product = $this->create_simple_shopify_product();
+
+		// Add weight data.
+		$shopify_product->variants->edges[0]->node->inventoryItem = (object) array(
+			'tracked'     => true,
+			'measurement' => (object) array(
+				'weight' => (object) array(
+					'value' => 1000.0,
+					'unit'  => 'GRAMS',
 				),
 			),
 		);
 
 		$result = $this->mapper->map_product_data( $shopify_product );
 
-		// Current stub behavior - will change when real implementation is added.
-		$this->assertEquals( array(), $result, 'Stub returns empty array' );
+		// Should convert grams to store unit (depends on WC settings).
+		$this->assertIsFloat( $result['weight'] );
+		$this->assertGreaterThan( 0, $result['weight'] );
+	}
+
+	/**
+	 * Test variable product detection.
+	 */
+	public function test_variable_product_detection() {
+		$variable_product = $this->create_variable_shopify_product();
+		$result           = $this->mapper->map_product_data( $variable_product );
+
+		$this->assertTrue( $result['is_variable'] );
+		$this->assertNotEmpty( $result['attributes'] );
+		$this->assertNotEmpty( $result['variations'] );
+		$this->assertCount( 2, $result['variations'] );
+	}
+
+	/**
+	 * Test product attributes mapping for variable products.
+	 */
+	public function test_product_attributes_mapping() {
+		$variable_product = $this->create_variable_shopify_product();
+		$result           = $this->mapper->map_product_data( $variable_product );
+
+		$this->assertCount( 2, $result['attributes'] );
+
+		// Test Size attribute.
+		$size_attr = $result['attributes'][0];
+		$this->assertEquals( 'Size', $size_attr['name'] );
+		$this->assertEquals( array( 'Small', 'Large' ), $size_attr['options'] );
+		$this->assertEquals( 1, $size_attr['position'] );
+		$this->assertTrue( $size_attr['is_visible'] );
+		$this->assertTrue( $size_attr['is_variation'] );
+
+		// Test Color attribute.
+		$color_attr = $result['attributes'][1];
+		$this->assertEquals( 'Color', $color_attr['name'] );
+		$this->assertEquals( array( 'Red', 'Blue' ), $color_attr['options'] );
+		$this->assertEquals( 2, $color_attr['position'] );
+	}
+
+	/**
+	 * Test product variations mapping.
+	 */
+	public function test_product_variations_mapping() {
+		$variable_product = $this->create_variable_shopify_product();
+		$result           = $this->mapper->map_product_data( $variable_product );
+
+		$this->assertCount( 2, $result['variations'] );
+
+		// Test first variation.
+		$variation1 = $result['variations'][0];
+		$this->assertEquals( '111', $variation1['original_id'] );
+		$this->assertEquals( '20.00', $variation1['regular_price'] );
+		$this->assertEquals( 'SMALL-RED', $variation1['sku'] );
+		$this->assertEquals( 1, $variation1['menu_order'] );
+		$this->assertEquals(
+			array(
+				'Size'  => 'Small',
+				'Color' => 'Red',
+			),
+			$variation1['attributes']
+		);
+
+		// Test second variation.
+		$variation2 = $result['variations'][1];
+		$this->assertEquals( '222', $variation2['original_id'] );
+		$this->assertEquals( '25.00', $variation2['regular_price'] );
+		$this->assertEquals( 'LARGE-BLUE', $variation2['sku'] );
+		$this->assertEquals( 2, $variation2['menu_order'] );
+		$this->assertEquals(
+			array(
+				'Size'  => 'Large',
+				'Color' => 'Blue',
+			),
+			$variation2['attributes']
+		);
+	}
+
+	/**
+	 * Test categories mapping from collections.
+	 */
+	public function test_categories_mapping() {
+		$shopify_product              = $this->create_simple_shopify_product();
+		$shopify_product->collections = (object) array(
+			'edges' => array(
+				(object) array(
+					'node' => (object) array(
+						'title'  => 'T-Shirts',
+						'handle' => 't-shirts',
+					),
+				),
+				(object) array(
+					'node' => (object) array(
+						'title'  => 'Clothing',
+						'handle' => 'clothing',
+					),
+				),
+			),
+		);
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertCount( 2, $result['categories'] );
+		$this->assertEquals(
+			array(
+				'name' => 'T-Shirts',
+				'slug' => 't-shirts',
+			),
+			$result['categories'][0]
+		);
+		$this->assertEquals(
+			array(
+				'name' => 'Clothing',
+				'slug' => 'clothing',
+			),
+			$result['categories'][1]
+		);
+	}
+
+	/**
+	 * Test tags mapping.
+	 */
+	public function test_tags_mapping() {
+		$shopify_product       = $this->create_simple_shopify_product();
+		$shopify_product->tags = array( 'summer', 'casual', 'cotton' );
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertCount( 3, $result['tags'] );
+		$this->assertEquals(
+			array(
+				'name' => 'summer',
+				'slug' => 'summer',
+			),
+			$result['tags'][0]
+		);
+		$this->assertEquals(
+			array(
+				'name' => 'casual',
+				'slug' => 'casual',
+			),
+			$result['tags'][1]
+		);
+		$this->assertEquals(
+			array(
+				'name' => 'cotton',
+				'slug' => 'cotton',
+			),
+			$result['tags'][2]
+		);
+	}
+
+	/**
+	 * Test brand mapping from vendor.
+	 */
+	public function test_brand_mapping() {
+		$shopify_product         = $this->create_simple_shopify_product();
+		$shopify_product->vendor = 'Cool Brand';
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertEquals(
+			array(
+				'name' => 'Cool Brand',
+				'slug' => 'cool-brand',
+			),
+			$result['brand']
+		);
+	}
+
+	/**
+	 * Test images mapping.
+	 */
+	public function test_images_mapping() {
+		$shopify_product                 = $this->create_simple_shopify_product();
+		$shopify_product->featured_media = (object) array( 'id' => 'gid://shopify/MediaImage/featured123' );
+		$shopify_product->media          = (object) array(
+			'edges' => array(
+				(object) array(
+					'node' => (object) array(
+						'id'    => 'gid://shopify/MediaImage/featured123',
+						'image' => (object) array(
+							'url'     => 'https://example.com/featured.jpg',
+							'altText' => 'Featured Image',
+						),
+					),
+				),
+				(object) array(
+					'node' => (object) array(
+						'id'    => 'gid://shopify/MediaImage/gallery456',
+						'image' => (object) array(
+							'url'     => 'https://example.com/gallery.jpg',
+							'altText' => 'Gallery Image',
+						),
+					),
+				),
+			),
+		);
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertCount( 2, $result['images'] );
+
+		// Test featured image.
+		$featured_image = $result['images'][0];
+		$this->assertEquals( 'gid://shopify/MediaImage/featured123', $featured_image['original_id'] );
+		$this->assertEquals( 'https://example.com/featured.jpg', $featured_image['url'] );
+		$this->assertEquals( 'Featured Image', $featured_image['alt'] );
+		$this->assertTrue( $featured_image['is_featured'] );
+
+		// Test gallery image.
+		$gallery_image = $result['images'][1];
+		$this->assertEquals( 'gid://shopify/MediaImage/gallery456', $gallery_image['original_id'] );
+		$this->assertEquals( 'https://example.com/gallery.jpg', $gallery_image['url'] );
+		$this->assertEquals( 'Gallery Image', $gallery_image['alt'] );
+		$this->assertFalse( $gallery_image['is_featured'] );
+	}
+
+	/**
+	 * Test SEO fields mapping.
+	 */
+	public function test_seo_fields_mapping() {
+		$shopify_product      = $this->create_simple_shopify_product();
+		$shopify_product->seo = (object) array(
+			'title'       => 'Amazing T-Shirt - Best Quality',
+			'description' => 'Buy the best quality t-shirt online. Free shipping available.',
+		);
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertEquals( 'Amazing T-Shirt - Best Quality', $result['metafields']['global_title_tag'] );
+		$this->assertEquals( 'Buy the best quality t-shirt online. Free shipping available.', $result['metafields']['global_description_tag'] );
+	}
+
+	/**
+	 * Test metafields mapping.
+	 */
+	public function test_metafields_mapping() {
+		$shopify_product             = $this->create_simple_shopify_product();
+		$shopify_product->metafields = (object) array(
+			'edges' => array(
+				(object) array(
+					'node' => (object) array(
+						'namespace' => 'custom',
+						'key'       => 'material',
+						'value'     => '100% Cotton',
+					),
+				),
+				(object) array(
+					'node' => (object) array(
+						'namespace' => 'seo',
+						'key'       => 'focus_keyword',
+						'value'     => 't-shirt',
+					),
+				),
+			),
+		);
+
+		$result = $this->mapper->map_product_data( $shopify_product );
+
+		$this->assertEquals( '100% Cotton', $result['metafields']['custom_material'] );
+		$this->assertEquals( 't-shirt', $result['metafields']['seo_focus_keyword'] );
+	}
+
+	/**
+	 * Test selective field processing with constructor args.
+	 */
+	public function test_selective_field_processing() {
+		$mapper_limited = new ShopifyMapper( array( 'fields' => array( 'title', 'slug', 'price' ) ) );
+		$mapper_limited->init();
+
+		$shopify_product = $this->create_simple_shopify_product();
+		$result          = $mapper_limited->map_product_data( $shopify_product );
+
+		// Should still have basic fields.
+		$this->assertEquals( 'Amazing T-Shirt', $result['name'] );
+		$this->assertEquals( 'amazing-t-shirt', $result['slug'] );
+		$this->assertEquals( '25.00', $result['regular_price'] );
+
+		// Should not have SKU key because 'sku' not in fields.
+		$this->assertArrayNotHasKey( 'sku', $result );
+	}
+
+	/**
+	 * Test error handling with malformed data.
+	 */
+	public function test_error_handling_with_malformed_data() {
+		// Test with minimal data.
+		$minimal_product = (object) array(
+			'id'        => 'gid://shopify/Product/123',
+			'title'     => 'Test Product',
+			'handle'    => 'test-product',
+			'status'    => 'ACTIVE',
+			'createdAt' => '2023-01-01T00:00:00Z',
+		);
+
+		$result = $this->mapper->map_product_data( $minimal_product );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'Test Product', $result['name'] );
+		$this->assertEquals( 'test-product', $result['slug'] );
+		$this->assertEquals( 'publish', $result['status'] );
+		$this->assertFalse( $result['is_variable'] );
+		$this->assertEquals( array(), $result['categories'] );
+		$this->assertEquals( array(), $result['tags'] );
+		$this->assertEquals( array(), $result['images'] );
+	}
+
+	/**
+	 * Create a simple Shopify product object for testing.
+	 *
+	 * @return object Shopify product object.
+	 */
+	private function create_simple_shopify_product(): object {
+		return (object) array(
+			'id'              => 'gid://shopify/Product/123456789',
+			'title'           => 'Amazing T-Shirt',
+			'handle'          => 'amazing-t-shirt',
+			'descriptionHtml' => 'A really amazing t-shirt',
+			'status'          => 'ACTIVE',
+			'createdAt'       => '2023-01-01T00:00:00Z',
+			'vendor'          => 'Cool Brand',
+			'variants'        => (object) array(
+				'edges' => array(
+					(object) array(
+						'node' => (object) array(
+							'id'                => 'gid://shopify/ProductVariant/987654321',
+							'price'             => '25.00',
+							'compareAtPrice'    => null,
+							'sku'               => 'AMAZ-TSHIRT-M',
+							'inventoryQuantity' => 100,
+							'inventoryPolicy'   => 'DENY',
+							'position'          => 1,
+						),
+					),
+				),
+			),
+			'tags'            => array(),
+		);
+	}
+
+	/**
+	 * Create a variable Shopify product object for testing.
+	 *
+	 * @return object Variable Shopify product object.
+	 */
+	private function create_variable_shopify_product(): object {
+		return (object) array(
+			'id'              => 'gid://shopify/Product/123456789',
+			'title'           => 'Variable T-Shirt',
+			'handle'          => 'variable-t-shirt',
+			'descriptionHtml' => 'A variable t-shirt with multiple options',
+			'status'          => 'ACTIVE',
+			'createdAt'       => '2023-01-01T00:00:00Z',
+			'vendor'          => 'Cool Brand',
+			'options'         => array(
+				(object) array(
+					'name'     => 'Size',
+					'values'   => array( 'Small', 'Large' ),
+					'position' => 1,
+				),
+				(object) array(
+					'name'     => 'Color',
+					'values'   => array( 'Red', 'Blue' ),
+					'position' => 2,
+				),
+			),
+			'variants'        => (object) array(
+				'edges' => array(
+					(object) array(
+						'node' => (object) array(
+							'id'              => 'gid://shopify/ProductVariant/111',
+							'price'           => '20.00',
+							'compareAtPrice'  => null,
+							'sku'             => 'SMALL-RED',
+							'inventoryPolicy' => 'DENY',
+							'position'        => 1,
+							'selectedOptions' => array(
+								(object) array(
+									'name'  => 'Size',
+									'value' => 'Small',
+								),
+								(object) array(
+									'name'  => 'Color',
+									'value' => 'Red',
+								),
+							),
+							'media'           => (object) array( 'edges' => array() ),
+						),
+					),
+					(object) array(
+						'node' => (object) array(
+							'id'              => 'gid://shopify/ProductVariant/222',
+							'price'           => '25.00',
+							'compareAtPrice'  => null,
+							'sku'             => 'LARGE-BLUE',
+							'inventoryPolicy' => 'DENY',
+							'position'        => 2,
+							'selectedOptions' => array(
+								(object) array(
+									'name'  => 'Size',
+									'value' => 'Large',
+								),
+								(object) array(
+									'name'  => 'Color',
+									'value' => 'Blue',
+								),
+							),
+							'media'           => (object) array( 'edges' => array() ),
+						),
+					),
+				),
+			),
+			'tags'            => array(),
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
@@ -126,10 +126,10 @@ class ShopifyMapperTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_product_classification_mapping() {
 		$shopify_product                        = $this->create_simple_shopify_product();
-		$shopify_product->product_type          = 'Apparel';
+		$shopify_product->productType           = 'Apparel';
 		$shopify_product->category              = (object) array( 'name' => 'Shirts' );
-		$shopify_product->is_gift_card          = false;
-		$shopify_product->requires_selling_plan = true;
+		$shopify_product->isGiftCard            = false;
+		$shopify_product->requiresSellingPlan   = true;
 
 		$result = $this->mapper->map_product_data( $shopify_product );
 


### PR DESCRIPTION
## Overview

This PR implements comprehensive **Product Data Mapping** functionality for the WooCommerce CLI Migrator's Shopify platform support. It transforms raw Shopify GraphQL product data into standardized format for WooCommerce importing.

## Changes

### **New Files**
- `src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapper.php` - Complete implementation
- Updated `tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php`


### **Key Features Implemented**

#### **Core Product Mapping**
- **Basic Fields**: name, slug, description, status, dates, visibility
- **Enhanced Fields**: publication status, product classification, SEO preservation
- **Simple Products**: pricing (sale detection), inventory, weight conversion, SKU
- **Variable Products**: attributes, variations with complete variant data
- **Media**: images with featured detection, alt text, gallery ordering
- **Taxonomies**: categories (collections), tags, brands (vendor)
- **Metafields**: custom data + SEO fields preservation

#### **Advanced Features**
- **Sale Price Detection**: `compareAtPrice` > `price` logic
- **Weight Unit Conversion**: GRAMS/KILOGRAMS/POUNDS/OUNCES → store unit
- **Publication Tracking**: `publishedAt`, `availableForSale` status
- **Product Classification**: gift cards, subscriptions, product types
- **SEO Preservation**: Yoast-compatible metafields
- **Selective Processing**: Constructor field filtering

## Testing
Since we'd need a controller to test it, there are no manual testing steps for the mapper yet.

### **Unit Tests** ✅
```bash
# Run tests locally
pnpm run test:php:env tests/php/src/Internal/CLI/Migrator/Platforms/Shopify/ShopifyMapperTest.php
```

### **Integration Status**
The `ShopifyMapper` is **ready for integration** but not yet connected to CLI commands:

- ✅ **Infrastructure Ready**: `PlatformRegistry::get_mapper()` can instantiate the mapper
- ✅ **Platform Registered**: `ShopifyPlatform` registers mapper class correctly  
- ❌ **CLI Integration Pending**: `ProductsCommand` doesn't use mapper yet (planned for the next PRs)

**Current CLI behavior** (shows raw Shopify data only):
```bash
wp wc migrate products --fetch --limit=1 --platform=shopify
# Output: Raw product titles, IDs, status - no mapping applied
```

