### PR TITLE
Email editor: Add pattern filtering by post type

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-5180-add-pattern-filtering-by-post-type
+++ b/packages/js/email-editor/changelog/wooplug-5180-add-pattern-filtering-by-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add filtering email patterns by the email postType.

--- a/packages/php/email-editor/changelog/wooplug-5180-add-pattern-filtering-by-post-type
+++ b/packages/php/email-editor/changelog/wooplug-5180-add-pattern-filtering-by-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add the new post_types property to the Abstract_Pattern class.

--- a/packages/php/email-editor/src/Engine/Patterns/class-abstract-pattern.php
+++ b/packages/php/email-editor/src/Engine/Patterns/class-abstract-pattern.php
@@ -37,6 +37,12 @@ abstract class Abstract_Pattern {
 	 */
 	protected $template_types = array();
 	/**
+	 * List of supported post types.
+	 *
+	 * @var string[] $post_types
+	 */
+	protected $post_types = array();
+	/**
 	 * Flag to enable/disable inserter.
 	 *
 	 * @var bool $inserter
@@ -93,6 +99,7 @@ abstract class Abstract_Pattern {
 			'inserter'      => $this->inserter,
 			'blockTypes'    => $this->block_types,
 			'templateTypes' => $this->template_types,
+			'postTypes'     => $this->post_types,
 			'source'        => $this->source,
 			'viewportWidth' => $this->viewport_width,
 		);

--- a/plugins/woocommerce/changelog/wooplug-5180-add-pattern-filtering-by-post-type
+++ b/plugins/woocommerce/changelog/wooplug-5180-add-pattern-filtering-by-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Email editor: set Woo email pattern post types.

--- a/plugins/woocommerce/src/Internal/EmailEditor/EmailPatterns/WooEmailContentPattern.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/EmailPatterns/WooEmailContentPattern.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Internal\EmailEditor\EmailPatterns;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Patterns\Abstract_Pattern;
+use Automattic\WooCommerce\Internal\EmailEditor\Integration;
 
 /**
  * Pattern class for WooCommerce email content.
@@ -45,6 +46,12 @@ class WooEmailContentPattern extends Abstract_Pattern {
 	 */
 	public $namespace = 'woocommerce';      // Required.
 
+	/**
+	 * List of supported post types.
+	 *
+	 * @var string[]
+	 */
+	protected $post_types = array( Integration::EMAIL_POST_TYPE );
 	/**
 	 * Get the pattern content.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes https://github.com/woocommerce/woocommerce/issues/59995.
Closes WOOPLUG-5180

- There is an updated functionality in filtering email patterns by the email postType when the registered pattern has set supported postTypes.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1580" height="929" alt="Screenshot 2025-07-25 at 14 31 54" src="https://github.com/user-attachments/assets/91f44d45-29ca-4d14-8484-f616d32d7019" />|<img width="1579" height="754" alt="Screenshot 2025-07-25 at 14 28 42" src="https://github.com/user-attachments/assets/ed50ee67-fcd2-4128-ad08-34217ed807a7" />|

Screenshots were captured in the MailPoet email editor integration.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from __WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)__
2. Open an email in the editor __WooCommerce → Settings → Emails__
3. Register a new pattern with `post_types` that does not match `woo_mail` postType
4. Register a new pattern without specified `post_types`
5. Visit the URL `http://localhost:8888/wp-admin/post-new.php?post_type=woo_email` and check that the displayed patterns match the configuration.


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
