### PR TITLE
[Do not merge] WPS Migration: Capture payment asynchronously

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -136,10 +136,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		if ( 'yes' === $this->enabled ) {
 			add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'order_received_text' ), 10, 2 );
 		}
-
-		// Load the webhook handler.
-		include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-webhook-handler.php';
-		new WC_Gateway_Paypal_Webhook_Handler();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -376,7 +376,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
-		if ( $this->use_orders_v2() ) {
+		if ( $this->should_use_orders_v2() ) {
 			$paypal_order = $paypal_request->create_paypal_order( $order );
 			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
 				throw new Exception( 'PayPal order creation failed' );
@@ -590,7 +590,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @return bool
 	 */
-	protected function use_orders_v2() {
+	protected function should_use_orders_v2() {
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: We expect this flag to be true if the merchant can be migrated,
 		// i.e. does not need PayPal API keys, and they have accepted the ToS.

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -34,7 +34,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @var bool
 	 */
-	public static $log_enabled = false;
+	public static $log_enabled = null;
 
 	/**
 	 * Logger instance
@@ -159,6 +159,11 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *                      emergency|alert|critical|error|warning|notice|info|debug.
 	 */
 	public static function log( $message, $level = 'info' ) {
+		if ( is_null( self::$log_enabled ) ) {
+			$settings          = get_option( 'woocommerce_paypal_settings' );
+			self::$log_enabled = 'yes' === ( $settings['debug'] ?? 'no' );
+		}
+
 		if ( self::$log_enabled ) {
 			if ( empty( self::$log ) ) {
 				self::$log = wc_get_logger();
@@ -363,6 +368,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @param  int $order_id Order ID.
 	 * @return array
+	 * @throws Exception If the PayPal order creation fails.
 	 */
 	public function process_payment( $order_id ) {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
@@ -370,9 +376,26 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
+		if ( $this->should_use_orders_v2() ) {
+			$paypal_order = $paypal_request->create_paypal_order( $order );
+			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
+				throw new Exception(
+					esc_html__( 'We are unable to process your PayPal payment at this time. Please try again or use a different payment method.', 'woocommerce' )
+				);
+			}
+
+			// Save the PayPal order ID. This is different from the WooCommerce order ID.
+			$order->update_meta_data( '_paypal_order_id', $paypal_order['id'] );
+			$order->save();
+
+			$redirect_url = $paypal_order['redirect_url'];
+		} else {
+			$redirect_url = $paypal_request->get_request_url( $order, $this->testmode );
+		}
+
 		return array(
 			'result'   => 'success',
-			'redirect' => $paypal_request->get_request_url( $order, $this->testmode ),
+			'redirect' => $redirect_url,
 		);
 	}
 
@@ -562,5 +585,28 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		);
 
 		return is_countable( $paypal_orders ) ? 1 === count( $paypal_orders ) : false;
+	}
+
+	/**
+	 * Checks if the gateway should use Orders v2 API.
+	 *
+	 * @return bool
+	 */
+	protected function should_use_orders_v2() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: We expect this flag to be true if the merchant can be migrated,
+		// i.e. does not need PayPal API keys, and they have accepted the ToS.
+
+		/**
+		 * Filters whether the gateway should use Orders v2 API.
+		 *
+		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 *
+		 * @since 10.1.0
+		 */
+		return apply_filters(
+			'woocommerce_paypal_use_orders_v2',
+			'yes' === $this->get_option( 'use_orders_v2' )
+		);
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -368,6 +368,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @param  int $order_id Order ID.
 	 * @return array
+	 * @throws Exception If the PayPal order creation fails.
 	 */
 	public function process_payment( $order_id ) {
 		include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
@@ -587,22 +588,23 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	/**
 	 * Checks if the gateway should use Orders v2 API.
 	 *
-	 * TODO: We expect this flag to be true if the merchant can be migrated,
-	 * i.e. does not need PayPal API keys, and they have accepted the ToS.
-	 *
 	 * @return bool
 	 */
 	protected function use_orders_v2() {
-		$paypal_settings = get_option( 'woocommerce_paypal_settings' );
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: We expect this flag to be true if the merchant can be migrated,
+		// i.e. does not need PayPal API keys, and they have accepted the ToS.
 
 		/**
 		 * Filters whether the gateway should use Orders v2 API.
 		 *
 		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 *
+		 * @since 10.1.0
 		 */
 		return apply_filters(
 			'woocommerce_paypal_use_orders_v2',
-			isset( $paypal_settings['use_orders_v2'] ) && 'yes' === $paypal_settings['use_orders_v2']
+			'yes' === $this->get_option( 'use_orders_v2' )
 		);
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -376,7 +376,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
-		if ( $this->should_use_orders_v2() ) {
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
 			$paypal_order = $paypal_request->create_paypal_order( $order );
 			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
 				throw new Exception(
@@ -585,28 +585,5 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		);
 
 		return is_countable( $paypal_orders ) ? 1 === count( $paypal_orders ) : false;
-	}
-
-	/**
-	 * Checks if the gateway should use Orders v2 API.
-	 *
-	 * @return bool
-	 */
-	protected function should_use_orders_v2() {
-		// phpcs:ignore Generic.Commenting.Todo.TaskFound
-		// TODO: We expect this flag to be true if the merchant can be migrated,
-		// i.e. does not need PayPal API keys, and they have accepted the ToS.
-
-		/**
-		 * Filters whether the gateway should use Orders v2 API.
-		 *
-		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
-		 *
-		 * @since 10.1.0
-		 */
-		return apply_filters(
-			'woocommerce_paypal_use_orders_v2',
-			'yes' === $this->get_option( 'use_orders_v2' )
-		);
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -610,3 +610,42 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		);
 	}
 }
+
+/**
+ * Register PayPal scheduled actions on init.
+ * This ensures the action is available even when the gateway isn't instantiated.
+ */
+add_action( 'init', function() {
+    if ( ! has_action( 'woocommerce_paypal_capture_payment' ) ) {
+		// Process scheduled payment capture.
+        add_action( 'woocommerce_paypal_capture_payment', function( $order_id, $capture_url ) {
+            if ( ! $order_id || ! $capture_url ) {
+				return;
+			}
+	
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				WC_Gateway_Paypal::log( 'Order not found for capture: ' . $order_id );
+				return;
+			}
+	
+			// Skip if the order is already paid.
+			if ( $order->is_paid() ) {
+				WC_Gateway_Paypal::log( 'Order already processed, skip capturing order: ' . $order_id );
+				return;
+			}
+	
+			WC_Gateway_Paypal::log( 'Beginning to process scheduled payment capture for order ' . $order_id );
+			$payment_gateways = WC()->payment_gateways()->payment_gateways();
+			if ( ! isset( $payment_gateways['paypal'] ) ) {
+				WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
+				return;
+			}
+
+			require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
+			$gateway        = $payment_gateways['paypal'];
+			$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+			$paypal_request->capture_payment( $order, $capture_url );
+        }, 10, 2 );
+    }
+});

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -17,6 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
+
 /**
  * WC_Gateway_Paypal Class.
  */
@@ -642,7 +644,6 @@ add_action( 'init', function() {
 				return;
 			}
 
-			require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
 			$gateway        = $payment_gateways['paypal'];
 			$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
 			$paypal_request->capture_payment( $order, $capture_url );

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -136,6 +136,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		if ( 'yes' === $this->enabled ) {
 			add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'order_received_text' ), 10, 2 );
 		}
+
+		// Load the webhook handler.
+		include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-webhook-handler.php';
+		new WC_Gateway_Paypal_Webhook_Handler();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -376,7 +376,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
-		if ( $this->should_use_orders_v2() ) {
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
 			$paypal_order = $paypal_request->create_paypal_order( $order );
 			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
 				throw new Exception(

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
+require_once __DIR__ . '/includes/class-wc-gateway-paypal-request.php';
 
 /**
  * WC_Gateway_Paypal Class.
@@ -617,36 +617,44 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
  * Register PayPal scheduled actions on init.
  * This ensures the action is available even when the gateway isn't instantiated.
  */
-add_action( 'init', function() {
-    if ( ! has_action( 'woocommerce_paypal_capture_payment' ) ) {
-		// Process scheduled payment capture.
-        add_action( 'woocommerce_paypal_capture_payment', function( $order_id, $capture_url ) {
-            if ( ! $order_id || ! $capture_url ) {
-				return;
-			}
-	
-			$order = wc_get_order( $order_id );
-			if ( ! $order ) {
-				WC_Gateway_Paypal::log( 'Order not found for capture: ' . $order_id );
-				return;
-			}
-	
-			// Skip if the order is already paid.
-			if ( $order->is_paid() ) {
-				WC_Gateway_Paypal::log( 'Order already processed, skip capturing order: ' . $order_id );
-				return;
-			}
-	
-			WC_Gateway_Paypal::log( 'Beginning to process scheduled payment capture for order ' . $order_id );
-			$payment_gateways = WC()->payment_gateways()->payment_gateways();
-			if ( ! isset( $payment_gateways['paypal'] ) ) {
-				WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
-				return;
-			}
+add_action(
+	'init',
+	function () {
+		if ( ! has_action( 'woocommerce_paypal_capture_payment' ) ) {
+			// Process scheduled payment capture.
+			add_action(
+				'woocommerce_paypal_capture_payment',
+				function ( $order_id, $capture_url ) {
+					if ( ! $order_id || ! $capture_url ) {
+						return;
+					}
 
-			$gateway        = $payment_gateways['paypal'];
-			$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
-			$paypal_request->capture_payment( $order, $capture_url );
-        }, 10, 2 );
-    }
-});
+					$order = wc_get_order( $order_id );
+					if ( ! $order ) {
+						WC_Gateway_Paypal::log( 'Order not found for capture: ' . $order_id );
+						return;
+					}
+
+					// Skip if the order is already paid.
+					if ( $order->is_paid() ) {
+						WC_Gateway_Paypal::log( 'Order already processed, skip capturing order: ' . $order_id );
+						return;
+					}
+
+					WC_Gateway_Paypal::log( 'Beginning to process scheduled payment capture for order ' . $order_id );
+					$payment_gateways = WC()->payment_gateways()->payment_gateways();
+					if ( ! isset( $payment_gateways['paypal'] ) ) {
+						WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
+						return;
+					}
+
+					$gateway        = $payment_gateways['paypal'];
+					$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+					$paypal_request->capture_payment( $order, $capture_url );
+				},
+				10,
+				2
+			);
+		}
+	}
+);

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -34,7 +34,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @var bool
 	 */
-	public static $log_enabled = false;
+	public static $log_enabled = null;
 
 	/**
 	 * Logger instance
@@ -159,6 +159,11 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *                      emergency|alert|critical|error|warning|notice|info|debug.
 	 */
 	public static function log( $message, $level = 'info' ) {
+		if ( is_null( self::$log_enabled ) ) {
+			$settings          = get_option( 'woocommerce_paypal_settings' );
+			self::$log_enabled = 'yes' === ( $settings['debug'] ?? 'no' );
+		}
+
 		if ( self::$log_enabled ) {
 			if ( empty( self::$log ) ) {
 				self::$log = wc_get_logger();

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -370,9 +370,24 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$paypal_request = new WC_Gateway_Paypal_Request( $this );
 
+		if ( $this->use_orders_v2() ) {
+			$paypal_order = $paypal_request->create_paypal_order( $order );
+			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
+				throw new Exception( 'PayPal order creation failed' );
+			}
+
+			// Save the PayPal order ID. This is different from the WooCommerce order ID.
+			$order->update_meta_data( '_paypal_order_id', $paypal_order['id'] );
+			$order->save();
+
+			$redirect_url = $paypal_order['redirect_url'];
+		} else {
+			$redirect_url = $paypal_request->get_request_url( $order, $this->testmode );
+		}
+
 		return array(
 			'result'   => 'success',
-			'redirect' => $paypal_request->get_request_url( $order, $this->testmode ),
+			'redirect' => $redirect_url,
 		);
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -379,7 +379,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		if ( $this->should_use_orders_v2() ) {
 			$paypal_order = $paypal_request->create_paypal_order( $order );
 			if ( ! $paypal_order || empty( $paypal_order['id'] ) || empty( $paypal_order['redirect_url'] ) ) {
-				throw new Exception( 'PayPal order creation failed' );
+				throw new Exception(
+					esc_html__( 'We are unable to process your PayPal payment at this time. Please try again or use a different payment method.', 'woocommerce' )
+				);
 			}
 
 			// Save the PayPal order ID. This is different from the WooCommerce order ID.

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -563,4 +563,26 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		return is_countable( $paypal_orders ) ? 1 === count( $paypal_orders ) : false;
 	}
+
+	/**
+	 * Checks if the gateway should use Orders v2 API.
+	 *
+	 * TODO: We expect this flag to be true if the merchant can be migrated,
+	 * i.e. does not need PayPal API keys, and they have accepted the ToS.
+	 *
+	 * @return bool
+	 */
+	protected function use_orders_v2() {
+		$paypal_settings = get_option( 'woocommerce_paypal_settings' );
+
+		/**
+		 * Filters whether the gateway should use Orders v2 API.
+		 *
+		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_use_orders_v2',
+			isset( $paypal_settings['use_orders_v2'] ) && 'yes' === $paypal_settings['use_orders_v2']
+		);
+	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * PayPal Helper Class
+ *
+ * @package WooCommerce\Gateways
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helper for PayPal gateway.
+ */
+class WC_Gateway_Paypal_Helper {
+
+	/**
+	 * Check if the gateway should use Orders v2 API.
+	 *
+	 * @return bool
+	 */
+	public static function should_use_orders_v2() {
+        // phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: We expect this flag to be true if the merchant can be migrated,
+		// i.e. does not need PayPal API keys, and they have accepted the ToS.
+
+		$settings      = get_option( 'woocommerce_paypal_settings', array() );
+		$use_orders_v2 = isset( $settings['use_orders_v2'] ) && 'yes' === $settings['use_orders_v2'];
+
+		/**
+		 * Filters whether the gateway should use Orders v2 API.
+		 *
+		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 *
+		 * @since 10.1.0
+		 */
+		return apply_filters(
+			'woocommerce_paypal_use_orders_v2',
+			$use_orders_v2
+		);
+	}
+}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-helper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PayPal Helper Class
+ *
+ * @package WooCommerce\Gateways
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helper for PayPal gateway.
+ */
+class WC_Gateway_Paypal_Helper {
+
+	/**
+	 * Check if the gateway should use Orders v2 API.
+	 *
+	 * @return bool
+	 */
+	public static function should_use_orders_v2() {
+        // phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: We expect this flag to be true if the merchant can be migrated,
+		// i.e. does not need PayPal API keys, and they have accepted the ToS.
+
+		$settings      = get_option( 'woocommerce_paypal_settings', array() );
+		$use_orders_v2 = isset( $settings['use_orders_v2'] ) && 'yes' === $settings['use_orders_v2'];
+
+		/**
+		 * Filters whether the gateway should use Orders v2 API.
+		 *
+		 * @param bool $use_orders_v2 Whether the gateway should use Orders v2 API.
+		 *
+		 * @since 10.1.0
+		 */
+		return apply_filters(
+			'woocommerce_paypal_use_orders_v2',
+			$use_orders_v2
+		);
+	}
+}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -203,6 +203,7 @@ class WC_Gateway_Paypal_Request {
 				)
 			);
 			$order->update_status( OrderStatus::FAILED );
+			$order->save();
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -879,6 +879,6 @@ class WC_Gateway_Paypal_Request {
 			$decimals = 0;
 		}
 
-		return number_format( $price, $decimals, '.', '' );
+		return number_format( (float) $price, $decimals, '.', '' );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use Automattic\WooCommerce\Enums\OrderStatus;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -140,6 +141,72 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Capture a PayPal payment using the Orders v2 API.
+	 *
+	 * This method captures a PayPal payment and updates the order status.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param string $capture_url The URL to capture the payment.
+	 * @return void
+	 * @throws Exception If the PayPal payment capture fails.
+	 */
+	public function capture_payment( $order, $capture_url ) {
+		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
+		if ( ! $paypal_order_id ) {
+			WC_Gateway_Paypal::log( 'PayPal order ID not found. Cannot capture payment.' );
+			return;
+		}
+
+		if ( ! $capture_url ) {
+			WC_Gateway_Paypal::log( 'Capture URL not found. Cannot capture payment.' );
+			return;
+		}
+
+		try {
+			$request_body = array(
+				'capture_url' => $capture_url,
+				'paypal_order_id' => $paypal_order_id,
+			);
+
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
+			// TODO: Replace with the wpcom endpoint when it's ready.
+			$response     = wp_remote_post(
+				$this->get_paypal_capture_payment_request_url(),
+				array(
+					'method'  => 'POST',
+					'headers' => array(
+						'Content-Type' => 'application/json',
+					),
+					'body'    => wp_json_encode( $request_body ),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
+				return;
+			}
+
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$body          = wp_remote_retrieve_body( $response );
+
+			if ( 200 !== $http_code ) {
+				throw new Exception( 'PayPal payment capture failed. Response status: ' . $http_code . '. Response body: ' . $body );
+			}
+
+		} catch ( Exception $e ) {
+			WC_Gateway_Paypal::log( $e->getMessage() );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID */
+					__( 'PayPal payment capture failed. PayPal Order ID: %1$s', 'woocommerce' ),
+					$paypal_order_id
+				)
+			);
+			$order->update_status( OrderStatus::FAILED );
+		}
+	}
+
+	/**
 	 * Get the approve link from the response data.
 	 *
 	 * @param int   $http_code The HTTP code of the response.
@@ -172,6 +239,17 @@ class WC_Gateway_Paypal_Request {
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
+	}
+
+	/**
+	 * Get the PayPal capture-payment request URL.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_capture_payment_request_url() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/capture-payment' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -100,42 +100,50 @@ class WC_Gateway_Paypal_Request {
 			$request_body = $this->get_create_paypal_order_request_body( $order );
 
 			// TODO: Replace with the wpcom endpoint when it's ready.
-			$response = wp_remote_post( $this->get_paypal_create_order_request_url(), array(
-				'method' => 'POST',
-				'headers' => array(
-					'Content-Type' => 'application/json',
-				),
-				'body' => json_encode( $request_body ),
-			) );
-			$http_code = wp_remote_retrieve_response_code( $response );
-			$body = wp_remote_retrieve_body( $response );
+			$response      = wp_remote_post(
+				$this->get_paypal_create_order_request_url(),
+				array(
+					'method'  => 'POST',
+					'headers' => array(
+						'Content-Type' => 'application/json',
+					),
+					'body'    => wp_json_encode( $request_body ),
+				)
+			);
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
-			error_log( 'PayPal create order response: ' . print_r( $response_data, true ) );
+			error_log( 'PayPal create order response: ' . wc_print_r( $response_data, true ) );
 			if ( 200 !== $http_code || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
 				throw new Exception( 'PayPal order creation failed. Response status:' . $http_code );
 			}
 
-			// Find the 'approve' link in the response -- this is where we will redirect the customer to
+			// Find the 'approve' link in the response -- this is where we will redirect the customer to.
 			$redirect_url = null;
 			foreach ( $response_data['links'] as $link ) {
-				if ( $link['rel'] === 'approve' && $link['method'] === 'GET' ) {
+				if ( 'approve' === $link['rel'] && 'GET' === $link['method'] ) {
 					$redirect_url = $link['href'];
 					break;
 				}
 			}
 
-			return [
-				'id' => $response_data['id'],
+			return array(
+				'id'           => $response_data['id'],
 				'redirect_url' => $redirect_url,
-			];
+			);
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			return null;
 		}
 	}
 
-	// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+	/**
+	 * Get the PayPal create-order request URL.
+	 * TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+	 *
+	 * @return string
+	 */
 	private function get_paypal_create_order_request_url() {
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
 	}
@@ -147,28 +155,30 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	private function get_create_paypal_order_request_body( $order ) {
-		return[
-    		'intent' => 'CAPTURE', // TODO:Or 'AUTHORIZE' for capture-later
-			'purchase_units' => [
-				[
+		return array(
+			'intent'              => 'CAPTURE', // TODO: Or 'AUTHORIZE' for capture-later.
+			'purchase_units'      => array(
+				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),
-					'amount' => [
+					'amount' => array(
 						'currency_code' => get_woocommerce_currency(),
 						'value' => $order->get_total(),
-					],
-					//'items' => $this->get_paypal_order_items( $order ), // TODO: Add line items.
+					),
+					// 'items' => $this->get_paypal_order_items( $order ), // TODO: Add line items.
 					// 'description' => '', // TODO: Add description.
-					'payee' => [
+					'payee' => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
-					],
-				],
-			],
-			'application_context' => [
-				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ), // Customer redirected here on approval
-				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),  // Customer redirected here on cancellation
-				//'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion
-			],
-		];
+					),
+				),
+			),
+			'application_context' => array(
+				// Customer redirected here on approval.
+				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+				// Customer redirected here on cancellation.
+				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+				// 'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion.
+			),
+		);
 	}
 
 	/**
@@ -181,12 +191,12 @@ class WC_Gateway_Paypal_Request {
 	 */
 	private function get_paypal_order_custom_id( $order ) {
 		$custom_id = wp_json_encode(
-			[
+			array(
 				'order_id' => $order->get_id(),
 				'order_key' => $order->get_order_key(),
 				// Endpoint for the proxy to forward webhooks to.
 				'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ),
-			]
+			)
 		);
 
 		if ( strlen( $custom_id ) > 255 ) {

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -191,12 +191,10 @@ class WC_Gateway_Paypal_Request {
 					'amount'    => array(
 						'currency_code' => $currency,
 						'value'         => $order->get_total(),
-						// Note: We are not including discount in the breakdown, as PayPal tries to subtract
-						// it from the total, and ends up rejecting the order as it does not tally correctly.
 						'breakdown'     => array(
 							'item_total' => array(
 								'currency_code' => $currency,
-								'value'         => $this->get_paypal_order_items_total( $order ),
+								'value'         => $this->get_paypal_order_items_subtotal( $order ),
 							),
 							'shipping'   => array(
 								'currency_code' => $currency,
@@ -205,6 +203,10 @@ class WC_Gateway_Paypal_Request {
 							'tax_total'  => array(
 								'currency_code' => $currency,
 								'value'         => $order->get_total_tax(),
+							),
+							'discount'   => array(
+								'currency_code' => $currency,
+								'value'         => $order->get_discount_total(),
 							),
 						),
 					),
@@ -265,7 +267,8 @@ class WC_Gateway_Paypal_Request {
 				'quantity'    => $item->get_quantity(),
 				'unit_amount' => array(
 					'currency_code' => $order->get_currency(),
-					'value'         => $order->get_item_total( $item, $include_tax = false, $rounding_enabled = false ),
+					// We want to use the subtotal (before discounts), as we are including the discount in the breakdown.
+					'value'         => $order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
 				),
 			);
 		}
@@ -274,15 +277,15 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
-	 * Get the total for all items.
+	 * Get the subtotal for all items, before discounts.
 	 *
 	 * @param WC_Order $order Order object.
 	 * @return float
 	 */
-	private function get_paypal_order_items_total( $order ) {
+	private function get_paypal_order_items_subtotal( $order ) {
 		$total = 0;
 		foreach ( $order->get_items() as $item ) {
-			$total += (float) $item->get_total();
+			$total += (float) $item->get_subtotal();
 		}
 
 		return $total;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -264,7 +264,7 @@ class WC_Gateway_Paypal_Request {
 				'name'        => $item->get_name(),
 				'quantity'    => $item->get_quantity(),
 				'unit_amount' => array(
-					'currency_code' => get_woocommerce_currency(),
+					'currency_code' => $order->get_currency(),
 					'value'         => $order->get_item_total( $item, $include_tax = false, $rounding_enabled = false ),
 				),
 			);

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -100,7 +100,7 @@ class WC_Gateway_Paypal_Request {
 			$request_body = $this->get_create_paypal_order_request_body( $order );
 
 			// TODO: Replace with the wpcom endpoint when it's ready.
-			$request = WP_REST_Request::from_url( get_site_url( null, '/wp-json/wc-paypal-gateway-proxy/v1/create-order' ) );
+			$request = WP_REST_Request::from_url( $this->get_paypal_create_order_request_url() );
 			$request->set_method( 'POST' );
 			$request->set_header( 'Content-Type', 'application/json' );
 			// TODO: Authenticate with wpcom.
@@ -130,6 +130,11 @@ class WC_Gateway_Paypal_Request {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			return null;
 		}
+	}
+
+	// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+	private function get_paypal_create_order_request_url() {
+		return get_site_url( null, '/wc/v3/paypal-proxy/create-order' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -116,7 +116,7 @@ class WC_Gateway_Paypal_Request {
 			$response_data = json_decode( $body, true );
 
 			if ( ! in_array( $http_code, array( 200, 201 ), true ) ) {
-				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code );
+				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 
 			$redirect_url = $this->get_approve_link( $http_code, $response_data );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -115,6 +115,9 @@ class WC_Gateway_Paypal_Request {
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
+			if ( json_last_error() !== JSON_ERROR_NONE ) {
+				throw new Exception( 'Invalid JSON response from PayPal: ' . json_last_error_msg() );
+			}
 			if ( ( 200 !== $http_code && 201 !== $http_code ) || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
 				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code );
 			}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -115,9 +115,6 @@ class WC_Gateway_Paypal_Request {
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
-			if ( json_last_error() !== JSON_ERROR_NONE ) {
-				throw new Exception( 'Invalid JSON response from PayPal: ' . json_last_error_msg() );
-			}
 			if ( ( 200 !== $http_code && 201 !== $http_code ) || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
 				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code );
 			}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -166,8 +166,22 @@ class WC_Gateway_Paypal_Request {
 					'amount'    => array(
 						'currency_code' => get_woocommerce_currency(),
 						'value'         => $order->get_total(),
+						'breakdown'     => array(
+							'item_total' => array(
+								'currency_code' => get_woocommerce_currency(),
+								'value'         => $this->get_paypal_order_items_total( $order ),
+							),
+							'shipping'   => array(
+								'currency_code' => get_woocommerce_currency(),
+								'value'         => $order->get_shipping_total(),
+							),
+							'tax_total'  => array(
+								'currency_code' => get_woocommerce_currency(),
+								'value'         => $order->get_total_tax(),
+							),
+						),
 					),
-					// 'items'  => $this->get_paypal_order_items( $order ), // TODO: Add line items.
+					'items'     => $this->get_paypal_order_items( $order ),
 					'payee'     => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
 					),
@@ -208,6 +222,44 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return $custom_id;
+	}
+
+	/**
+	 * Get the order items for the PayPal create-order request
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	private function get_paypal_order_items( $order ) {
+		$items = array();
+
+		foreach ( $order->get_items() as $item ) {
+			$items[] = array(
+				'name'        => $item->get_name(),
+				'quantity'    => $item->get_quantity(),
+				'unit_amount' => array(
+					'currency_code' => get_woocommerce_currency(),
+					'value'         => $order->get_item_total( $item, false, false ),
+				),
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get the total for all items.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return float
+	 */
+	private function get_paypal_order_items_total( $order ) {
+		$total = 0;
+		foreach ( $order->get_items() as $item ) {
+			$total += (float) $item->get_total();
+		}
+
+		return $total;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -89,6 +89,223 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Create a PayPal order using the Orders v2 API.
+	 *
+	 * This method creates a PayPal order and returns the order details including
+	 * the approval URL where customers will be redirected to complete payment.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array|null
+	 * @throws Exception If the PayPal order creation fails.
+	 */
+	public function create_paypal_order( $order ) {
+		try {
+			$request_body = $this->get_paypal_create_order_request_body( $order );
+
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
+			// TODO: Replace with the wpcom endpoint when it's ready.
+			$response = wp_remote_post(
+				$this->get_paypal_create_order_request_url(),
+				array(
+					'method'  => 'POST',
+					'headers' => array(
+						'Content-Type' => 'application/json',
+					),
+					'body'    => wp_json_encode( $request_body ),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new Exception( 'PayPal order creation failed. Response error: ' . $response->get_error_message() );
+			}
+
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$body          = wp_remote_retrieve_body( $response );
+			$response_data = json_decode( $body, true );
+
+			if ( ! in_array( $http_code, array( 200, 201 ), true ) ) {
+				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code . '. Response body: ' . $body );
+			}
+
+			$redirect_url = $this->get_approve_link( $http_code, $response_data );
+
+			return array(
+				'id'           => $response_data['id'],
+				'redirect_url' => $redirect_url,
+			);
+		} catch ( Exception $e ) {
+			WC_Gateway_Paypal::log( $e->getMessage() );
+			return null;
+		}
+	}
+
+	/**
+	 * Get the approve link from the response data.
+	 *
+	 * @param int   $http_code The HTTP code of the response.
+	 * @param array $response_data The response data.
+	 * @return string|null
+	 */
+	private function get_approve_link( $http_code, $response_data ) {
+		// See https://developer.paypal.com/docs/api/orders/v2/#orders_create.
+		if ( 200 === $http_code && isset( $response_data['status'] ) && 'PAYER_ACTION_REQUIRED' === $response_data['status'] ) {
+			$rel = 'payer-action';
+		} else {
+			$rel = 'approve';
+		}
+
+		foreach ( $response_data['links'] as $link ) {
+			if ( $rel === $link['rel'] && 'GET' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+				return esc_url_raw( $link['href'] );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the PayPal create-order request URL.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_create_order_request_url() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
+	}
+
+	/**
+	 * Build the request body for the PayPal create-order request.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	private function get_paypal_create_order_request_body( $order ) {
+		$currency = $order->get_currency();
+
+		return array(
+			'intent'              => $this->get_paypal_order_intent(),
+			'purchase_units'      => array(
+				array(
+					'custom_id' => $this->get_paypal_order_custom_id( $order ),
+					'amount'    => array(
+						'currency_code' => $currency,
+						'value'         => $order->get_total(),
+						'breakdown'     => array(
+							'item_total' => array(
+								'currency_code' => $currency,
+								'value'         => $this->get_paypal_order_items_subtotal( $order ),
+							),
+							'shipping'   => array(
+								'currency_code' => $currency,
+								'value'         => $order->get_shipping_total(),
+							),
+							'tax_total'  => array(
+								'currency_code' => $currency,
+								'value'         => $order->get_total_tax(),
+							),
+							'discount'   => array(
+								'currency_code' => $currency,
+								'value'         => $order->get_discount_total(),
+							),
+						),
+					),
+					'items'     => $this->get_paypal_order_items( $order ),
+					'payee'     => array(
+						'email_address' => $this->gateway->get_option( 'email' ),
+					),
+				),
+			),
+			'application_context' => array(
+				// Customer redirected here on approval.
+				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+				// Customer redirected here on cancellation.
+				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+				// phpcs:ignore Generic.Commenting.Todo.TaskFound,Squiz.PHP.CommentedOutCode.Found
+				// 'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion.
+			),
+		);
+	}
+
+	/**
+	 * Build the custom ID for the PayPal order. The custom ID will be used by the proxy for webhook forwarding,
+	 * and by later steps to identify the order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return string
+	 * @throws Exception If the custom ID is too long.
+	 */
+	private function get_paypal_order_custom_id( $order ) {
+		$custom_id = wp_json_encode(
+			array(
+				'order_id'  => $order->get_id(),
+				'order_key' => $order->get_order_key(),
+				// Endpoint for the proxy to forward webhooks to.
+				'endpoint'  => get_site_url( null, '/wp-json/wc/v3/paypal-webhooks' ),
+			)
+		);
+
+		if ( strlen( $custom_id ) > 255 ) {
+			throw new Exception( 'PayPal order custom ID is too long. Max length is 255 chars.' );
+		}
+
+		return $custom_id;
+	}
+
+	/**
+	 * Get the order items for the PayPal create-order request
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	private function get_paypal_order_items( $order ) {
+		$items = array();
+
+		foreach ( $order->get_items() as $item ) {
+			$items[] = array(
+				'name'        => $item->get_name(),
+				'quantity'    => $item->get_quantity(),
+				'unit_amount' => array(
+					'currency_code' => $order->get_currency(),
+					// We want to use the subtotal (before discounts), as we are including the discount in the breakdown.
+					'value'         => $order->get_item_subtotal( $item, $include_tax = false, $rounding_enabled = false ),
+				),
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get the subtotal for all items, before discounts.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return float
+	 */
+	private function get_paypal_order_items_subtotal( $order ) {
+		$total = 0;
+		foreach ( $order->get_items() as $item ) {
+			$total += (float) $item->get_subtotal();
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Get the value for the intent field in the create-order request.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_order_intent() {
+		$payment_action = $this->gateway->get_option( 'paymentaction' );
+		if ( 'authorization' === $payment_action ) {
+			return 'AUTHORIZE';
+		}
+
+		return 'CAPTURE';
+	}
+
+	/**
 	 * Limit length of an arg.
 	 *
 	 * @param  string  $string Argument to limit.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -5,7 +5,10 @@
  * @package WooCommerce\Gateways
  */
 
+declare(strict_types=1);
+
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use Automattic\WooCommerce\Enums\OrderStatus;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -140,6 +143,72 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Capture a PayPal payment using the Orders v2 API.
+	 *
+	 * This method captures a PayPal payment and updates the order status.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param string   $capture_url The URL to capture the payment.
+	 * @return void
+	 * @throws Exception If the PayPal payment capture fails.
+	 */
+	public function capture_payment( $order, $capture_url ) {
+		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
+		if ( ! $paypal_order_id ) {
+			WC_Gateway_Paypal::log( 'PayPal order ID not found. Cannot capture payment.' );
+			return;
+		}
+
+		if ( ! $capture_url ) {
+			WC_Gateway_Paypal::log( 'Capture URL not found. Cannot capture payment.' );
+			return;
+		}
+
+		try {
+			$request_body = array(
+				'capture_url'     => $capture_url,
+				'paypal_order_id' => $paypal_order_id,
+			);
+
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
+			// TODO: Replace with the wpcom endpoint when it's ready.
+			$response = wp_remote_post(
+				$this->get_paypal_capture_payment_request_url(),
+				array(
+					'method'  => 'POST',
+					'headers' => array(
+						'Content-Type' => 'application/json',
+					),
+					'body'    => wp_json_encode( $request_body ),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
+				return;
+			}
+
+			$http_code = wp_remote_retrieve_response_code( $response );
+			$body      = wp_remote_retrieve_body( $response );
+
+			if ( 200 !== $http_code ) {
+				throw new Exception( 'PayPal payment capture failed. Response status: ' . $http_code . '. Response body: ' . $body );
+			}
+		} catch ( Exception $e ) {
+			WC_Gateway_Paypal::log( $e->getMessage() );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID */
+					__( 'PayPal payment capture failed. PayPal Order ID: %1$s', 'woocommerce' ),
+					$paypal_order_id
+				)
+			);
+			$order->update_status( OrderStatus::FAILED );
+			$order->save();
+		}
+	}
+
+	/**
 	 * Get the approve link from the response data.
 	 *
 	 * @param int   $http_code The HTTP code of the response.
@@ -172,6 +241,17 @@ class WC_Gateway_Paypal_Request {
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
+	}
+
+	/**
+	 * Get the PayPal capture-payment request URL.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_capture_payment_request_url() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/capture-payment' );
 	}
 
 	/**
@@ -799,6 +879,6 @@ class WC_Gateway_Paypal_Request {
 			$decimals = 0;
 		}
 
-		return number_format( $price, $decimals, '.', '' );
+		return number_format( (float) $price, $decimals, '.', '' );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -236,7 +236,7 @@ class WC_Gateway_Paypal_Request {
 				'quantity'    => $item->get_quantity(),
 				'unit_amount' => array(
 					'currency_code' => get_woocommerce_currency(),
-					'value'         => $order->get_item_total( $item, false, false ),
+					'value'         => $order->get_item_total( $item, $include_tax = false, $rounding_enabled = false ),
 				),
 			);
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -100,22 +100,25 @@ class WC_Gateway_Paypal_Request {
 			$request_body = $this->get_create_paypal_order_request_body( $order );
 
 			// TODO: Replace with the wpcom endpoint when it's ready.
-			$request = WP_REST_Request::from_url( $this->get_paypal_create_order_request_url() );
-			$request->set_method( 'POST' );
-			$request->set_header( 'Content-Type', 'application/json' );
-			// TODO: Authenticate with wpcom.
-			// $request->set_header( 'Authorization', 'Bearer ' . $wpcom_blog_token );
-			$request->set_body( json_encode( $request_body ) );
-			$response = rest_do_request( $request );
+			$response = wp_remote_post( $this->get_paypal_create_order_request_url(), array(
+				'method' => 'POST',
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body' => json_encode( $request_body ),
+			) );
+			$http_code = wp_remote_retrieve_response_code( $response );
+			$body = wp_remote_retrieve_body( $response );
+			$response_data = json_decode( $body, true );
 
-			$data = $response->get_data();
-			if ( 200 !== $response->get_status() || ! isset( $data['id'] ) || ! isset( $data['links'] ) ) {
-				throw new Exception( 'PayPal order creation failed. Response status:' . $response->get_status() );
+			error_log( 'PayPal create order response: ' . print_r( $response_data, true ) );
+			if ( 200 !== $http_code || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
+				throw new Exception( 'PayPal order creation failed. Response status:' . $http_code );
 			}
 
 			// Find the 'approve' link in the response -- this is where we will redirect the customer to
 			$redirect_url = null;
-			foreach ( $data['links'] as $link ) {
+			foreach ( $response_data['links'] as $link ) {
 				if ( $link['rel'] === 'approve' && $link['method'] === 'GET' ) {
 					$redirect_url = $link['href'];
 					break;
@@ -123,7 +126,7 @@ class WC_Gateway_Paypal_Request {
 			}
 
 			return [
-				'id' => $data['id'],
+				'id' => $response_data['id'],
 				'redirect_url' => $redirect_url,
 			];
 		} catch ( Exception $e ) {
@@ -134,7 +137,7 @@ class WC_Gateway_Paypal_Request {
 
 	// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 	private function get_paypal_create_order_request_url() {
-		return get_site_url( null, '/wc/v3/paypal-proxy/create-order' );
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -89,6 +89,106 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Create a PayPal order using the Orders v2 API.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array|null
+	 * @throws Exception If the PayPal order creation fails.
+	 */
+	public function create_paypal_order( $order ) {
+		try {
+			$request_body = $this->get_create_paypal_order_request_body( $order );
+
+			// TODO: Replace with the wpcom endpoint when it's ready.
+			$request = WP_REST_Request::from_url( get_site_url( null, '/wp-json/wc-paypal-gateway-proxy/v1/create-order' ) );
+			$request->set_method( 'POST' );
+			$request->set_header( 'Content-Type', 'application/json' );
+			// TODO: Authenticate with wpcom.
+			// $request->set_header( 'Authorization', 'Bearer ' . $wpcom_blog_token );
+			$request->set_body( json_encode( $request_body ) );
+			$response = rest_do_request( $request );
+
+			$data = $response->get_data();
+			if ( 200 !== $response->get_status() || ! isset( $data['id'] ) || ! isset( $data['links'] ) ) {
+				throw new Exception( 'PayPal order creation failed. Response status:' . $response->get_status() );
+			}
+
+			// Find the 'approve' link in the response -- this is where we will redirect the customer to
+			$redirect_url = null;
+			foreach ( $data['links'] as $link ) {
+				if ( $link['rel'] === 'approve' && $link['method'] === 'GET' ) {
+					$redirect_url = $link['href'];
+					break;
+				}
+			}
+
+			return [
+				'id' => $data['id'],
+				'redirect_url' => $redirect_url,
+			];
+		} catch ( Exception $e ) {
+			WC_Gateway_Paypal::log( $e->getMessage() );
+			return null;
+		}
+	}
+
+	/**
+	 * Build the request body for the PayPal create-order request.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	private function get_create_paypal_order_request_body( $order ) {
+		return[
+    		'intent' => 'CAPTURE', // TODO:Or 'AUTHORIZE' for capture-later
+			'purchase_units' => [
+				[
+					'custom_id' => $this->get_paypal_order_custom_id( $order ),
+					'amount' => [
+						'currency_code' => get_woocommerce_currency(),
+						'value' => $order->get_total(),
+					],
+					//'items' => $this->get_paypal_order_items( $order ), // TODO: Add line items.
+					// 'description' => '', // TODO: Add description.
+					'payee' => [
+						'email_address' => $this->gateway->get_option( 'email' ),
+					],
+				],
+			],
+			'application_context' => [
+				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ), // Customer redirected here on approval
+				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),  // Customer redirected here on cancellation
+				//'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion
+			],
+		];
+	}
+
+	/**
+	 * Build the custom ID for the PayPal order. The custom ID will be used by the proxy for webhook forwarding,
+	 * and by later steps to identify the order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return string
+	 * @throws Exception If the custom ID is too long.
+	 */
+	private function get_paypal_order_custom_id( $order ) {
+		$custom_id = wp_json_encode(
+			[
+				'order_id' => $order->get_id(),
+				'order_key' => $order->get_order_key(),
+				// Endpoint for the proxy to forward webhooks to.
+				'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ),
+			]
+		);
+
+		if ( strlen( $custom_id ) > 255 ) {
+			throw new Exception( 'PayPal order custom ID is too long. Max length is 255 chars.' );
+		}
+
+		return $custom_id;
+	}
+
+	/**
 	 * Limit length of an arg.
 	 *
 	 * @param  string  $string Argument to limit.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -115,18 +115,11 @@ class WC_Gateway_Paypal_Request {
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
-			if ( ( 200 !== $http_code && 201 !== $http_code ) || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
+			if ( ! in_array( $http_code, array( 200, 201 ), true ) ) {
 				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code );
 			}
 
-			// Find the 'approve' link in the response -- this is where we will redirect the customer to.
-			$redirect_url = null;
-			foreach ( $response_data['links'] as $link ) {
-				if ( 'approve' === $link['rel'] && 'GET' === $link['method'] ) {
-					$redirect_url = $link['href'];
-					break;
-				}
-			}
+			$redirect_url = $this->get_approve_link( $http_code, $response_data );
 
 			return array(
 				'id'           => $response_data['id'],
@@ -136,6 +129,30 @@ class WC_Gateway_Paypal_Request {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			return null;
 		}
+	}
+
+	/**
+	 * Get the approve link from the response data.
+	 *
+	 * @param int   $http_code The HTTP code of the response.
+	 * @param array $response_data The response data.
+	 * @return string|null
+	 */
+	private function get_approve_link( $http_code, $response_data ) {
+		// See https://developer.paypal.com/docs/api/orders/v2/#orders_create.
+		if ( 200 === $http_code && isset( $response_data['status'] ) && 'PAYER_ACTION_REQUIRED' === $response_data['status'] ) {
+			$rel = 'payer-action';
+		} else {
+			$rel = 'approve';
+		}
+
+		foreach ( $response_data['links'] as $link ) {
+			if ( $rel === $link['rel'] && 'GET' === $link['method'] ) {
+				return $link['href'];
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -192,10 +192,10 @@ class WC_Gateway_Paypal_Request {
 	private function get_paypal_order_custom_id( $order ) {
 		$custom_id = wp_json_encode(
 			array(
-				'order_id' => $order->get_id(),
+				'order_id'  => $order->get_id(),
 				'order_key' => $order->get_order_key(),
 				// Endpoint for the proxy to forward webhooks to.
-				'endpoint' => get_site_url( null, '/wp-json/wc-paypal-gateway/v1/webhook' ),
+				'endpoint'  => get_site_url( null, '/wp-json/wc/v3/paypal-webhooks' ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -185,6 +185,13 @@ class WC_Gateway_Paypal_Request {
 
 		return array(
 			'intent'              => $this->get_paypal_order_intent(),
+			'payment_source'      => array(
+				'paypal' => array(
+					'experience_context' => array(
+						'user_action' => 'PAY_NOW',
+					),
+				),
+			),
 			'purchase_units'      => array(
 				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -173,27 +173,29 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	private function get_paypal_create_order_request_body( $order ) {
+		$currency = $order->get_currency();
+
 		return array(
 			'intent'              => $this->get_paypal_order_intent(),
 			'purchase_units'      => array(
 				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),
 					'amount'    => array(
-						'currency_code' => get_woocommerce_currency(),
+						'currency_code' => $currency,
 						'value'         => $order->get_total(),
 						// Note: We are not including discount in the breakdown, as PayPal tries to subtract
 						// it from the total, and ends up rejecting the order as it does not tally correctly.
 						'breakdown'     => array(
 							'item_total' => array(
-								'currency_code' => get_woocommerce_currency(),
+								'currency_code' => $currency,
 								'value'         => $this->get_paypal_order_items_total( $order ),
 							),
 							'shipping'   => array(
-								'currency_code' => get_woocommerce_currency(),
+								'currency_code' => $currency,
 								'value'         => $order->get_shipping_total(),
 							),
 							'tax_total'  => array(
-								'currency_code' => get_woocommerce_currency(),
+								'currency_code' => $currency,
 								'value'         => $order->get_total_tax(),
 							),
 						),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -115,6 +115,7 @@ class WC_Gateway_Paypal_Request {
 						'Content-Type' => 'application/json',
 					),
 					'body'    => wp_json_encode( $request_body ),
+					'timeout' => 30,
 				)
 			);
 
@@ -180,6 +181,7 @@ class WC_Gateway_Paypal_Request {
 						'Content-Type' => 'application/json',
 					),
 					'body'    => wp_json_encode( $request_body ),
+					'timeout' => 30,
 				)
 			);
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Gateways
  */
 
+declare(strict_types=1);
+
 use Automattic\WooCommerce\Utilities\NumberUtil;
 use Automattic\WooCommerce\Enums\OrderStatus;
 
@@ -146,7 +148,7 @@ class WC_Gateway_Paypal_Request {
 	 * This method captures a PayPal payment and updates the order status.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param string $capture_url The URL to capture the payment.
+	 * @param string   $capture_url The URL to capture the payment.
 	 * @return void
 	 * @throws Exception If the PayPal payment capture fails.
 	 */
@@ -164,13 +166,13 @@ class WC_Gateway_Paypal_Request {
 
 		try {
 			$request_body = array(
-				'capture_url' => $capture_url,
+				'capture_url'     => $capture_url,
 				'paypal_order_id' => $paypal_order_id,
 			);
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
-			$response     = wp_remote_post(
+			$response = wp_remote_post(
 				$this->get_paypal_capture_payment_request_url(),
 				array(
 					'method'  => 'POST',
@@ -186,13 +188,12 @@ class WC_Gateway_Paypal_Request {
 				return;
 			}
 
-			$http_code     = wp_remote_retrieve_response_code( $response );
-			$body          = wp_remote_retrieve_body( $response );
+			$http_code = wp_remote_retrieve_response_code( $response );
+			$body      = wp_remote_retrieve_body( $response );
 
 			if ( 200 !== $http_code ) {
 				throw new Exception( 'PayPal payment capture failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
-
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			$order->add_order_note(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -152,8 +152,8 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		foreach ( $response_data['links'] as $link ) {
-			if ( $rel === $link['rel'] && 'GET' === $link['method'] ) {
-				return $link['href'];
+			if ( $rel === $link['rel'] && 'GET' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+				return esc_url_raw( $link['href'] );
 			}
 		}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -97,7 +97,7 @@ class WC_Gateway_Paypal_Request {
 	 */
 	public function create_paypal_order( $order ) {
 		try {
-			$request_body = $this->get_create_paypal_order_request_body( $order );
+			$request_body = $this->get_paypal_create_order_request_body( $order );
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
@@ -172,7 +172,7 @@ class WC_Gateway_Paypal_Request {
 	 * @param WC_Order $order Order object.
 	 * @return array
 	 */
-	private function get_create_paypal_order_request_body( $order ) {
+	private function get_paypal_create_order_request_body( $order ) {
 		return array(
 			'intent'              => $this->get_paypal_order_intent(),
 			'purchase_units'      => array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -156,10 +156,8 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	private function get_create_paypal_order_request_body( $order ) {
-		// phpcs:disable Generic.Commenting.Todo.TaskFound
-		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 		return array(
-			'intent'              => 'CAPTURE', // TODO: Or 'AUTHORIZE' for capture-later.
+			'intent'              => $this->get_paypal_order_intent(),
 			'purchase_units'      => array(
 				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),
@@ -192,11 +190,10 @@ class WC_Gateway_Paypal_Request {
 				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
 				// Customer redirected here on cancellation.
 				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+				// phpcs:ignore Generic.Commenting.Todo.TaskFound,Squiz.PHP.CommentedOutCode.Found
 				// 'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion.
 			),
 		);
-		// phpcs:enable Generic.Commenting.Todo.TaskFound
-		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
 	}
 
 	/**
@@ -260,6 +257,20 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return $total;
+	}
+
+	/**
+	 * Get the value for the intent field in the create-order request.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_order_intent() {
+		$payment_action = $this->gateway->get_option( 'paymentaction' );
+		if ( 'authorization' === $payment_action ) {
+			return 'AUTHORIZE';
+		}
+
+		return 'CAPTURE';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -99,6 +99,7 @@ class WC_Gateway_Paypal_Request {
 		try {
 			$request_body = $this->get_create_paypal_order_request_body( $order );
 
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
 			$response      = wp_remote_post(
 				$this->get_paypal_create_order_request_url(),
@@ -114,7 +115,6 @@ class WC_Gateway_Paypal_Request {
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
-			error_log( 'PayPal create order response: ' . wc_print_r( $response_data, true ) );
 			if ( 200 !== $http_code || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
 				throw new Exception( 'PayPal order creation failed. Response status:' . $http_code );
 			}
@@ -140,11 +140,12 @@ class WC_Gateway_Paypal_Request {
 
 	/**
 	 * Get the PayPal create-order request URL.
-	 * TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 	 *
 	 * @return string
 	 */
 	private function get_paypal_create_order_request_url() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/create-order' );
 	}
 
@@ -155,18 +156,19 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	private function get_create_paypal_order_request_body( $order ) {
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 		return array(
 			'intent'              => 'CAPTURE', // TODO: Or 'AUTHORIZE' for capture-later.
 			'purchase_units'      => array(
 				array(
 					'custom_id' => $this->get_paypal_order_custom_id( $order ),
-					'amount' => array(
+					'amount'    => array(
 						'currency_code' => get_woocommerce_currency(),
-						'value' => $order->get_total(),
+						'value'         => $order->get_total(),
 					),
-					// 'items' => $this->get_paypal_order_items( $order ), // TODO: Add line items.
-					// 'description' => '', // TODO: Add description.
-					'payee' => array(
+					// 'items'  => $this->get_paypal_order_items( $order ), // TODO: Add line items.
+					'payee'     => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
 					),
 				),
@@ -179,6 +181,8 @@ class WC_Gateway_Paypal_Request {
 				// 'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion.
 			),
 		);
+		// phpcs:enable Generic.Commenting.Todo.TaskFound
+		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -101,7 +101,7 @@ class WC_Gateway_Paypal_Request {
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
-			$response      = wp_remote_post(
+			$response = wp_remote_post(
 				$this->get_paypal_create_order_request_url(),
 				array(
 					'method'  => 'POST',
@@ -111,6 +111,11 @@ class WC_Gateway_Paypal_Request {
 					'body'    => wp_json_encode( $request_body ),
 				)
 			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new Exception( 'PayPal order creation failed. Response error: ' . $response->get_error_message() );
+			}
+
 			$http_code     = wp_remote_retrieve_response_code( $response );
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -91,6 +91,9 @@ class WC_Gateway_Paypal_Request {
 	/**
 	 * Create a PayPal order using the Orders v2 API.
 	 *
+	 * This method creates a PayPal order and returns the order details including
+	 * the approval URL where customers will be redirected to complete payment.
+	 *
 	 * @param WC_Order $order Order object.
 	 * @return array|null
 	 * @throws Exception If the PayPal order creation fails.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -181,6 +181,8 @@ class WC_Gateway_Paypal_Request {
 					'amount'    => array(
 						'currency_code' => get_woocommerce_currency(),
 						'value'         => $order->get_total(),
+						// Note: We are not including discount in the breakdown, as PayPal tries to subtract
+						// it from the total, and ends up rejecting the order as it does not tally correctly.
 						'breakdown'     => array(
 							'item_total' => array(
 								'currency_code' => get_woocommerce_currency(),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -115,8 +115,8 @@ class WC_Gateway_Paypal_Request {
 			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
-			if ( 200 !== $http_code || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
-				throw new Exception( 'PayPal order creation failed. Response status:' . $http_code );
+			if ( ( 200 !== $http_code && 201 !== $http_code ) || ! isset( $response_data['id'] ) || ! isset( $response_data['links'] ) ) {
+				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code );
 			}
 
 			// Find the 'approve' link in the response -- this is where we will redirect the customer to.

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -1,69 +1,89 @@
 <?php
+
+/**
+ * Class WC_Gateway_Paypal_Webhook_Handler file.
+ *
+ * @package WooCommerce\Gateways
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
-
+/**
+ * Handles webhook events.
+ */
 class WC_Gateway_Paypal_Webhook_Handler {
-    public function process_webhook( WP_REST_Request $request ) {
-        // TODO: Validate the webhook signature
 
-        $data = $request->get_json_params();
-        WC_Gateway_Paypal::log( 'Webhook received: ' . wc_print_r( $data, true ) );
+	/**
+	 * Process the webhook event.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function process_webhook( WP_REST_Request $request ) {
+		// TODO: Validate the webhook signature.
 
-        switch ( $data['event_type'] ) {
-            case 'CHECKOUT.ORDER.APPROVED':
-                $this->process_checkout_order_approved( $data );
-                break;
-            default:
-                WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
-                break;
-        }
-    }
+		$data = $request->get_json_params();
+		WC_Gateway_Paypal::log( 'Webhook received: ' . wc_print_r( $data, true ) );
 
-    private function process_checkout_order_approved( $data ) {
-        $custom_id = $data['resource']['purchase_units'][0]['custom_id'];
-        $order = $this->get_wc_order( $custom_id );
-        if ( ! $order ) {
-            WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
-            return;
-        }
+		switch ( $data['event_type'] ) {
+			case 'CHECKOUT.ORDER.APPROVED':
+				$this->process_checkout_order_approved( $data );
+				break;
+			default:
+				WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
+				break;
+		}
+	}
 
-        $status = $data['resource']['status'] ?? null;
-        if ( $status === 'APPROVED' ) {
-            WC_Gateway_Paypal::log( 'PayPal order approved. Order ID: ' . $order->get_id() );
+	/**
+	 * Process the CHECKOUT.ORDER.APPROVED webhook event.
+	 *
+	 * @param array $event The webhook event data.
+	 */
+	private function process_checkout_order_approved( $event ) {
+		$custom_id = $event['resource']['purchase_units'][0]['custom_id'];
+		$order     = $this->get_wc_order( $custom_id );
+		if ( ! $order ) {
+			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
 
-            // TODO: Capture the payment.
-        } else {
-            WC_Gateway_Paypal::log( 'PayPal order not approved. Order ID: ' . $order->get_id() . ' Status: ' . $status );
-        }
-    }
+		$status = $event['resource']['status'] ?? null;
+		if ( 'APPROVED' === $status ) {
+			WC_Gateway_Paypal::log( 'PayPal order approved. Order ID: ' . $order->get_id() );
 
-    /**
-     * Get the WC order from the custom ID.
-     *
-     * @param string $custom_id The custom ID string from the PayPal order.
-     * @return WC_Order|null
-     */
-    private function get_wc_order( $custom_id ) {
-        $data = json_decode( $custom_data );
-        $order_id = $data->order_id ?? null;
-        if ( ! $order_id ) {
-            return null;
-        }
+			// TODO: Capture the payment.
 
-        $order = wc_get_order( $order_id );
-        if ( ! $order ) {
-            return null;
-        }
+		} else {
+			WC_Gateway_Paypal::log( 'PayPal order not approved. Order ID: ' . $order->get_id() . ' Status: ' . $status );
+		}
+	}
 
-        // Validate the order key.
-        $order_key = $data->order_key ?? null;
-        if ( $order_key !== $order->get_order_key() ) {
-            return null;
-        }
+	/**
+	 * Get the WC order from the custom ID.
+	 *
+	 * @param string $custom_id The custom ID string from the PayPal order.
+	 * @return WC_Order|null
+	 */
+	private function get_wc_order( $custom_id ) {
+		$data     = json_decode( $custom_id );
+		$order_id = $data->order_id ?? null;
+		if ( ! $order_id ) {
+			return null;
+		}
 
-        return $order;
-    }
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return null;
+		}
+
+		// Validate the order key.
+		$order_key = $data->order_key ?? null;
+		if ( $order_key !== $order->get_order_key() ) {
+			return null;
+		}
+
+		return $order;
+	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -49,14 +49,30 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			return;
 		}
 
-		$status = $event['resource']['status'] ?? null;
+		$status          = $event['resource']['status'] ?? null;
+		$paypal_order_id = $event['resource']['id'] ?? null;
 		if ( 'APPROVED' === $status ) {
-			WC_Gateway_Paypal::log( 'PayPal order approved. Order ID: ' . $order->get_id() );
+			WC_Gateway_Paypal::log( 'PayPal payment approved. Order ID: ' . $order->get_id() );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID */
+					__( 'PayPal payment approved. PayPal Order ID: %1$s', 'woocommerce' ),
+					$paypal_order_id
+				)
+			);
 
 			// TODO: Capture the payment.
 
 		} else {
-			WC_Gateway_Paypal::log( 'PayPal order not approved. Order ID: ' . $order->get_id() . ' Status: ' . $status );
+			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
+			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID */
+					__( 'PayPal payment approval failed. PayPal Order ID: %1$s. Status: %2$s', 'woocommerce' ),
+					$paypal_order_id
+				)
+			);
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -6,36 +6,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
 
 class WC_Gateway_Paypal_Webhook_Handler {
-    public function __construct() {
-        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-    }
-
-    public function register_routes() {
-        register_rest_route( 'wc-paypal-gateway/v1', '/webhook', [
-            'methods'             => 'POST',
-            'callback'            => array( $this, 'process_webhook' ),
-            'permission_callback' => array( $this, 'get_permission' ),
-        ] );
-
-        // TODO: Test only. Remove before merging feature.
-        register_rest_route( 'wc-paypal-gateway/v1', '/test-webhook', [
-            'methods'             => 'GET',
-            'callback'            => array( $this, 'test_webhook' ),
-            'permission_callback' => '__return_true',
-        ] );
-    }
-
-    private function get_permission() {
-        // TODO: Should we check if the webhook is coming from wpcom?
-        return true;
-    }
-
-    public function test_webhook( WP_REST_Request $request ) {
-        $data = $request->get_json_params();
-        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
-        return new WP_REST_Response( 'Test webhook processed', 200 );
-    }
-
     public function process_webhook( WP_REST_Request $request ) {
         // TODO: Validate the webhook signature
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -1,0 +1,99 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
+
+class WC_Gateway_Paypal_Webhook_Handler {
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    public function register_routes() {
+        register_rest_route( 'wc-paypal-gateway/v1', '/webhook', [
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'process_webhook' ),
+            'permission_callback' => array( $this, 'get_permission' ),
+        ] );
+
+        // TODO: Test only. Remove before merging feature.
+        register_rest_route( 'wc-paypal-gateway/v1', '/test-webhook', [
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'test_webhook' ),
+            'permission_callback' => '__return_true',
+        ] );
+    }
+
+    private function get_permission() {
+        // TODO: Should we check if the webhook is coming from wpcom?
+        return true;
+    }
+
+    public function test_webhook( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
+        return new WP_REST_Response( 'Test webhook processed', 200 );
+    }
+
+    public function process_webhook( WP_REST_Request $request ) {
+        // TODO: Validate the webhook signature
+
+        $data = $request->get_json_params();
+        WC_Gateway_Paypal::log( 'Webhook received: ' . wc_print_r( $data, true ) );
+
+        switch ( $data['event_type'] ) {
+            case 'CHECKOUT.ORDER.APPROVED':
+                $this->process_checkout_order_approved( $data );
+                break;
+            default:
+                WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
+                break;
+        }
+    }
+
+    private function process_checkout_order_approved( $data ) {
+        $custom_id = $data['resource']['purchase_units'][0]['custom_id'];
+        $order = $this->get_wc_order( $custom_id );
+        if ( ! $order ) {
+            WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+            return;
+        }
+
+        $status = $data['resource']['status'] ?? null;
+        if ( $status === 'APPROVED' ) {
+            WC_Gateway_Paypal::log( 'PayPal order approved. Order ID: ' . $order->get_id() );
+
+            // TODO: Capture the payment.
+        } else {
+            WC_Gateway_Paypal::log( 'PayPal order not approved. Order ID: ' . $order->get_id() . ' Status: ' . $status );
+        }
+    }
+
+    /**
+     * Get the WC order from the custom ID.
+     *
+     * @param string $custom_id The custom ID string from the PayPal order.
+     * @return WC_Order|null
+     */
+    private function get_wc_order( $custom_id ) {
+        $data = json_decode( $custom_data );
+        $order_id = $data->order_id ?? null;
+        if ( ! $order_id ) {
+            return null;
+        }
+
+        $order = wc_get_order( $order_id );
+        if ( ! $order ) {
+            return null;
+        }
+
+        // Validate the order key.
+        $order_key = $data->order_key ?? null;
+        if ( $order_key !== $order->get_order_key() ) {
+            return null;
+        }
+
+        return $order;
+    }
+}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -87,11 +87,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @return WC_Order|null
 	 */
 	private function get_wc_order( $custom_id ) {
-		$data = json_decode( $custom_id );
-		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			WC_Gateway_Paypal::log( 'Invalid JSON in custom ID: ' . wc_print_r( $custom_id, true ) );
-			return null;
-		}
+		$data     = json_decode( $custom_id );
 		$order_id = $data->order_id ?? null;
 		if ( ! $order_id ) {
 			return null;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -86,7 +86,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @return WC_Order|null
 	 */
 	private function get_wc_order( $custom_id ) {
-		$data     = json_decode( $custom_id );
+		$data = json_decode( $custom_id );
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			WC_Gateway_Paypal::log( 'Invalid JSON in custom ID: ' . wc_print_r( $custom_id, true ) );
+			return null;
+		}
 		$order_id = $data->order_id ?? null;
 		if ( ! $order_id ) {
 			return null;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -68,8 +68,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 
-			// Capture the payment after approval.
-			$this->capture_payment( $order, $event['resource']['links'] );
+			// Queue capture for asynchronous processing.
+			$this->schedule_payment_capture( $order, $event['resource']['links'] );
 		} else {
 			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
@@ -131,12 +131,13 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	}
 
 	/**
-	 * Capture the payment.
+	 * Schedule payment capture for background processing.
 	 *
 	 * @param WC_Order $order The order object.
 	 * @param array    $links The links from the webhook event.
 	 */
-	private function capture_payment( $order, $links ) {
+	private function schedule_payment_capture( $order, $links ) {
+		// Find capture URL
 		$capture_url = null;
 		foreach ( $links as $link ) {
 			if ( 'capture' === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
@@ -145,13 +146,22 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			}
 		}
 
-		$payment_gateways = WC()->payment_gateways()->payment_gateways();
-		if ( ! isset( $payment_gateways['paypal'] ) ) {
-			WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
+		if ( ! $capture_url ) {
+			WC_Gateway_Paypal::log( 'No capture URL found in webhook links', 'error' );
 			return;
 		}
-		$gateway        = $payment_gateways['paypal'];
-		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
-		$paypal_request->capture_payment( $order, $capture_url );
+
+		// Schedule background job.
+		WC()->queue()->schedule_single(
+			time() + 10, // Capture in 10 seconds
+			'woocommerce_paypal_capture_payment',
+			array(
+				'order_id'    => $order->get_id(),
+				'capture_url' => $capture_url,
+			),
+			'paypal-capture'
+		);
+
+		WC_Gateway_Paypal::log( 'Payment capture scheduled for order: ' . $order->get_id() );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/class-wc-gateway-paypal-request.php';
+
 /**
  * Handles webhook events.
  */
@@ -31,6 +33,9 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		switch ( $data['event_type'] ) {
 			case 'CHECKOUT.ORDER.APPROVED':
 				$this->process_checkout_order_approved( $data );
+				break;
+			case 'PAYMENT.CAPTURE.COMPLETED':
+				$this->process_payment_capture_completed( $data );
 				break;
 			default:
 				WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
@@ -63,9 +68,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 
-			// phpcs:disable Generic.Commenting.Todo.TaskFound
-			// TODO: Capture the payment.
-
+			// Capture the payment after approval.
+			$this->capture_payment( $order, $event['resource']['links'] );
 		} else {
 			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
@@ -78,6 +82,25 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Process the PAYMENT.CAPTURE.COMPLETED webhook event.
+	 *
+	 * @param array $event The webhook event data.
+	 */
+	private function process_payment_capture_completed( $event ) {
+		$custom_id = $event['resource']['custom_id'];
+		$order     = $this->get_wc_order( $custom_id );
+		if ( ! $order ) {
+			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
+
+		$order->set_transaction_id( $event['resource']['id'] );
+		$order->payment_complete();
+		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
+		$order->save();
 	}
 
 	/**
@@ -105,5 +128,30 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		}
 
 		return $order;
+	}
+
+	/**
+	 * Capture the payment.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @param array    $links The links from the webhook event.
+	 */
+	private function capture_payment( $order, $links ) {
+		$capture_url = null;
+		foreach ( $links as $link ) {
+			if ( 'capture' === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+				$capture_url = esc_url_raw( $link['href'] );
+				break;
+			}
+		}
+
+		$payment_gateways = WC()->payment_gateways()->payment_gateways();
+		if ( ! isset( $payment_gateways['paypal'] ) ) {
+			WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
+			return;
+		}
+		$gateway        = $payment_gateways['paypal'];
+		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+		$paypal_request->capture_payment( $order, $capture_url );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
+require_once __DIR__ . '/class-wc-gateway-paypal-request.php';
 
 /**
  * Handles webhook events.
@@ -134,12 +134,12 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * Capture the payment.
 	 *
 	 * @param WC_Order $order The order object.
-	 * @param array $links The links from the webhook event.
+	 * @param array    $links The links from the webhook event.
 	 */
 	private function capture_payment( $order, $links ) {
 		$capture_url = null;
 		foreach ( $links as $link ) {
-			if ( $link['rel'] === 'capture' && $link['method'] === 'POST' && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+			if ( 'capture' === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
 				$capture_url = esc_url_raw( $link['href'] );
 				break;
 			}
@@ -150,7 +150,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
 			return;
 		}
-		$gateway = $payment_gateways['paypal'];
+		$gateway        = $payment_gateways['paypal'];
 		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
 		$paypal_request->capture_payment( $order, $capture_url );
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -71,9 +71,10 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
 			$order->add_order_note(
 				sprintf(
-					/* translators: %1$s: PayPal order ID */
+					/* translators: %1$s: PayPal order ID, %2$s: Status */
 					__( 'PayPal payment approval failed. PayPal Order ID: %1$s. Status: %2$s', 'woocommerce' ),
-					$paypal_order_id
+					$paypal_order_id,
+					$status
 				)
 			);
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -1,10 +1,11 @@
 <?php
-
 /**
  * Class WC_Gateway_Paypal_Webhook_Handler file.
  *
  * @package WooCommerce\Gateways
  */
+
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -21,6 +22,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @param WP_REST_Request $request The request object.
 	 */
 	public function process_webhook( WP_REST_Request $request ) {
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
 		// TODO: Validate the webhook signature.
 
 		$data = $request->get_json_params();
@@ -61,6 +63,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Capture the payment.
 
 		} else {

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once dirname( __FILE__ ) . '/class-wc-gateway-paypal-request.php';
+
 /**
  * Handles webhook events.
  */
@@ -63,9 +65,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 
-			// phpcs:disable Generic.Commenting.Todo.TaskFound
-			// TODO: Capture the payment.
-
+			// Capture the payment after approval.
+			$this->capture_payment( $order, $event['resource']['links'] );
 		} else {
 			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
@@ -105,5 +106,25 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		}
 
 		return $order;
+	}
+
+	/**
+	 * Capture the payment.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @param array $links The links from the webhook event.
+	 */
+	private function capture_payment( $order, $links ) {
+		$capture_url = null;
+		foreach ( $links as $link ) {
+			if ( $link['rel'] === 'capture' && $link['method'] === 'POST' && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+				$capture_url = esc_url_raw( $link['href'] );
+				break;
+			}
+		}
+
+		$gateway = WC()->payment_gateways()->payment_gateways()['paypal'];
+		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
+		$paypal_request->capture_payment( $order, $capture_url );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Class WC_Gateway_Paypal_Webhook_Handler file.
+ *
+ * @package WooCommerce\Gateways
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles webhook events.
+ */
+class WC_Gateway_Paypal_Webhook_Handler {
+
+	/**
+	 * Process the webhook event.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function process_webhook( WP_REST_Request $request ) {
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
+		// TODO: Validate the webhook signature.
+
+		$data = $request->get_json_params();
+		WC_Gateway_Paypal::log( 'Webhook received: ' . wc_print_r( $data, true ) );
+
+		switch ( $data['event_type'] ) {
+			case 'CHECKOUT.ORDER.APPROVED':
+				$this->process_checkout_order_approved( $data );
+				break;
+			default:
+				WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
+				break;
+		}
+	}
+
+	/**
+	 * Process the CHECKOUT.ORDER.APPROVED webhook event.
+	 *
+	 * @param array $event The webhook event data.
+	 */
+	private function process_checkout_order_approved( $event ) {
+		$custom_id = $event['resource']['purchase_units'][0]['custom_id'];
+		$order     = $this->get_wc_order( $custom_id );
+		if ( ! $order ) {
+			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
+
+		$status          = $event['resource']['status'] ?? null;
+		$paypal_order_id = $event['resource']['id'] ?? null;
+		if ( 'APPROVED' === $status ) {
+			WC_Gateway_Paypal::log( 'PayPal payment approved. Order ID: ' . $order->get_id() );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID */
+					__( 'PayPal payment approved. PayPal Order ID: %1$s', 'woocommerce' ),
+					$paypal_order_id
+				)
+			);
+
+			// phpcs:disable Generic.Commenting.Todo.TaskFound
+			// TODO: Capture the payment.
+
+		} else {
+			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
+			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: PayPal order ID, %2$s: Status */
+					__( 'PayPal payment approval failed. PayPal Order ID: %1$s. Status: %2$s', 'woocommerce' ),
+					$paypal_order_id,
+					$status
+				)
+			);
+		}
+	}
+
+	/**
+	 * Get the WC order from the custom ID.
+	 *
+	 * @param string $custom_id The custom ID string from the PayPal order.
+	 * @return WC_Order|null
+	 */
+	private function get_wc_order( $custom_id ) {
+		$data     = json_decode( $custom_id );
+		$order_id = $data->order_id ?? null;
+		if ( ! $order_id ) {
+			return null;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return null;
+		}
+
+		// Validate the order key.
+		$order_key = $data->order_key ?? null;
+		if ( $order_key !== $order->get_order_key() ) {
+			return null;
+		}
+
+		return $order;
+	}
+}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -97,8 +97,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			return;
 		}
 
-		$order->payment_complete();
 		$order->set_transaction_id( $event['resource']['id'] );
+		$order->payment_complete();
 		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
 		$order->save();
 	}
@@ -145,7 +145,12 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			}
 		}
 
-		$gateway = WC()->payment_gateways()->payment_gateways()['paypal'];
+		$payment_gateways = WC()->payment_gateways()->payment_gateways();
+		if ( ! isset( $payment_gateways['paypal'] ) ) {
+			WC_Gateway_Paypal::log( 'PayPal gateway is not available.' );
+			return;
+		}
+		$gateway = $payment_gateways['paypal'];
 		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
 		$paypal_request->capture_payment( $order, $capture_url );
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -34,6 +34,9 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			case 'CHECKOUT.ORDER.APPROVED':
 				$this->process_checkout_order_approved( $data );
 				break;
+			case 'PAYMENT.CAPTURE.COMPLETED':
+				$this->process_payment_capture_completed( $data );
+				break;
 			default:
 				WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
 				break;
@@ -79,6 +82,25 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Process the PAYMENT.CAPTURE.COMPLETED webhook event.
+	 *
+	 * @param array $event The webhook event data.
+	 */
+	private function process_payment_capture_completed( $event ) {
+		$custom_id = $event['resource']['custom_id'];
+		$order     = $this->get_wc_order( $custom_id );
+		if ( ! $order ) {
+			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
+
+		$order->payment_complete();
+		$order->set_transaction_id( $event['resource']['id'] );
+		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
+		$order->save();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -137,7 +137,6 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @param array    $links The links from the webhook event.
 	 */
 	private function schedule_payment_capture( $order, $links ) {
-		// Find capture URL
 		$capture_url = null;
 		foreach ( $links as $link ) {
 			if ( 'capture' === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
@@ -151,9 +150,9 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			return;
 		}
 
-		// Schedule background job.
+		// Schedule a background job to capture the payment.
 		WC()->queue()->schedule_single(
-			time() + 10, // Capture in 10 seconds
+			time() + 10, // Capture in 10 seconds.
 			'woocommerce_paypal_capture_payment',
 			array(
 				'order_id'    => $order->get_id(),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -5,32 +5,39 @@
  * @package WooCommerce\Classes\Payment
  */
 
+declare(strict_types=1);
+
 use Automattic\WooCommerce\Utilities\LoggingUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-return array(
-	'enabled'               => array(
+// Include the helper if the class is not already loaded.
+if ( ! class_exists( 'WC_Gateway_PayPal_Helper' ) ) {
+	require_once __DIR__ . '/class-wc-gateway-paypal-helper.php';
+}
+
+$settings = array(
+	'enabled'          => array(
 		'title'   => __( 'Enable/Disable', 'woocommerce' ),
 		'type'    => 'checkbox',
 		'label'   => __( 'Enable PayPal Standard', 'woocommerce' ),
 		'default' => 'no',
 	),
-	'title'                 => array(
+	'title'            => array(
 		'title'       => __( 'Title', 'woocommerce' ),
 		'type'        => 'safe_text',
 		'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 		'default'     => __( 'PayPal', 'woocommerce' ),
 		'desc_tip'    => true,
 	),
-	'description'           => array(
+	'description'      => array(
 		'title'       => __( 'Description', 'woocommerce' ),
 		'type'        => 'text',
 		'desc_tip'    => true,
 		'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce' ),
 		'default'     => __( "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.", 'woocommerce' ),
 	),
-	'email'                 => array(
+	'email'            => array(
 		'title'       => __( 'PayPal email', 'woocommerce' ),
 		'type'        => 'email',
 		'description' => __( 'Please enter your PayPal email address; this is needed in order to take payment.', 'woocommerce' ),
@@ -38,12 +45,12 @@ return array(
 		'desc_tip'    => true,
 		'placeholder' => 'you@youremail.com',
 	),
-	'advanced'              => array(
+	'advanced'         => array(
 		'title'       => __( 'Advanced options', 'woocommerce' ),
 		'type'        => 'title',
 		'description' => '',
 	),
-	'testmode'              => array(
+	'testmode'         => array(
 		'title'       => __( 'PayPal sandbox', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable PayPal sandbox', 'woocommerce' ),
@@ -51,7 +58,7 @@ return array(
 		/* translators: %s: URL */
 		'description' => sprintf( __( 'PayPal sandbox can be used to test payments. Sign up for a <a href="%s">developer account</a>.', 'woocommerce' ), 'https://developer.paypal.com/' ),
 	),
-	'debug'                 => array(
+	'debug'            => array(
 		'title'       => __( 'Debug log', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable logging', 'woocommerce' ),
@@ -63,14 +70,14 @@ return array(
 			esc_url( LoggingUtil::get_logs_tab_url() )
 		),
 	),
-	'ipn_notification'      => array(
+	'ipn_notification' => array(
 		'title'       => __( 'IPN email notifications', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
 		'default'     => 'yes',
 		'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
 	),
-	'receiver_email'        => array(
+	'receiver_email'   => array(
 		'title'       => __( 'Receiver email', 'woocommerce' ),
 		'type'        => 'email',
 		'description' => __( 'If your main PayPal email differs from the PayPal email entered above, input your main receiver email for your PayPal account here. This is used to validate IPN requests.', 'woocommerce' ),
@@ -78,7 +85,7 @@ return array(
 		'desc_tip'    => true,
 		'placeholder' => 'you@youremail.com',
 	),
-	'identity_token'        => array(
+	'identity_token'   => array(
 		'title'       => __( 'PayPal identity token', 'woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Optionally enable "Payment Data Transfer" (Profile > Profile and Settings > My Selling Tools > Website Preferences) and then copy your identity token here. This will allow payments to be verified without the need for PayPal IPN.', 'woocommerce' ),
@@ -86,28 +93,28 @@ return array(
 		'desc_tip'    => true,
 		'placeholder' => '',
 	),
-	'invoice_prefix'        => array(
+	'invoice_prefix'   => array(
 		'title'       => __( 'Invoice prefix', 'woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Please enter a prefix for your invoice numbers. If you use your PayPal account for multiple stores ensure this prefix is unique as PayPal will not allow orders with the same invoice number.', 'woocommerce' ),
 		'default'     => 'WC-',
 		'desc_tip'    => true,
 	),
-	'send_shipping'         => array(
+	'send_shipping'    => array(
 		'title'       => __( 'Shipping details', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Send shipping details to PayPal instead of billing.', 'woocommerce' ),
 		'description' => __( 'PayPal allows us to send one address. If you are using PayPal for shipping labels you may prefer to send the shipping address rather than billing. Turning this option off may prevent PayPal Seller protection from applying.', 'woocommerce' ),
 		'default'     => 'yes',
 	),
-	'address_override'      => array(
+	'address_override' => array(
 		'title'       => __( 'Address override', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable "address_override" to prevent address information from being changed.', 'woocommerce' ),
 		'description' => __( 'PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
 		'default'     => 'no',
 	),
-	'paymentaction'         => array(
+	'paymentaction'    => array(
 		'title'       => __( 'Payment action', 'woocommerce' ),
 		'type'        => 'select',
 		'class'       => 'wc-enhanced-select',
@@ -119,7 +126,7 @@ return array(
 			'authorization' => __( 'Authorize', 'woocommerce' ),
 		),
 	),
-	'image_url'             => array(
+	'image_url'        => array(
 		'title'       => __( 'Image url', 'woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Optionally enter the URL to a 150x50px image displayed as your logo in the upper left corner of the PayPal checkout pages.', 'woocommerce' ),
@@ -127,58 +134,66 @@ return array(
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
 	),
-	'api_details'           => array(
-		'title'       => __( 'API credentials', 'woocommerce' ),
-		'type'        => 'title',
-		/* translators: %s: URL */
-		'description' => sprintf( __( 'Enter your PayPal API credentials to process refunds via PayPal. Learn how to access your <a href="%s">PayPal API Credentials</a>.', 'woocommerce' ), 'https://developer.paypal.com/webapps/developer/docs/classic/api/apiCredentials/#create-an-api-signature' ),
-	),
-	'api_username'          => array(
-		'title'       => __( 'Live API username', 'woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-	'api_password'          => array(
-		'title'       => __( 'Live API password', 'woocommerce' ),
-		'type'        => 'password',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-	'api_signature'         => array(
-		'title'       => __( 'Live API signature', 'woocommerce' ),
-		'type'        => 'password',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-	'sandbox_api_username'  => array(
-		'title'       => __( 'Sandbox API username', 'woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-	'sandbox_api_password'  => array(
-		'title'       => __( 'Sandbox API password', 'woocommerce' ),
-		'type'        => 'password',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-	'sandbox_api_signature' => array(
-		'title'       => __( 'Sandbox API signature', 'woocommerce' ),
-		'type'        => 'password',
-		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
 );
+
+if ( ! WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
+	$api_settings = array(
+		'api_details'           => array(
+			'title'       => __( 'API credentials', 'woocommerce' ),
+			'type'        => 'title',
+			/* translators: %s: URL */
+			'description' => sprintf( __( 'Enter your PayPal API credentials to process refunds via PayPal. Learn how to access your <a href="%s">PayPal API Credentials</a>.', 'woocommerce' ), 'https://developer.paypal.com/webapps/developer/docs/classic/api/apiCredentials/#create-an-api-signature' ),
+		),
+		'api_username'          => array(
+			'title'       => __( 'Live API username', 'woocommerce' ),
+			'type'        => 'text',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+		'api_password'          => array(
+			'title'       => __( 'Live API password', 'woocommerce' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+		'api_signature'         => array(
+			'title'       => __( 'Live API signature', 'woocommerce' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+		'sandbox_api_username'  => array(
+			'title'       => __( 'Sandbox API username', 'woocommerce' ),
+			'type'        => 'text',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+		'sandbox_api_password'  => array(
+			'title'       => __( 'Sandbox API password', 'woocommerce' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+		'sandbox_api_signature' => array(
+			'title'       => __( 'Sandbox API signature', 'woocommerce' ),
+			'type'        => 'password',
+			'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+	);
+	$settings     = array_merge( $settings, $api_settings );
+}
+
+return $settings;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -9,7 +9,10 @@ use Automattic\WooCommerce\Utilities\LoggingUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-return array(
+// Include the helper
+require_once __DIR__ . '/class-wc-gateway-paypal-helper.php';
+
+$settings = array(
 	'enabled'               => array(
 		'title'   => __( 'Enable/Disable', 'woocommerce' ),
 		'type'    => 'checkbox',
@@ -127,7 +130,11 @@ return array(
 		'desc_tip'    => true,
 		'placeholder' => __( 'Optional', 'woocommerce' ),
 	),
-	'api_details'           => array(
+);
+
+if ( ! WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
+	$api_settings = array(
+		'api_details'           => array(
 		'title'       => __( 'API credentials', 'woocommerce' ),
 		'type'        => 'title',
 		/* translators: %s: URL */
@@ -179,6 +186,10 @@ return array(
 		'description' => __( 'Get your API credentials from PayPal.', 'woocommerce' ),
 		'default'     => '',
 		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
-);
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
+	);
+	$settings = array_merge( $settings, $api_settings );
+}
+
+return $settings;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -1,0 +1,258 @@
+<?php
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+// phpcs:disable Generic.Commenting.Todo.TaskFound
+
+/**
+ * TODO: IMPORTANT: This controller is for testing only.
+ * TODO: REMOVE ME before merging the feature branch.
+ *
+ * REST API PayPal proxy controller
+ *
+ * Handles requests to the /paypal-proxy endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   2.6.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API PayPal proxy controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'paypal-proxy';
+
+	/**
+	 * Register the routes for the PayPal proxy.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/test-request',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'test_request' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/create-order',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_paypal_order' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/capture-payment',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'capture_payment' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * For testing the request endpoint.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function test_request( WP_REST_Request $request ) {
+		$data = $request->get_json_params();
+		error_log( '(Proxy) PayPal test request received: ' . wc_print_r( $data, true ) );
+		return new WP_REST_Response( 'Test request processed', 200 );
+	}
+
+	/**
+	 * Create a PayPal order using Orders v2 API.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function create_paypal_order( WP_REST_Request $request ) {
+		$request_data = $request->get_json_params();
+		error_log( '(Proxy) PayPal create order request received: ' . wc_print_r( $request_data, true ) );
+
+		$access_token = $this->get_paypal_access_token();
+		if ( ! $access_token ) {
+			error_log( '(Proxy) Failed to get PayPal access token.' );
+			return new WP_REST_Response(
+				array( 'error' => 'Failed to get PayPal access token.' ),
+				500
+			);
+		}
+
+		$args = array(
+			'method'    => 'POST',
+			'headers'   => array(
+				'Content-Type'      => 'application/json',
+				'Authorization'     => 'Bearer ' . $access_token,
+				'PayPal-Request-Id' => uniqid(), // A unique ID for idempotency (recommended by PayPal).
+			),
+			'body'      => wp_json_encode( $request_data ),
+			'timeout'   => 45, // TODO: Set a timeout.
+			'sslverify' => false, // TODO: Set sslverify.
+		);
+
+		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $args, true ) );
+
+		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/checkout/orders', $args );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$body          = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal order creation response: ' . wc_print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+				200
+			);
+		} else {
+			error_log( '(Proxy) Create order request failed: ' . wc_print_r( $response_data, true ) );
+			return new WP_REST_Response(
+				array(
+					'error' => 'Order creation failed.',
+					'data'  => $response_data,
+				),
+				500
+			);
+		}
+	}
+
+	/**
+	 * Capture the PayPal payment using Orders v2 API.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function capture_payment( WP_REST_Request $request ) {
+		$request_data = $request->get_json_params();
+		error_log( '(Proxy) PayPal capture payment request received: ' . wc_print_r( $request_data, true ) );
+
+		$access_token = $this->get_paypal_access_token();
+		if ( ! $access_token ) {
+			error_log( '(Proxy) Failed to get PayPal access token. Cannot capture payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Failed to get PayPal access token.',
+				),
+				500
+			);
+		}
+
+		if ( empty( $request_data['capture_url'] ) || empty( $request_data['paypal_order_id'] ) ) {
+			error_log( '(Proxy) Capture URL or PayPal order ID missing. Cannot capture payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Capture URL or PayPal order ID missing.',
+				),
+				400
+			);
+		}
+
+		$capture_url     = $request_data['capture_url'];
+		$paypal_order_id = $request_data['paypal_order_id'];
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => array(
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+			),
+			'body'    => wp_json_encode( array( 'id' => $paypal_order_id ) ),
+		);
+
+		$response      = wp_remote_post( $capture_url, $args );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$body          = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal capture payment response: ' . wc_print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+				200
+			);
+		} else {
+			error_log( '(Proxy) Failed to capture PayPal order. ' . wc_print_r( $response_data, true ) );
+			return new WP_REST_Response(
+				$response_data,
+				500
+			);
+		}
+	}
+
+	/**
+	 * Get the PayPal API access token.
+	 *
+	 * @return string|null The access token.
+	 */
+	private function get_paypal_access_token() {
+		$paypal_client_id     = get_option( 'wc_paypal_api_client_id' );
+		$paypal_client_secret = get_option( 'wc_paypal_api_client_secret' );
+
+		if ( ! $paypal_client_id || ! $paypal_client_secret ) {
+			error_log( '(Proxy) PayPal client ID or secret not found. Cannot get access token.' );
+			return null;
+		}
+
+		$args = array(
+			'method'    => 'POST',
+			'headers'   => array(
+				'Content-Type'  => 'application/x-www-form-urlencoded',
+				'Authorization' => 'Basic ' . base64_encode( $paypal_client_id . ':' . $paypal_client_secret ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			),
+			'body'      => 'grant_type=client_credentials',
+			'timeout'   => 45, // TODO: Set a timeout.
+			'sslverify' => false, // TODO: Set sslverify.
+		);
+		error_log( '(Proxy) PayPal access token request: ' . wc_print_r( $args, true ) );
+
+		$response  = wp_remote_post( 'https://api-m.sandbox.paypal.com/v1/oauth2/token', $args );
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body      = wp_remote_retrieve_body( $response );
+		$data      = json_decode( $body, true );
+
+		// Check if the request was successful (HTTP 200 OK) and access token exists.
+		if ( 200 === $http_code && isset( $data['access_token'] ) ) {
+			error_log( '(Proxy) PayPal access token request successful.' );
+			return $data['access_token'];
+		} else {
+			error_log( '(Proxy) Failed to get PayPal access token. ' . wc_print_r( $data, true ) );
+			return null;
+		}
+	}
+}
+
+/**
+ * TODO: IMPORTANT: This controller is for testing only.
+ * TODO: REMOVE ME before merging the feature branch.
+ */

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -91,6 +91,12 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 	public function process_webhook( WP_REST_Request $request ) {
 		include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
 		$webhook_handler = new WC_Gateway_Paypal_Webhook_Handler();
-		$webhook_handler->process_webhook( $request );
+
+		try {
+			$webhook_handler->process_webhook( $request );
+			return new WP_REST_Response( array( 'message' => 'Webhook processed successfully' ), 200 );
+		} catch ( Exception $e ) {
+			return new WP_REST_Response( array( 'error' => $e->getMessage() ), 500 );
+		}
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -26,7 +26,7 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 	 */
 	protected $namespace = 'wc/v3';
 
-    /**
+	/**
 	 * Route base.
 	 *
 	 * @var string
@@ -35,10 +35,12 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 
 	/**
 	 * Register the routes for the PayPal webhook handler.
+	 *
+	 * @return void
 	 */
 	public function register_routes() {
-        // TODO: Remove me before merging the feature branch.
-        // GET /v3/paypal-webhooks/test-webhook
+		// TODO: Remove me before merging the feature branch.
+		// GET /v3/paypal-webhooks/test-webhook.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/test-webhook',
@@ -51,33 +53,40 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 			)
 		);
 
-        // POST /v3/paypal-webhooks
-        register_rest_route(
-            $this->namespace,
-            '/' . $this->rest_base,
-            array(
-                'methods'             => WP_REST_Server::CREATABLE,
-                'callback'            => array( $this, 'handle_paypal_webhook' ),
-                'permission_callback' => array( $this, 'get_permission' ),
-            )
-        );
+		// POST /v3/paypal-webhooks.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_paypal_webhook' ),
+				'permission_callback' => '__return_true',
+			)
+		);
 	}
 
-    // TODO: Remove me before merging the feature branch.
-    public function test_webhook( WP_REST_Request $request ) {
-        $data = $request->get_json_params();
-        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
-        return new WP_REST_Response( 'Test webhook processed', 200 );
-    }
+	/**
+	 * Test the webhook.
+	 * TODO: Remove me before merging the feature branch.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function test_webhook( WP_REST_Request $request ) {
+		$data = $request->get_json_params();
+		error_log( 'PayPal test webhook received: ' . wc_print_r( $data, true ) );
+		return new WP_REST_Response( 'Test webhook processed', 200 );
+	}
 
-    private function get_permission() {
-        // TODO: Should we check if the webhook is coming from wpcom?
-        return true;
-    }
-
-    public function process_webhook( WP_REST_Request $request ) {
-        include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
-        $webhook_handler = new WC_Gateway_Paypal_Webhook_Handler();
-        $webhook_handler->process_webhook( $request );
-    }
+	/**
+	 * Process the webhook.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return void
+	 */
+	public function process_webhook( WP_REST_Request $request ) {
+		include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
+		$webhook_handler = new WC_Gateway_Paypal_Webhook_Handler();
+		$webhook_handler->process_webhook( $request );
+	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * REST API PayPal webhooks controller
+ *
+ * Handles requests to the /paypal-webhooks endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   2.6.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API PayPal webhook handler controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+    /**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'paypal-webhooks';
+
+	/**
+	 * Register the routes for the PayPal webhook handler.
+	 */
+	public function register_routes() {
+        // TODO: Remove me before merging the feature branch.
+        // GET /v3/paypal-webhooks/test-webhook
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/test-webhook',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'test_webhook' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+        // POST /v3/paypal-webhooks
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'handle_paypal_webhook' ),
+                'permission_callback' => array( $this, 'get_permission' ),
+            )
+        );
+	}
+
+    // TODO: Remove me before merging the feature branch.
+    public function test_webhook( WP_REST_Request $request ) {
+        $data = $request->get_json_params();
+        error_log( 'PayPal test webhook received: ' . print_r( $data, true ) );
+        return new WP_REST_Response( 'Test webhook processed', 200 );
+    }
+
+    private function get_permission() {
+        // TODO: Should we check if the webhook is coming from wpcom?
+        return true;
+    }
+
+    public function process_webhook( WP_REST_Request $request ) {
+        include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
+        $webhook_handler = new WC_Gateway_Paypal_Webhook_Handler();
+        $webhook_handler->process_webhook( $request );
+    }
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ *
+ * REST API PayPal webhooks controller
+ *
+ * Handles requests to the /paypal-webhooks endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   2.6.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API PayPal webhook handler controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'paypal-webhooks';
+
+	/**
+	 * Register the routes for the PayPal webhook handler.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
+		// TODO: Remove me before merging the feature branch.
+		// GET /v3/paypal-webhooks/test-webhook.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/test-webhook',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'test_webhook' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+		// POST /v3/paypal-webhooks.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'process_webhook' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Test the webhook.
+	 *
+	 * phpcs:disable Generic.Commenting.Todo.TaskFound
+	 * TODO: Remove me before merging the feature branch.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function test_webhook( WP_REST_Request $request ) {
+		$data = $request->get_json_params();
+		return new WP_REST_Response( 'Test webhook processed', 200 );
+	}
+
+	/**
+	 * Process the webhook.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function process_webhook( WP_REST_Request $request ) {
+		include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';
+		$webhook_handler = new WC_Gateway_Paypal_Webhook_Handler();
+
+		try {
+			$webhook_handler->process_webhook( $request );
+			return new WP_REST_Response( array( 'message' => 'Webhook processed successfully' ), 200 );
+		} catch ( Exception $e ) {
+			return new WP_REST_Response( array( 'error' => $e->getMessage() ), 500 );
+		}
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -59,7 +59,7 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'handle_paypal_webhook' ),
+				'callback'            => array( $this, 'process_webhook' ),
 				'permission_callback' => '__return_true',
 			)
 		);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -9,6 +9,8 @@
  * @since   2.6.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -39,6 +41,7 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 	 * @return void
 	 */
 	public function register_routes() {
+		// phpcs:disable Generic.Commenting.Todo.TaskFound
 		// TODO: Remove me before merging the feature branch.
 		// GET /v3/paypal-webhooks/test-webhook.
 		register_rest_route(
@@ -67,6 +70,8 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 
 	/**
 	 * Test the webhook.
+	 *
+	 * phpcs:disable Generic.Commenting.Todo.TaskFound
 	 * TODO: Remove me before merging the feature branch.
 	 *
 	 * @param WP_REST_Request $request The request object.
@@ -74,7 +79,6 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 	 */
 	public function test_webhook( WP_REST_Request $request ) {
 		$data = $request->get_json_params();
-		error_log( 'PayPal test webhook received: ' . wc_print_r( $data, true ) );
 		return new WP_REST_Response( 'Test webhook processed', 200 );
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-controller.php
@@ -86,7 +86,7 @@ class WC_REST_Paypal_Webhooks_Controller extends WC_REST_Controller {
 	 * Process the webhook.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return void
+	 * @return WP_REST_Response The response object.
 	 */
 	public function process_webhook( WP_REST_Request $request ) {
 		include_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php';

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
@@ -1,0 +1,175 @@
+<?php
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+// phpcs:disable Generic.Commenting.Todo.TaskFound
+
+/**
+ * TODO: IMPORTANT: This controller is for testing only.
+ * TODO: REMOVE ME before merging the feature branch.
+ *
+ * REST API PayPal webhooks proxy controller
+ *
+ * Handles requests to the /paypal-webhooks-proxy endpoint.
+ *
+ * @package WooCommerce\RestApi
+ * @since   2.6.0
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API PayPal webhooks proxy controller class.
+ *
+ * @package WooCommerce\RestApi
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'paypal-webhooks-proxy';
+
+	/**
+	 * Register the routes for the PayPal proxy.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/test-webhook',
+			array(
+				array(
+					'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::CREATABLE ),
+					'callback'            => array( $this, 'test_webhook' ),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/webhook',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'process_webhook' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Test the webhook.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function test_webhook( WP_REST_Request $request ) {
+		$data = $request->get_json_params();
+		error_log( 'PayPal test webhook received: ' . wc_print_r( $data, true ) );
+		return new WP_REST_Response( 'Test webhook processed', 200 );
+	}
+
+	/**
+	 * Handle webhook events from PayPal.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function process_webhook( WP_REST_Request $request ) {
+		// TODO: Validate the webhook signature.
+		// https://developer.paypal.com/api/rest/webhooks/rest/#link-messageverification.
+
+		$data = $request->get_json_params();
+		error_log( '(Proxy) PayPal webhook received: ' . wc_print_r( $data, true ) );
+
+		switch ( $data['event_type'] ) {
+			case 'CHECKOUT.ORDER.APPROVED':
+				$custom_client_data = $data['resource']['purchase_units'][0]['custom_id'];
+				$client_endpoint    = $this->get_client_webhook_endpoint( $custom_client_data );
+
+				if ( ! $client_endpoint ) {
+					error_log( 'No client webhook endpoint found' );
+					return new WP_REST_Response( 'No client webhook endpoint found', 400 );
+				}
+
+				$response = $this->forward_webhook_to_client( $client_endpoint, $data );
+				if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+					error_log( 'Webhook forwarding failed: ' . wc_print_r( $response, true ) );
+					return new WP_REST_Response( 'Webhook forwarding failed', 500 );
+				}
+				break;
+			case 'PAYMENT.CAPTURE.COMPLETED':
+				$custom_client_data = $data['resource']['custom_id'];
+				$client_endpoint    = $this->get_client_webhook_endpoint( $custom_client_data );
+
+				if ( ! $client_endpoint ) {
+					error_log( 'No client webhook endpoint found' );
+					return new WP_REST_Response( 'No client webhook endpoint found', 400 );
+				}
+
+				$response = $this->forward_webhook_to_client( $client_endpoint, $data );
+				if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+					error_log( 'Webhook forwarding failed: ' . wc_print_r( $response, true ) );
+					return new WP_REST_Response( 'Webhook forwarding failed', 500 );
+				}
+
+				break;
+			default:
+				error_log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
+				break;
+		}
+
+		return new WP_REST_Response( 'Webhook processed', 200 );
+	}
+
+	/**
+	 * Get the client webhook endpoint from the custom data.
+	 *
+	 * @param string $custom_client_data The custom data.
+	 * @return string|null The client webhook endpoint.
+	 */
+	private function get_client_webhook_endpoint( $custom_client_data ) {
+		$data     = json_decode( $custom_client_data );
+		$endpoint = $data->endpoint ?? null;
+
+		if ( ! $endpoint || ! wp_http_validate_url( $endpoint ) ) {
+			error_log( 'Invalid client webhook endpoint: ' . $endpoint );
+			return null;
+		}
+
+		return $endpoint;
+	}
+
+	/**
+	 * Forward the webhook to the client.
+	 *
+	 * @param string $client_endpoint The client webhook endpoint.
+	 * @param array  $data The webhook data.
+	 * @return WP_REST_Response The response object.
+	 */
+	private function forward_webhook_to_client( $client_endpoint, $data ) {
+		error_log( 'Forwarding webhook to client: ' . $client_endpoint );
+
+		// Forward the webhook to the client.
+		$request = WP_REST_Request::from_url( $client_endpoint );
+		$request->set_method( 'POST' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $data ) );
+		return rest_do_request( $request );
+	}
+}
+
+/**
+ * TODO: IMPORTANT: This controller is for testing only.
+ * TODO: REMOVE ME before merging the feature branch.
+ */

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -200,6 +200,7 @@ class Server {
 			// phpcs:ignore Generic.Commenting.Todo.TaskFound
 			// TODO: IMPORTANT Remove me before merging the feature branch.
 			'paypal-webhooks-proxy'    => 'WC_REST_Paypal_Webhooks_Proxy_Controller',
+			'paypal-webhooks'          => 'WC_REST_Paypal_Webhooks_Controller',
 		);
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -194,6 +194,12 @@ class Server {
 			'data-continents'          => 'WC_REST_Data_Continents_Controller',
 			'data-countries'           => 'WC_REST_Data_Countries_Controller',
 			'data-currencies'          => 'WC_REST_Data_Currencies_Controller',
+			// phpcs:ignore Generic.Commenting.Todo.TaskFound
+			// TODO: IMPORTANT Remove me before merging the feature branch.
+			'paypal-proxy'             => 'WC_REST_Paypal_Proxy_Controller',
+			// phpcs:ignore Generic.Commenting.Todo.TaskFound
+			// TODO: IMPORTANT Remove me before merging the feature branch.
+			'paypal-webhooks-proxy'    => 'WC_REST_Paypal_Webhooks_Proxy_Controller',
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Unit tests for WC_Gateway_Paypal_Request class.
+ *
+ * @package WooCommerce\Tests\Paypal.
+ */
+
+declare(strict_types=1);
+
+require_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php';
+
+/**
+ * Class WC_Gateway_Paypal_Test.
+ */
+class WC_Gateway_Paypal_Request_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test create_paypal_order when API returns error.
+	 */
+	public function test_create_paypal_order_error() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		add_filter( 'pre_http_request', array( $this, 'create_paypal_order_error' ), 10, 2 );
+
+		$request = new WC_Gateway_Paypal_Request( new WC_Gateway_Paypal() );
+		$result  = $request->create_paypal_order( $order );
+
+		remove_filter( 'pre_http_request', array( $this, 'create_paypal_order_error' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test create_paypal_order when API returns success.
+	 */
+	public function test_create_paypal_order_success() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		add_filter( 'pre_http_request', array( $this, 'create_paypal_order_success' ), 10, 2 );
+
+		$request = new WC_Gateway_Paypal_Request( new WC_Gateway_Paypal() );
+		$result  = $request->create_paypal_order( $order );
+
+		remove_filter( 'pre_http_request', array( $this, 'create_paypal_order_success' ) );
+
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'redirect_url', $result );
+	}
+
+	/**
+	 * Test that the create_paypal_order params are correct.
+	 */
+	public function test_create_paypal_order_params_are_correct() {
+		$order = WC_Helper_Order::create_order();
+		$order->add_product( WC_Helper_Product::create_simple_product(), 2 );
+		$order->set_shipping_total( 10 );
+		$order->set_total( 40 );
+		$order->set_currency( 'USD' );
+		$order->save();
+
+		$item = current( $order->get_items() );
+		$item->set_total_tax( 10 );
+		$item->save();
+
+		add_filter( 'pre_http_request', array( $this, 'check_create_paypal_order_params' ), 10, 2 );
+
+		$request = new WC_Gateway_Paypal_Request( new WC_Gateway_Paypal() );
+		$result  = $request->create_paypal_order( $order );
+
+		remove_filter( 'pre_http_request', array( $this, 'check_create_paypal_order_params' ) );
+	}
+
+	/**
+	 * Check that the create_paypal_order params are correct.
+	 *
+	 * @param bool  $value      Original value.
+	 * @param array $parsed_args Parsed arguments.
+	 *
+	 * @return array Return a 200 response.
+	 */
+	public function check_create_paypal_order_params( $value, $parsed_args ) {
+		$this->assertEquals( 'application/json', $parsed_args['headers']['Content-Type'] );
+		$this->assertEquals( 'POST', $parsed_args['method'] );
+		$body = json_decode( $parsed_args['body'], true );
+		$this->assertEquals( 'CAPTURE', $body['intent'] );
+
+		$purchase_unit = $body['purchase_units'][0];
+		$this->assertEquals( '40.00', $purchase_unit['amount']['value'] );
+		$this->assertEquals( 'USD', $purchase_unit['amount']['currency_code'] );
+		$this->assertEquals( 'USD', $purchase_unit['amount']['breakdown']['item_total']['currency_code'] );
+		$this->assertEquals( 'USD', $purchase_unit['amount']['breakdown']['shipping']['currency_code'] );
+		$this->assertEquals( 'USD', $purchase_unit['amount']['breakdown']['tax_total']['currency_code'] );
+		$this->assertEquals( '20.00', $purchase_unit['amount']['breakdown']['item_total']['value'] );
+		$this->assertEquals( '10.00', $purchase_unit['amount']['breakdown']['shipping']['value'] );
+		$this->assertEquals( '10.00', $purchase_unit['amount']['breakdown']['tax_total']['value'] );
+
+		$items = $purchase_unit['items'];
+		$this->assertEquals( 'Dummy Product', $items[0]['name'] );
+		$this->assertEquals( '2', $items[0]['quantity'] );
+		$this->assertEquals( '20.00', $items[0]['unit_amount']['value'] );
+		$this->assertEquals( 'USD', $items[0]['unit_amount']['currency_code'] );
+
+		$this->assertArrayHasKey( 'return_url', $body['application_context'] );
+		$this->assertArrayHasKey( 'cancel_url', $body['application_context'] );
+
+		$custom_id = json_decode( $body['purchase_units'][0]['custom_id'], true );
+		$this->assertEquals( $order->get_id(), $custom_id['order_id'] );
+		$this->assertEquals( $order->get_order_key(), $custom_id['order_key'] );
+		$this->assertHasKey( 'endpoint', $custom_id );
+
+		return $this->create_paypal_order_success( $value, $parsed_args );
+	}
+
+	/**
+	 * Helper function for creating PayPal order success response.
+	 *
+	 * @param bool  $value      Original pre-value, likely to be false.
+	 * @param array $parsed_url Parsed URL object.
+	 *
+	 * @return array Return a 200 response.
+	 */
+	public function create_paypal_order_success( $value, $parsed_url ) {
+		return array(
+			'response' => array(
+				'code' => 200,
+			),
+			'body'     => wp_json_encode(
+				array(
+					'id'    => '123',
+					'links' => array(
+						array(
+							'rel'    => 'approve',
+							'href'   => 'https://www.paypal.com/checkoutnow?token=123',
+							'method' => 'GET',
+						),
+					),
+				)
+			),
+		);
+	}
+
+	/**
+	 * Helper function for creating PayPal order error response.
+	 *
+	 * @param bool  $value      Original pre-value, likely to be false.
+	 * @param array $parsed_url Parsed URL object.
+	 *
+	 * @return array Return a 500 error response.
+	 */
+	public function create_paypal_order_error( $value, $parsed_url ) {
+		// Return a 500 error.
+		return array( 'response' => array( 'code' => 500 ) );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR implements the asynchronous payment capture. In first iteration, we sent the capture request synchronously during the approval webhook processing. In cases of failed capture requests, this may end up sending an unsuccessful response for the webhook request. And also might delay the webhook response to PayPal. To avoid these scenarios, this PR implements the capture via an asynchronous job.

1. At first, it retrieved the URL for payment capture from the payment approval webhook event.
2. Then it schedules a job to capture the payment asynchronously.
3. Registers a callback to send the request to capture the payment.

Iteration on PAYPAL-31
Closes PAYPAL-45

### How to test the changes in this Pull Request:
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Configure PayPal Standard's setting:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- For Payment action, select Capture
5. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
```
6. As a shopper, add a product to cart and go to checkout.
7. You should see PayPal as a payment option.
8. Click "Proceed to PayPal".
9. Use your Personal sandbox account credentials to log in and approve the purchase.
10. You should get redirected to the "Order Confirmation" page.
11. Wait a few seconds, and go to the wp-admin order page.
12. There should be an order note about payment capture.
13. The order's status should be "Processing". (or "Completed" for digital products )
14. In the order details section, the transaction ID should be linked. 
15. Click the transaction ID. It should take you to the PayPal transaction page.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
