### PR TITLE
Make Product SKU and Product Details blocks update based on the selected variation in the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-59442-details-sku-variation-data
+++ b/plugins/woocommerce/changelog/fix-59442-details-sku-variation-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make Product SKU and Product Details blocks update based on the selected variation in the Add to Cart + Options block

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -64,13 +64,13 @@ const productElementStore = store(
 		state: {
 			get productData(): ProductData | undefined {
 				if ( ! productDataState?.productId ) {
-					return;
+					return undefined;
 				}
 
 				const productData =
-					wooState?.products?.[ productDataState?.productId ]
+					wooState?.products?.[ productDataState.productId ]
 						?.variations?.[ productDataState?.variationId || 0 ] ||
-					wooState?.products?.[ productDataState?.productId ];
+					wooState?.products?.[ productDataState.productId ];
 
 				return productData;
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -67,12 +67,11 @@ const productElementStore = store(
 					return undefined;
 				}
 
-				const productData =
+				return (
 					wooState?.products?.[ productDataState.productId ]
 						?.variations?.[ productDataState?.variationId || 0 ] ||
-					wooState?.products?.[ productDataState.productId ];
-
-				return productData;
+					wooState?.products?.[ productDataState.productId ]
+				);
 			},
 		},
 		callbacks: {

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -4,7 +4,10 @@
 import { getElement, store, getContext } from '@wordpress/interactivity';
 import '@woocommerce/stores/woocommerce/product-data';
 import type { ProductDataStore } from '@woocommerce/stores/woocommerce/product-data';
-import type { Store as WooCommerce } from '@woocommerce/stores/woocommerce/cart';
+import type {
+	ProductData,
+	Store as WooCommerce,
+} from '@woocommerce/stores/woocommerce/cart';
 import { sanitize } from 'dompurify'; // eslint-disable-line import/named
 
 // Stores are locked to prevent 3PD usage until the API is stable.
@@ -58,6 +61,20 @@ export type Context = {
 const productElementStore = store(
 	'woocommerce/product-elements',
 	{
+		state: {
+			get productData(): ProductData | undefined {
+				if ( ! productDataState?.productId ) {
+					return;
+				}
+
+				const productData =
+					wooState?.products?.[ productDataState?.productId ]
+						?.variations?.[ productDataState?.variationId || 0 ] ||
+					wooState?.products?.[ productDataState?.productId ];
+
+				return productData;
+			},
+		},
 		callbacks: {
 			updateValue: () => {
 				const element = getElement();
@@ -69,11 +86,7 @@ const productElementStore = store(
 				const { productElementKey } = getContext< Context >();
 
 				const productElementHtml =
-					wooState?.products?.[ productDataState?.productId ]
-						?.variations?.[ productDataState?.variationId || 0 ]?.[
-						productElementKey
-					] ||
-					wooState?.products?.[ productDataState?.productId ]?.[
+					productElementStore?.state?.productData?.[
 						productElementKey
 					];
 

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/frontend.ts
@@ -47,7 +47,12 @@ const ALLOWED_ATTR = [
 ];
 
 export type Context = {
-	productElementKey: 'price_html' | 'availability';
+	productElementKey:
+		| 'price_html'
+		| 'availability'
+		| 'sku'
+		| 'weight'
+		| 'dimensions';
 };
 
 const productElementStore = store(

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -35,6 +35,23 @@ export type ClientCartItem = Omit< OptimisticCartItem, 'variation' > & {
 	variation?: SelectedAttributes[];
 };
 
+export type ProductData = {
+	price_html?: string;
+	availability?: string;
+	sku?: string;
+	weight?: string;
+	dimensions?: string;
+	variations?: {
+		[ variationId: number ]: {
+			price_html?: string;
+			availability?: string;
+			sku?: string;
+			weight?: string;
+			dimensions?: string;
+		};
+	};
+};
+
 export type Store = {
 	state: {
 		errorMessages?: {
@@ -47,22 +64,7 @@ export type Store = {
 			totals: CartResponseTotals;
 		};
 		products?: {
-			[ productId: number ]: {
-				price_html?: string;
-				availability?: string;
-				sku?: string;
-				weight?: string;
-				dimensions?: string;
-				variations?: {
-					[ variationId: number ]: {
-						price_html?: string;
-						availability?: string;
-						sku?: string;
-						weight?: string;
-						dimensions?: string;
-					};
-				};
-			};
+			[ productId: number ]: ProductData;
 		};
 	};
 	actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -50,10 +50,16 @@ export type Store = {
 			[ productId: number ]: {
 				price_html?: string;
 				availability?: string;
+				sku?: string;
+				weight?: string;
+				dimensions?: string;
 				variations?: {
 					[ variationId: number ]: {
 						price_html?: string;
-						availability: string;
+						availability?: string;
+						sku?: string;
+						weight?: string;
+						dimensions?: string;
 					};
 				};
 			};

--- a/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
+++ b/plugins/woocommerce/client/blocks/tests/e2e/bin/scripts/products.sh
@@ -31,14 +31,9 @@ wp wc product update $beanie_product_id --tags="[ { \"id\": $tag_id } ]" --user=
 cap_product_id=$(wp post list --post_type=product --field=ID --name="Cap" --format=ids)
 wp post meta update $beanie_product_id _crosssell_ids "$cap_product_id"
 
-# Set a product out of stock
+# Set a product out of stock.
 tshirt_with_logo_product_id=$(wp post list --post_type=product --field=ID --name="T-Shirt with Logo" --format=ids)
 wp wc product update $tshirt_with_logo_product_id --in_stock=false --user=1
-
-# Set a variable product as having 100 in stock and one of its variations as out of stock
-hoodie_product_variation_id=$(wp post list --post_type=product_variation --field=ID --name="Hoodie - Blue, No" --format=ids)
-wp wc product update $hoodie_product_id --manage_stock=true --stock_quantity=100 --user=1
-wp wc product_variation update $hoodie_product_id $hoodie_product_variation_id --manage_stock=true --in_stock=false --user=1
 
 # Make a product visible only with password.
 sunglasses_product_id=$(wp post list --post_type=product --field=ID --name="Sunglasses" --format=ids)

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -104,7 +104,32 @@ test.describe( 'Add to Cart + Options Block', () => {
 		pageObject,
 		editor,
 	} ) => {
+		// Set a variable product as having 100 in stock and one of its variations as being out of stock.
+		// This way we can test that sibling blocks update with the variation data.
+		let cliOutput = await wpCLI(
+			`post list --post_type=product --field=ID --name="Hoodie" --format=ids`
+		);
+		const hoodieProductId = cliOutput.stdout.match( /\d+/g )?.pop();
+		cliOutput = await wpCLI(
+			'post list --post_type=product_variation --field=ID --name="Hoodie - Blue, No" --format=ids'
+		);
+		const hoodieProductVariationId = cliOutput.stdout
+			.match( /\d+/g )
+			?.pop();
+		await wpCLI(
+			`wc product update ${ hoodieProductId } --manage_stock=true --stock_quantity=100 --user=1`
+		);
+		await wpCLI(
+			`wc product_variation update ${ hoodieProductId } ${ hoodieProductVariationId } --manage_stock=true --in_stock=false --weight=2 --user=1`
+		);
+
 		await pageObject.updateSingleProductTemplate();
+
+		// We insert the blockified Product Details block to test that it updates
+		// with the correct variation data.
+		await editor.insertBlock( {
+			name: 'woocommerce/product-details',
+		} );
 
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
@@ -134,14 +159,32 @@ test.describe( 'Add to Cart + Options Block', () => {
 		} );
 
 		await test.step( 'updates stock indicator and product price when attributes are selected', async () => {
+			// Open additional information accordion so we can check the weight.
+			await page
+				.getByRole( 'button', { name: 'Additional Information' } )
+				.click();
 			await expect( productPrice ).toHaveText( /\$42.00 – \$45.00.*/ );
 			await expect( page.getByText( '100 in stock' ) ).toBeVisible();
+			await expect( page.getByText( 'SKU: woo-hoodie' ) ).toBeVisible();
+			await expect(
+				page
+					.getByLabel( 'Additional Information', { exact: true } )
+					.getByText( '1.5 lbs' )
+			).toBeVisible();
 
 			await colorBlueOption.click();
 			await logoNoOption.click();
 
-			await expect( page.getByText( 'Out of stock' ) ).toBeVisible();
 			await expect( productPrice ).toHaveText( '$45.00' );
+			await expect( page.getByText( 'Out of stock' ) ).toBeVisible();
+			await expect(
+				page.getByText( 'SKU: woo-hoodie-blue' )
+			).toBeVisible();
+			await expect(
+				page
+					.getByLabel( 'Additional Information', { exact: true } )
+					.getByText( '2 lbs' )
+			).toBeVisible();
 		} );
 
 		await test.step( 'successfully adds to cart when attributes are selected', async () => {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -67,6 +67,31 @@ class ProductSKU extends AbstractBlock {
 			return '';
 		}
 
+		$is_interactive = $product->is_type( 'variable' );
+
+		if ( $is_interactive ) {
+			$variations                = $product->get_available_variations( 'objects' );
+			$formatted_variations_data = array();
+			foreach ( $variations as $variation ) {
+				$formatted_variations_data[ $variation->get_id() ] = array(
+					'sku' => $variation->get_sku(),
+				);
+			}
+
+			wp_interactivity_state(
+				'woocommerce',
+				array(
+					'products' => array(
+						$product->get_id() => array(
+							'sku'        => $product_sku,
+							'variations' => $formatted_variations_data,
+						),
+					),
+				)
+			);
+			wp_enqueue_script_module( 'woocommerce/product-elements' );
+		}
+
 		$styles_and_classes = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		$prefix = isset( $attributes['prefix'] ) ? wp_kses_post( ( $attributes['prefix'] ) ) : __( 'SKU: ', 'woocommerce' );
@@ -82,7 +107,7 @@ class ProductSKU extends AbstractBlock {
 		return sprintf(
 			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta wp-block-post-terms %1$s" style="%2$s">
 				%3$s
-				<span class="sku">%4$s</span>
+				<span class="sku" data-wp-interactive="woocommerce/product-elements" data-wp-context=\'{"productElementKey": "sku"}\' data-wp-watch="callbacks.updateValue">%4$s</span>
 				%5$s
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSKU.php
@@ -104,15 +104,18 @@ class ProductSKU extends AbstractBlock {
 			$suffix = sprintf( '<span class="wp-block-post-terms__suffix">%s</span>', $suffix );
 		}
 
+		$interactive_attributes = $is_interactive ? 'data-wp-interactive="woocommerce/product-elements" data-wp-text="state.productData.sku"' : '';
+
 		return sprintf(
 			'<div class="wc-block-components-product-sku wc-block-grid__product-sku wp-block-woocommerce-product-sku product_meta wp-block-post-terms %1$s" style="%2$s">
 				%3$s
-				<span class="sku" data-wp-interactive="woocommerce/product-elements" data-wp-context=\'{"productElementKey": "sku"}\' data-wp-watch="callbacks.updateValue">%4$s</span>
-				%5$s
+				<span class="sku" %4$s>%5$s</span>
+				%6$s
 			</div>',
 			esc_attr( $styles_and_classes['classes'] ),
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
 			$prefix,
+			$interactive_attributes,
 			$product_sku,
 			$suffix
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -80,8 +80,8 @@ class ProductSpecifications extends AbstractBlock {
 				array(
 					'products' => array(
 						$product->get_id() => array(
-							'weight'     => $product_data['weight'],
-							'dimensions' => $product_data['dimensions'],
+							'weight'     => $product_data['weight']['value'] ?? '',
+							'dimensions' => $product_data['dimensions']['value'] ?? '',
 							'variations' => $formatted_variations_data,
 						),
 					),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -63,6 +63,33 @@ class ProductSpecifications extends AbstractBlock {
 			);
 		}
 
+		$is_interactive = $product->is_type( 'variable' );
+
+		if ( $is_interactive ) {
+			$variations                = $product->get_available_variations( 'objects' );
+			$formatted_variations_data = array();
+			foreach ( $variations as $variation ) {
+				$formatted_variations_data[ $variation->get_id() ] = array(
+					'weight'     => wc_format_weight( $variation->get_weight() ),
+					'dimensions' => wc_format_dimensions( $variation->get_dimensions( false ) ),
+				);
+			}
+
+			wp_interactivity_state(
+				'woocommerce',
+				array(
+					'products' => array(
+						$product->get_id() => array(
+							'weight'     => $product_data['weight'],
+							'dimensions' => $product_data['dimensions'],
+							'variations' => $formatted_variations_data,
+						),
+					),
+				)
+			);
+			wp_enqueue_script_module( 'woocommerce/product-elements' );
+		}
+
 		if ( $show_attributes ) {
 			foreach ( $product->get_attributes() as $attribute ) {
 				$values = array();
@@ -119,9 +146,15 @@ class ProductSpecifications extends AbstractBlock {
 							<th scope="row" class="wp-block-product-specifications-item__label">
 								<?php echo wp_kses_post( $product_attribute['label'] ); ?>
 							</th>
-							<td class="wp-block-product-specifications-item__value">
-								<?php echo wp_kses_post( $product_attribute['value'] ); ?>
-							</td>
+							<?php if ( $is_interactive && in_array( $product_attribute_key, array( 'weight', 'dimensions' ), true ) ) : ?>
+								<td class="wp-block-product-specifications-item__value" data-wp-interactive="woocommerce/product-elements" data-wp-context='{"productElementKey": "<?php echo esc_attr( $product_attribute_key ); ?>"}' data-wp-watch="callbacks.updateValue">
+									<?php echo wp_kses_post( $product_attribute['value'] ); ?>
+								</td>
+							<?php else : ?>	
+								<td class="wp-block-product-specifications-item__value">
+									<?php echo wp_kses_post( $product_attribute['value'] ); ?>
+								</td>
+							<?php endif; ?>
 						</tr>
 					<?php endforeach; ?>
 				</tbody>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductSpecifications.php
@@ -71,7 +71,7 @@ class ProductSpecifications extends AbstractBlock {
 			foreach ( $variations as $variation ) {
 				$formatted_variations_data[ $variation->get_id() ] = array(
 					'weight'     => wc_format_weight( $variation->get_weight() ),
-					'dimensions' => wc_format_dimensions( $variation->get_dimensions( false ) ),
+					'dimensions' => html_entity_decode( wc_format_dimensions( $variation->get_dimensions( false ) ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
 				);
 			}
 
@@ -81,7 +81,7 @@ class ProductSpecifications extends AbstractBlock {
 					'products' => array(
 						$product->get_id() => array(
 							'weight'     => $product_data['weight']['value'] ?? '',
-							'dimensions' => $product_data['dimensions']['value'] ?? '',
+							'dimensions' => html_entity_decode( $product_data['dimensions']['value'] ?? '', ENT_QUOTES, get_bloginfo( 'charset' ) ),
 							'variations' => $formatted_variations_data,
 						),
 					),
@@ -147,7 +147,7 @@ class ProductSpecifications extends AbstractBlock {
 								<?php echo wp_kses_post( $product_attribute['label'] ); ?>
 							</th>
 							<?php if ( $is_interactive && in_array( $product_attribute_key, array( 'weight', 'dimensions' ), true ) ) : ?>
-								<td class="wp-block-product-specifications-item__value" data-wp-interactive="woocommerce/product-elements" data-wp-context='{"productElementKey": "<?php echo esc_attr( $product_attribute_key ); ?>"}' data-wp-watch="callbacks.updateValue">
+								<td class="wp-block-product-specifications-item__value" data-wp-interactive="woocommerce/product-elements" data-wp-text="state.productData.<?php echo esc_attr( $product_attribute_key ); ?>">
 									<?php echo wp_kses_post( $product_attribute['value'] ); ?>
 								</td>
 							<?php else : ?>	

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -150,11 +150,7 @@ class ProductStockIndicator extends AbstractBlock {
 
 			wp_enqueue_script_module( 'woocommerce/product-elements' );
 			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
-			$context                                   = array(
-				'productElementKey' => 'availability',
-			);
-			$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
-			$watch_attribute                           = 'data-wp-watch="callbacks.updateValue"';
+			$wrapper_attributes['data-wp-text']        = 'state.productData.availability';
 		}
 
 		$output_text = $low_stock_text ?? $availability['availability'];
@@ -164,7 +160,6 @@ class ProductStockIndicator extends AbstractBlock {
 		$output .= isset( $classes_and_styles['styles'] ) ? ' style="' . esc_attr( $classes_and_styles['styles'] ) . '"' : '';
 		if ( $is_interactive && 'out-of-stock' !== $availability['class'] ) {
 			$output .= ' ' . get_block_wrapper_attributes( $wrapper_attributes );
-			$output .= ' ' . $watch_attribute;
 		}
 		$output .= '>';
 		$output .= wp_kses_post( $output_text );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59440.
Closes #59442.

This PR makes it so the _Product SKU_ and _Product Details_ block update with the data from the current selected variation.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product and switch to the blockified _Add to Cart + Options_ block. Make sure the _Product SKU_ and the blockified _Product Details_ blocks are in the page.
2. Also, make sure there is at least one variation that has a different SKU, weight, and size than the parent variable product.
3. In the frontend, switch between variations and verify the SKU, weight and size are updated as you switch variations.

https://github.com/user-attachments/assets/0005b5a1-6cc8-400f-a4eb-f8cbeb8f2da5
