### PR TITLE
WPS Migration: Authorize payment

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -476,6 +476,14 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	public function capture_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
+			include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
+
+			$paypal_request = new WC_Gateway_Paypal_Request( $this );
+			$paypal_request->capture_authorized_payment( $order );
+			return;
+		}
+
 		if ( self::ID === $order->get_payment_method() && 'pending' === $order->get_meta( '_paypal_status', true ) && $order->get_transaction_id() ) {
 			$this->init_api();
 			$result = WC_Gateway_Paypal_API_Handler::do_capture( $order );

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -477,7 +477,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$order = wc_get_order( $order_id );
 
 		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
-			include_once dirname( __FILE__ ) . '/includes/class-wc-gateway-paypal-request.php';
+			include_once __DIR__ . '/includes/class-wc-gateway-paypal-request.php';
 
 			$paypal_request = new WC_Gateway_Paypal_Request( $this );
 			$paypal_request->capture_authorized_payment( $order );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -143,37 +143,47 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
-	 * Capture a PayPal payment using the Orders v2 API.
+	 * Authorize or capture a PayPal payment using the Orders v2 API.
 	 *
-	 * This method captures a PayPal payment and updates the order status.
+	 * This method authorizes or captures a PayPal payment and updates the order status.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param string   $capture_url The URL to capture the payment.
+	 * @param string   $action_url The URL to authorize or capture the payment.
+	 * @param string   $action The action to perform. Either 'authorize' or 'capture'.
 	 * @return void
-	 * @throws Exception If the PayPal payment capture fails.
+	 * @throws Exception If the PayPal payment authorization or capture fails.
 	 */
-	public function capture_payment( $order, $capture_url ) {
+	public function authorize_or_capture_payment( $order, $action_url, $action = 'capture' ) {
 		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
 		if ( ! $paypal_order_id ) {
-			WC_Gateway_Paypal::log( 'PayPal order ID not found. Cannot capture payment.' );
+			WC_Gateway_Paypal::log( 'PayPal order ID not found. Cannot ' . $action . ' payment.' );
 			return;
 		}
 
-		if ( ! $capture_url ) {
-			WC_Gateway_Paypal::log( 'Capture URL not found. Cannot capture payment.' );
+		if ( ! $action_url ) {
+			WC_Gateway_Paypal::log( 'Action URL not found. Cannot ' . $action . ' payment.' );
 			return;
 		}
 
 		try {
-			$request_body = array(
-				'capture_url'     => $capture_url,
-				'paypal_order_id' => $paypal_order_id,
-			);
+			if ( 'capture' === $action ) {
+				$request_url  = $this->get_paypal_capture_payment_request_url();
+				$request_body = array(
+					'capture_url'   => $action_url,
+					'paypal_order_id' => $paypal_order_id,
+				);
+			} else {
+				$request_url  = $this->get_paypal_authorize_payment_request_url();
+				$request_body = array(
+					'authorize_url'     => $action_url,
+					'paypal_order_id' => $paypal_order_id,
+				);
+			}
 
 			// phpcs:disable Generic.Commenting.Todo.TaskFound
 			// TODO: Replace with the wpcom endpoint when it's ready.
 			$response = wp_remote_post(
-				$this->get_paypal_capture_payment_request_url(),
+				$request_url,
 				array(
 					'method'  => 'POST',
 					'headers' => array(
@@ -184,7 +194,7 @@ class WC_Gateway_Paypal_Request {
 			);
 
 			if ( is_wp_error( $response ) ) {
-				WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
+				WC_Gateway_Paypal::log( 'PayPal ' . $action . ' payment request failed. Response error: ' . $response->get_error_message() );
 				return;
 			}
 
@@ -192,19 +202,29 @@ class WC_Gateway_Paypal_Request {
 			$body      = wp_remote_retrieve_body( $response );
 
 			if ( 200 !== $http_code ) {
-				throw new Exception( 'PayPal payment capture failed. Response status: ' . $http_code . '. Response body: ' . $body );
+				throw new Exception( 'PayPal ' . $action . ' payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			$order->add_order_note(
 				sprintf(
 					/* translators: %1$s: PayPal order ID */
-					__( 'PayPal payment capture failed. PayPal Order ID: %1$s', 'woocommerce' ),
+					__( 'PayPal ' . $action . ' payment failed. PayPal Order ID: %1$s', 'woocommerce' ),
 					$paypal_order_id
 				)
 			);
 			$order->update_status( OrderStatus::FAILED );
 			$order->save();
+		} finally {
+			if ( 'authorize' === $action ) {
+				$order->add_order_note(
+					sprintf(
+						__( 'PayPal payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce' ),
+					)
+				);
+				$order->update_status( OrderStatus::ON_HOLD );
+				$order->save();
+			}
 		}
 	}
 
@@ -252,6 +272,17 @@ class WC_Gateway_Paypal_Request {
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/capture-payment' );
+	}
+
+	/**
+	 * Get the PayPal authorize-payment request URL.
+	 *
+	 * @return string
+	 */
+	private function get_paypal_authorize_payment_request_url() {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/authorize-payment' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -215,16 +215,6 @@ class WC_Gateway_Paypal_Request {
 			);
 			$order->update_status( OrderStatus::FAILED );
 			$order->save();
-		} finally {
-			if ( 'authorize' === $action ) {
-				$order->add_order_note(
-					sprintf(
-						__( 'PayPal payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce' ),
-					)
-				);
-				$order->update_status( OrderStatus::ON_HOLD );
-				$order->save();
-			}
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -219,6 +219,51 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Capture a PayPal payment that has been authorized.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return void
+	 */
+	public function capture_authorized_payment( $order ) {
+		if ( ! $order || ! $order->get_transaction_id() ) {
+			WC_Gateway_Paypal::log( 'PayPal authorization ID not found. Cannot capture payment.' );
+			return;
+		}
+
+		// Skip if the payment is already captured.
+		if ( 'COMPLETED' === $order->get_meta( '_paypal_status', true ) ) {
+			WC_Gateway_Paypal::log( 'PayPal payment is already captured. Skipping capture. Order ID: ' . $order->get_id() );
+			return;
+		}
+
+		$request_url  = $this->get_paypal_capture_authorized_payment_request_url( $order->get_transaction_id() );
+
+		$response = wp_remote_post(
+			$request_url,
+			array(
+				'method'  => 'POST',
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode( array() ),
+				'timeout' => 60,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
+			return;
+		}
+
+		$http_code = wp_remote_retrieve_response_code( $response );
+		$body      = wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $http_code ) {
+			WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
+		}
+	}
+
+	/**
 	 * Get the approve link from the response data.
 	 *
 	 * @param int   $http_code The HTTP code of the response.
@@ -273,6 +318,18 @@ class WC_Gateway_Paypal_Request {
 		// phpcs:ignore Generic.Commenting.Todo.TaskFound
 		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
 		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/authorize-payment' );
+	}
+
+	/**
+	 * Get the PayPal capture-authorized-payment request URL.
+	 *
+	 * @param string $authorization_id The PayPal authorization ID.
+	 * @return string
+	 */
+	private function get_paypal_capture_authorized_payment_request_url( $authorization_id ) {
+		// phpcs:ignore Generic.Commenting.Todo.TaskFound
+		// TODO: This will be replaced with a constant pointing to the wpcom endpoint.
+		return get_site_url( null, 'wp-json/wc/v3/paypal-proxy/capture-authorized-payment/' . $authorization_id );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -184,14 +184,14 @@ class WC_Gateway_Paypal_Request {
 				$request_body = array(
 					'capture_url'     => $action_url,
 					'paypal_order_id' => $paypal_order_id,
-          'testmode'        => $this->gateway->testmode,
+					'testmode'        => $this->gateway->testmode,
 				);
 			} else {
 				$request_url  = $this->get_paypal_authorize_payment_request_url();
 				$request_body = array(
 					'authorize_url'   => $action_url,
 					'paypal_order_id' => $paypal_order_id,
-          'testmode'        => $this->gateway->testmode,
+					'testmode'        => $this->gateway->testmode,
 				);
 			}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -177,13 +177,13 @@ class WC_Gateway_Paypal_Request {
 			if ( 'capture' === $action ) {
 				$request_url  = $this->get_paypal_capture_payment_request_url();
 				$request_body = array(
-					'capture_url'   => $action_url,
+					'capture_url'     => $action_url,
 					'paypal_order_id' => $paypal_order_id,
 				);
 			} else {
 				$request_url  = $this->get_paypal_authorize_payment_request_url();
 				$request_body = array(
-					'authorize_url'     => $action_url,
+					'authorize_url'   => $action_url,
 					'paypal_order_id' => $paypal_order_id,
 				);
 			}
@@ -217,8 +217,9 @@ class WC_Gateway_Paypal_Request {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			$order->add_order_note(
 				sprintf(
-					/* translators: %1$s: PayPal order ID */
-					__( 'PayPal ' . $action . ' payment failed. PayPal Order ID: %1$s', 'woocommerce' ),
+					/* translators: %1$s: Action, %2$s: PayPal order ID */
+					__( 'PayPal %1$s payment failed. PayPal Order ID: %2$s', 'woocommerce' ),
+					$action,
 					$paypal_order_id
 				)
 			);
@@ -245,7 +246,7 @@ class WC_Gateway_Paypal_Request {
 			return;
 		}
 
-		$request_url  = $this->get_paypal_capture_authorized_payment_request_url( $order->get_transaction_id() );
+		$request_url = $this->get_paypal_capture_authorized_payment_request_url( $order->get_transaction_id() );
 
 		$response = wp_remote_post(
 			$request_url,

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -262,7 +262,7 @@ class WC_Gateway_Paypal_Request {
 				'headers' => array(
 					'Content-Type' => 'application/json',
 				),
-				'body'    => wp_json_encode( array() ),
+				'body'    => wp_json_encode( array( 'testmode' => $this->gateway->testmode ) ),
 				'timeout' => 60,
 			)
 		);

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -68,8 +68,12 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				)
 			);
 
-			// Capture the payment after approval.
-			$this->capture_payment( $order, $event['resource']['links'] );
+			// Authorize or capture the payment after approval.
+			if ( 'CAPTURE' === $event['resource']['intent'] ) {
+				$this->authorize_or_capture_payment( $order, $event['resource']['links'], 'capture' );
+			} else {
+				$this->authorize_or_capture_payment( $order, $event['resource']['links'], 'authorize' );
+			}
 		} else {
 			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );
@@ -136,11 +140,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @param WC_Order $order The order object.
 	 * @param array    $links The links from the webhook event.
 	 */
-	private function capture_payment( $order, $links ) {
-		$capture_url = null;
+	private function authorize_or_capture_payment( $order, $links, $action ) {
+		$action_url = null;
 		foreach ( $links as $link ) {
-			if ( 'capture' === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
-				$capture_url = esc_url_raw( $link['href'] );
+			if ( $action === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {
+				$action_url = esc_url_raw( $link['href'] );
 				break;
 			}
 		}
@@ -152,6 +156,6 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		}
 		$gateway        = $payment_gateways['paypal'];
 		$paypal_request = new WC_Gateway_Paypal_Request( $gateway );
-		$paypal_request->capture_payment( $order, $capture_url );
+		$paypal_request->authorize_or_capture_payment( $order, $action_url, $action );
 	}
 }

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -65,6 +65,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$paypal_order_id = $event['resource']['id'] ?? null;
 		if ( 'APPROVED' === $status ) {
 			WC_Gateway_Paypal::log( 'PayPal payment approved. Order ID: ' . $order->get_id() );
+			$order->update_meta_data( '_paypal_status', $status );
 			$order->add_order_note(
 				sprintf(
 					/* translators: %1$s: PayPal order ID */
@@ -107,6 +108,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		}
 
 		$order->set_transaction_id( $event['resource']['id'] );
+		$order->update_meta_data( '_paypal_status', $event['resource']['status'] );
 		$order->payment_complete();
 		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
 		$order->save();

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Automattic\WooCommerce\Enums\OrderStatus;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -36,6 +38,9 @@ class WC_Gateway_Paypal_Webhook_Handler {
 				break;
 			case 'PAYMENT.CAPTURE.COMPLETED':
 				$this->process_payment_capture_completed( $data );
+				break;
+			case 'PAYMENT.AUTHORIZATION.CREATED':
+				$this->process_payment_authorization_created( $data );
 				break;
 			default:
 				WC_Gateway_Paypal::log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
@@ -104,6 +109,29 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$order->set_transaction_id( $event['resource']['id'] );
 		$order->payment_complete();
 		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
+		$order->save();
+	}
+
+	/**
+	 * Process the PAYMENT.AUTHORIZATION.CREATED webhook event.
+	 *
+	 * @param array $event The webhook event data.
+	 */
+	private function process_payment_authorization_created( $event ) {
+		$custom_id = $event['resource']['custom_id'];
+		$order     = $this->get_wc_order( $custom_id );
+		if ( ! $order ) {
+			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
+
+		$order->set_transaction_id( $event['resource']['id'] );
+		$order->add_order_note(
+			sprintf(
+				__( 'PayPal payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce' ),
+			)
+		);
+		$order->update_status( OrderStatus::ON_HOLD );
 		$order->save();
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -110,7 +110,13 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$order->set_transaction_id( $event['resource']['id'] );
 		$order->update_meta_data( '_paypal_status', $event['resource']['status'] );
 		$order->payment_complete();
-		$order->add_order_note( 'PayPal payment captured. ID: ' . $event['resource']['id'] );
+		$order->add_order_note(
+			/* translators: %1$s: Transaction ID */
+			sprintf(
+				__( 'PayPal payment captured. Transaction ID: %1$s.', 'woocommerce' ),
+				$event['resource']['id']
+			)
+		);
 		$order->save();
 	}
 
@@ -129,8 +135,10 @@ class WC_Gateway_Paypal_Webhook_Handler {
 
 		$order->set_transaction_id( $event['resource']['id'] );
 		$order->add_order_note(
+			/* translators: %1$s: Transaction ID */
 			sprintf(
-				__( 'PayPal payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce' ),
+				__( 'PayPal payment authorized. Transaction ID: %1$s.\nChange payment status to processing or complete to capture funds.', 'woocommerce' ),
+				$event['resource']['id']
 			)
 		);
 		$order->update_status( OrderStatus::ON_HOLD );
@@ -169,6 +177,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 *
 	 * @param WC_Order $order The order object.
 	 * @param array    $links The links from the webhook event.
+	 * @param string   $action The action to perform (capture or authorize).
+	 * @return void
 	 */
 	private function authorize_or_capture_payment( $order, $links, $action ) {
 		$action_url = null;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -134,7 +134,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$order->add_order_note(
 			sprintf(
 				/* translators: %1$s: Transaction ID */
-				__( 'PayPal payment authorized. Transaction ID: %1$s.\nChange payment status to processing or complete to capture funds.', 'woocommerce' ),
+				__( 'PayPal payment authorized. Transaction ID: %1$s.<\br>Change payment status to processing or complete to capture funds.', 'woocommerce' ),
 				$event['resource']['id']
 			)
 		);
@@ -178,6 +178,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @return void
 	 */
 	private function authorize_or_capture_payment( $order, $links, $action ) {
+		wc_get_logger()->info( 'called from webhook handler: ' . $action );
 		$action_url = null;
 		foreach ( $links as $link ) {
 			if ( $action === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -75,11 +75,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			);
 
 			// Authorize or capture the payment after approval.
-			if ( 'CAPTURE' === $event['resource']['intent'] ) {
-				$this->authorize_or_capture_payment( $order, $event['resource']['links'], 'capture' );
-			} else {
-				$this->authorize_or_capture_payment( $order, $event['resource']['links'], 'authorize' );
-			}
+			$action = 'CAPTURE' === $event['resource']['intent'] ? 'capture' : 'authorize';
+			$this->authorize_or_capture_payment( $order, $event['resource']['links'], $action );
 		} else {
 			// This is unexpected for a CHECKOUT.ORDER.APPROVED event.
 			WC_Gateway_Paypal::log( 'PayPal payment approval failed. Order ID: ' . $order->get_id() . ' Status: ' . $status );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -111,8 +111,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$order->update_meta_data( '_paypal_status', $event['resource']['status'] );
 		$order->payment_complete();
 		$order->add_order_note(
-			/* translators: %1$s: Transaction ID */
 			sprintf(
+				/* translators: %1$s: Transaction ID */
 				__( 'PayPal payment captured. Transaction ID: %1$s.', 'woocommerce' ),
 				$event['resource']['id']
 			)
@@ -135,8 +135,8 @@ class WC_Gateway_Paypal_Webhook_Handler {
 
 		$order->set_transaction_id( $event['resource']['id'] );
 		$order->add_order_note(
-			/* translators: %1$s: Transaction ID */
 			sprintf(
+				/* translators: %1$s: Transaction ID */
 				__( 'PayPal payment authorized. Transaction ID: %1$s.\nChange payment status to processing or complete to capture funds.', 'woocommerce' ),
 				$event['resource']['id']
 			)

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -88,7 +88,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/capture-authorized-payment/{authorization_id}',
+			'/' . $this->rest_base . '/capture-authorized-payment/(?P<authorization_id>[a-zA-Z0-9]+)',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'capture_authorized_payment' ),
@@ -302,8 +302,8 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response The response object.
 	 */
 	public function capture_authorized_payment( WP_REST_Request $request ) {
-		$request_data = $request->get_json_params();
-		error_log( '(Proxy) PayPal capture authorized payment request received: ' . wc_print_r( $request_data, true ) );
+		$authorization_id = $request->get_param('authorization_id');
+		error_log( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
 
 		$access_token = $this->get_paypal_access_token();
 		if ( ! $access_token ) {
@@ -317,12 +317,12 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		}
 
-		if ( empty( $request_data['authorization_id'] ) ) {
+		if ( empty( $authorization_id ) ) {
 			error_log( '(Proxy) Authorization ID missing. Cannot capture authorized payment.' );
 			return new WP_REST_Response(
 				array(
 					'status'  => 'error',
-					'message' => 'Authorize URL or PayPal order ID missing.',
+					'message' => 'Authorization ID missing.',
 				),
 				400
 			);
@@ -336,7 +336,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			),
 		);
 
-		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/payments/authorizations/' . $request_data['authorization_id'] . '/capture', $args );
+		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/payments/authorizations/' . $authorization_id . '/capture', $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -75,6 +75,16 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				'permission_callback' => '__return_true',
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/authorize-payment',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'authorize_payment' ),
+				'permission_callback' => '__return_true',
+			)
+		);
 	}
 
 	/**
@@ -203,6 +213,71 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		} else {
 			error_log( '(Proxy) Failed to capture PayPal order. ' . wc_print_r( $response_data, true ) );
+			return new WP_REST_Response(
+				$response_data,
+				500
+			);
+		}
+	}
+
+	/**
+	 * Capture the PayPal payment using Orders v2 API.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function authorize_payment( WP_REST_Request $request ) {
+		$request_data = $request->get_json_params();
+		error_log( '(Proxy) PayPal authorize payment request received: ' . wc_print_r( $request_data, true ) );
+
+		$access_token = $this->get_paypal_access_token();
+		if ( ! $access_token ) {
+			error_log( '(Proxy) Failed to get PayPal access token. Cannot authorize payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Failed to get PayPal access token.',
+				),
+				500
+			);
+		}
+
+		if ( empty( $request_data['authorize_url'] ) || empty( $request_data['paypal_order_id'] ) ) {
+			error_log( '(Proxy) Authorize URL or PayPal order ID missing. Cannot authorize payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Authorize URL or PayPal order ID missing.',
+				),
+				400
+			);
+		}
+
+		$authorize_url   = $request_data['authorize_url'];
+		$paypal_order_id = $request_data['paypal_order_id'];
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => array(
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+			),
+			'body'    => wp_json_encode( array( 'id' => $paypal_order_id ) ),
+		);
+
+		$response      = wp_remote_post( $authorize_url, $args );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$body          = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal authorize payment response: ' . wc_print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+				200
+			);
+		} else {
+			error_log( '(Proxy) Failed to authorize PayPal order. ' . wc_print_r( $response_data, true ) );
 			return new WP_REST_Response(
 				$response_data,
 				500

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -85,6 +85,16 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				'permission_callback' => '__return_true',
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/capture-authorized-payment/{authorization_id}',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'capture_authorized_payment' ),
+				'permission_callback' => '__return_true',
+			)
+		);
 	}
 
 	/**
@@ -278,6 +288,67 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		} else {
 			error_log( '(Proxy) Failed to authorize PayPal order. ' . wc_print_r( $response_data, true ) );
+			return new WP_REST_Response(
+				$response_data,
+				500
+			);
+		}
+	}
+
+	/**
+	 * Capture the PayPal payment that has been authorized.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response object.
+	 */
+	public function capture_authorized_payment( WP_REST_Request $request ) {
+		$request_data = $request->get_json_params();
+		error_log( '(Proxy) PayPal capture authorized payment request received: ' . wc_print_r( $request_data, true ) );
+
+		$access_token = $this->get_paypal_access_token();
+		if ( ! $access_token ) {
+			error_log( '(Proxy) Failed to get PayPal access token. Cannot authorize payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Failed to get PayPal access token.',
+				),
+				500
+			);
+		}
+
+		if ( empty( $request_data['authorization_id'] ) ) {
+			error_log( '(Proxy) Authorization ID missing. Cannot capture authorized payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Authorize URL or PayPal order ID missing.',
+				),
+				400
+			);
+		}
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => array(
+				'Content-Type'  => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+			),
+		);
+
+		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/payments/authorizations/' . $request_data['authorization_id'] . '/capture', $args );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$body          = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
+		error_log( '(Proxy) PayPal capture authorized payment response: ' . wc_print_r( $response_data, true ) );
+
+		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
+			return new WP_REST_Response(
+				$response_data,
+				200
+			);
+		} else {
+			error_log( '(Proxy) Failed to capture authorized PayPal payment. ' . wc_print_r( $response_data, true ) );
 			return new WP_REST_Response(
 				$response_data,
 				500

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -302,7 +302,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response The response object.
 	 */
 	public function capture_authorized_payment( WP_REST_Request $request ) {
-		$authorization_id = $request->get_param('authorization_id');
+		$authorization_id = $request->get_param( 'authorization_id' );
 		error_log( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
 
 		$access_token = $this->get_paypal_access_token();

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -255,9 +255,25 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function authorize_payment( WP_REST_Request $request ) {
 		$request_data = $request->get_json_params();
+
+		$required_params = array( 'testmode', 'authorize_url', 'paypal_order_id' );
+		foreach ( $required_params as $param ) {
+			if ( ! isset( $request_data[ $param ] ) ) {
+				error_log( '(Proxy) PayPal authorize payment request missing required param: ' . $param . '.' );
+				return new WP_REST_Response(
+					array( 'error' => 'PayPal authorize payment request missing required param: ' . $param . '.' ),
+					400
+				);
+			}
+		}
+
 		error_log( '(Proxy) PayPal authorize payment request received: ' . wc_print_r( $request_data, true ) );
 
-		$access_token = $this->get_paypal_access_token();
+		$testmode        = $request_data['testmode'];
+		$authorize_url   = $request_data['authorize_url'];
+		$paypal_order_id = $request_data['paypal_order_id'];
+
+		$access_token = $this->get_paypal_access_token( $testmode );
 		if ( ! $access_token ) {
 			error_log( '(Proxy) Failed to get PayPal access token. Cannot authorize payment.' );
 			return new WP_REST_Response(
@@ -268,20 +284,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 				500
 			);
 		}
-
-		if ( empty( $request_data['authorize_url'] ) || empty( $request_data['paypal_order_id'] ) ) {
-			error_log( '(Proxy) Authorize URL or PayPal order ID missing. Cannot authorize payment.' );
-			return new WP_REST_Response(
-				array(
-					'status'  => 'error',
-					'message' => 'Authorize URL or PayPal order ID missing.',
-				),
-				400
-			);
-		}
-
-		$authorize_url   = $request_data['authorize_url'];
-		$paypal_order_id = $request_data['paypal_order_id'];
 
 		$args = array(
 			'method'  => 'POST',
@@ -320,9 +322,33 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function capture_authorized_payment( WP_REST_Request $request ) {
 		$authorization_id = $request->get_param( 'authorization_id' );
+		$request_data     = $request->get_json_params();
+
+		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
+		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment request received for request data: ' . wc_print_r( $request_data, true ) );
+
 		error_log( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
 
-		$access_token = $this->get_paypal_access_token();
+		if ( empty( $authorization_id ) || ! isset( $request_data['testmode'] ) ) {
+			error_log( '(Proxy) Authorization ID missing. Cannot capture authorized payment.' );
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => 'Authorization ID missing.',
+				),
+				400
+			);
+		}
+
+		if ( ! isset( $request_data[ 'testmode' ] ) ) {
+			error_log( '(Proxy) PayPal authorize payment request missing required param: ' . $param . '.' );
+			return new WP_REST_Response(
+				array( 'error' => 'PayPal capture authorized payment request missing required param: ' . $param . '.' ),
+				400
+			);
+		}
+
+		$access_token = $this->get_paypal_access_token( $request_data[ 'testmode' ] );
 		if ( ! $access_token ) {
 			error_log( '(Proxy) Failed to get PayPal access token. Cannot authorize payment.' );
 			return new WP_REST_Response(
@@ -334,17 +360,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		}
 
-		if ( empty( $authorization_id ) ) {
-			error_log( '(Proxy) Authorization ID missing. Cannot capture authorized payment.' );
-			return new WP_REST_Response(
-				array(
-					'status'  => 'error',
-					'message' => 'Authorization ID missing.',
-				),
-				400
-			);
-		}
-
 		$args = array(
 			'method'  => 'POST',
 			'headers' => array(
@@ -353,11 +368,13 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			),
 		);
 
-		$response      = wp_remote_post( 'https://api-m.sandbox.paypal.com/v2/payments/authorizations/' . $authorization_id . '/capture', $args );
+		$response      = wp_remote_post( $this->get_paypal_api_request_url( $request_data[ 'testmode' ] ) . '/v2/payments/authorizations/' . $authorization_id . '/capture', $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );
 		error_log( '(Proxy) PayPal capture authorized payment response: ' . wc_print_r( $response_data, true ) );
+
+		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment response: ' . wc_print_r( $response_data, true ) );
 
 		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
 			return new WP_REST_Response(

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -340,7 +340,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		}
 
-		if ( ! isset( $request_data[ 'testmode' ] ) ) {
+		if ( ! isset( $request_data['testmode'] ) ) {
 			error_log( '(Proxy) PayPal authorize payment request missing required param: ' . $param . '.' );
 			return new WP_REST_Response(
 				array( 'error' => 'PayPal capture authorized payment request missing required param: ' . $param . '.' ),
@@ -348,7 +348,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		}
 
-		$access_token = $this->get_paypal_access_token( $request_data[ 'testmode' ] );
+		$access_token = $this->get_paypal_access_token( $request_data['testmode'] );
 		if ( ! $access_token ) {
 			error_log( '(Proxy) Failed to get PayPal access token. Cannot authorize payment.' );
 			return new WP_REST_Response(
@@ -368,7 +368,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			),
 		);
 
-		$response      = wp_remote_post( $this->get_paypal_api_request_url( $request_data[ 'testmode' ] ) . '/v2/payments/authorizations/' . $authorization_id . '/capture', $args );
+		$response      = wp_remote_post( $this->get_paypal_api_request_url( $request_data['testmode'] ) . '/v2/payments/authorizations/' . $authorization_id . '/capture', $args );
 		$http_code     = wp_remote_retrieve_response_code( $response );
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
@@ -124,6 +124,22 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 				}
 
 				break;
+			case 'PAYMENT.AUTHORIZATION.CREATED':
+				$custom_client_data = $data['resource']['custom_id'];
+				$client_endpoint    = $this->get_client_webhook_endpoint( $custom_client_data );
+
+				if ( ! $client_endpoint ) {
+					error_log( 'No client webhook endpoint found' );
+					return new WP_REST_Response( 'No client webhook endpoint found', 400 );
+				}
+
+				$response = $this->forward_webhook_to_client( $client_endpoint, $data );
+				if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+					error_log( 'Webhook forwarding failed: ' . wc_print_r( $response, true ) );
+					return new WP_REST_Response( 'Webhook forwarding failed', 500 );
+				}
+
+				break;
 			default:
 				error_log( 'Unhandled PayPal webhook event: ' . wc_print_r( $data, true ) );
 				break;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Added authorization support for orders v2.
- When `Payment action` is set to `Authorize`, we will send a request to the `authorize_url` instead of `capture_url` which is received in the `CHECKOUT.ORDER.APPROVED` webhook event.
- This will create an authorized transaction in PayPal.
- The order status is set as `on-hold`.
- In legacy implementation, the payment is captured when the user changes the order status from `on-hold` to `processing` or `completed`.  The same has been implemented for the new flow.
- On order status change, we send a request to capture the authorized payment.
- If the capture is successful, PayPal sends a `PAYMENT.CAPTURE.COMPLETED` webhook which is already covered in the code.

Closes PAYPAL-48

### Screenshots or screen recordings:

<img width="306" height="699" alt="Screenshot 2025-07-28 at 12 18 24 PM" src="https://github.com/user-attachments/assets/7a8f717d-2d30-461d-8854-35b5f2d23ee7" />

### How to test the changes in this Pull Request:
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Configure PayPal Standard's settings:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- **For Payment action, select Authorize**
5. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
```
6. As a shopper, add a product to cart and go to checkout.
7. You should see PayPal as a payment option.
8. Click "Proceed to PayPal".
9. Use your Personal sandbox account credentials to log in and approve the purchase.
10. You should get redirected to the "Order Confirmation" page.
11. Wait a few seconds, and go to the wp-admin order page.
12. There should be an order note about payment authorization and the order status should be `on-hold`.
13. In the order details section, the transaction ID should be linked. 
15. Click the transaction ID. It should take you to the PayPal transaction page. Confirm that the transaction status is `Authorized`.
16. Go back to the order edit page and change the order status to `processing`.
17. Wait a few seconds and refresh the page.
18. There should be an order note about payment capture.
19. Go to the PayPal transaction page. Confirm that the transaction status is `Authorized`.

**Note**
- The behavior of capturing the authorized payment on order status change is in parity with the existing behavior.
- From the PayPal dashboard, there is an option to capture the payment from the corresponding transaction page. This action is not working in my PP sandbox and it never gets captured. Theoretically, when the capture from the PP dashboard works it would send a `PAYMENT.CAPTURE.COMPLETED` webhook, which is already covered in the code.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
