### PR TITLE
WPS migration: include testmode flag in requests

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -110,7 +110,7 @@ class WC_Gateway_Paypal_Request {
 	 */
 	public function create_paypal_order( $order ) {
 		try {
-			$request_body = $this->get_paypal_create_order_request_body( $order );
+			$order_request_params = $this->get_paypal_create_order_request_params( $order );
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
@@ -121,7 +121,12 @@ class WC_Gateway_Paypal_Request {
 					'headers' => array(
 						'Content-Type' => 'application/json',
 					),
-					'body'    => wp_json_encode( $request_body ),
+					'body'    => wp_json_encode(
+						array(
+							'testmode' => $this->gateway->get_option( 'testmode' ),
+							'order'    => $order_request_params,
+						)
+					),
 				)
 			);
 
@@ -262,12 +267,12 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
-	 * Build the request body for the PayPal create-order request.
+	 * Build the request parameters for the PayPal create-order request.
 	 *
 	 * @param WC_Order $order Order object.
 	 * @return array
 	 */
-	private function get_paypal_create_order_request_body( $order ) {
+	private function get_paypal_create_order_request_params( $order ) {
 		$currency = $order->get_currency();
 
 		return array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -123,7 +123,7 @@ class WC_Gateway_Paypal_Request {
 					),
 					'body'    => wp_json_encode(
 						array(
-							'testmode' => $this->gateway->get_option( 'testmode' ),
+							'testmode' => $this->gateway->testmode,
 							'order'    => $order_request_params,
 						)
 					),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -180,6 +180,7 @@ class WC_Gateway_Paypal_Request {
 			$request_body = array(
 				'capture_url'     => $capture_url,
 				'paypal_order_id' => $paypal_order_id,
+				'testmode'        => $this->gateway->testmode,
 			);
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -104,7 +104,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				400
 			);
 		}
-		$order = $request_data['order'];
+		$order    = $request_data['order'];
 		$testmode = $request_data['testmode'];
 		error_log( '(Proxy) PayPal create order request received: ' . wc_print_r( $request_data, true ) );
 
@@ -157,11 +157,11 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	/**
 	 * Get the PayPal create order request URL.
 	 *
-	 * @param bool $is_testmode Whether to use the sandbox environment.
+	 * @param bool $testmode Whether to use the sandbox environment.
 	 * @return string The request URL.
 	 */
-	private function get_paypal_create_order_request_url( $is_testmode = true ) {
-		return $is_testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
+	private function get_paypal_create_order_request_url( $testmode = true ) {
+		return $testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -97,6 +97,15 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function create_paypal_order( WP_REST_Request $request ) {
 		$request_data = $request->get_json_params();
+		if ( empty( $request_data['order'] ) || ! isset( $request_data['testmode'] ) ) {
+			error_log( '(Proxy) PayPal create order request missing params. ' . wc_print_r( $request_data, true ) );
+			return new WP_REST_Response(
+				array( 'error' => 'PayPal create order request missing params.' ),
+				400
+			);
+		}
+		$order = $request_data['order'];
+		$testmode = $request_data['testmode'];
 		error_log( '(Proxy) PayPal create order request received: ' . wc_print_r( $request_data, true ) );
 
 		$access_token = $this->get_paypal_access_token();
@@ -115,14 +124,14 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				'Authorization'     => 'Bearer ' . $access_token,
 				'PayPal-Request-Id' => uniqid(), // A unique ID for idempotency (recommended by PayPal).
 			),
-			'body'      => wp_json_encode( $request_data ),
+			'body'      => wp_json_encode( $order ),
 			'timeout'   => 45, // TODO: Set a timeout.
 			'sslverify' => false, // TODO: Set sslverify.
 		);
 
 		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $args, true ) );
 
-		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/checkout/orders', $args );
+		$response      = wp_remote_post( $this->get_paypal_create_order_request_url( $testmode ), $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );
@@ -143,6 +152,16 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				500
 			);
 		}
+	}
+
+	/**
+	 * Get the PayPal create order request URL.
+	 *
+	 * @param bool $is_testmode Whether to use the sandbox environment.
+	 * @return string The request URL.
+	 */
+	private function get_paypal_create_order_request_url( $is_testmode = true ) {
+		return $is_testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -160,7 +160,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 * @param bool $testmode Whether to use the sandbox environment.
 	 * @return string The request URL.
 	 */
-	private function get_paypal_create_order_request_url( $testmode = true ) {
+	private function get_paypal_create_order_request_url( $testmode ) {
 		return $testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -108,7 +108,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		$testmode = $request_data['testmode'];
 		error_log( '(Proxy) PayPal create order request received: ' . wc_print_r( $request_data, true ) );
 
-		$access_token = $this->get_paypal_access_token();
+		$access_token = $this->get_paypal_access_token( $testmode );
 		if ( ! $access_token ) {
 			error_log( '(Proxy) Failed to get PayPal access token.' );
 			return new WP_REST_Response(
@@ -155,16 +155,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Get the PayPal create order request URL.
-	 *
-	 * @param bool $testmode Whether to use the sandbox environment.
-	 * @return string The request URL.
-	 */
-	private function get_paypal_create_order_request_url( $testmode ) {
-		return $testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
-	}
-
-	/**
 	 * Capture the PayPal payment using Orders v2 API.
 	 *
 	 * @param WP_REST_Request $request The request object.
@@ -172,9 +162,25 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function capture_payment( WP_REST_Request $request ) {
 		$request_data = $request->get_json_params();
+
+		$required_params = array( 'testmode', 'capture_url', 'paypal_order_id' );
+		foreach ( $required_params as $param ) {
+			if ( ! isset( $request_data[$param] ) ) {
+				error_log( '(Proxy) PayPal capture payment request missing required param: ' . $param . '.' );
+				return new WP_REST_Response(
+					array( 'error' => 'PayPal capture payment request missing required param: ' . $param . '.' ),
+					400
+				);
+			}
+		}
+
 		error_log( '(Proxy) PayPal capture payment request received: ' . wc_print_r( $request_data, true ) );
 
-		$access_token = $this->get_paypal_access_token();
+		$testmode        = $request_data['testmode'];
+		$capture_url     = $request_data['capture_url'];
+		$paypal_order_id = $request_data['paypal_order_id'];
+
+		$access_token = $this->get_paypal_access_token( $testmode );
 		if ( ! $access_token ) {
 			error_log( '(Proxy) Failed to get PayPal access token. Cannot capture payment.' );
 			return new WP_REST_Response(
@@ -185,20 +191,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				500
 			);
 		}
-
-		if ( empty( $request_data['capture_url'] ) || empty( $request_data['paypal_order_id'] ) ) {
-			error_log( '(Proxy) Capture URL or PayPal order ID missing. Cannot capture payment.' );
-			return new WP_REST_Response(
-				array(
-					'status'  => 'error',
-					'message' => 'Capture URL or PayPal order ID missing.',
-				),
-				400
-			);
-		}
-
-		$capture_url     = $request_data['capture_url'];
-		$paypal_order_id = $request_data['paypal_order_id'];
 
 		$args = array(
 			'method'  => 'POST',
@@ -234,7 +226,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 *
 	 * @return string|null The access token.
 	 */
-	private function get_paypal_access_token() {
+	private function get_paypal_access_token( $testmode ) {
 		$paypal_client_id     = get_option( 'wc_paypal_api_client_id' );
 		$paypal_client_secret = get_option( 'wc_paypal_api_client_secret' );
 
@@ -255,7 +247,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		);
 		error_log( '(Proxy) PayPal access token request: ' . wc_print_r( $args, true ) );
 
-		$response  = wp_remote_post( 'https://api-m.sandbox.paypal.com/v1/oauth2/token', $args );
+		$response  = wp_remote_post( $this->get_paypal_access_token_request_url( $testmode ), $args );
 		$http_code = wp_remote_retrieve_response_code( $response );
 		$body      = wp_remote_retrieve_body( $response );
 		$data      = json_decode( $body, true );
@@ -268,6 +260,26 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			error_log( '(Proxy) Failed to get PayPal access token. ' . wc_print_r( $data, true ) );
 			return null;
 		}
+	}
+
+	/**
+	 * Get the PayPal create order request URL.
+	 *
+	 * @param bool $testmode Whether to use the sandbox environment.
+	 * @return string The request URL.
+	 */
+	private function get_paypal_create_order_request_url( $testmode ) {
+		return $testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
+	}
+
+	/**
+	 * Get the PayPal access token request URL.
+	 *
+	 * @param bool $testmode Whether to use the sandbox environment.
+	 * @return string The request URL.
+	 */
+	private function get_paypal_access_token_request_url( $testmode ) {
+		return $testmode ? 'https://api-m.sandbox.paypal.com/v1/oauth2/token' : 'https://api-m.paypal.com/v1/oauth2/token';
 	}
 }
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -97,7 +97,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function create_paypal_order( WP_REST_Request $request ) {
 		$request_data = $request->get_json_params();
-		if ( empty( $request_data['order'] ) || ! isset( $request_data['testmode'] ) ) {
+		if ( ! isset( $request_data['order'] ) || ! isset( $request_data['testmode'] ) ) {
 			error_log( '(Proxy) PayPal create order request missing params. ' . wc_print_r( $request_data, true ) );
 			return new WP_REST_Response(
 				array( 'error' => 'PayPal create order request missing params.' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -165,7 +165,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 
 		$required_params = array( 'testmode', 'capture_url', 'paypal_order_id' );
 		foreach ( $required_params as $param ) {
-			if ( ! isset( $request_data[$param] ) ) {
+			if ( ! isset( $request_data[ $param ] ) ) {
 				error_log( '(Proxy) PayPal capture payment request missing required param: ' . $param . '.' );
 				return new WP_REST_Response(
 					array( 'error' => 'PayPal capture payment request missing required param: ' . $param . '.' ),
@@ -224,6 +224,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	/**
 	 * Get the PayPal API access token.
 	 *
+	 * @param bool $testmode Whether to use the sandbox environment.
 	 * @return string|null The access token.
 	 */
 	private function get_paypal_access_token( $testmode ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -129,7 +129,12 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			'sslverify' => false, // TODO: Set sslverify.
 		);
 
-		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $args, true ) );
+		// Sanitize the $args array to mask sensitive headers before logging.
+		$sanitized_args = $args;
+		if ( isset( $sanitized_args['headers']['Authorization'] ) ) {
+			$sanitized_args['headers']['Authorization'] = 'Bearer [REDACTED]';
+		}
+		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $sanitized_args, true ) );
 
 		$response      = wp_remote_post( $this->get_paypal_create_order_request_url( $testmode ), $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -137,7 +137,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 
 		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $this->sanitize_args( $args ), true ) );
 
-		$response      = wp_remote_post( $this->get_paypal_create_order_request_url( $testmode ), $args );
+		$response      = wp_remote_post( $this->get_paypal_api_request_url( $testmode ) . '/v2/checkout/orders', $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );
@@ -254,7 +254,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		);
 		error_log( '(Proxy) PayPal access token request: ' . wc_print_r( $this->sanitize_args( $args ), true ) );
 
-		$response  = wp_remote_post( $this->get_paypal_access_token_request_url( $testmode ), $args );
+		$response  = wp_remote_post( $this->get_paypal_api_request_url( $testmode ) . '/v1/oauth2/token', $args );
 		$http_code = wp_remote_retrieve_response_code( $response );
 		$body      = wp_remote_retrieve_body( $response );
 		$data      = json_decode( $body, true );
@@ -270,23 +270,13 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Get the PayPal create order request URL.
+	 * Get the PayPal Orders v2 API request URL.
 	 *
 	 * @param bool $testmode Whether to use the sandbox environment.
 	 * @return string The request URL.
 	 */
-	private function get_paypal_create_order_request_url( $testmode ) {
-		return $testmode ? 'https://api-m.sandbox.paypal.com/v2/checkout/orders' : 'https://api-m.paypal.com/v2/checkout/orders';
-	}
-
-	/**
-	 * Get the PayPal access token request URL.
-	 *
-	 * @param bool $testmode Whether to use the sandbox environment.
-	 * @return string The request URL.
-	 */
-	private function get_paypal_access_token_request_url( $testmode ) {
-		return $testmode ? 'https://api-m.sandbox.paypal.com/v1/oauth2/token' : 'https://api-m.paypal.com/v1/oauth2/token';
+	private function get_paypal_api_request_url( $testmode ) {
+		return $testmode ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -104,7 +104,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				error_log( '(Proxy) PayPal create order request missing required param: ' . $param . '.' );
 				return new WP_REST_Response(
 					array( 'error' => 'PayPal create order request missing required param: ' . $param . '.' ),
-				400
+					400
 				);
 			}
 		}
@@ -299,7 +299,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		$sanitized_args = $args;
 		if ( isset( $sanitized_args['headers']['Authorization'] ) ) {
 			// Get authorization type from the Authorization header.
-			$authorization_type = strpos( $sanitized_args['headers']['Authorization'], 'Bearer ' ) === 0 ? 'Bearer' : 'Basic';
+			$authorization_type                         = strpos( $sanitized_args['headers']['Authorization'], 'Bearer ' ) === 0 ? 'Bearer' : 'Basic';
 			$sanitized_args['headers']['Authorization'] = $authorization_type . ' [REDACTED]';
 		}
 		return $sanitized_args;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -97,15 +97,21 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function create_paypal_order( WP_REST_Request $request ) {
 		$request_data = $request->get_json_params();
-		if ( ! isset( $request_data['order'] ) || ! isset( $request_data['testmode'] ) ) {
-			error_log( '(Proxy) PayPal create order request missing params. ' . wc_print_r( $request_data, true ) );
-			return new WP_REST_Response(
-				array( 'error' => 'PayPal create order request missing params.' ),
+
+		$required_params = array( 'order', 'testmode' );
+		foreach ( $required_params as $param ) {
+			if ( ! isset( $request_data[ $param ] ) ) {
+				error_log( '(Proxy) PayPal create order request missing required param: ' . $param . '.' );
+				return new WP_REST_Response(
+					array( 'error' => 'PayPal create order request missing required param: ' . $param . '.' ),
 				400
-			);
+				);
+			}
 		}
+
 		$order    = $request_data['order'];
 		$testmode = $request_data['testmode'];
+
 		error_log( '(Proxy) PayPal create order request received: ' . wc_print_r( $request_data, true ) );
 
 		$access_token = $this->get_paypal_access_token( $testmode );
@@ -129,12 +135,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			'sslverify' => false, // TODO: Set sslverify.
 		);
 
-		// Sanitize the $args array to mask sensitive headers before logging.
-		$sanitized_args = $args;
-		if ( isset( $sanitized_args['headers']['Authorization'] ) ) {
-			$sanitized_args['headers']['Authorization'] = 'Bearer [REDACTED]';
-		}
-		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $sanitized_args, true ) );
+		error_log( '(Proxy) PayPal order creation request: ' . wc_print_r( $this->sanitize_args( $args ), true ) );
 
 		$response      = wp_remote_post( $this->get_paypal_create_order_request_url( $testmode ), $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
@@ -251,7 +252,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			'timeout'   => 45, // TODO: Set a timeout.
 			'sslverify' => false, // TODO: Set sslverify.
 		);
-		error_log( '(Proxy) PayPal access token request: ' . wc_print_r( $args, true ) );
+		error_log( '(Proxy) PayPal access token request: ' . wc_print_r( $this->sanitize_args( $args ), true ) );
 
 		$response  = wp_remote_post( $this->get_paypal_access_token_request_url( $testmode ), $args );
 		$http_code = wp_remote_retrieve_response_code( $response );
@@ -286,6 +287,22 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	private function get_paypal_access_token_request_url( $testmode ) {
 		return $testmode ? 'https://api-m.sandbox.paypal.com/v1/oauth2/token' : 'https://api-m.paypal.com/v1/oauth2/token';
+	}
+
+	/**
+	 * Sanitize the args array to mask sensitive headers before logging.
+	 *
+	 * @param array $args The args array.
+	 * @return array The sanitized args array.
+	 */
+	private function sanitize_args( $args ) {
+		$sanitized_args = $args;
+		if ( isset( $sanitized_args['headers']['Authorization'] ) ) {
+			// Get authorization type from the Authorization header.
+			$authorization_type = strpos( $sanitized_args['headers']['Authorization'], 'Bearer ' ) === 0 ? 'Bearer' : 'Basic';
+			$sanitized_args['headers']['Authorization'] = $authorization_type . ' [REDACTED]';
+		}
+		return $sanitized_args;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Part of the WPS migration project. **Merges into feature/paypal-wps-migration.**

Towards PAYPAL-40.

This PR updates the order creation and capture payment requests to also pass `testmode` flag info to the proxy. The proxy needs it in order to determine which PayPal endpoints to hit.

Note: I also updated our temporary, client-side proxy code (`plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php`), for easy testing. This temp proxy will be replaced by the wpcom proxy, and the file will be deleted before the feature branch is merged.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable PayPal gateway and Orders v2.
   ```
   wp option patch update woocommerce_paypal_settings _should_load 'yes'
   wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
   ```
2. Add your PayPal API client and secret (for the test proxy).
   ```
   wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
   wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
   ```
3. As a shopper, add a product to cart and go to checkout.
4. Verify that you can still complete the purchase via PayPal.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This merges into a feature branch.

</details>
