### PR TITLE
[dev] CI: retry plugin installation when setting up E2E environment.

### DIFF
--- a/plugins/woocommerce/tests/e2e-pw/bin/install-plugin.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/install-plugin.sh
@@ -17,15 +17,9 @@ if [[ -z "$PLUGIN_SLUG" ]]; then
 	exit 1
 fi
 
-
 echo "Installing $PLUGIN_NAME from $PLUGIN_REPOSITORY"
-
-echo "Uninstalling plugin if it's already installed..."
-pnpm wp-env run tests-cli wp plugin uninstall "$PLUGIN_SLUG" --deactivate || true
-
-echo "Downloading plugin..."
-download_url=$(curl -s "https://api.github.com/repos/$PLUGIN_REPOSITORY/releases/latest" | grep browser_download_url | cut -d '"' -f 4)
-pnpm wp-env run tests-cli wp plugin install "$download_url" --activate
+download_url=$( curl -s "https://api.github.com/repos/$PLUGIN_REPOSITORY/releases/latest" | grep browser_download_url | cut -d '"' -f 4 )
+pnpm wp-env run tests-cli wp plugin install "$download_url" --force --activate || ( sleep 5 && pnpm wp-env run tests-cli wp plugin install "$download_url" --force --activate )
 
 pnpm wp-env run tests-cli wp plugin list
 pnpm wp-env run tests-cli wp plugin is-active "$PLUGIN_SLUG" || ( echo "Plugin \"$PLUGIN_SLUG\" is not active!" && exit 1 )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1753391975685489-slack-C03CPM3UXDJ

Add a retry for plugin installation in the E2E environment setup. That's a long-lasting minor issue, but a low-hanging fruit.

### How to test the changes in this Pull Request:

- CI-checks shall pass

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>