### PR TITLE
Fix REST API coupon validation for percentage amounts over 100%

### DIFF
--- a/plugins/woocommerce/changelog/60067-fix-wooplug-5205-rest-api-unexpected-response-when-creating-an-invalid-coupon
+++ b/plugins/woocommerce/changelog/60067-fix-wooplug-5205-rest-api-unexpected-response-when-creating-an-invalid-coupon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix REST API coupon validation for percentage amounts over 100%. Resolves issue where percentage coupons with amounts > 100 were created with 0.00 amount instead of returning validation error.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -286,6 +286,11 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 			return new WP_Error( 'woocommerce_rest_empty_coupon_code', sprintf( __( 'The coupon code cannot be empty.', 'woocommerce' ), 'code' ), array( 'status' => 400 ) );
 		}
 
+		// Handle setting discount type first because that is needed for validation.
+		if ( isset( $request['discount_type'] ) ) {
+			$coupon->set_discount_type( $request['discount_type'] );
+		}
+
 		// Handle all writable props.
 		foreach ( $data_keys as $key ) {
 			$value = $request[ $key ];
@@ -315,13 +320,6 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 						break;
 					default:
 						if ( is_callable( array( $coupon, "set_{$key}" ) ) ) {
-							// Special validation for amount when discount_type is percent.
-							if ( 'amount' === $key && 'percent' === ( $request['discount_type'] ?? 'fixed_cart' ) ) {
-								$amount = wc_format_decimal( $value );
-								if ( $amount > 100 ) {
-									return new WP_Error( 'woocommerce_rest_invalid_coupon_amount', __( 'Percentage discount cannot exceed 100%.', 'woocommerce' ), array( 'status' => 400 ) );
-								}
-							}
 							$coupon->{"set_{$key}"}( $value );
 						}
 						break;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * REST API Coupons controller
  *
@@ -19,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
+
 
 	/**
 	 * Endpoint namespace.
@@ -46,7 +48,9 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
@@ -58,7 +62,8 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => array_merge(
-						$this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+						$this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+						array(
 							'code' => array(
 								'description' => __( 'Coupon code.', 'woocommerce' ),
 								'required'    => true,
@@ -72,7 +77,9 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
 				'args'   => array(
 					'id' => array(
 						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
@@ -110,7 +117,9 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/batch', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/batch',
+			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'batch_items' ),
@@ -304,6 +313,13 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 						break;
 					default:
 						if ( is_callable( array( $coupon, "set_{$key}" ) ) ) {
+							// Special validation for amount when discount_type is percent.
+							if ( 'amount' === $key && 'percent' === ( $request['discount_type'] ?? 'fixed_cart' ) ) {
+								$amount = wc_format_decimal( $value );
+								if ( $amount > 100 ) {
+									return new WP_Error( 'woocommerce_rest_invalid_coupon_amount', __( 'Percentage discount cannot exceed 100%.', 'woocommerce' ), array( 'status' => 400 ) );
+								}
+							}
 							$coupon->{"set_{$key}"}( $value );
 						}
 						break;
@@ -351,7 +367,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'status' => array(
+				'status'                      => array(
 					'description' => __( 'The status of the coupon. Should always be draft, published, or pending review', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -22,6 +22,8 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 
 
+
+
 	/**
 	 * Endpoint namespace.
 	 *

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -63,7 +63,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon();
+		$coupon   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/coupons/' . $coupon->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -81,7 +81,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 	public function test_coupons_get_each_field_one_by_one() {
 		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
-		$coupon = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon();
+		$coupon                   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon();
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v3/coupons/' . $coupon->get_id() );
@@ -102,12 +102,12 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$coupon_1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'dummycoupon-1', 'draft' );
 		$post_1   = get_post( $coupon_1->get_id() );
-		$coupon_2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'dummycoupon-2');
+		$coupon_2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'dummycoupon-2' );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v3/coupons' );
 		$request->set_query_params(
 			array(
-				'status'    => 'publish'
+				'status' => 'publish',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -142,5 +142,86 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'trash', get_post_status( $coupon->get_id() ) );
+	}
+
+	/**
+	 * Test creating coupon with invalid percentage amount.
+	 */
+	public function test_create_coupon_invalid_percentage_amount() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
+		$request->set_body_params(
+			array(
+				'code'          => 'invalid-percent-test',
+				'discount_type' => 'percent',
+				'amount'        => '200',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		// Should return 400 error
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Should contain validation error message
+		$data = $response->get_data();
+		$this->assertStringContainsString( 'Percentage discount cannot exceed 100%', $data['message'] );
+
+		// Ensure coupon was not created
+		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'invalid-percent-test' ) );
+	}
+
+	/**
+	 * Test creating coupon with valid percentage amount.
+	 */
+	public function test_create_coupon_valid_percentage_amount() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
+		$request->set_body_params(
+			array(
+				'code'          => 'valid-percent-test',
+				'discount_type' => 'percent',
+				'amount'        => '50',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		// Should succeed
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( '50.00', $data['amount'] );
+		$this->assertEquals( 'percent', $data['discount_type'] );
+	}
+
+	/**
+	 * Test creating coupon with negative amount.
+	 */
+	public function test_create_coupon_negative_amount() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
+		$request->set_body_params(
+			array(
+				'code'          => 'negative-amount-test',
+				'discount_type' => 'fixed_cart',
+				'amount'        => '-10',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		// Should return 400 error
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Should contain validation error message
+		$data = $response->get_data();
+		$this->assertStringContainsString( 'Coupon amount cannot be negative', $data['message'] );
+
+		// Ensure coupon was not created
+		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'negative-amount-test' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -168,7 +168,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		// Should contain validation error message.
 		$data = $response->get_data();
-		$this->assertStringContainsString( 'Percentage discount cannot exceed 100%', $data['message'] );
+		$this->assertStringContainsString( 'Invalid discount amount', $data['message'] );
 
 		// Ensure coupon was not created.
 		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'invalid-percent-test' ) );
@@ -225,5 +225,33 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		// Ensure coupon was not created.
 		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'negative-amount-test' ) );
+	}
+
+	/**
+	 * Test creating coupon with negative percentage amount.
+	 */
+	public function test_create_coupon_negative_percentage_amount() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
+		$request->set_body_params(
+			array(
+				'code'          => 'negative-percent-test',
+				'discount_type' => 'percent',
+				'amount'        => '-25',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		// Should return 400 error.
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Should contain validation error message from coupon class.
+		$data = $response->get_data();
+		$this->assertStringContainsString( 'Invalid discount amount', $data['message'] );
+
+		// Ensure coupon was not created.
+		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'negative-percent-test' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -219,7 +219,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		// Should contain validation error message
 		$data = $response->get_data();
-		$this->assertStringContainsString( 'Coupon amount cannot be negative', $data['message'] );
+		$this->assertStringContainsString( 'Invalid discount amount', $data['message'] );
 
 		// Ensure coupon was not created
 		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'negative-amount-test' ) );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller-tests.php
@@ -6,6 +6,8 @@
  */
 class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
+
+
 	/**
 	 * Setup our test server, endpoints, and user info.
 	 */
@@ -161,14 +163,14 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( $request );
 
-		// Should return 400 error
+		// Should return 400 error.
 		$this->assertEquals( 400, $response->get_status() );
 
-		// Should contain validation error message
+		// Should contain validation error message.
 		$data = $response->get_data();
 		$this->assertStringContainsString( 'Percentage discount cannot exceed 100%', $data['message'] );
 
-		// Ensure coupon was not created
+		// Ensure coupon was not created.
 		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'invalid-percent-test' ) );
 	}
 
@@ -189,7 +191,7 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( $request );
 
-		// Should succeed
+		// Should succeed.
 		$this->assertEquals( 201, $response->get_status() );
 
 		$data = $response->get_data();
@@ -214,14 +216,14 @@ class WC_REST_Coupons_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( $request );
 
-		// Should return 400 error
+		// Should return 400 error.
 		$this->assertEquals( 400, $response->get_status() );
 
-		// Should contain validation error message
+		// Should contain validation error message.
 		$data = $response->get_data();
 		$this->assertStringContainsString( 'Invalid discount amount', $data['message'] );
 
-		// Ensure coupon was not created
+		// Ensure coupon was not created.
 		$this->assertEquals( 0, wc_get_coupon_id_by_code( 'negative-amount-test' ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a validation bug in the WooCommerce REST API where percentage coupons with amounts over 100% were being created with amount "0.00" instead of returning a proper validation error.

**Root Cause**: The validation logic was not executing in REST API requests before setting the property because `set_amount` was being executed before the discount type got set. 

**Solution**: 
3. **Explicitly set discount type before other props** - This ensures the existing validation in `WC_Coupon::set_amount` works as expected.
4. **Comprehensive tests** - Added test coverage for both valid and invalid scenarios (they were missing).

Closes #60066.

### How to test the changes in this Pull Request:

1. Set up WooCommerce with REST API access
2. Send a POST request to `/wp-json/wc/v3/coupons` with JSON body: `{"code": "invalid-test", "discount_type": "percent", "amount": "200"}`
3. Verify it returns 400 error with message "Percentage discount cannot exceed 100%." (before fix: would return 201 success with amount "0.00")

### Testing that has already taken place:

- **Unit Tests**: Added comprehensive test coverage for all validation scenarios
- **Manual Testing**: Verified all test cases work as expected
- **Backward Compatibility**: Ensured existing valid coupons continue to work
- **Performance**: No performance impact - validation occurs at object creation time

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix REST API coupon validation for percentage amounts over 100%. Resolves issue where percentage coupons with amounts > 100 were created with 0.00 amount instead of returning validation error.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>