### PR TITLE
Fix adding groupped products to cart from the Add to Cart + Options block when the Mini-Cart block was missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-grouped-product-missing-add-to-cart
+++ b/plugins/woocommerce/changelog/fix-grouped-product-missing-add-to-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix adding groupped products to cart from the Add to Cart + Options block when the Mini-Cart block was missing

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -292,7 +292,7 @@ const { state, actions } = store< Store >(
 			},
 
 			*batchAddCartItems( items: OptimisticCartItem[] ) {
-				const previousCart = structuredClone( state.cart );
+				const previousCart = JSON.stringify( state.cart );
 				const quantityChanges: QuantityChanges = {};
 
 				// Updates the database.
@@ -439,7 +439,7 @@ const { state, actions } = store< Store >(
 				} catch ( error ) {
 					// Reverts the optimistic update.
 					// Todo: Prevent racing conditions with multiple addToCart calls for the same item.
-					state.cart = previousCart;
+					state.cart = JSON.parse( previousCart );
 
 					// Shows the error notice.
 					actions.showNoticeError( error as Error );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Issue originally encountered by @dinhtungdu.

When using the _Add to Cart + Options_ block without the _Mini-Cart_ block being present to the cart, there was a JS error that blocked adding products to the cart:

<img width="2371" height="1224" alt="image" src="https://github.com/user-attachments/assets/a19a214c-d75e-432c-9885-0f01703cf06d" />

That was caused by the usage of `structuredClone()` with a Proxy object. My understanding is that it worked when the Mini-Cart block was on the page because, in that case, we loaded the `wp-polyfill` dependency, which has its own `structuredClone()` implementation. I assume there is a slight difference between the `wp-polyfill` and the browser implementation of `structuredClone()` and that's why it was failing in one case and not in the other.

While one solution would be to enqueue `wp-polyfill` as a dependency of the _Add to Cart + Options_ block. I don't think that's a good idea, as we should consider the browsers' implementation as the reference.

Based on this, this PR moves away from using `structuredClone()` in favor of `JSON.stringify()` and `JSON.parse()`. In addition to being more reliable, it's also what we are doing in `addCartItem()`, this way we keep `batchAddCartItems()` aligned.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Remove the _Mini-Cart_ block from the header of your site.
4. Go to the frontend of a grouped product.
5. Verify you can add child products to the cart without errors.