### PR TITLE
Run all jobs instead of just wc-admin-data

### DIFF
--- a/plugins/woocommerce/changelog/update-batch-queue-flaky-tests
+++ b/plugins/woocommerce/changelog/update-batch-queue-flaky-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update pending jobs to run all groups in flaky batch queue tests

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -152,7 +152,7 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 			)
 		);
 		// Verify that a second follow up action was queued.
-		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
 			2,
 			OrdersScheduler::queue()->search(
@@ -175,7 +175,7 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 			)
 		);
 		// Verify that no follow up action was queued.
-		WC_Helper_Queue::run_all_pending( 'wc-admin-data' );
+		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
 			0,
 			OrdersScheduler::queue()->search(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -151,31 +151,6 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 				)
 			)
 		);
-		// Debug: Check what pending actions exist before running them
-		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
-		fwrite( STDERR, "=== DEBUG: Pending actions before first run_all_pending ===\n" );
-		fwrite( STDERR, "Total pending actions: " . count( $pending_actions ) . "\n" );
-		fwrite( STDERR, "Total wc-admin-data pending actions: " . count( $pending_actions_wc_admin ) . "\n" );
-		fwrite( STDERR, "--- ALL PENDING ACTIONS ---\n" );
-		foreach ( $pending_actions as $action ) {
-			fwrite( STDERR, sprintf(
-				"Action: hook=%s, group=%s, args=%s\n",
-				$action->get_hook(),
-				$action->get_group(),
-				json_encode( $action->get_args() )
-			) );
-		}
-		fwrite( STDERR, "--- WC-ADMIN-DATA ACTIONS ONLY ---\n" );
-		foreach ( $pending_actions_wc_admin as $action ) {
-			fwrite( STDERR, sprintf(
-				"Action: hook=%s, group=%s, args=%s\n",
-				$action->get_hook(),
-				$action->get_group(),
-				json_encode( $action->get_args() )
-			) );
-		}
-
 		// Verify that a second follow up action was queued.
 		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
@@ -199,33 +174,8 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 				)
 			)
 		);
-		// Debug: Check what pending actions exist before second run_all_pending
-		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
-		fwrite( STDERR, "=== DEBUG: Pending actions before second run_all_pending ===\n" );
-		fwrite( STDERR, "Total pending actions: " . count( $pending_actions ) . "\n" );
-		fwrite( STDERR, "Total wc-admin-data pending actions: " . count( $pending_actions_wc_admin ) . "\n" );
-		fwrite( STDERR, "--- ALL PENDING ACTIONS ---\n" );
-		foreach ( $pending_actions as $action ) {
-			fwrite( STDERR, sprintf(
-				"Action: hook=%s, group=%s, args=%s\n",
-				$action->get_hook(),
-				$action->get_group(),
-				json_encode( $action->get_args() )
-			) );
-		}
-		fwrite( STDERR, "--- WC-ADMIN-DATA ACTIONS ONLY ---\n" );
-		foreach ( $pending_actions_wc_admin as $action ) {
-			fwrite( STDERR, sprintf(
-				"Action: hook=%s, group=%s, args=%s\n",
-				$action->get_hook(),
-				$action->get_group(),
-				json_encode( $action->get_args() )
-			) );
-		}
-
 		// Verify that no follow up action was queued.
-		
+
 		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
 			0,

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -175,7 +175,6 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 			)
 		);
 		// Verify that no follow up action was queued.
-
 		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
 			0,

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -154,22 +154,22 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 		// Debug: Check what pending actions exist before running them
 		$pending_actions = WC_Helper_Queue::get_all_pending();
 		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
-		error_log( '=== DEBUG: Pending actions before first run_all_pending ===' );
-		error_log( 'Total pending actions: ' . count( $pending_actions ) );
-		error_log( 'Total wc-admin-data pending actions: ' . count( $pending_actions_wc_admin ) );
-		error_log( '--- ALL PENDING ACTIONS ---' );
+		fwrite( STDERR, "=== DEBUG: Pending actions before first run_all_pending ===\n" );
+		fwrite( STDERR, "Total pending actions: " . count( $pending_actions ) . "\n" );
+		fwrite( STDERR, "Total wc-admin-data pending actions: " . count( $pending_actions_wc_admin ) . "\n" );
+		fwrite( STDERR, "--- ALL PENDING ACTIONS ---\n" );
 		foreach ( $pending_actions as $action ) {
-			error_log( sprintf(
-				'Action: hook=%s, group=%s, args=%s',
+			fwrite( STDERR, sprintf(
+				"Action: hook=%s, group=%s, args=%s\n",
 				$action->get_hook(),
 				$action->get_group(),
 				json_encode( $action->get_args() )
 			) );
 		}
-		error_log( '--- WC-ADMIN-DATA ACTIONS ONLY ---' );
+		fwrite( STDERR, "--- WC-ADMIN-DATA ACTIONS ONLY ---\n" );
 		foreach ( $pending_actions_wc_admin as $action ) {
-			error_log( sprintf(
-				'Action: hook=%s, group=%s, args=%s',
+			fwrite( STDERR, sprintf(
+				"Action: hook=%s, group=%s, args=%s\n",
 				$action->get_hook(),
 				$action->get_group(),
 				json_encode( $action->get_args() )
@@ -202,22 +202,22 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 		// Debug: Check what pending actions exist before second run_all_pending
 		$pending_actions = WC_Helper_Queue::get_all_pending();
 		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
-		error_log( '=== DEBUG: Pending actions before second run_all_pending ===' );
-		error_log( 'Total pending actions: ' . count( $pending_actions ) );
-		error_log( 'Total wc-admin-data pending actions: ' . count( $pending_actions_wc_admin ) );
-		error_log( '--- ALL PENDING ACTIONS ---' );
+		fwrite( STDERR, "=== DEBUG: Pending actions before second run_all_pending ===\n" );
+		fwrite( STDERR, "Total pending actions: " . count( $pending_actions ) . "\n" );
+		fwrite( STDERR, "Total wc-admin-data pending actions: " . count( $pending_actions_wc_admin ) . "\n" );
+		fwrite( STDERR, "--- ALL PENDING ACTIONS ---\n" );
 		foreach ( $pending_actions as $action ) {
-			error_log( sprintf(
-				'Action: hook=%s, group=%s, args=%s',
+			fwrite( STDERR, sprintf(
+				"Action: hook=%s, group=%s, args=%s\n",
 				$action->get_hook(),
 				$action->get_group(),
 				json_encode( $action->get_args() )
 			) );
 		}
-		error_log( '--- WC-ADMIN-DATA ACTIONS ONLY ---' );
+		fwrite( STDERR, "--- WC-ADMIN-DATA ACTIONS ONLY ---\n" );
 		foreach ( $pending_actions_wc_admin as $action ) {
-			error_log( sprintf(
-				'Action: hook=%s, group=%s, args=%s',
+			fwrite( STDERR, sprintf(
+				"Action: hook=%s, group=%s, args=%s\n",
 				$action->get_hook(),
 				$action->get_group(),
 				json_encode( $action->get_args() )

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/batch-queue.php
@@ -151,6 +151,31 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 				)
 			)
 		);
+		// Debug: Check what pending actions exist before running them
+		$pending_actions = WC_Helper_Queue::get_all_pending();
+		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
+		error_log( '=== DEBUG: Pending actions before first run_all_pending ===' );
+		error_log( 'Total pending actions: ' . count( $pending_actions ) );
+		error_log( 'Total wc-admin-data pending actions: ' . count( $pending_actions_wc_admin ) );
+		error_log( '--- ALL PENDING ACTIONS ---' );
+		foreach ( $pending_actions as $action ) {
+			error_log( sprintf(
+				'Action: hook=%s, group=%s, args=%s',
+				$action->get_hook(),
+				$action->get_group(),
+				json_encode( $action->get_args() )
+			) );
+		}
+		error_log( '--- WC-ADMIN-DATA ACTIONS ONLY ---' );
+		foreach ( $pending_actions_wc_admin as $action ) {
+			error_log( sprintf(
+				'Action: hook=%s, group=%s, args=%s',
+				$action->get_hook(),
+				$action->get_group(),
+				json_encode( $action->get_args() )
+			) );
+		}
+
 		// Verify that a second follow up action was queued.
 		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
@@ -174,7 +199,33 @@ class WC_Admin_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case 
 				)
 			)
 		);
+		// Debug: Check what pending actions exist before second run_all_pending
+		$pending_actions = WC_Helper_Queue::get_all_pending();
+		$pending_actions_wc_admin = WC_Helper_Queue::get_all_pending( 'wc-admin-data' );
+		error_log( '=== DEBUG: Pending actions before second run_all_pending ===' );
+		error_log( 'Total pending actions: ' . count( $pending_actions ) );
+		error_log( 'Total wc-admin-data pending actions: ' . count( $pending_actions_wc_admin ) );
+		error_log( '--- ALL PENDING ACTIONS ---' );
+		foreach ( $pending_actions as $action ) {
+			error_log( sprintf(
+				'Action: hook=%s, group=%s, args=%s',
+				$action->get_hook(),
+				$action->get_group(),
+				json_encode( $action->get_args() )
+			) );
+		}
+		error_log( '--- WC-ADMIN-DATA ACTIONS ONLY ---' );
+		foreach ( $pending_actions_wc_admin as $action ) {
+			error_log( sprintf(
+				'Action: hook=%s, group=%s, args=%s',
+				$action->get_hook(),
+				$action->get_group(),
+				json_encode( $action->get_args() )
+			) );
+		}
+
 		// Verify that no follow up action was queued.
+		
 		WC_Helper_Queue::run_all_pending();
 		$this->assertCount(
 			0,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the group limitation for running pending actions introduced in https://github.com/woocommerce/woocommerce/pull/59325.

This is an attempt to fix flaky tests.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure all PHP unit tests pass.

<!-- End testing instructions -->

### Testing that has already taken place:

Tested multiple times in GitHub with passing tests.  Still not entirely sure why this might fix things.

There are some differences in [actions that were pending between groups](https://github.com/woocommerce/woocommerce/actions/runs/16525538611/job/46737803658?pr=60021), but no clear differences that would cause the issues we're seeing with tests.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
