### PR TITLE
Use CSS variables for Product Gallery sizes

### DIFF
--- a/plugins/woocommerce/changelog/update-product-gallery-css-variables
+++ b/plugins/woocommerce/changelog/update-product-gallery-css-variables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use CSS variables for Product Gallery sizes

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/inner-blocks/product-gallery-thumbnails/edit.tsx
@@ -87,17 +87,18 @@ export const Edit = ( {
 	}, [ thumbnailSize ] );
 
 	const thumbnailSizeValue = Number( thumbnailSize.replace( '%', '' ) );
-	const className = clsx(
-		'wc-block-product-gallery-thumbnails',
-		`wc-block-product-gallery-thumbnails--thumbnails-size-${ thumbnailSizeValue }`,
-		{
-			'wc-block-product-gallery-thumbnails--overflow-right':
-				overflowState.right,
-			'wc-block-product-gallery-thumbnails--overflow-bottom':
-				overflowState.bottom,
-		}
-	);
-	const blockProps = useBlockProps( { className } );
+	const className = clsx( 'wc-block-product-gallery-thumbnails', {
+		'wc-block-product-gallery-thumbnails--overflow-right':
+			overflowState.right,
+		'wc-block-product-gallery-thumbnails--overflow-bottom':
+			overflowState.bottom,
+	} );
+	const blockProps = useBlockProps( {
+		className,
+		style: {
+			'--wc-block-product-gallery-thumbnails-size': thumbnailSizeValue,
+		},
+	} );
 	const imageStyles: Record< string, string | undefined > = {
 		aspectRatio,
 	};

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -110,49 +110,47 @@ $dialog-padding: 20px;
 		:where(.wc-block-product-gallery-thumbnails__scrollable) {
 			flex-direction: column;
 		}
-		@for $i from 10 through 50 {
-			&:has(.wc-block-components-product-image--aspect-ratio-auto),
-			&:has(.wc-block-components-product-image--aspect-ratio-1) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 1 / calc(100 / $i);
-				}
+		&:has(.wc-block-components-product-image--aspect-ratio-auto),
+		&:has(.wc-block-components-product-image--aspect-ratio-1) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 1 / calc(100 / var(--wc-block-product-gallery-thumbnails-size));
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-4-3) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 4 / calc(100 / $i * 3);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-4-3) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 4 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 3);
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-3-4) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 3 / calc(100 / $i * 4);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-3-4) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 3 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 4);
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-3-2) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 3 / calc(100 / $i * 2);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-3-2) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 3 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 2);
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-2-3) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 2 / calc(100 / $i * 3);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-2-3) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 2 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 3);
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-16-9) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 16 / calc(100 / $i * 9);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-16-9) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 16 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 9);
 			}
-			&:has(.wc-block-components-product-image--aspect-ratio-9-16) {
-				:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-					flex-basis: calc($i * 1%);
-					aspect-ratio: 9 / calc(100 / $i * 16);
-				}
+		}
+		&:has(.wc-block-components-product-image--aspect-ratio-9-16) {
+			:where(.wc-block-product-gallery-thumbnails) {
+				flex-basis: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+				aspect-ratio: 9 / calc(100 / var(--wc-block-product-gallery-thumbnails-size) * 16);
 			}
 		}
 	}
@@ -246,12 +244,10 @@ $dialog-padding: 20px;
 	@include horizontal-thumbnails;
 
 	// These are min - max range values for thumbnails size.
-	@for $i from 10 through 50 {
-		&:where(.wc-block-product-gallery-thumbnails--thumbnails-size-#{$i}) {
-			width: 100%;
-			height: calc($i * 1%);
-			aspect-ratio: calc(100 / $i) / 1;
-		}
+	&:where(.wc-block-product-gallery-thumbnails) {
+		width: 100%;
+		height: calc(var(--wc-block-product-gallery-thumbnails-size) * 1%);
+		aspect-ratio: calc(100 / var(--wc-block-product-gallery-thumbnails-size)) / 1;
 	}
 }
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -65,16 +65,15 @@ class ProductGalleryThumbnails extends AbstractBlock {
 			return '';
 		}
 
-		$thumbnail_size   = str_replace( '%', '', $attributes['thumbnailSize'] ?? '25%' );
-		$thumbnails_class = 'wc-block-product-gallery-thumbnails--thumbnails-size-' . $thumbnail_size;
+		$thumbnail_size = str_replace( '%', '', $attributes['thumbnailSize'] ?? '25%' );
 
 		$img_class = 'wc-block-product-gallery-thumbnails__thumbnail__image';
 
 		ob_start();
 		?>
 		<div
-			class="wc-block-product-gallery-thumbnails <?php echo esc_attr( $classes_and_styles['classes'] . ' ' . $thumbnails_class ); ?>"
-			style="<?php echo esc_attr( $classes_and_styles['styles'] ); ?>"
+			class="wc-block-product-gallery-thumbnails <?php echo esc_attr( $classes_and_styles['classes'] ); ?>"
+			style="<?php echo '--wc-block-product-gallery-thumbnails-size:' . absint( $thumbnail_size ) . ';' . esc_attr( $classes_and_styles['styles'] ); ?>"
 			data-wp-interactive="woocommerce/product-gallery"
 			data-wp-class--wc-block-product-gallery-thumbnails--overflow-top="context.thumbnailsOverflow.top"
 			data-wp-class--wc-block-product-gallery-thumbnails--overflow-bottom="context.thumbnailsOverflow.bottom"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I think the _Product Gallery_ CSS can be simplified to avoid using SCSS loops by using variables, which should help make the CSS files smaller.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product.
2. Update the old _Product Image Gallery_ block to the blockified _Product Gallery_ block.
3. Play around with its attributes, specially _Thumbnail size_ and _Aspect ratio_ in the _Thumbnails_ inner block:

<img width="595" height="687" alt="imatge" src="https://github.com/user-attachments/assets/c3b8d487-3d2a-4452-930a-404703873c7d" />

4. Play around with other attributes, like changing the thumbnails from being in one side to being at the top or bottom.
5. Verify it always looks good in the frontend and there are no regressions.