### PR TITLE
Prevent the Add to Cart button words to break into several lines

### DIFF
--- a/plugins/woocommerce/changelog/fix-59793-product-button-word-break
+++ b/plugins/woocommerce/changelog/fix-59793-product-button-word-break
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the Add to Cart button words to break into several lines

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -1,5 +1,4 @@
 .wp-block-button.wc-block-components-product-button {
-	word-break: break-word;
 	white-space: normal;
 	display: flex;
 	justify-content: center;
@@ -39,7 +38,6 @@
 	}
 
 	.wp-block-button__link {
-		word-break: break-word;
 		white-space: normal;
 		display: inline-flex;
 		justify-content: center;
@@ -86,7 +84,7 @@
 		display: inline-flex;
 		justify-content: center;
 		white-space: normal;
-		word-break: break-word;
+		word-break: normal;
 		overflow: hidden;
 		align-items: center;
 		line-height: inherit;

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -118,6 +118,7 @@
 				margin-top: 0;
 				margin-bottom: 0;
 				vertical-align: middle;
+				word-break: normal;
 			}
 
 			.variations {

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 <!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -25,7 +25,7 @@
 
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59793.

This PR adds `word-break: normal;` to Add to Cart buttons, I don't think there is any legit case where we want words to break unexpectedly and make the button look broken.

In addition to that, it makes the quantity selector and the button to wrap into two lines in the Add to Cart + Options block when there is not enough horizontal space. I kept this change limited to the _Add to Cart + Options_ block because I don't think we should make big CSS changes on legacy templates/blocks. But I'm happy to discuss. :slightly_smiling_face: 

### How to test the changes in this Pull Request:

1. Using the non-blockified _Add to Cart with Options_ block.
2. Go to the single product page and zoom in or make your browser window smaller.
3. Verify the Add to Cart button words don't break.

Before | After
--- | ---
<img width="1775" height="1563" alt="imatge" src="https://github.com/user-attachments/assets/87997039-fdcd-4ef4-9b7c-dffdb766be05" /> | <img width="1775" height="1563" alt="imatge" src="https://github.com/user-attachments/assets/aeb462a3-75f0-42ea-9c99-f40a7629409d" />

4. Now go to Appearance > Editor > Templates > Single Product and update to the blockified _Add to Cart + Options_ block.
5. In the frontend, verify the quantity input and the button break in two lines.

Before | After
--- | ---
<img width="1885" height="1729" alt="imatge" src="https://github.com/user-attachments/assets/ac3f3205-2e7c-430d-9698-9285759af35e" /> | <img width="1885" height="1729" alt="imatge" src="https://github.com/user-attachments/assets/41e347ed-26d2-4f0d-aa6e-891762641488" />