### PR TITLE
Update/support SKU in checkout links

### DIFF
--- a/plugins/woocommerce/changelog/update-support-sku-in-checkout-links
+++ b/plugins/woocommerce/changelog/update-support-sku-in-checkout-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Support SKU as product identifiers awhen using checkout links

--- a/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
+++ b/plugins/woocommerce/src/Blocks/Domain/Services/CheckoutLink.php
@@ -96,13 +96,14 @@ class CheckoutLink {
 
 		foreach ( $raw_products as $product_id_qty ) {
 			if ( strpos( $product_id_qty, ':' ) !== false ) {
-				list( $product_id, $qty ) = explode( ':', $product_id_qty );
+				list( $product_identifier, $qty ) = explode( ':', $product_id_qty );
 			} else {
-				$product_id = $product_id_qty;
-				$qty        = 1;
+				$product_identifier = $product_id_qty;
+				$qty                = 1;
 			}
-			$product_id = absint( $product_id );
-			$qty        = absint( $qty );
+			$qty = absint( $qty );
+
+			$product_id = $this->resolve_product_id( $product_identifier );
 
 			if ( ! $product_id || ! $qty ) {
 				continue;
@@ -112,6 +113,37 @@ class CheckoutLink {
 		}
 
 		return $products;
+	}
+
+	/**
+	 * Resolve product identifier to product ID.
+	 * First tries as numeric ID, then falls back to SKU lookup.
+	 *
+	 * @param string $identifier Product ID or SKU.
+	 * @return int Product ID if found, 0 otherwise.
+	 */
+	protected function resolve_product_id( $identifier ) {
+		$identifier = trim( $identifier );
+
+		if ( empty( $identifier ) ) {
+			return 0;
+		}
+
+		// First try as numeric product ID.
+		if ( is_numeric( $identifier ) ) {
+			$product_id = absint( $identifier );
+			if ( $product_id && wc_get_product( $product_id ) ) {
+				return $product_id;
+			}
+		}
+
+		// Fallback to SKU lookup.
+		$product_id = wc_get_product_id_by_sku( $identifier );
+		if ( $product_id && wc_get_product( $product_id ) ) {
+			return $product_id;
+		}
+
+		return 0;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Domain/Services/CheckoutLinkTest.php
@@ -20,6 +20,11 @@ class CheckoutLinkTest extends TestCase {
 		// Reset global cart/session if needed.
 		$GLOBALS['added_to_cart']   = [];
 		$GLOBALS['applied_coupons'] = [];
+
+		// Clear WooCommerce cart.
+		if ( WC()->cart ) {
+			WC()->cart->empty_cart();
+		}
 	}
 
 	/**
@@ -29,6 +34,12 @@ class CheckoutLinkTest extends TestCase {
 		$_GET                       = [];
 		$GLOBALS['added_to_cart']   = [];
 		$GLOBALS['applied_coupons'] = [];
+
+		// Clear WooCommerce cart.
+		if ( WC()->cart ) {
+			WC()->cart->empty_cart();
+		}
+
 		parent::tearDown();
 	}
 
@@ -91,5 +102,152 @@ class CheckoutLinkTest extends TestCase {
 		foreach ( $test_products as $product ) {
 			wp_delete_post( $product->get_id(), true );
 		}
+	}
+
+	/**
+	 * Test that products can be added using SKUs.
+	 */
+	public function test_products_can_be_added_using_skus() {
+		$test_products = [
+			\WC_Helper_Product::create_simple_product(),
+			\WC_Helper_Product::create_simple_product(),
+		];
+
+		// Set SKUs for test products.
+		$test_products[0]->set_sku( 'TEST-SKU-001' );
+		$test_products[0]->save();
+		$test_products[1]->set_sku( 'TEST-SKU-002' );
+		$test_products[1]->save();
+
+		$product_skus = [
+			$test_products[0]->get_sku(),
+			$test_products[1]->get_sku(),
+		];
+		$product_ids  = [
+			$test_products[0]->get_id(),
+			$test_products[1]->get_id(),
+		];
+
+		$_GET['products'] = implode( ',', $product_skus );
+
+		$service = new class() extends CheckoutLink {
+			/**
+			 * Get the checkout link for testing.
+			 *
+			 * @return string The checkout link.
+			 */
+			public function get_checkout_link_test() {
+				return parent::get_checkout_link();
+			}
+		};
+
+		$url = $service->get_checkout_link_test();
+
+		$cart_contents    = WC()->cart->get_cart();
+		$cart_product_ids = array_map(
+			function ( $item ) {
+				return $item['product_id'];
+			},
+			$cart_contents
+		);
+
+		$this->assertEquals( array_values( $product_ids ), array_values( $cart_product_ids ) );
+
+		// Clean up.
+		foreach ( $test_products as $product ) {
+			wp_delete_post( $product->get_id(), true );
+		}
+	}
+
+	/**
+	 * Test mixed ID and SKU usage.
+	 */
+	public function test_mixed_id_and_sku_usage() {
+		$test_products = [
+			\WC_Helper_Product::create_simple_product(),
+			\WC_Helper_Product::create_simple_product(),
+		];
+
+		// Set SKU for first product, use ID for second.
+		$test_products[0]->set_sku( 'MIXED-TEST-SKU' );
+		$test_products[0]->save();
+
+		$product_identifiers = [
+			$test_products[0]->get_sku(),  // Use SKU.
+			$test_products[1]->get_id(),   // Use ID.
+		];
+		$expected_ids        = [
+			$test_products[0]->get_id(),
+			$test_products[1]->get_id(),
+		];
+
+		$_GET['products'] = implode( ',', $product_identifiers );
+
+		$service = new class() extends CheckoutLink {
+			/**
+			 * Get the checkout link for testing.
+			 *
+			 * @return string The checkout link.
+			 */
+			public function get_checkout_link_test() {
+				return parent::get_checkout_link();
+			}
+		};
+
+		$url = $service->get_checkout_link_test();
+
+		$cart_contents    = WC()->cart->get_cart();
+		$cart_product_ids = array_map(
+			function ( $item ) {
+				return $item['product_id'];
+			},
+			$cart_contents
+		);
+
+		$this->assertEquals( array_values( $expected_ids ), array_values( $cart_product_ids ) );
+
+		// Clean up.
+		foreach ( $test_products as $product ) {
+			wp_delete_post( $product->get_id(), true );
+		}
+	}
+
+	/**
+	 * Test that invalid SKUs and IDs are skipped.
+	 */
+	public function test_invalid_skus_and_ids_are_skipped() {
+		$test_product = \WC_Helper_Product::create_simple_product();
+		$test_product->set_sku( 'VALID-SKU' );
+		$test_product->save();
+
+		// Mix valid and invalid identifiers.
+		$_GET['products'] = 'VALID-SKU,INVALID-SKU,99999,';
+
+		$service = new class() extends CheckoutLink {
+			/**
+			 * Get the checkout link for testing.
+			 *
+			 * @return string The checkout link.
+			 */
+			public function get_checkout_link_test() {
+				return parent::get_checkout_link();
+			}
+		};
+
+		$url = $service->get_checkout_link_test();
+
+		$cart_contents    = WC()->cart->get_cart();
+		$cart_product_ids = array_map(
+			function ( $item ) {
+				return $item['product_id'];
+			},
+			$cart_contents
+		);
+
+		// Only the valid SKU should be added.
+		$this->assertEquals( [ $test_product->get_id() ], array_values( $cart_product_ids ) );
+
+		// Clean up.
+		wp_delete_post( $test_product->get_id(), true );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/58140 introduced a `/checkout-link` endpoint that allows users to pre-populate their cart by visiting a URL with product IDs and product Qty, and optional coupon code.

This PR allows users to use SKU as product identifiers fallbacks and updates the logic to check for SKU when the product ID is not found. 

Feature requested in https://linear.app/a8c/project/woo-fb-callable-woo-checkout-urls-from-facebook-shops-9d3245a76199/updates#projectUpdate-996f833b&comment-5ed79224

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Valid Cart Link**
   - Visit `/checkout-link?products=<valid_id_1>,<valid_sku_2>&coupon=<valid_coupon>`
   - You should be redirected to checkout with both products in the cart and the coupon applied.

2. **Valid Cart Link w/ product quantities**
   - Visit `/checkout-link?products=<valid_id_1>:2,<valid_sku_2>&coupon=<valid_coupon>`
   - You should be redirected to checkout with both products in the cart and the coupon applied.
   - <valid_id_1> should have a quantity of 2
   
3. **Invalid Coupon**
   - Visit `/checkout-link?products=<valid_id_1>,<valid_sku_2>&coupon=INVALID_COUPON`
   - You should see a notice: `Coupon "INVALID_COUPON" cannot be applied because it does not exist.`

4. **Invalid Product (mixed)**
   - Visit `/checkout-link?products=<valid_sku_2>,999999`
   - You should see a notice: `Product with ID "999999" was not found and cannot be added to the cart.`
   - The valid product should still be in the cart.

5. **Only Invalid Product**
   - Visit `/checkout-link?products=999999`
   - You should be redirected to the cart page.
   - You should see a notice: `The provided checkout link was out of date or invalid. No products were added to the cart.`
<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
