### PR TITLE
Product Gallery: Fix incorrect image size on wider screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-aspect-ratio-product-gallery-2
+++ b/plugins/woocommerce/changelog/fix-aspect-ratio-product-gallery-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix to changes applied recently
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/style.scss
@@ -25,6 +25,7 @@ $dialog-padding: 20px;
 
 	:where(.wc-block-product-gallery-large-image__wrapper) {
 		flex-shrink: 0;
+		min-width: 100%;
 		max-width: 100%;
 		display: flex;
 		align-items: center;
@@ -40,6 +41,7 @@ $dialog-padding: 20px;
 	.wc-block-components-product-image.wc-block-components-product-image {
 		margin: 0;
 		height: 100%;
+		width: 100%;
 
 		:where(a) {
 			height: 100%;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/59790 I've made significant changes in how the images are styled and cropped. Apparently, due to image sizes and screen width I tested it with:
- default Single Product block which is super narrow in posts especially with two columns layout
- default SIngle Product template where layout is limited by Max Wide with two columns layout
I missed the wider layouts case where images were not fitting the expected container and the it gets broken (especially on Firefox and Safari browsers, while in Chrome with good resolution images it looked fairly fine).

In this PR I'm fixing this.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Videos going through Chrome > Firefox > Safari

**Original** 

Browser | Before | After |
| ------ | ----- | -- |
|   Chrome     |   <img width="1298" height="1003" alt="image" src="https://github.com/user-attachments/assets/a541bbb0-d2c6-4013-8eca-fe55aa4e6182" />    |<img width="1295" height="1019" alt="image" src="https://github.com/user-attachments/assets/e26319f7-d3e3-4c82-855c-587f1cbc31b3" />
|   Firefox     |    <img width="1273" height="1016" alt="image" src="https://github.com/user-attachments/assets/85f0c45a-7349-43a6-abbd-58ea625ddec7" />   | <img width="1301" height="1034" alt="image" src="https://github.com/user-attachments/assets/7223e14a-8c56-43ad-b8e6-c1be03859dad" />
|   Safari     |   <img width="1286" height="1027" alt="image" src="https://github.com/user-attachments/assets/47a70d6d-a14c-434c-9fc6-18f152c24858" />    | <img width="1309" height="1018" alt="image" src="https://github.com/user-attachments/assets/56a5bc69-85dc-4f7e-9ace-00ce0502b804" />


**Square** 

Browser | Before | After |
| ------ | ----- | -- |
|   Chrome     |    <img width="1287" height="1020" alt="image" src="https://github.com/user-attachments/assets/ec799a44-0f44-4fde-bdd1-396fb23adbba" />   | <img width="1275" height="1020" alt="image" src="https://github.com/user-attachments/assets/c491e42d-40e3-4056-a046-6c8664cc5e3e" />
|   Firefox     |  <img width="1283" height="997" alt="image" src="https://github.com/user-attachments/assets/4cb7d136-f0fd-44d6-9559-7842379e1c61" />     | <img width="1276" height="1014" alt="image" src="https://github.com/user-attachments/assets/726bbb2c-9631-45ac-9e74-7eab733d6674" />
|   Safari     |    <img width="1253" height="1012" alt="image" src="https://github.com/user-attachments/assets/6eaba993-c0a7-4c1c-82bf-8b74896e824b" />   | <img width="1266" height="1025" alt="image" src="https://github.com/user-attachments/assets/ee890b80-d44a-4830-803d-f6c64459f464" />


**Tall 9/16** 

Browser | Before | After |
| ------ | ----- | -- |
|   Chrome     |  <img width="1257" height="1271" alt="image" src="https://github.com/user-attachments/assets/06d66f57-1aeb-471d-9758-f44e30a41d01" />     |<img width="1247" height="1267" alt="image" src="https://github.com/user-attachments/assets/a12c934e-1b79-42b7-90fa-66d3459907ea" />
|   Firefox     |  <img width="1276" height="1274" alt="image" src="https://github.com/user-attachments/assets/e61af776-b0a1-4185-a5d3-c3399fd401a9" />     | <img width="1262" height="1282" alt="image" src="https://github.com/user-attachments/assets/c3b7deed-9960-4ccb-9148-494e92901de7" />
|   Safari     |    <img width="1286" height="1308" alt="image" src="https://github.com/user-attachments/assets/0ecdfe85-cba9-4514-9465-45491f6b5ca1" />   | <img width="1279" height="1308" alt="image" src="https://github.com/user-attachments/assets/ce040790-7aea-4eea-a601-0c06650089fd" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Create product with multiple images of different sizes and orientations
1. Add new post
2. Insert Product block and choose product you created
3. Insert Product Gallery in Product, move it as a direct child of Product Gallery and remove other content so you essentially end up with "standalone" Product Gallery in Product block

<img width="362" height="139" alt="image" src="https://github.com/user-attachments/assets/4dbe0fe3-1578-4e9a-a501-f42ef77d7333" />

5. Change the width of Product block to Wide width

<img width="293" height="211" alt="image" src="https://github.com/user-attachments/assets/8ab581b5-f310-4297-9b15-fbd604ac9527" />

6. Save and go to frontend
7. **Expected:** Images are "growing" to fit the available space either to max width or max height, whatever comes first

Orientation | Original aspect ratio
-- | --
Portrait | <img width="1504" height="1199" alt="image" src="https://github.com/user-attachments/assets/7e68b538-20b3-4f0b-94ff-68b49304dda1" />
Landscape | <img width="1523" height="1202" alt="image" src="https://github.com/user-attachments/assets/fdefe854-d893-44fd-9851-c5036faf260d" />

8. Go back to Editor and change aspect of Product Image to some other values:
  - square
  - and any other (any should be representative for the remaining ones)
9. Repeat steps 6 - 7
10. **Expected:** This time images are _cropped_ to the set aspect ratio

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
