### PR TITLE
WPS Migration: address settings parity

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -301,6 +301,7 @@ class WC_Gateway_Paypal_Request {
 					'payee'     => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
 					),
+					'shipping'    => $this->get_paypal_order_shipping( $order ),
 				),
 			),
 			'application_context' => array(
@@ -390,6 +391,34 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return 'CAPTURE';
+	}
+
+	/**
+	 * Get the shipping information for the PayPal create-order request.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return array
+	 */
+	private function get_paypal_order_shipping( $order ) {
+		if ( ! $order->needs_shipping_address() ) {
+			return null;
+		}
+
+		$address_type = 'yes' === $this->gateway->get_option( 'send_shipping' ) ? 'shipping' : 'billing';
+
+		return array(
+			'name'    => array(
+				'full_name' => $order->{"get_formatted_{$address_type}_full_name"}(),
+			),
+			'address' => array(
+				'address_line_1' => $this->limit_length( $order->{"get_{$address_type}_address_1"}(), 300 ),
+				'address_line_2' => $this->limit_length( $order->{"get_{$address_type}_address_2"}(), 300 ),
+				'admin_area_1'   => $this->limit_length( $order->{"get_{$address_type}_state"}(), 300 ),
+				'admin_area_2'   => $this->limit_length( $order->{"get_{$address_type}_city"}(), 120 ),
+				'postal_code'    => $this->limit_length( $order->{"get_{$address_type}_postcode"}(), 60 ),
+				'country_code'   => $order->{"get_{$address_type}_country"}(),
+			),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -400,7 +400,7 @@ class WC_Gateway_Paypal_Request {
 	 * @param WC_Order $order Order object.
 	 * @return string
 	 */
-	private function get_paypal_shipping_preference( $order) {
+	private function get_paypal_shipping_preference( $order ) {
 		if ( ! $order->needs_shipping_address() ) {
 			return 'NO_SHIPPING';
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -311,7 +311,7 @@ class WC_Gateway_Paypal_Request {
 					'payee'      => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
 					),
-					'shipping'  => $this->get_paypal_order_shipping( $order ),
+					'shipping'   => $this->get_paypal_order_shipping( $order ),
 				),
 			),
 			'application_context' => array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -301,15 +301,15 @@ class WC_Gateway_Paypal_Request {
 					'payee'     => array(
 						'email_address' => $this->gateway->get_option( 'email' ),
 					),
-					'shipping'    => $this->get_paypal_order_shipping( $order ),
+					'shipping'  => $this->get_paypal_order_shipping( $order ),
 				),
 			),
 			'application_context' => array(
 				'shipping_preference' => $this->get_paypal_shipping_preference( $order ),
 				// Customer redirected here on approval.
-				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+				'return_url'          => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
 				// Customer redirected here on cancellation.
-				'cancel_url' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+				'cancel_url'          => esc_url_raw( $order->get_cancel_order_url_raw() ),
 				// phpcs:ignore Generic.Commenting.Todo.TaskFound,Squiz.PHP.CommentedOutCode.Found
 				// 'locale' => get_locale(), // TODO: PayPal has its own locale format, will need conversion.
 			),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -305,6 +305,7 @@ class WC_Gateway_Paypal_Request {
 				),
 			),
 			'application_context' => array(
+				'shipping_preference' => $this->get_paypal_shipping_preference( $order ),
 				// Customer redirected here on approval.
 				'return_url' => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
 				// Customer redirected here on cancellation.
@@ -391,6 +392,21 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return 'CAPTURE';
+	}
+
+	/**
+	 * Get the shipping preference for the PayPal create-order request.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return string
+	 */
+	private function get_paypal_shipping_preference( $order) {
+		if ( ! $order->needs_shipping_address() ) {
+			return 'NO_SHIPPING';
+		}
+
+		$address_override = $this->gateway->get_option( 'address_override' ) === 'yes';
+		return $address_override ? 'SET_PROVIDED_ADDRESS' : 'GET_FROM_FILE';
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR achieves feature parity for `Shipping Details` and `Address Override` options in the PayPal settings page.

`Shipping Details`: If this box is checked (`yes`) we send the shipping address to PayPal, otherwise we send the billing address
`Address override`: If this box is checked (`yes`), address sent from the merchant site is used as the shipping address. Shopper can not select another address from the PP modal.

Towards PAYPAL-46

### How to test the changes in this Pull Request:

#### Basic setup
1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Configure PayPal Standard's settings:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- For Payment action, select Capture
5. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
```

#### Testing the changes

1. As an admin, go to WooCommerce > Settings > Payments > and enable PayPal Standard.
2. Test this branch with different values of `Shipping details` and `Address override`. Following is a table of expected behavior based on the current behavior in WPS.

| Shipping Details | Address Override | Address displayed on the modal | Can Change Address on modal | Address in PP Transaction |
|---|---|---|---|---|
| yes | no | Shipping adress from WC checkout page. | Yes, can choose a different address | Same one from the modal |
| yes | yes | Shipping adress from WC checkout page. | No | Same one from the modal |
| no | yes | Billing adress from WC checkout page. | No | Same one from the modal |
| no | no | Billing adress from WC checkout page. | Yes, can choose a different address | Same one from the modal |

3. As a shopper, add a product to cart and go to checkout.
4. You should see PayPal as a payment option.
5. Click "Proceed to PayPal".
6. Use your Personal sandbox account credentials to log in and check the modal.
7. Confirm that the shipping address matches the above table.
8. Click to pay. You should get redirected to the "Order Confirmation" page.
9. Wait a few seconds, and go to the wp-admin order page.
10. In the order details section, the transaction ID should be linked. 
11. Click the transaction ID. It should take you to the PayPal transaction page.
12. Check the shipping address. It should match what you finally selected on the modal.

**Note** If you change and select a different shipping address on the PP modal, it does not reflect on the store order. The WC order still shows the shipping address from the checkout page. Though this is also the current behavior in legacy, we should fix it at some point.
 
### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
