### PR TITLE
Add a last second check that a milestone isn't set on a PR before assigning the default.

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -43,7 +43,7 @@ jobs:
               with:
                 script: |
                   const pr_number = context.payload.pull_request.number;
-                  const { data: { issue }} = await github.rest.issues.get({
+                   const { data: issue } = await github.rest.issues.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: pr_number

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -37,8 +37,21 @@ jobs:
               uses: shivammathur/setup-php@8e2ac35f639d3e794c1da1f28999385ab6fdf0fc
               with:
                   php-version: '7.4'
+            - name: Check if PR has milestone
+              id: check_milestone
+              uses: actions/github-script@v7
+              with:
+                script: |
+                  const pr_number = context.payload.pull_request.number;
+                  const {  issue } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr_number
+                  });
+                  core.setOutput('milestone_exists', !!issue.milestone);
             - name: 'Run the script to assign a milestone'
-              if: github.event.pull_request.base.ref == 'trunk'
+              if: github.event.pull_request.base.ref == 'trunk' &&
+                steps.check_milestone.outputs.milestone_exists == 'false'
               run: php assign-milestone-to-merged-pr.php
               env:
                   PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -43,7 +43,7 @@ jobs:
               with:
                 script: |
                   const pr_number = context.payload.pull_request.number;
-                  const {  issue } = await github.rest.issues.get({
+                  const { data: { issue }} = await github.rest.issues.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: pr_number


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a step to the post merge workflows to make sure that a milestone hasn't already been assigned to a milestone prior to assigning a default milestone.  This is to avoid race conditions we've been seeing where contributors are assigning a milestone immediately after merging in order to backport the changes to the release branch, only to have the post-merge process change the milestone back.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the the repository.
2. Merge this PR into trunk.
3. Create at least 2 milestones following the standard pattern, e.g.  10.1.0 and 10.2.0
4. Create a new PR with any changes against trunk.
5. Merge that PR and immediately change the milestone to the lower version, e.g. 10.1.0.  
6. Verify that the step to reassign the mileston to 10.2.0 didn't run.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [X] This Pull Request does not require a changelog entry. (Comment required below)
Workflow changes.
<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
