### PR TITLE
Interactivity API powered MiniCart - Remove feature flag in favor of experimental feature

### DIFF
--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -5,7 +5,6 @@
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": false,
-		"experimental-iapi-mini-cart": false,
 		"experimental-iapi-runtime": false,
 		"coming-soon-newsletter-template": false,
 		"coupons": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -5,7 +5,6 @@
 		"product-block-editor": true,
 		"product-data-views": false,
 		"experimental-blocks": true,
-		"experimental-iapi-mini-cart": false,
 		"experimental-iapi-runtime": false,
 		"coming-soon-newsletter-template": false,
 		"coupons": true,

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * EmptyMiniCartContentsBlock class.
@@ -23,7 +23,7 @@ class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_empty_mini_cart_contents( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/FilledMiniCartContentsBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * FilledMiniCartContentsBlock class.
@@ -23,7 +23,7 @@ class FilledMiniCartContentsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_filled_mini_cart_contents( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 use Automattic\WooCommerce\Blocks\Utils\Utils;
 use Automattic\WooCommerce\Blocks\Utils\MiniCartUtils;
 use Automattic\WooCommerce\Blocks\Utils\BlockHooksTrait;
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Blocks\Utils\BlocksSharedState;
 use Automattic\Block_Delimiter;
 
@@ -130,7 +130,7 @@ class MiniCart extends AbstractBlock {
 	 * blocks without static block.json metadata.
 	 */
 	public function enable_interactivity_support() {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'woocommerce/mini-cart' );
 
 			if ( $block_type ) {
@@ -187,7 +187,7 @@ class MiniCart extends AbstractBlock {
 	 * @return array|string
 	 */
 	protected function get_block_type_script( $key = null ) {
-		if ( is_cart() || is_checkout() || Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( is_cart() || is_checkout() || FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return;
 		}
 
@@ -291,7 +291,7 @@ class MiniCart extends AbstractBlock {
 	 * Prints the variable containing information about the scripts to lazy load.
 	 */
 	public function print_lazy_load_scripts() {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return;
 		}
 
@@ -476,7 +476,7 @@ class MiniCart extends AbstractBlock {
 		 * In the cart and checkout pages, the block is either rendered hidden or removed.
 		 * It is not interactive, so it can fall back to the existing implementation.
 		 */
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) && ! is_cart() && ! is_checkout() ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) && ! is_cart() && ! is_checkout() ) {
 			return $this->render_experimental_iapi_mini_cart( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCartButtonBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartCartButtonBlock class.
@@ -66,7 +66,7 @@ class MiniCartCartButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartCheckoutButtonBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartCheckoutButtonBlock class.
@@ -54,7 +54,7 @@ class MiniCartCheckoutButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartContents.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
@@ -104,7 +104,7 @@ class MiniCartContents extends AbstractBlock {
 			return '';
 		}
 
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_mini_cart_contents( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartFooterBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartFooterBlock class.
@@ -101,7 +101,7 @@ class MiniCartFooterBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_mini_cart_footer( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartItemsBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartItemsBlock class.
@@ -23,7 +23,7 @@ class MiniCartItemsBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartProductsTableBlock class.
@@ -24,7 +24,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartShoppingButtonBlock class.
@@ -23,7 +23,7 @@ class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_markup( $attributes, $content, $block );
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartTitleBlock class.
@@ -23,7 +23,7 @@ class MiniCartTitleBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_title_block( $attributes, $content, $block );
 		}
 		return $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleItemsCounterBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartTitleItemsCounterBlock class.
@@ -23,7 +23,7 @@ class MiniCartTitleItemsCounterBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_title_label_block();
 		}
 		return $content;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartTitleLabelBlock.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * MiniCartTitleLabelBlock class.
@@ -23,7 +23,7 @@ class MiniCartTitleLabelBlock extends AbstractInnerBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( Features::is_enabled( 'experimental-iapi-mini-cart' ) ) {
+		if ( FeaturesUtil::feature_is_enabled( 'experimental-iapi-mini-cart' ) ) {
 			return $this->render_experimental_iapi_title_label_block( $attributes, $content, $block );
 		}
 		return $content;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -486,9 +486,10 @@ class FeaturesController {
 				'is_experimental'    => false,
 			),
 			'experimental-iapi-mini-cart' => array(
-				'name'            => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
-				'description'     => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
-				'is_experimental' => true,
+				'name'               => __( 'Interactivity API powered Mini Cart', 'woocommerce' ),
+				'description'        => __( 'Enable the new version of the Mini Cart that uses the Interactivity API instead of React in the frontend.', 'woocommerce' ),
+				'is_experimental'    => true,
+				'enabled_by_default' => in_array( wp_get_environment_type(), array( 'development', 'local' ), true ),
 			),
 		);
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -163,32 +163,6 @@ class FeaturesController {
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'set_change_feature_enable_nonce' ), 20, 1 );
 		add_action( 'admin_init', array( $this, 'change_feature_enable_from_query_params' ), 20, 0 );
 		add_action( self::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'display_email_improvements_feedback_notice' ), 10, 2 );
-		add_filter( 'woocommerce_admin_features', array( $this, 'sync_iapi_mini_cart_feature' ) );
-	}
-
-	/**
-	 * Synchronize the 'experimental-iapi-mini-cart' feature flag with the admin Features system.
-	 *
-	 * @param array $features The original list of features.
-	 * @return array The modified list of features.
-	 */
-	public function sync_iapi_mini_cart_feature( $features ) {
-		$option_name = 'woocommerce_feature_experimental-iapi-mini-cart_enabled';
-		$is_enabled  = 'yes' === get_option( $option_name, 'no' );
-
-		if ( $is_enabled ) {
-			if ( ! in_array( 'experimental-iapi-mini-cart', $features, true ) ) {
-				$features[] = 'experimental-iapi-mini-cart';
-			}
-		} else {
-			$features = array_filter(
-				$features,
-				function ( $feature ) {
-					return 'experimental-iapi-mini-cart' !== $feature;
-				}
-			);
-		}
-		return $features;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the feature flags we created for the iAPI-powered Mini Cart blocks and keeps the experimental feature, enabling it by default only in development.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In the Admin panel, go to WooCommerce > Advanced > Features > Experimental Features.
2. Check that the "Interactivity API powered Mini Cart" is enabled by default.
3. Visit the site and go to a page with the Mini Cart block.
4. Ensure it uses the Interactivity API version (e.g., checking that the HTML contains directives).
5. Go back to the Admin panel.
6. Disable the feature.
7. Visit a page with the Mini Cart block again.
8. Ensure it uses the React version.
9. Execute `wp option delete woocommerce_feature_experimental-iapi-mini-cart_enabled` with the WP CLI.
10. Ensure the setting is enabled by default.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
