### PR TITLE
Build `.0-dev` release at code freeze time

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -153,19 +153,39 @@ jobs:
       branch: trunk
       bump-type: dev
 
-  build-zip:
-    name: Build WooCommerce release ZIP
+  build-dev-release:
+    name: 'Build WooCommerce -dev release'
     uses: ./.github/workflows/release-build-zip-file.yml
     needs: [prepare-for-code-freeze, run-code-freeze]
     with:
       skip_verify: true
-      create_github_release: false
+      create_github_release: true
       branch: ${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}
+
+  publish-dev-release:
+    name: 'Publish -dev release'
+    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    needs: [prepare-for-code-freeze, build-dev-release]
+    outputs:
+      release-zip: ${{ steps.publish-release.outputs.release-zip }}
+    steps:
+      - id: publish-release
+        run: |
+          gh release edit '${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev' \
+            --prerelease \
+            --latest=false \
+            --notes='' \
+            --draft=false
+
+          echo "release-zip=https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev/woocommerce.zip" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
 
   notify-slack:
     name: Notify Slack
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: [build-zip, prepare-for-code-freeze]
+    needs: [publish-dev-release, prepare-for-code-freeze]
     steps:
       - name: Notify Slack on success
         uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
@@ -175,14 +195,14 @@ jobs:
           slack-text: |
             :ice_cube: Code Freeze completed for `${{ needs.prepare-for-code-freeze.outputs.nextReleaseBranch }}` :checking:
             If you need a fix or change to be included in this release, please request a backport following the <https://developer.woocommerce.com/docs/contribution/releases/backporting|Backporting Guide>.
-            <${{ needs.build-zip.outputs.artifact_url }}|Download zip>
+            <${{ needs.publish-dev-release.outputs.release-zip }}|Download zip>
           slack-optional-unfurl_links: false
           slack-optional-unfurl_media: false
 
   trigger-webhook:
     name: Trigger Release Webhook
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: [build-zip, prepare-for-code-freeze]
+    needs: [publish-dev-release, prepare-for-code-freeze]
     steps:
       - name: Trigger Code Freeze Webhook
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
@@ -193,7 +213,7 @@ jobs:
             const payload = {
               action: 'feature-freeze',
               version: '${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}',
-              build_zip: '${{ needs.build-zip.outputs.artifact_url }}',
+              build_zip: '${{ needs.publish-dev-release.outputs.release-zip }}',
               post_status: process.env.ENVIRONMENT === 'production' ? 'publish' : 'draft'
             };
 

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -170,6 +170,9 @@ jobs:
       release-zip: ${{ steps.publish-release.outputs.release-zip }}
     steps:
       - id: publish-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release edit '${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev' \
             --prerelease \
@@ -178,9 +181,6 @@ jobs:
             --draft=false
 
           echo "release-zip=https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev/woocommerce.zip" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
 
   notify-slack:
     name: Notify Slack


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR updates the code freeze workflow to build, tag and publish a `.0-dev` pre-release to be used for testing against QIT.

Related to #59999 and WOOPLUG-5182.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository.
2. In your forked repo, go to **Settings > Secrets and variables > Actions** and create or update the following repository secrets: 
   - `CODE_FREEZE_BOT_TOKEN`, get the token value from the `Test Assistant bot` from the secret store.
   - `WOO_RELEASE_SLACK_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
   - `WOO_RELEASE_SLACK_NOTIFICATION_CHANNEL`: You can use the test channel `test-woo-core-release-notifications`.
   - Set `ENVIRONMENT`, `WPCOM_WEBHOOK_SECRET` and `WPCOM_RELEASE_WEBHOOK_URL` accordingly.
3. Go to **Actions > Release: Enforce Code Freeze** and run the workflow.
4. Once it completes, confirm that:
   - A release `10.2.0-dev` has been tagged and published in your repo. It must be a **pre-release**.
   - The release has a `woocommerce.zip` file attached and the details in it (plugin header, etc.) match the expected version (`10.2.0-dev`).
   - A branch `release/10.2` has been created.
   - A PR bumping versions to `10.3.0-dev` has been opened against `trunk`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
