### PR TITLE
Add to Cart + Options minor fixes

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-multiple-fixes
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-multiple-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show appender when the Add to Cart + Options have no inner blocks and make the Add to Cart Button count update when selecting an out-of-stock variation

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -60,6 +60,10 @@ const productButtonStore = {
 				( item ) => item.id === state.productId
 			);
 
+			if ( products.length === 0 ) {
+				return 0;
+			}
+
 			// Return the product quantity when the item is a non-variable product.
 			if ( products[ 0 ]?.type !== 'variation' ) {
 				return products[ 0 ]?.quantity || 0;

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -221,9 +221,7 @@ const productButtonStore = {
 			// We skip the animation altogether if the Add to Cart + Options form is invalid.
 			if (
 				context.tempQuantity !== state.quantity &&
-				context.animationStatus === AnimationStatus.IDLE &&
-				( addToCartWithOptionsState?.isFormValid === undefined ||
-					addToCartWithOptionsState?.isFormValid )
+				context.animationStatus === AnimationStatus.IDLE
 			) {
 				context.animationStatus = AnimationStatus.SLIDE_OUT;
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -292,22 +292,22 @@ const { state, actions } = store< Store >(
 
 				// Optimistically updates the number of items in the cart.
 				if ( item ) {
-					if ( updateOptimistically ) {
-						item.quantity = quantity;
-					}
 					if ( item.key ) {
 						quantityChanges.cartItemsPendingQuantity = [ item.key ];
 					}
-				} else {
 					if ( updateOptimistically ) {
-						item = {
-							id,
-							quantity,
-							variation,
-						} as OptimisticCartItem;
+						item.quantity = quantity;
+					}
+				} else {
+					item = {
+						id,
+						quantity,
+						variation,
+					} as OptimisticCartItem;
+					quantityChanges.productsPendingAdd = [ id ];
+					if ( updateOptimistically ) {
 						state.cart.items.push( item );
 					}
-					quantityChanges.productsPendingAdd = [ id ];
 				}
 
 				// Updates the database.

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -29,6 +29,7 @@ export type OptimisticCartItem = {
 	variation?: CartVariationItem[];
 	name: string;
 	type: string;
+	updateOptimistically?: boolean;
 };
 
 export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
@@ -257,7 +258,12 @@ const { state, actions } = store< Store >(
 				}
 			},
 
-			*addCartItem( { id, quantity, variation }: OptimisticCartItem ) {
+			*addCartItem( {
+				id,
+				quantity,
+				variation,
+				updateOptimistically = true,
+			}: OptimisticCartItem ) {
 				let item = state.cart.items.find( ( cartItem ) => {
 					if ( cartItem.type === 'variation' ) {
 						// If it's a variation, check that attributes match.
@@ -286,12 +292,21 @@ const { state, actions } = store< Store >(
 
 				// Optimistically updates the number of items in the cart.
 				if ( item ) {
-					item.quantity = quantity;
-					if ( item.key )
+					if ( updateOptimistically ) {
+						item.quantity = quantity;
+					}
+					if ( item.key ) {
 						quantityChanges.cartItemsPendingQuantity = [ item.key ];
+					}
 				} else {
-					item = { id, quantity, variation } as OptimisticCartItem;
-					state.cart.items.push( item );
+					if ( updateOptimistically ) {
+						item = {
+							id,
+							quantity,
+							variation,
+						} as OptimisticCartItem;
+						state.cart.items.push( item );
+					}
 					quantityChanges.productsPendingAdd = [ id ];
 				}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -42,6 +42,7 @@ const TemplatePartInnerBlocks = ( {
 		},
 		[ templatePartId ]
 	);
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		value: blocks,
 		onInput,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/edit/edit-template-part.tsx
@@ -42,12 +42,11 @@ const TemplatePartInnerBlocks = ( {
 		},
 		[ templatePartId ]
 	);
-
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		value: blocks,
 		onInput,
 		onChange,
-		renderAppender: () =>
+		renderAppender:
 			! isLoading && blocks.length === 0
 				? InnerBlocks.ButtonBlockAppender
 				: null,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -465,7 +465,8 @@ const addToCartWithOptionsStore = store<
 
 					yield actions.batchAddCartItems( addedItems );
 				} else {
-					const { variationId } = addToCartWithOptionsStore.state;
+					const { isFormValid, variationId } =
+						addToCartWithOptionsStore.state;
 					const id = variationId || productId;
 					const newQuantity = getNewQuantity(
 						id,
@@ -483,6 +484,7 @@ const addToCartWithOptionsStore = store<
 						quantity: newQuantity,
 						variation: selectedAttributes,
 						type: productType,
+						updateOptimistically: isFormValid,
 					} );
 				}
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/variation-selector/frontend.ts
@@ -220,6 +220,13 @@ const { actions, state } = store< VariableProductAddToCartWithOptionsStore >(
 						selectedAttribute.attribute === attribute
 				);
 
+				if ( value === '' ) {
+					if ( index >= 0 ) {
+						selectedAttributes.splice( index, 1 );
+					}
+					return;
+				}
+
 				if ( index >= 0 ) {
 					selectedAttributes[ index ] = {
 						attribute,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -631,7 +631,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				<div
 					class="wc-block-components-notice-banner"
 					data-wp-class--is-error="state.isError"
-					data-wp-class--is-success ="state.isSuccess"
+					data-wp-class--is-success="state.isSuccess"
 					data-wp-class--is-info="state.isInfo"
 					data-wp-class--is-dismissible="context.notice.dismissible"
 					data-wp-bind--role="state.role"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -277,7 +277,7 @@ class ProductButton extends AbstractBlock {
 				'{div_directives}'         => $is_ajax_button ? $div_directives : '',
 				'{button_directives}'      => $is_ajax_button ? $button_directives : $anchor_directive,
 				'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',
-				'{view_cart_html}'         => $is_ajax_button && CartCheckoutUtils::has_cart_page() ? $this->get_view_cart_html() : '',
+				'{view_cart_html}'         => $is_ajax_button && CartCheckoutUtils::has_cart_page() && ! $is_descendant_of_add_to_cart_form ? $this->get_view_cart_html() : '',
 			)
 		);
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -217,7 +217,7 @@ class ProductButton extends AbstractBlock {
 		$context_directives = wp_interactivity_data_wp_context( $context );
 
 		$button_directives = $is_descendant_of_add_to_cart_form ?
-			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid"' :
+			'data-wp-class--disabled="woocommerce/add-to-cart-with-options::!state.isFormValid" data-wp-on--click="actions.handlePressedState"' :
 			'data-wp-on--click="actions.addCartItem"';
 		$anchor_directive  = $is_descendant_of_add_to_cart_form ? '' : 'data-wp-on--click="woocommerce/product-collection::actions.viewProduct"';
 
@@ -228,7 +228,6 @@ class ProductButton extends AbstractBlock {
 			data-wp-on--animationend="actions.handleAnimationEnd"
 			data-wp-watch="callbacks.startAnimation"
 			data-wp-run="callbacks.syncTempQuantityOnLoad"
-			data-wp-on--click="actions.handlePressedState"
 		';
 
 		$wrapper_attributes = get_block_wrapper_attributes(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes several fixes for the _Add to Cart + Options_ block:

- Fix missing appender when Add to Cart + Options have no inner blocks (https://github.com/woocommerce/woocommerce/commit/4f6b4a02e5ad972bf9888d22f5505acf54ab99c1).
- Fix Add to Cart Button count not updating when selecting an out-of-stock variation (79adda963efc55da23100782a6704db6167a5b29).
- Don't print 'View Cart' HTML in _Add to Cart + Options_ block (https://github.com/woocommerce/woocommerce/commit/5cd44f79e3487f28b7dda9d71b26ba5b60855f56), it was never displayed.
- In grouped products, make the _Added to cart_ text appear when clicking on any part of the button, not only on the `<span>` containing the text (649730bfcd2858252259a5449e1da8ad557bf04d).
- Correctly resets attributes when they are unselected (2e3d31357ae7cec0ac56b866803bfefd006cd485).
- Some more minor cleanups in the code.

Because they were quite small, I thought it was better to group them in one single PR.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product and update to the blockified _Add to Cart + Options_ block if not yet in the template.
2. Remove all inner blocks.
3. Verify there is an appender:

Before | After
--- | ---
<img width="640" height="467" alt="imatge" src="https://github.com/user-attachments/assets/74fc54d1-da7a-4292-a656-caea2778eb03" /> | <img width="640" height="467" alt="imatge" src="https://github.com/user-attachments/assets/2503e57b-97f8-41ce-a5a1-30d8fc130f44" />

4. Now, go to the frontend of a variable product, making sure at least one variable is out of stock.
5. Add a variation that is in stock to cart.
6. Now, select the out of stock variation.
7. Verify the button changed from "1 in cart" to "Add to cart".

https://github.com/user-attachments/assets/04c924ae-1d14-49a0-a96b-a0961e0f5e0d

8. Now, go to the frontend of a grouped product. Increase the quantity of one of the child products and click on the _Add to cart_ button, but click on its padding, not on the text (in other words, we want to click the `<button>` without clicking the `<span>` containing the text).
9. Verify the text changed to _Added to cart_.

https://github.com/user-attachments/assets/d02c5f8b-d0a4-4e3a-a9f0-9e516612e817
