### PR TITLE
WPS migration: authenticated requests to proxy

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -55,6 +55,8 @@ class WC_Gateway_Paypal_Request {
 	protected $endpoint;
 
 
+	private const WPCOM_PROXY_ENDPOINT_API_VERSION = 2;
+
 	/**
 	 * Constructor.
 	 *
@@ -112,23 +114,21 @@ class WC_Gateway_Paypal_Request {
 		try {
 			$order_request_params = $this->get_paypal_create_order_request_params( $order );
 
-			// phpcs:disable Generic.Commenting.Todo.TaskFound
-			// TODO: Replace with the wpcom endpoint when it's ready.
-			$response = wp_remote_post(
-				$this->get_paypal_create_order_request_url(),
+			$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+				'/wc-gateway-paypal-proxy/create-order',
+				self::WPCOM_PROXY_ENDPOINT_API_VERSION,
 				array(
+					'headers' => array( 'Content-Type' => 'application/json' ),
 					'method'  => 'POST',
-					'headers' => array(
-						'Content-Type' => 'application/json',
-					),
-					'body'    => wp_json_encode(
-						array(
-							'testmode' => $this->gateway->testmode,
-							'order'    => $order_request_params,
-						)
-					),
 					'timeout' => 60,
-				)
+				),
+				wp_json_encode(
+					array(
+						'testmode' => $this->gateway->testmode,
+						'order'    => $order_request_params,
+					)
+				),
+				'wpcom'
 			);
 
 			if ( is_wp_error( $response ) ) {
@@ -186,14 +186,14 @@ class WC_Gateway_Paypal_Request {
 
 		try {
 			if ( 'capture' === $action ) {
-				$request_url  = $this->get_paypal_capture_payment_request_url();
+				$endpoint     = 'payments/capture';
 				$request_body = array(
 					'capture_url'     => $action_url,
 					'paypal_order_id' => $paypal_order_id,
 					'testmode'        => $this->gateway->testmode,
 				);
 			} else {
-				$request_url  = $this->get_paypal_authorize_payment_request_url();
+				$endpoint     = 'payments/authorize';
 				$request_body = array(
 					'authorize_url'   => $action_url,
 					'paypal_order_id' => $paypal_order_id,
@@ -201,23 +201,20 @@ class WC_Gateway_Paypal_Request {
 				);
 			}
 
-			// phpcs:disable Generic.Commenting.Todo.TaskFound
-			// TODO: Replace with the wpcom endpoint when it's ready.
-			$response = wp_remote_post(
-				$request_url,
+			$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+				'/transact/paypal_standard/' . $endpoint,
+				self::WPCOM_PROXY_ENDPOINT_API_VERSION,
 				array(
+					'headers' => array( 'Content-Type' => 'application/json' ),
 					'method'  => 'POST',
-					'headers' => array(
-						'Content-Type' => 'application/json',
-					),
-					'body'    => wp_json_encode( $request_body ),
 					'timeout' => 60,
-				)
+				),
+				wp_json_encode( $request_body ),
+				'wpcom'
 			);
 
 			if ( is_wp_error( $response ) ) {
-				WC_Gateway_Paypal::log( 'PayPal ' . $action . ' payment request failed. Response error: ' . $response->get_error_message() );
-				return;
+				throw new Exception( 'PayPal ' . $action . ' payment request failed. Response error: ' . $response->get_error_message() );
 			}
 
 			$http_code = wp_remote_retrieve_response_code( $response );

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -54,8 +55,29 @@ class WC_Gateway_Paypal_Request {
 	 */
 	protected $endpoint;
 
-
+	/**
+	 * The API version for the proxy endpoint.
+	 *
+	 * @var int
+	 */
 	private const WPCOM_PROXY_ENDPOINT_API_VERSION = 2;
+
+	/**
+	 * The base for the proxy REST endpoint.
+	 *
+	 * @var string
+	 */
+	private const WPCOM_PROXY_REST_BASE = 'transact/paypal_standard/proxy';
+
+	/**
+	 * Proxy REST endpoints.
+	 *
+	 * @var string
+	 */
+	private const WPCOM_PROXY_ORDER_ENDPOINT                = 'order';
+	private const WPCOM_PROXY_PAYMENT_CAPTURE_ENDPOINT      = 'payment/capture';
+	private const WPCOM_PROXY_PAYMENT_AUTHORIZE_ENDPOINT    = 'payment/authorize';
+	private const WPCOM_PROXY_PAYMENT_CAPTURE_AUTH_ENDPOINT = 'payment/capture_auth';
 
 	/**
 	 * Constructor.
@@ -112,24 +134,11 @@ class WC_Gateway_Paypal_Request {
 	 */
 	public function create_paypal_order( $order ) {
 		try {
-			$order_request_params = $this->get_paypal_create_order_request_params( $order );
-
-			$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
-				'/wc-gateway-paypal-proxy/create-order',
-				self::WPCOM_PROXY_ENDPOINT_API_VERSION,
-				array(
-					'headers' => array( 'Content-Type' => 'application/json' ),
-					'method'  => 'POST',
-					'timeout' => 60,
-				),
-				wp_json_encode(
-					array(
-						'testmode' => $this->gateway->testmode,
-						'order'    => $order_request_params,
-					)
-				),
-				'wpcom'
+			$request_body = array(
+				'test_mode' => $this->gateway->testmode,
+				'order'     => $this->get_paypal_create_order_request_params( $order ),
 			);
+			$response     = $this->send_wpcom_proxy_request( 'POST', self::WPCOM_PROXY_ORDER_ENDPOINT, $request_body );
 
 			if ( is_wp_error( $response ) ) {
 				throw new Exception( 'PayPal order creation failed. Response error: ' . $response->get_error_message() );
@@ -186,32 +195,22 @@ class WC_Gateway_Paypal_Request {
 
 		try {
 			if ( 'capture' === $action ) {
-				$endpoint     = 'payments/capture';
+				$endpoint     = self::WPCOM_PROXY_PAYMENT_CAPTURE_ENDPOINT;
 				$request_body = array(
 					'capture_url'     => $action_url,
 					'paypal_order_id' => $paypal_order_id,
-					'testmode'        => $this->gateway->testmode,
+					'test_mode'       => $this->gateway->testmode,
 				);
 			} else {
-				$endpoint     = 'payments/authorize';
+				$endpoint     = self::WPCOM_PROXY_PAYMENT_AUTHORIZE_ENDPOINT;
 				$request_body = array(
 					'authorize_url'   => $action_url,
 					'paypal_order_id' => $paypal_order_id,
-					'testmode'        => $this->gateway->testmode,
+					'test_mode'       => $this->gateway->testmode,
 				);
 			}
 
-			$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
-				'/transact/paypal_standard/' . $endpoint,
-				self::WPCOM_PROXY_ENDPOINT_API_VERSION,
-				array(
-					'headers' => array( 'Content-Type' => 'application/json' ),
-					'method'  => 'POST',
-					'timeout' => 60,
-				),
-				wp_json_encode( $request_body ),
-				'wpcom'
-			);
+			$response = $this->send_wpcom_proxy_request( 'POST', $endpoint, $request_body );
 
 			if ( is_wp_error( $response ) ) {
 				throw new Exception( 'PayPal ' . $action . ' payment request failed. Response error: ' . $response->get_error_message() );
@@ -256,19 +255,11 @@ class WC_Gateway_Paypal_Request {
 			return;
 		}
 
-		$request_url = $this->get_paypal_capture_authorized_payment_request_url( $order->get_transaction_id() );
-
-		$response = wp_remote_post(
-			$request_url,
-			array(
-				'method'  => 'POST',
-				'headers' => array(
-					'Content-Type' => 'application/json',
-				),
-				'body'    => wp_json_encode( array( 'testmode' => $this->gateway->testmode ) ),
-				'timeout' => 60,
-			)
+		$request_body = array(
+			'test_mode'        => $this->gateway->testmode,
+			'authorization_id' => $order->get_transaction_id(),
 		);
+		$response     = $this->send_wpcom_proxy_request( 'POST', self::WPCOM_PROXY_PAYMENT_CAPTURE_AUTH_ENDPOINT, $request_body );
 
 		if ( is_wp_error( $response ) ) {
 			WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
@@ -544,6 +535,42 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Send a request to the API proxy.
+	 *
+	 * @param string $method The HTTP method to use.
+	 * @param string $endpoint The endpoint to request.
+	 * @param array  $request_body The request body.
+	 *
+	 * @return array|null The API response body, or null if the request fails.
+	 * @throws Exception If the site ID is not found.
+	 */
+	private function send_wpcom_proxy_request( $method, $endpoint, $request_body ) {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			WC_Gateway_Paypal::log( sprintf( 'Site ID not found. Cannot send request to %s.', $endpoint ) );
+			throw new Exception( 'Site ID not found. Cannot send proxy request.' );
+		}
+
+		if ( 'GET' === $method ) {
+			$endpoint .= '?' . http_build_query( $request_body );
+		}
+
+		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/%s/%s', $site_id, self::WPCOM_PROXY_REST_BASE, $endpoint ),
+			self::WPCOM_PROXY_ENDPOINT_API_VERSION,
+			array(
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'method'  => $method,
+				'timeout' => 60,
+			),
+			'GET' === $method ? null : wp_json_encode( $request_body ),
+			'wpcom'
+		);
+
+		return $response;
+	}
+
+	/**
 	 * Limit length of an arg.
 	 *
 	 * @param  string  $string Argument to limit.
@@ -556,10 +583,8 @@ class WC_Gateway_Paypal_Request {
 			if ( mb_strlen( $string ) > $limit ) {
 				$string = mb_strimwidth( $string, 0, $str_limit ) . '...';
 			}
-		} else {
-			if ( strlen( $string ) > $limit ) {
+		} elseif ( strlen( $string ) > $limit ) {
 				$string = substr( $string, 0, $str_limit ) . '...';
-			}
 		}
 		return $string;
 	}
@@ -635,7 +660,6 @@ class WC_Gateway_Paypal_Request {
 			),
 			$order
 		);
-
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -223,7 +223,7 @@ class WC_Gateway_Paypal_Request {
 			$http_code = wp_remote_retrieve_response_code( $response );
 			$body      = wp_remote_retrieve_body( $response );
 
-			if ( 200 !== $http_code ) {
+			if ( 200 !== $http_code && 201 !== $http_code ) {
 				throw new Exception( 'PayPal ' . $action . ' payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 		} catch ( Exception $e ) {

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-request-test.php
@@ -15,6 +15,29 @@ require_once WC_ABSPATH . 'includes/gateways/paypal/includes/class-wc-gateway-pa
 class WC_Gateway_Paypal_Request_Test extends \WC_Unit_Test_Case {
 
 	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', array( $this, 'return_valid_site_id' ) );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'return_blog_token' ) );
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_option_jetpack_options', array( $this, 'return_valid_site_id' ) );
+		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'return_blog_token' ) );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Test create_paypal_order when API returns error.
 	 */
 	public function test_create_paypal_order_error() {
@@ -152,5 +175,27 @@ class WC_Gateway_Paypal_Request_Test extends \WC_Unit_Test_Case {
 	public function create_paypal_order_error( $value, $parsed_url ) {
 		// Return a 500 error.
 		return array( 'response' => array( 'code' => 500 ) );
+	}
+
+	/**
+	 * Helper method to return valid site ID for Jetpack options.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return int
+	 */
+	public function return_valid_site_id( $value ) {
+		return array( 'id' => 12345 );
+	}
+
+	/**
+	 * Helper method to return valid blog token for Jetpack options.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return array
+	 */
+	public function return_blog_token( $value ) {
+		return array( 'blog_token' => 'IAM.AJETPACKBLOGTOKEN' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Closes PAYPAL-47.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You will also need the server code: https://github.com/Automattic/transact-platform-server/pull/7601 
2. Enable PayPal Standard, and onboard the merchant and provider with Transact, if not yet onboarded: 
   - `wp option patch insert woocommerce_paypal_settings _should_load 'yes'` (or `patch update`) to enable PayPal Standard.
   - Go to WooCommerce > Settings > Payments, and enable PayPal Standard
   - Inside the PayPal settings,
      - enable **PayPal sandbox**, 
      - enter `sb-eco47t44825840@business.example.com` in the **PayPal email** field.
   - `wp option patch insert woocommerce_paypal_settings is_tos_accepted 'yes'` (or `patch update`) to simulate ToS accepted flag.
   - Trigger the Transact onboarding via a settings save -- check-uncheck any setting to enable the Save Changes button.
   - Verify in the Transact database that the merchant and provider accounts have been created.
3. Enter the client id and secret in `local/secrets.php`.
   - Get the client ID and secret from https://mc.a8c.com/secret-store/?secret_id=13318 (See notes.)
   ```
   define( 'WC_GATEWAY_PAYPAL_PROXY_CLIENT_ID', '<client_id>' );
   define( 'WC_GATEWAY_PAYPAL_PROXY_CLIENT_SECRET', '<client_secret>' );
   ```
5. As a shopper, add a product to your cart and choose PayPal on checkout.
6. Verify that you are redirected to the payment approval page.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
