### PR TITLE
Fix fatal errors from email style sync with some themes

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5126-fatal-errors-from-email-style-sync-with-some-themes
+++ b/plugins/woocommerce/changelog/wooplug-5126-fatal-errors-from-email-style-sync-with-some-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error in email style sync in themes using refs in global styles colors

--- a/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-slotfill.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-email/settings-email-color-palette-slotfill.tsx
@@ -63,11 +63,11 @@ export const registerSettingsEmailColorPaletteFill = () => {
 	let defaultColors = {} as DefaultColors;
 	try {
 		const {
-			base_color_default: baseColor,
-			bg_color_default: bgColor,
-			body_bg_color_default: bodyBgColor,
-			body_text_color_default: bodyTextColor,
-			footer_text_color_default: footerTextColor,
+			base: baseColor,
+			bg: bgColor,
+			body_bg: bodyBgColor,
+			body_text: bodyTextColor,
+			footer_text: footerTextColor,
 		} = JSON.parse( defaultColorsData || '' );
 		defaultColors = {
 			baseColor,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -84,13 +84,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$email_improvements_enabled = $this->get_email_improvements_enabled();
 
 		// These defaults should be chosen by the same logic as the other color option properties.
-		list(
-			'base_color_default' => $base_color_default,
-			'bg_color_default' => $bg_color_default,
-			'body_bg_color_default' => $body_bg_color_default,
-			'body_text_color_default' => $body_text_color_default,
-			'footer_text_color_default' => $footer_text_color_default,
-		) = EmailColors::get_default_colors( $email_improvements_enabled );
+		$default_colors = EmailColors::get_default_colors( $email_improvements_enabled );
 
 		if ( $block_email_editor_enabled ) {
 			$email_notifications_field = 'email_notification_block_emails';
@@ -247,11 +241,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					array(
 						'title'    => __( 'Accent', 'woocommerce' ),
 						/* translators: %s: default color */
-						'desc'     => sprintf( __( 'Customize the color of your buttons and links. Default %s.', 'woocommerce' ), '<code>' . $base_color_default . '</code>' ),
+						'desc'     => sprintf( __( 'Customize the color of your buttons and links. Default %s.', 'woocommerce' ), '<code>' . $default_colors['base'] . '</code>' ),
 						'id'       => 'woocommerce_email_base_color',
 						'type'     => 'color',
 						'css'      => 'width:6em;',
-						'default'  => $base_color_default,
+						'default'  => $default_colors['base'],
 						'autoload' => false,
 						'desc_tip' => true,
 					),
@@ -259,11 +253,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					array(
 						'title'    => __( 'Email background', 'woocommerce' ),
 						/* translators: %s: default color */
-						'desc'     => sprintf( __( 'Select a color for the background of your emails. Default %s.', 'woocommerce' ), '<code>' . $bg_color_default . '</code>' ),
+						'desc'     => sprintf( __( 'Select a color for the background of your emails. Default %s.', 'woocommerce' ), '<code>' . $default_colors['bg'] . '</code>' ),
 						'id'       => 'woocommerce_email_background_color',
 						'type'     => 'color',
 						'css'      => 'width:6em;',
-						'default'  => $bg_color_default,
+						'default'  => $default_colors['bg'],
 						'autoload' => false,
 						'desc_tip' => true,
 					),
@@ -271,11 +265,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					array(
 						'title'    => __( 'Content background', 'woocommerce' ),
 						/* translators: %s: default color */
-						'desc'     => sprintf( __( 'Choose a background color for the content area of your emails. Default %s.', 'woocommerce' ), '<code>' . $body_bg_color_default . '</code>' ),
+						'desc'     => sprintf( __( 'Choose a background color for the content area of your emails. Default %s.', 'woocommerce' ), '<code>' . $default_colors['body_bg'] . '</code>' ),
 						'id'       => 'woocommerce_email_body_background_color',
 						'type'     => 'color',
 						'css'      => 'width:6em;',
-						'default'  => $body_bg_color_default,
+						'default'  => $default_colors['body_bg'],
 						'autoload' => false,
 						'desc_tip' => true,
 					),
@@ -283,11 +277,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					array(
 						'title'    => __( 'Heading & text', 'woocommerce' ),
 						/* translators: %s: default color */
-						'desc'     => sprintf( __( 'Set the color of your headings and text. Default %s.', 'woocommerce' ), '<code>' . $body_text_color_default . '</code>' ),
+						'desc'     => sprintf( __( 'Set the color of your headings and text. Default %s.', 'woocommerce' ), '<code>' . $default_colors['body_text'] . '</code>' ),
 						'id'       => 'woocommerce_email_text_color',
 						'type'     => 'color',
 						'css'      => 'width:6em;',
-						'default'  => $body_text_color_default,
+						'default'  => $default_colors['body_text'],
 						'autoload' => false,
 						'desc_tip' => true,
 					),
@@ -295,11 +289,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					array(
 						'title'    => __( 'Secondary text', 'woocommerce' ),
 						/* translators: %s: footer default color */
-						'desc'     => sprintf( __( 'Choose a color for your secondary text, such as your footer content. Default %s.', 'woocommerce' ), '<code>' . $footer_text_color_default . '</code>' ),
+						'desc'     => sprintf( __( 'Choose a color for your secondary text, such as your footer content. Default %s.', 'woocommerce' ), '<code>' . $default_colors['footer_text'] . '</code>' ),
 						'id'       => 'woocommerce_email_footer_text_color',
 						'type'     => 'color',
 						'css'      => 'width:6em;',
-						'default'  => $footer_text_color_default,
+						'default'  => $default_colors['footer_text'],
 						'autoload' => false,
 						'desc_tip' => true,
 					),

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -27,36 +27,36 @@ class EmailColors {
 			$email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 		}
 
-		$base_color_default        = '#720eec';
-		$bg_color_default          = '#f7f7f7';
-		$body_bg_color_default     = '#ffffff';
-		$body_text_color_default   = '#3c3c3c';
-		$footer_text_color_default = '#3c3c3c';
+		$base        = '#720eec';
+		$bg          = '#f7f7f7';
+		$body_bg     = '#ffffff';
+		$body_text   = '#3c3c3c';
+		$footer_text = '#3c3c3c';
 
 		if ( $email_improvements_enabled ) {
-			$base_color_default        = '#8526ff';
-			$bg_color_default          = '#ffffff';
-			$body_bg_color_default     = '#ffffff';
-			$body_text_color_default   = '#1e1e1e';
-			$footer_text_color_default = '#787c82';
+			$base        = '#8526ff';
+			$bg          = '#ffffff';
+			$body_bg     = '#ffffff';
+			$body_text   = '#1e1e1e';
+			$footer_text = '#787c82';
 
 			$global_colors = self::get_colors_from_global_styles();
 
 			if ( $global_colors ) {
-				$base_color_default        = $global_colors['base'];
-				$bg_color_default          = $global_colors['bg'];
-				$body_bg_color_default     = $global_colors['body_bg'];
-				$body_text_color_default   = $global_colors['body_text'];
-				$footer_text_color_default = $global_colors['footer_text'];
+				$base        = $global_colors['base'];
+				$bg          = $global_colors['bg'];
+				$body_bg     = $global_colors['body_bg'];
+				$body_text   = $global_colors['body_text'];
+				$footer_text = $global_colors['footer_text'];
 			}
 		}
 
 		return compact(
-			'base_color_default',
-			'bg_color_default',
-			'body_bg_color_default',
-			'body_text_color_default',
-			'footer_text_color_default',
+			'base',
+			'bg',
+			'body_bg',
+			'body_text',
+			'footer_text',
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -40,24 +40,13 @@ class EmailColors {
 			$body_text_color_default   = '#1e1e1e';
 			$footer_text_color_default = '#787c82';
 
-			if ( wp_is_block_theme() && function_exists( 'wp_get_global_styles' ) ) {
-				$global_styles             = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
-				$base_color_global         = ! empty( $global_styles['elements']['button']['color']['background'] )
-					? sanitize_hex_color( $global_styles['elements']['button']['color']['background'] ) : '';
-				$bg_color_global           = ! empty( $global_styles['color']['background'] )
-					? sanitize_hex_color( $global_styles['color']['background'] ) : '';
-				$body_bg_color_global      = ! empty( $global_styles['color']['background'] )
-					? sanitize_hex_color( $global_styles['color']['background'] ) : '';
-				$body_text_color_global    = ! empty( $global_styles['color']['text'] )
-					? sanitize_hex_color( $global_styles['color']['text'] ) : '';
-				$footer_text_color_global  = ! empty( $global_styles['elements']['caption']['color']['text'] )
-					? sanitize_hex_color( $global_styles['elements']['caption']['color']['text'] ) : '';
-				$base_color_default        = $base_color_global ? $base_color_global : $base_color_default;
-				$bg_color_default          = $bg_color_global ? $bg_color_global : $bg_color_default;
-				$body_bg_color_default     = $body_bg_color_global ? $body_bg_color_global : $body_bg_color_default;
-				$body_text_color_default   = $body_text_color_global ? $body_text_color_global : $body_text_color_default;
-				$footer_text_color_default = $footer_text_color_global ? $footer_text_color_global : $footer_text_color_default;
-			}
+			$global_colors = self::get_colors_from_global_styles();
+
+			$base_color_default        = $global_colors['base'] ? $global_colors['base'] : $base_color_default;
+			$bg_color_default          = $global_colors['bg'] ? $global_colors['bg'] : $bg_color_default;
+			$body_bg_color_default     = $global_colors['body_bg'] ? $global_colors['body_bg'] : $body_bg_color_default;
+			$body_text_color_default   = $global_colors['body_text'] ? $global_colors['body_text'] : $body_text_color_default;
+			$footer_text_color_default = $global_colors['footer_text'] ? $global_colors['footer_text'] : $footer_text_color_default;
 		}
 
 		return compact(
@@ -66,6 +55,45 @@ class EmailColors {
 			'body_bg_color_default',
 			'body_text_color_default',
 			'footer_text_color_default',
+		);
+	}
+
+	/**
+	 * Get email colors from global styles.
+	 *
+	 * @return array Array of colors.
+	 */
+	public static function get_colors_from_global_styles() {
+		if ( ! wp_is_block_theme() || ! function_exists( 'wp_get_global_styles' ) ) {
+			return array(
+				'base'        => '',
+				'bg'          => '',
+				'body_bg'     => '',
+				'body_text'   => '',
+				'footer_text' => '',
+			);
+		}
+
+		$styles = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
+
+		$bg          = $styles['color']['background'] ?? '';
+		$body_bg     = $styles['color']['background'] ?? '';
+		$body_text   = $styles['color']['text'] ?? '';
+		$base        = $styles['elements']['button']['color']['background'] ?? '';
+		$footer_text = $styles['elements']['caption']['color']['text'] ?? '';
+
+		$bg          = is_string( $bg ) ? sanitize_hex_color( $bg ) : '';
+		$body_bg     = is_string( $body_bg ) ? sanitize_hex_color( $body_bg ) : '';
+		$body_text   = is_string( $body_text ) ? sanitize_hex_color( $body_text ) : '';
+		$base        = is_string( $base ) ? sanitize_hex_color( $base ) : '';
+		$footer_text = is_string( $footer_text ) ? sanitize_hex_color( $footer_text ) : '';
+
+		return compact(
+			'base',
+			'bg',
+			'body_bg',
+			'body_text',
+			'footer_text',
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -40,7 +40,7 @@ class EmailColors {
 			$body_text   = '#1e1e1e';
 			$footer_text = '#787c82';
 
-			$global_colors = self::get_colors_from_global_styles();
+			$global_colors = static::get_colors_from_global_styles();
 
 			if ( $global_colors ) {
 				$base        = $global_colors['base'];
@@ -66,11 +66,11 @@ class EmailColors {
 	 * @return array|null Array of colors or null if global styles are not available or complete.
 	 */
 	public static function get_colors_from_global_styles() {
-		if ( ! wp_is_block_theme() || ! function_exists( 'wp_get_global_styles' ) ) {
+		if ( ! static::wp_is_block_theme() || ! static::function_exists( 'wp_get_global_styles' ) ) {
 			return null;
 		}
 
-		$styles = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
+		$styles = static::wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
 
 		$bg          = $styles['color']['background'] ?? null;
 		$body_bg     = $styles['color']['background'] ?? null;
@@ -96,5 +96,35 @@ class EmailColors {
 			'body_text',
 			'footer_text',
 		);
+	}
+
+	/**
+	 * Wrapper for wp_is_block_theme() so we can mock it in tests.
+	 *
+	 * @return bool
+	 */
+	protected static function wp_is_block_theme() {
+		return function_exists( 'wp_is_block_theme' ) ? wp_is_block_theme() : false;
+	}
+
+	/**
+	 * Wrapper for function_exists() so we can mock it in tests.
+	 *
+	 * @param string $function_name The function name to check.
+	 * @return bool
+	 */
+	protected static function function_exists( $function_name ) {
+		return function_exists( $function_name );
+	}
+
+	/**
+	 * Wrapper for wp_get_global_styles() so we can mock it in tests.
+	 *
+	 * @param array $args    The arguments for the wp_get_global_styles function.
+	 * @param array $options The options for the wp_get_global_styles function.
+	 * @return array|null
+	 */
+	protected static function wp_get_global_styles( $args = array(), $options = array() ) {
+		return function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles( $args, $options ) : null;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -72,11 +72,11 @@ class EmailColors {
 
 		$styles = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
 
-		$bg          = $styles['color']['background'] ?? '';
-		$body_bg     = $styles['color']['background'] ?? '';
-		$body_text   = $styles['color']['text'] ?? '';
-		$base        = $styles['elements']['button']['color']['background'] ?? '';
-		$footer_text = $styles['elements']['caption']['color']['text'] ?? '';
+		$bg          = $styles['color']['background'] ?? null;
+		$body_bg     = $styles['color']['background'] ?? null;
+		$body_text   = $styles['color']['text'] ?? null;
+		$base        = $styles['elements']['button']['color']['background'] ?? null;
+		$footer_text = $styles['elements']['caption']['color']['text'] ?? null;
 
 		$bg          = is_string( $bg ) ? sanitize_hex_color( $bg ) : '';
 		$body_bg     = is_string( $body_bg ) ? sanitize_hex_color( $body_bg ) : '';

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -85,8 +85,8 @@ class EmailColors {
 		$bg          = is_string( $bg ) ? sanitize_hex_color( $bg ) : '';
 		$body_bg     = is_string( $body_bg ) ? sanitize_hex_color( $body_bg ) : '';
 		$body_text   = is_string( $body_text ) ? sanitize_hex_color( $body_text ) : '';
-		$base        = is_string( $base ) ? sanitize_hex_color( $base ) : '';
-		$footer_text = is_string( $footer_text ) ? sanitize_hex_color( $footer_text ) : '';
+		$base        = is_string( $base ) ? sanitize_hex_color( $base ) : $body_text;
+		$footer_text = is_string( $footer_text ) ? sanitize_hex_color( $footer_text ) : $body_text;
 
 		return compact(
 			'base',

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -42,11 +42,13 @@ class EmailColors {
 
 			$global_colors = self::get_colors_from_global_styles();
 
-			$base_color_default        = $global_colors['base'] ? $global_colors['base'] : $base_color_default;
-			$bg_color_default          = $global_colors['bg'] ? $global_colors['bg'] : $bg_color_default;
-			$body_bg_color_default     = $global_colors['body_bg'] ? $global_colors['body_bg'] : $body_bg_color_default;
-			$body_text_color_default   = $global_colors['body_text'] ? $global_colors['body_text'] : $body_text_color_default;
-			$footer_text_color_default = $global_colors['footer_text'] ? $global_colors['footer_text'] : $footer_text_color_default;
+			if ( $global_colors ) {
+				$base_color_default        = $global_colors['base'];
+				$bg_color_default          = $global_colors['bg'];
+				$body_bg_color_default     = $global_colors['body_bg'];
+				$body_text_color_default   = $global_colors['body_text'];
+				$footer_text_color_default = $global_colors['footer_text'];
+			}
 		}
 
 		return compact(
@@ -61,17 +63,11 @@ class EmailColors {
 	/**
 	 * Get email colors from global styles.
 	 *
-	 * @return array Array of colors.
+	 * @return array|null Array of colors or null if global styles are not available or complete.
 	 */
 	public static function get_colors_from_global_styles() {
 		if ( ! wp_is_block_theme() || ! function_exists( 'wp_get_global_styles' ) ) {
-			return array(
-				'base'        => '',
-				'bg'          => '',
-				'body_bg'     => '',
-				'body_text'   => '',
-				'footer_text' => '',
-			);
+			return null;
 		}
 
 		$styles = wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
@@ -87,6 +83,11 @@ class EmailColors {
 		$body_text   = is_string( $body_text ) ? sanitize_hex_color( $body_text ) : '';
 		$base        = is_string( $base ) ? sanitize_hex_color( $base ) : $body_text;
 		$footer_text = is_string( $footer_text ) ? sanitize_hex_color( $footer_text ) : $body_text;
+
+		// Only return colors if all are set, otherwise email styles might not match and the email can become unreadable.
+		if ( ! $bg || ! $body_bg || ! $body_text || ! $base || ! $footer_text ) {
+			return null;
+		}
 
 		return compact(
 			'base',

--- a/plugins/woocommerce/src/Internal/Email/EmailColors.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailColors.php
@@ -66,11 +66,11 @@ class EmailColors {
 	 * @return array|null Array of colors or null if global styles are not available or complete.
 	 */
 	public static function get_colors_from_global_styles() {
-		if ( ! static::wp_is_block_theme() || ! static::function_exists( 'wp_get_global_styles' ) ) {
+		$styles = static::get_global_styles_data();
+
+		if ( ! $styles ) {
 			return null;
 		}
-
-		$styles = static::wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
 
 		$bg          = $styles['color']['background'] ?? null;
 		$body_bg     = $styles['color']['background'] ?? null;
@@ -99,32 +99,14 @@ class EmailColors {
 	}
 
 	/**
-	 * Wrapper for wp_is_block_theme() so we can mock it in tests.
+	 * Method to retrieve global styles data.
 	 *
-	 * @return bool
-	 */
-	protected static function wp_is_block_theme() {
-		return function_exists( 'wp_is_block_theme' ) ? wp_is_block_theme() : false;
-	}
-
-	/**
-	 * Wrapper for function_exists() so we can mock it in tests.
-	 *
-	 * @param string $function_name The function name to check.
-	 * @return bool
-	 */
-	protected static function function_exists( $function_name ) {
-		return function_exists( $function_name );
-	}
-
-	/**
-	 * Wrapper for wp_get_global_styles() so we can mock it in tests.
-	 *
-	 * @param array $args    The arguments for the wp_get_global_styles function.
-	 * @param array $options The options for the wp_get_global_styles function.
 	 * @return array|null
 	 */
-	protected static function wp_get_global_styles( $args = array(), $options = array() ) {
-		return function_exists( 'wp_get_global_styles' ) ? wp_get_global_styles( $args, $options ) : null;
+	protected static function get_global_styles_data() {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || ! function_exists( 'wp_get_global_styles' ) ) {
+			return null;
+		}
+		return wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Email/EmailStyleSync.php
+++ b/plugins/woocommerce/src/Internal/Email/EmailStyleSync.php
@@ -106,78 +106,29 @@ class EmailStyleSync implements RegisterHooksInterface {
 	 * Update email colors from theme colors.
 	 */
 	protected function update_email_colors() {
-		$colors = $this->get_theme_colors();
+		$colors = EmailColors::get_default_colors();
 		if ( empty( $colors ) ) {
 			return;
 		}
 
-		if ( ! empty( $colors['base_color'] ) ) {
-			update_option( 'woocommerce_email_base_color', $colors['base_color'] );
+		if ( ! empty( $colors['base'] ) ) {
+			update_option( 'woocommerce_email_base_color', $colors['base'] );
 		}
 
-		if ( ! empty( $colors['bg_color'] ) ) {
-			update_option( 'woocommerce_email_background_color', $colors['bg_color'] );
+		if ( ! empty( $colors['bg'] ) ) {
+			update_option( 'woocommerce_email_background_color', $colors['bg'] );
 		}
 
-		if ( ! empty( $colors['body_bg_color'] ) ) {
-			update_option( 'woocommerce_email_body_background_color', $colors['body_bg_color'] );
+		if ( ! empty( $colors['body_bg'] ) ) {
+			update_option( 'woocommerce_email_body_background_color', $colors['body_bg'] );
 		}
 
-		if ( ! empty( $colors['body_text_color'] ) ) {
-			update_option( 'woocommerce_email_text_color', $colors['body_text_color'] );
+		if ( ! empty( $colors['body_text'] ) ) {
+			update_option( 'woocommerce_email_text_color', $colors['body_text'] );
 		}
 
-		if ( ! empty( $colors['footer_text_color'] ) ) {
-			update_option( 'woocommerce_email_footer_text_color', $colors['footer_text_color'] );
+		if ( ! empty( $colors['footer_text'] ) ) {
+			update_option( 'woocommerce_email_footer_text_color', $colors['footer_text'] );
 		}
-	}
-
-	/**
-	 * Get theme colors from theme.json.
-	 *
-	 * @param array|null $override_styles Optional array of styles to override.
-	 * @return array Array of theme colors.
-	 */
-	protected function get_theme_colors( ?array $override_styles = null ) {
-		if ( ! function_exists( 'wp_get_global_styles' ) ) {
-			return array();
-		}
-
-		$global_styles = $override_styles ?: wp_get_global_styles( array(), array( 'transforms' => array( 'resolve-variables' ) ) );
-
-		$default_colors = EmailColors::get_default_colors();
-		$base_color_default = $default_colors['base_color_default'];
-		$bg_color_default = $default_colors['bg_color_default'];
-		$body_bg_color_default = $default_colors['body_bg_color_default'];
-		$body_text_color_default = $default_colors['body_text_color_default'];
-		$footer_text_color_default = $default_colors['footer_text_color_default'];
-
-		$base_color = ! empty( $global_styles['elements']['button']['color']['background'] )
-			? sanitize_hex_color( $global_styles['elements']['button']['color']['background'] )
-			: $base_color_default;
-
-		$bg_color = ! empty( $global_styles['color']['background'] )
-			? sanitize_hex_color( $global_styles['color']['background'] )
-			: $bg_color_default;
-
-		$body_bg_color = ! empty( $global_styles['color']['background'] )
-			? sanitize_hex_color( $global_styles['color']['background'] )
-			: $body_bg_color_default;
-
-		$body_text_color = ! empty( $global_styles['color']['text'] )
-			? sanitize_hex_color( $global_styles['color']['text'] )
-			: $body_text_color_default;
-
-		$footer_text_color = ! empty( $global_styles['elements']['caption']['color']['text'] )
-			? sanitize_hex_color( $global_styles['elements']['caption']['color']['text'] )
-			: $footer_text_color_default;
-
-		return array(
-			'base_color' => $base_color,
-			'bg_color' => $bg_color,
-			'body_bg_color' => $body_bg_color,
-			'body_text_color' => $body_text_color,
-			'footer_text_color' => $footer_text_color,
-		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
@@ -1,0 +1,384 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Email;
+
+use Automattic\WooCommerce\Internal\Email\EmailColors;
+use WC_Unit_Test_Case;
+
+/**
+ * EmailColors test.
+ *
+ * @covers \Automattic\WooCommerce\Internal\Email\EmailColors
+ */
+class EmailColorsTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Test get_default_colors when email improvements are disabled.
+	 */
+	public function test_get_default_colors_email_improvements_disabled() {
+		$result = EmailColors::get_default_colors( false );
+
+		$expected = array(
+			'base'        => '#720eec',
+			'bg'          => '#f7f7f7',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#3c3c3c',
+			'footer_text' => '#3c3c3c',
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_default_colors when email improvements are enabled but global styles are not available.
+	 */
+	public function test_get_default_colors_email_improvements_enabled_no_global_styles() {
+		// Create a test class that overrides the get_colors_from_global_styles method.
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override get_colors_from_global_styles to return null.
+			 *
+			 * @return null
+			 */
+			public static function get_colors_from_global_styles() {
+				return null;
+			}
+		};
+
+		$result = $test_class::get_default_colors( true );
+
+		$expected = array(
+			'base'        => '#8526ff',
+			'bg'          => '#ffffff',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#1e1e1e',
+			'footer_text' => '#787c82',
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_default_colors when email improvements are enabled and global styles are available.
+	 */
+	public function test_get_default_colors_email_improvements_enabled_with_global_styles() {
+		$global_colors = array(
+			'base'        => '#ff0000',
+			'bg'          => '#f0f0f0',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#000000',
+			'footer_text' => '#666666',
+		);
+
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override get_colors_from_global_styles to return test colors.
+			 *
+			 * @return array
+			 */
+			public static function get_colors_from_global_styles() {
+				return array(
+					'base'        => '#ff0000',
+					'bg'          => '#f0f0f0',
+					'body_bg'     => '#ffffff',
+					'body_text'   => '#000000',
+					'footer_text' => '#666666',
+				);
+			}
+		};
+
+		$result = $test_class::get_default_colors( true );
+
+		$this->assertEquals( $global_colors, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles when not a block theme.
+	 */
+	public function test_get_colors_from_global_styles_not_block_theme() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return false.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return false;
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$this->assertEquals( null, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles when wp_get_global_styles function doesn't exist.
+	 */
+	public function test_get_colors_from_global_styles_function_not_exists() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return true.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return true;
+			}
+
+			/**
+			 * Override function_exists to return false for wp_get_global_styles.
+			 *
+			 * @param string $function_name Function name to check.
+			 * @return bool
+			 */
+			public static function function_exists( $function_name ) {
+				if ( 'wp_get_global_styles' === $function_name ) {
+					return false;
+				}
+				return parent::function_exists( $function_name );
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$this->assertEquals( null, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles with complete global styles.
+	 */
+	public function test_get_colors_from_global_styles_complete_styles() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return true.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return true;
+			}
+
+			/**
+			 * Override function_exists to return true.
+			 *
+			 * @param string $function_name Function name to check.
+			 * @return bool
+			 */
+			public static function function_exists( $function_name ) {
+				return true;
+			}
+
+			/**
+			 * Override wp_get_global_styles to return test styles.
+			 *
+			 * @param array $args Arguments.
+			 * @param array $options Options.
+			 * @return array
+			 */
+			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+				return array(
+					'color'    => array(
+						'background' => '#ffffff',
+						'text'       => '#000000',
+					),
+					'elements' => array(
+						'button'  => array(
+							'color' => array(
+								'background' => '#8526ff',
+							),
+						),
+						'caption' => array(
+							'color' => array(
+								'text' => '#666666',
+							),
+						),
+					),
+				);
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$expected = array(
+			'base'        => '#8526ff',
+			'bg'          => '#ffffff',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#000000',
+			'footer_text' => '#666666',
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles with incomplete global styles (missing button color).
+	 */
+	public function test_get_colors_from_global_styles_incomplete_styles_missing_button() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return true.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return true;
+			}
+
+			/**
+			 * Override function_exists to return true.
+			 *
+			 * @param string $function_name Function name to check.
+			 * @return bool
+			 */
+			public static function function_exists( $function_name ) {
+				return true;
+			}
+
+			/**
+			 * Override wp_get_global_styles to return incomplete styles.
+			 *
+			 * @param array $args Arguments.
+			 * @param array $options Options.
+			 * @return array
+			 */
+			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+				return array(
+					'color'    => array(
+						'background' => '#ffffff',
+						'text'       => '#000000',
+					),
+					'elements' => array(
+						'caption' => array(
+							'color' => array(
+								'text' => '#666666',
+							),
+						),
+					),
+				);
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$expected = array(
+			'base'        => '#000000', // Should fallback to body_text.
+			'bg'          => '#ffffff',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#000000',
+			'footer_text' => '#666666',
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles with incomplete global styles (missing footer text).
+	 */
+	public function test_get_colors_from_global_styles_incomplete_styles_missing_footer() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return true.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return true;
+			}
+
+			/**
+			 * Override function_exists to return true.
+			 *
+			 * @param string $function_name Function name to check.
+			 * @return bool
+			 */
+			public static function function_exists( $function_name ) {
+				return true;
+			}
+
+			/**
+			 * Override wp_get_global_styles to return incomplete styles.
+			 *
+			 * @param array $args Arguments.
+			 * @param array $options Options.
+			 * @return array
+			 */
+			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+				return array(
+					'color'    => array(
+						'background' => '#ffffff',
+						'text'       => '#000000',
+					),
+					'elements' => array(
+						'button' => array(
+							'color' => array(
+								'background' => '#8526ff',
+							),
+						),
+					),
+				);
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$expected = array(
+			'base'        => '#8526ff',
+			'bg'          => '#ffffff',
+			'body_bg'     => '#ffffff',
+			'body_text'   => '#000000',
+			'footer_text' => '#000000', // Should fallback to body_text.
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test get_colors_from_global_styles returns null when required colors are missing.
+	 */
+	public function test_get_colors_from_global_styles_returns_null_when_colors_missing() {
+		$test_class = new class() extends EmailColors {
+			/**
+			 * Override wp_is_block_theme to return true.
+			 *
+			 * @return bool
+			 */
+			public static function wp_is_block_theme() {
+				return true;
+			}
+
+			/**
+			 * Override function_exists to return true.
+			 *
+			 * @param string $function_name Function name to check.
+			 * @return bool
+			 */
+			public static function function_exists( $function_name ) {
+				return true;
+			}
+
+			/**
+			 * Override wp_get_global_styles to return incomplete styles.
+			 *
+			 * @param array $args Arguments.
+			 * @param array $options Options.
+			 * @return array
+			 */
+			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+				return array(
+					'color'    => array(
+						'background' => '#ffffff',
+						// Missing text color.
+					),
+					'elements' => array(),
+				);
+			}
+		};
+
+		$result = $test_class::get_colors_from_global_styles();
+
+		$this->assertEquals( null, $result );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
@@ -95,7 +95,7 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test get_colors_from_global_styles when not a block theme.
+	 * Test get_colors_from_global_styles when not a block theme or wp_get_global_styles function doesn't exist.
 	 */
 	public function test_get_colors_from_global_styles_not_block_theme() {
 		$test_class = new class() extends EmailColors {
@@ -104,41 +104,8 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 			 *
 			 * @return bool
 			 */
-			public static function wp_is_block_theme() {
-				return false;
-			}
-		};
-
-		$result = $test_class::get_colors_from_global_styles();
-
-		$this->assertEquals( null, $result );
-	}
-
-	/**
-	 * Test get_colors_from_global_styles when wp_get_global_styles function doesn't exist.
-	 */
-	public function test_get_colors_from_global_styles_function_not_exists() {
-		$test_class = new class() extends EmailColors {
-			/**
-			 * Override wp_is_block_theme to return true.
-			 *
-			 * @return bool
-			 */
-			public static function wp_is_block_theme() {
-				return true;
-			}
-
-			/**
-			 * Override function_exists to return false for wp_get_global_styles.
-			 *
-			 * @param string $function_name Function name to check.
-			 * @return bool
-			 */
-			public static function function_exists( $function_name ) {
-				if ( 'wp_get_global_styles' === $function_name ) {
-					return false;
-				}
-				return parent::function_exists( $function_name );
+			public static function get_global_styles_data() {
+				return null;
 			}
 		};
 
@@ -153,32 +120,13 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	public function test_get_colors_from_global_styles_complete_styles() {
 		$test_class = new class() extends EmailColors {
 			/**
-			 * Override wp_is_block_theme to return true.
-			 *
-			 * @return bool
-			 */
-			public static function wp_is_block_theme() {
-				return true;
-			}
-
-			/**
-			 * Override function_exists to return true.
-			 *
-			 * @param string $function_name Function name to check.
-			 * @return bool
-			 */
-			public static function function_exists( $function_name ) {
-				return true;
-			}
-
-			/**
-			 * Override wp_get_global_styles to return test styles.
+			 * Override get_global_styles_data to return test styles.
 			 *
 			 * @param array $args Arguments.
 			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+			public static function get_global_styles_data( $args = array(), $options = array() ) {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -219,32 +167,13 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	public function test_get_colors_from_global_styles_incomplete_styles_missing_button() {
 		$test_class = new class() extends EmailColors {
 			/**
-			 * Override wp_is_block_theme to return true.
-			 *
-			 * @return bool
-			 */
-			public static function wp_is_block_theme() {
-				return true;
-			}
-
-			/**
-			 * Override function_exists to return true.
-			 *
-			 * @param string $function_name Function name to check.
-			 * @return bool
-			 */
-			public static function function_exists( $function_name ) {
-				return true;
-			}
-
-			/**
-			 * Override wp_get_global_styles to return incomplete styles.
+			 * Override get_global_styles_data to return incomplete styles.
 			 *
 			 * @param array $args Arguments.
 			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+			public static function get_global_styles_data( $args = array(), $options = array() ) {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -280,32 +209,13 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	public function test_get_colors_from_global_styles_incomplete_styles_missing_footer() {
 		$test_class = new class() extends EmailColors {
 			/**
-			 * Override wp_is_block_theme to return true.
-			 *
-			 * @return bool
-			 */
-			public static function wp_is_block_theme() {
-				return true;
-			}
-
-			/**
-			 * Override function_exists to return true.
-			 *
-			 * @param string $function_name Function name to check.
-			 * @return bool
-			 */
-			public static function function_exists( $function_name ) {
-				return true;
-			}
-
-			/**
-			 * Override wp_get_global_styles to return incomplete styles.
+			 * Override get_global_styles_data to return incomplete styles.
 			 *
 			 * @param array $args Arguments.
 			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+			public static function get_global_styles_data( $args = array(), $options = array() ) {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -341,32 +251,13 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	public function test_get_colors_from_global_styles_returns_null_when_colors_missing() {
 		$test_class = new class() extends EmailColors {
 			/**
-			 * Override wp_is_block_theme to return true.
-			 *
-			 * @return bool
-			 */
-			public static function wp_is_block_theme() {
-				return true;
-			}
-
-			/**
-			 * Override function_exists to return true.
-			 *
-			 * @param string $function_name Function name to check.
-			 * @return bool
-			 */
-			public static function function_exists( $function_name ) {
-				return true;
-			}
-
-			/**
-			 * Override wp_get_global_styles to return incomplete styles.
+			 * Override get_global_styles_data to return incomplete styles.
 			 *
 			 * @param array $args Arguments.
 			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function wp_get_global_styles( $args = array(), $options = array() ) {
+			public static function get_global_styles_data( $args = array(), $options = array() ) {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailColorsTest.php
@@ -100,9 +100,9 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 	public function test_get_colors_from_global_styles_not_block_theme() {
 		$test_class = new class() extends EmailColors {
 			/**
-			 * Override wp_is_block_theme to return false.
+			 * Override get_global_styles_data to return null.
 			 *
-			 * @return bool
+			 * @return null
 			 */
 			public static function get_global_styles_data() {
 				return null;
@@ -122,11 +122,9 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 			/**
 			 * Override get_global_styles_data to return test styles.
 			 *
-			 * @param array $args Arguments.
-			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function get_global_styles_data( $args = array(), $options = array() ) {
+			public static function get_global_styles_data() {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -169,11 +167,9 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 			/**
 			 * Override get_global_styles_data to return incomplete styles.
 			 *
-			 * @param array $args Arguments.
-			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function get_global_styles_data( $args = array(), $options = array() ) {
+			public static function get_global_styles_data() {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -211,11 +207,9 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 			/**
 			 * Override get_global_styles_data to return incomplete styles.
 			 *
-			 * @param array $args Arguments.
-			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function get_global_styles_data( $args = array(), $options = array() ) {
+			public static function get_global_styles_data() {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',
@@ -253,11 +247,9 @@ class EmailColorsTest extends WC_Unit_Test_Case {
 			/**
 			 * Override get_global_styles_data to return incomplete styles.
 			 *
-			 * @param array $args Arguments.
-			 * @param array $options Options.
 			 * @return array
 			 */
-			public static function get_global_styles_data( $args = array(), $options = array() ) {
+			public static function get_global_styles_data() {
 				return array(
 					'color'    => array(
 						'background' => '#ffffff',

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Email;
 
 use Automattic\WooCommerce\Internal\Email\EmailStyleSync;
-use Automattic\WooCommerce\Internal\Email\EmailColors;
 use WC_Unit_Test_Case;
 
 /**

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
@@ -83,123 +83,11 @@ class EmailStyleSyncTest extends WC_Unit_Test_Case {
     }
 
     /**
-     * Test sync doesn't run when auto-sync is disabled.
-     */
-    public function test_sync_doesnt_run_when_disabled() {
-        $this->sut->set_auto_sync( false );
-
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['update_email_colors'] )
-            ->getMock();
-
-        $mock->expects( $this->never() )
-            ->method( 'update_email_colors' );
-
-        $mock->set_auto_sync( false );
-        $mock->sync_email_styles_with_theme();
-    }
-
-    /**
-     * Test sync doesn't run when theme doesn't have theme.json.
-     */
-    public function test_sync_doesnt_run_without_theme_json() {
-        add_filter( 'wp_theme_has_theme_json', array( $this, 'return_false' ) );
-
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['update_email_colors'] )
-            ->getMock();
-
-        $mock->expects( $this->never() )
-            ->method( 'update_email_colors' );
-
-        $mock->sync_email_styles_with_theme();
-
-        remove_filter( 'wp_theme_has_theme_json', array( $this, 'return_false' ) );
-    }
-
-    /**
-     * Test update_email_colors updates options correctly.
-     */
-    public function test_update_email_colors() {
-        // Create a reflection to access the private method
-        $reflection = new \ReflectionClass( $this->sut );
-        $method = $reflection->getMethod( 'update_email_colors' );
-        $method->setAccessible( true );
-
-        // Create a mock for get_theme_colors
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['get_theme_colors'] )
-            ->getMock();
-
-        $test_colors = array(
-            'base_color' => '#ff0000',
-            'bg_color' => '#eeeeee',
-            'body_bg_color' => '#ffffff',
-            'body_text_color' => '#333333',
-            'footer_text_color' => '#999999',
-        );
-
-        $mock->expects( $this->once() )
-            ->method( 'get_theme_colors' )
-            ->will( $this->returnValue( $test_colors ) );
-
-        // Call the method directly using reflection
-        $method->invoke( $mock );
-
-        // Verify options were updated
-        $this->assertEquals( '#ff0000', get_option( 'woocommerce_email_base_color' ) );
-        $this->assertEquals( '#eeeeee', get_option( 'woocommerce_email_background_color' ) );
-        $this->assertEquals( '#ffffff', get_option( 'woocommerce_email_body_background_color' ) );
-        $this->assertEquals( '#333333', get_option( 'woocommerce_email_text_color' ) );
-        $this->assertEquals( '#999999', get_option( 'woocommerce_email_footer_text_color' ) );
-    }
-
-    /**
-     * Test get_theme_colors returns expected values.
-     */
-    public function test_get_theme_colors() {
-        // Create a reflection to access the private method
-        $reflection = new \ReflectionClass( $this->sut );
-        $method = $reflection->getMethod( 'get_theme_colors' );
-        $method->setAccessible( true );
-
-        // Define test global styles
-        $test_global_styles = [
-            'elements' => [
-                'button' => [
-                    'color' => [
-                        'background' => '#ff0000'
-                    ]
-                ],
-                'caption' => [
-                    'color' => [
-                        'text' => '#999999'
-                    ]
-                ]
-            ],
-            'color' => [
-                'background' => '#eeeeee',
-                'text' => '#333333'
-            ]
-        ];
-
-        // Call the method with override_styles parameter
-        $colors = $method->invoke( $this->sut, $test_global_styles );
-
-        // Verify the colors
-        $this->assertEquals( '#ff0000', $colors['base_color'] );
-        $this->assertEquals( '#eeeeee', $colors['bg_color'] );
-        $this->assertEquals( '#eeeeee', $colors['body_bg_color'] );
-        $this->assertEquals( '#333333', $colors['body_text_color'] );
-        $this->assertEquals( '#999999', $colors['footer_text_color'] );
-    }
-
-    /**
      * Test maybe_sync_on_option_update triggers sync when auto-sync is enabled.
      */
     public function test_maybe_sync_on_option_update_when_enabled() {
         $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['update_email_colors'] )
+            ->onlyMethods( ['update_email_colors'] )
             ->getMock();
 
         $mock->expects( $this->once() )
@@ -213,7 +101,7 @@ class EmailStyleSyncTest extends WC_Unit_Test_Case {
      */
     public function test_maybe_sync_on_option_update_when_disabled() {
         $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['update_email_colors'] )
+            ->onlyMethods( ['update_email_colors'] )
             ->getMock();
 
         $mock->expects( $this->never() )
@@ -227,7 +115,7 @@ class EmailStyleSyncTest extends WC_Unit_Test_Case {
      */
     public function test_maybe_sync_on_option_update_when_unchanged() {
         $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->setMethods( ['update_email_colors'] )
+            ->onlyMethods( ['update_email_colors'] )
             ->getMock();
 
         $mock->expects( $this->never() )

--- a/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Email/EmailStyleSyncTest.php
@@ -13,125 +13,125 @@ use WC_Unit_Test_Case;
  * @covers \Automattic\WooCommerce\Internal\Email\EmailStyleSync
  */
 class EmailStyleSyncTest extends WC_Unit_Test_Case {
-    /**
-     * "System Under Test", an instance of the class to be tested.
-     *
-     * @var EmailStyleSync
-     */
-    private $sut;
+	/**
+	 * "System Under Test", an instance of the class to be tested.
+	 *
+	 * @var EmailStyleSync
+	 */
+	private $sut;
 
-    /**
-     * Original option values to restore after tests.
-     *
-     * @var array
-     */
-    private $original_options;
+	/**
+	 * Original option values to restore after tests.
+	 *
+	 * @var array
+	 */
+	private $original_options;
 
-    /**
-     * Set up.
-     */
-    public function setUp(): void {
-        parent::setUp();
-        $this->sut = new EmailStyleSync();
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new EmailStyleSync();
 
-        // Store original option values
-        $this->original_options = array(
-            EmailStyleSync::AUTO_SYNC_OPTION => get_option( EmailStyleSync::AUTO_SYNC_OPTION, false ),
-            'woocommerce_email_base_color' => get_option( 'woocommerce_email_base_color', '' ),
-            'woocommerce_email_background_color' => get_option( 'woocommerce_email_background_color', '' ),
-            'woocommerce_email_body_background_color' => get_option( 'woocommerce_email_body_background_color', '' ),
-            'woocommerce_email_text_color' => get_option( 'woocommerce_email_text_color', '' ),
-            'woocommerce_email_footer_text_color' => get_option( 'woocommerce_email_footer_text_color', '' ),
-        );
+		// Store original option values.
+		$this->original_options = array(
+			EmailStyleSync::AUTO_SYNC_OPTION          => get_option( EmailStyleSync::AUTO_SYNC_OPTION, false ),
+			'woocommerce_email_base_color'            => get_option( 'woocommerce_email_base_color', '' ),
+			'woocommerce_email_background_color'      => get_option( 'woocommerce_email_background_color', '' ),
+			'woocommerce_email_body_background_color' => get_option( 'woocommerce_email_body_background_color', '' ),
+			'woocommerce_email_text_color'            => get_option( 'woocommerce_email_text_color', '' ),
+			'woocommerce_email_footer_text_color'     => get_option( 'woocommerce_email_footer_text_color', '' ),
+		);
 
-        // Ensure we have a clean state for each test
-        delete_option( EmailStyleSync::AUTO_SYNC_OPTION );
-    }
+		// Ensure we have a clean state for each test.
+		delete_option( EmailStyleSync::AUTO_SYNC_OPTION );
+	}
 
-    /**
-     * Tear down.
-     */
-    public function tearDown(): void {
-        parent::tearDown();
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
 
-        // Restore original option values
-        foreach ( $this->original_options as $option_name => $option_value ) {
-            if ( $option_value ) {
-                update_option( $option_name, $option_value );
-            } else {
-                delete_option( $option_name );
-            }
-        }
-    }
+		// Restore original option values.
+		foreach ( $this->original_options as $option_name => $option_value ) {
+			if ( $option_value ) {
+				update_option( $option_name, $option_value );
+			} else {
+				delete_option( $option_name );
+			}
+		}
+	}
 
-    /**
-     * Test auto-sync is disabled by default.
-     */
-    public function test_auto_sync_disabled_by_default() {
-        $this->assertFalse( $this->sut->is_auto_sync_enabled() );
-    }
+	/**
+	 * Test auto-sync is disabled by default.
+	 */
+	public function test_auto_sync_disabled_by_default() {
+		$this->assertFalse( $this->sut->is_auto_sync_enabled() );
+	}
 
-    /**
-     * Test setting auto-sync option.
-     */
-    public function test_set_auto_sync() {
-        $this->sut->set_auto_sync( false );
-        $this->assertFalse( $this->sut->is_auto_sync_enabled() );
+	/**
+	 * Test setting auto-sync option.
+	 */
+	public function test_set_auto_sync() {
+		$this->sut->set_auto_sync( false );
+		$this->assertFalse( $this->sut->is_auto_sync_enabled() );
 
-        $this->sut->set_auto_sync( true );
-        $this->assertTrue( $this->sut->is_auto_sync_enabled() );
-    }
+		$this->sut->set_auto_sync( true );
+		$this->assertTrue( $this->sut->is_auto_sync_enabled() );
+	}
 
-    /**
-     * Test maybe_sync_on_option_update triggers sync when auto-sync is enabled.
-     */
-    public function test_maybe_sync_on_option_update_when_enabled() {
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->onlyMethods( ['update_email_colors'] )
-            ->getMock();
+	/**
+	 * Test maybe_sync_on_option_update triggers sync when auto-sync is enabled.
+	 */
+	public function test_maybe_sync_on_option_update_when_enabled() {
+		$mock = $this->getMockBuilder( EmailStyleSync::class )
+			->onlyMethods( array( 'update_email_colors' ) )
+			->getMock();
 
-        $mock->expects( $this->once() )
-            ->method( 'update_email_colors' );
+		$mock->expects( $this->once() )
+			->method( 'update_email_colors' );
 
-        $mock->maybe_sync_on_option_update( 'no', 'yes', EmailStyleSync::AUTO_SYNC_OPTION );
-    }
+		$mock->maybe_sync_on_option_update( 'no', 'yes', EmailStyleSync::AUTO_SYNC_OPTION );
+	}
 
-    /**
-     * Test maybe_sync_on_option_update doesn't trigger sync when auto-sync is disabled.
-     */
-    public function test_maybe_sync_on_option_update_when_disabled() {
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->onlyMethods( ['update_email_colors'] )
-            ->getMock();
+	/**
+	 * Test maybe_sync_on_option_update doesn't trigger sync when auto-sync is disabled.
+	 */
+	public function test_maybe_sync_on_option_update_when_disabled() {
+		$mock = $this->getMockBuilder( EmailStyleSync::class )
+			->onlyMethods( array( 'update_email_colors' ) )
+			->getMock();
 
-        $mock->expects( $this->never() )
-            ->method( 'update_email_colors' );
+		$mock->expects( $this->never() )
+			->method( 'update_email_colors' );
 
-        $mock->maybe_sync_on_option_update( 'yes', 'no', EmailStyleSync::AUTO_SYNC_OPTION );
-    }
+		$mock->maybe_sync_on_option_update( 'yes', 'no', EmailStyleSync::AUTO_SYNC_OPTION );
+	}
 
-    /**
-     * Test maybe_sync_on_option_update doesn't trigger sync when auto-sync value doesn't change.
-     */
-    public function test_maybe_sync_on_option_update_when_unchanged() {
-        $mock = $this->getMockBuilder( EmailStyleSync::class )
-            ->onlyMethods( ['update_email_colors'] )
-            ->getMock();
+	/**
+	 * Test maybe_sync_on_option_update doesn't trigger sync when auto-sync value doesn't change.
+	 */
+	public function test_maybe_sync_on_option_update_when_unchanged() {
+		$mock = $this->getMockBuilder( EmailStyleSync::class )
+			->onlyMethods( array( 'update_email_colors' ) )
+			->getMock();
 
-        $mock->expects( $this->never() )
-            ->method( 'update_email_colors' );
+		$mock->expects( $this->never() )
+			->method( 'update_email_colors' );
 
-        // Test when already enabled
-        $mock->maybe_sync_on_option_update( 'yes', 'yes', EmailStyleSync::AUTO_SYNC_OPTION );
+		// Test when already enabled.
+		$mock->maybe_sync_on_option_update( 'yes', 'yes', EmailStyleSync::AUTO_SYNC_OPTION );
 
-        // Test when already disabled
-        $mock->maybe_sync_on_option_update( 'no', 'no', EmailStyleSync::AUTO_SYNC_OPTION );
-    }
+		// Test when already disabled.
+		$mock->maybe_sync_on_option_update( 'no', 'no', EmailStyleSync::AUTO_SYNC_OPTION );
+	}
 
-    /**
-     * A hook for returning false in filters, safe to add and remove in tests.
-     */
-    public function return_false() {
-        return false;
-    }
+	/**
+	 * A hook for returning false in filters, safe to add and remove in tests.
+	 */
+	public function return_false() {
+		return false;
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The email style sync system expects global styles colors to be string values (e.g. a `#fff` hex color). However, a color can also be specified by referencing any other color in global styles, so instead of `'text' => '#000'` it's defined as `
'text' => [ 'ref' => 'styles.color.text' ]`. But when this array is fed into `sanitize_hex_color()` it throws fatal, because the underlying `preg_match` expects string and not an array. 

This PR introduces a couple of changes:
1. Only accepts string values. This means, that if a color is defined by reference, it will be ignored (we might add this functionality later).
2. Require all global styles values to be set. If any is missing, they will be ignored. This is to prevent mixing default and theme colors because we can't guarantee they'll match and the email will be readable when combined. 
3. Simplified working with global styles by a lot. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5126.

(For Bug Fixes) Bug introduced in PR #55918.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce.
2. Install **Rainfall** theme.
3. Observe that the website didn't crash.
4. Check **WooCommerce > Settings > Emails** that default Woo colors are used and not the theme colors. This is expected, because the theme uses colors by reference, which we don't support yet.
5. Install **Twenty-Twenty Four** theme.
6. Check that email styles are synced with theme. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
