### PR TITLE
Remove 'allows modifying the template parts' e2e test from Add to Cart + Options

### DIFF
--- a/plugins/woocommerce/changelog/remove-54976-allows-modifying-template-parts-test
+++ b/plugins/woocommerce/changelog/remove-54976-allows-modifying-template-parts-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove 'allows modifying the template parts' e2e test from Add to Cart + Options

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -20,35 +20,6 @@ const test = base.extend< { pageObject: AddToCartWithOptionsPage } >( {
 } );
 
 test.describe( 'Add to Cart + Options Block', () => {
-	test( 'allows modifying the template parts', async ( {
-		page,
-		pageObject,
-		editor,
-		admin,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
-			postType: 'wp_template',
-			canvas: 'edit',
-		} );
-
-		await editor.insertBlock( { name: pageObject.BLOCK_SLUG } );
-
-		await pageObject.insertParagraphInTemplatePart(
-			'This is a test paragraph added to the Add to Cart + Options template part.'
-		);
-
-		await editor.saveSiteEditorEntities();
-
-		await page.goto( '/product/cap' );
-
-		await expect(
-			page.getByText(
-				'This is a test paragraph added to the Add to Cart + Options template part.'
-			)
-		).toBeVisible();
-	} );
-
 	test( 'allows switching to 3rd-party product types', async ( {
 		pageObject,
 		editor,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Modifying the template parts is already covered by the '[doesn't allow selecting invalid variations in dropdown mode](https://github.com/woocommerce/woocommerce/blob/bd59c9558f3eb2ea4f7b621ee015eaf14628273e/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts#L239)' test, so I think we can remove the 'allows modifying the template parts' e2e test from the _Add to Cart + Options_ block.

Closes https://github.com/woocommerce/woocommerce/issues/54976.

### How to test the changes in this Pull Request:

1. Verify e2e tests keep passing.