### PR TITLE
Remove 'add-to-cart-with-options-stepper' feature flag

### DIFF
--- a/plugins/woocommerce/changelog/remove-add-to-cart-with-options-stepper-feature-flag
+++ b/plugins/woocommerce/changelog/remove-add-to-cart-with-options-stepper-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove 'add-to-cart-with-options-stepper' feature flag

--- a/plugins/woocommerce/client/admin/client/typings/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/typings/global.d.ts
@@ -42,9 +42,9 @@ declare global {
 				blueprint_max_step_size_bytes?: number;
 				onboarding?: {
 					profile?: {
-						industry?: number[]
-					}
-				}
+						industry?: number[];
+					};
+				};
 				siteVisibilitySettings: Record< string, string >;
 			};
 		};
@@ -125,9 +125,9 @@ declare global {
 	namespace wp.media {
 		interface frame {
 			open(): void;
-			on(event: string, callback: Function): void;
+			on( event: string, callback: Function ): void;
 			state(): {
-				get(state: string): any;
+				get( state: string ): any;
 			};
 		}
 

--- a/plugins/woocommerce/client/admin/client/typings/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/typings/global.d.ts
@@ -80,7 +80,6 @@ declare global {
 			'shipping-setting-tour': boolean;
 			'launch-your-store': boolean;
 			blueprint: boolean;
-			'add-to-cart-with-options-stepper-layout': boolean;
 		};
 		wp: {
 			updates?: {

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -41,7 +41,6 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": true,
 		"experimental-wc-rest-api": false
 	}
 }

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -41,7 +41,6 @@
 		"launch-your-store": true,
 		"product-editor-template-system": false,
 		"use-wp-horizon": false,
-		"add-to-cart-with-options-stepper-layout": true,
 		"experimental-wc-rest-api": true
 	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -8,8 +8,7 @@ import { BlockEditProps } from '@wordpress/blocks';
 import { Disabled, Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { isSiteEditorPage } from '@woocommerce/utils';
-import { getSettingWithCoercion, getSetting } from '@woocommerce/settings';
-import { isBoolean } from '@woocommerce/types';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -21,15 +21,8 @@ import type { Attributes } from './';
 const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 	const { setAttributes } = props;
 
-	const isStepperLayoutFeatureEnabled = getSettingWithCoercion(
-		'isStepperLayoutFeatureEnabled',
-		false,
-		isBoolean
-	);
-
 	const quantitySelectorStyleClass =
-		props.attributes.quantitySelectorStyle ===
-			QuantitySelectorStyle.Input || ! isStepperLayoutFeatureEnabled
+		props.attributes.quantitySelectorStyle === QuantitySelectorStyle.Input
 			? 'wc-block-add-to-cart-form--input'
 			: 'wc-block-add-to-cart-form--stepper';
 
@@ -58,9 +51,6 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 			<AddToCartFormSettings
 				quantitySelectorStyle={ props.attributes.quantitySelectorStyle }
 				setAttributes={ setAttributes }
-				features={ {
-					isStepperLayoutFeatureEnabled,
-				} }
 			/>
 			<div { ...blockProps }>
 				<Tooltip
@@ -73,9 +63,8 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 					<div className="wc-block-editor-add-to-cart-form-container">
 						<ProductShortDescriptionSkeleton isStatic={ true } />
 						<Disabled>
-							{ ( props.attributes.quantitySelectorStyle ===
-								QuantitySelectorStyle.Input ||
-								! isStepperLayoutFeatureEnabled ) && (
+							{ props.attributes.quantitySelectorStyle ===
+								QuantitySelectorStyle.Input && (
 								<>
 									<div className="quantity">
 										<input
@@ -113,52 +102,49 @@ const AddToCartFormEdit = ( props: BlockEditProps< Attributes > ) => {
 								</>
 							) }
 							{ props.attributes.quantitySelectorStyle ===
-								QuantitySelectorStyle.Stepper &&
-								isStepperLayoutFeatureEnabled && (
-									<>
-										<div className="quantity wc-block-components-quantity-selector">
-											<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">
-												−
-											</button>
-											<input
-												style={
-													// In the post editor, the editor isn't in an iframe, so WordPress styles are applied. We need to remove them.
-													! isSiteEditor
-														? {
-																backgroundColor:
-																	'#ffffff',
-																lineHeight:
-																	'normal',
-																minHeight:
-																	'unset',
-																boxSizing:
-																	'unset',
-																borderRadius:
-																	'unset',
-														  }
-														: {}
-												}
-												type="number"
-												value="1"
-												className="input-text qty text"
-												readOnly
-											/>
-											<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">
-												+
-											</button>
-										</div>
-										<div className={ buttonBlockClass }>
-											<button
-												className={ `single_add_to_cart_button alt wp-element-button ${ buttonLinkClass }` }
-											>
-												{ __(
-													'Add to cart',
-													'woocommerce'
-												) }
-											</button>
-										</div>
-									</>
-								) }
+								QuantitySelectorStyle.Stepper && (
+								<>
+									<div className="quantity wc-block-components-quantity-selector">
+										<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">
+											−
+										</button>
+										<input
+											style={
+												// In the post editor, the editor isn't in an iframe, so WordPress styles are applied. We need to remove them.
+												! isSiteEditor
+													? {
+															backgroundColor:
+																'#ffffff',
+															lineHeight:
+																'normal',
+															minHeight: 'unset',
+															boxSizing: 'unset',
+															borderRadius:
+																'unset',
+													  }
+													: {}
+											}
+											type="number"
+											value="1"
+											className="input-text qty text"
+											readOnly
+										/>
+										<button className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">
+											+
+										</button>
+									</div>
+									<div className={ buttonBlockClass }>
+										<button
+											className={ `single_add_to_cart_button alt wp-element-button ${ buttonLinkClass }` }
+										>
+											{ __(
+												'Add to cart',
+												'woocommerce'
+											) }
+										</button>
+									</div>
+								</>
+							) }
 						</Disabled>
 					</div>
 				</Tooltip>

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-elements/add-to-cart-form/settings.tsx
@@ -25,10 +25,6 @@ type AddToCartFormSettingsProps = {
 	setAttributes: ( attributes: {
 		quantitySelectorStyle: QuantitySelectorStyle;
 	} ) => void;
-
-	features: {
-		isStepperLayoutFeatureEnabled?: boolean;
-	};
 };
 
 const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
@@ -49,37 +45,32 @@ const getHelpText = ( quantitySelectorStyle: QuantitySelectorStyle ) => {
 export const AddToCartFormSettings = ( {
 	quantitySelectorStyle,
 	setAttributes,
-	features,
 }: AddToCartFormSettingsProps ) => {
-	const { isStepperLayoutFeatureEnabled } = features;
-
 	return (
 		<InspectorControls>
-			{ isStepperLayoutFeatureEnabled && (
-				<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
-					<ToggleGroupControl
-						__nextHasNoMarginBottom
-						value={ quantitySelectorStyle }
-						isBlock
-						onChange={ ( value: QuantitySelectorStyle ) => {
-							setAttributes( {
-								quantitySelectorStyle:
-									value as QuantitySelectorStyle,
-							} );
-						} }
-						help={ getHelpText( quantitySelectorStyle ) }
-					>
-						<ToggleGroupControlOption
-							label={ __( 'Input', 'woocommerce' ) }
-							value={ QuantitySelectorStyle.Input }
-						/>
-						<ToggleGroupControlOption
-							label={ __( 'Stepper', 'woocommerce' ) }
-							value={ QuantitySelectorStyle.Stepper }
-						/>
-					</ToggleGroupControl>
-				</PanelBody>
-			) }
+			<PanelBody title={ __( 'Quantity Selector', 'woocommerce' ) }>
+				<ToggleGroupControl
+					__nextHasNoMarginBottom
+					value={ quantitySelectorStyle }
+					isBlock
+					onChange={ ( value: QuantitySelectorStyle ) => {
+						setAttributes( {
+							quantitySelectorStyle:
+								value as QuantitySelectorStyle,
+						} );
+					} }
+					help={ getHelpText( quantitySelectorStyle ) }
+				>
+					<ToggleGroupControlOption
+						label={ __( 'Input', 'woocommerce' ) }
+						value={ QuantitySelectorStyle.Input }
+					/>
+					<ToggleGroupControlOption
+						label={ __( 'Stepper', 'woocommerce' ) }
+						value={ QuantitySelectorStyle.Stepper }
+					/>
+				</ToggleGroupControl>
+			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartForm.php
@@ -62,7 +62,6 @@ class AddToCartForm extends AbstractBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'isStepperLayoutFeatureEnabled', Features::is_enabled( 'add-to-cart-with-options-stepper-layout' ) );
 		$this->asset_data_registry->add( 'isBlockTheme', wp_is_block_theme() );
 	}
 
@@ -185,7 +184,7 @@ class AddToCartForm extends AbstractBlock {
 		 * The stepper buttons don't show when the product is sold individually or stock quantity is less or equal to 1 because the quantity input field is hidden.
 		 * Additionally, if min and max purchase quantity are the same, the buttons should not be rendered at all.
 		 */
-		$is_stepper_style = 'stepper' === $attributes['quantitySelectorStyle'] && ! $should_hide_quantity_selector && Features::is_enabled( 'add-to-cart-with-options-stepper-layout' );
+		$is_stepper_style = 'stepper' === $attributes['quantitySelectorStyle'] && ! $should_hide_quantity_selector;
 
 		if ( $is_descendent_of_single_product_block ) {
 			add_filter( 'woocommerce_add_to_cart_form_action', array( $this, 'add_to_cart_form_action' ), 10 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Stepper mode in the non-blockified _Add to Cart with Options_ block was introduced in WC 9.5 (https://github.com/woocommerce/woocommerce/pull/52573) and has been enabled by default since WC 9.7 (https://github.com/woocommerce/woocommerce/pull/54116). As we hadn't encountered any major issues since then, I think it's safe to remove the feature flag, and clean up the code a bit.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product.
2. Make sure you have the non-blockified _Add to Cart with Options_ block (if not, add it or downgrade from the blockified version).
3. Make sure you can switch between the _Input_ and _Stepper_ styles and changes are applied in the frontend.

<img width="1162" height="685" alt="imatge" src="https://github.com/user-attachments/assets/db905c12-21ee-44ea-8fbb-6b9b19f881ae" />
