### PR TITLE
WPS Migration: Settings refactor

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -136,6 +136,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		if ( 'yes' === $this->enabled ) {
 			add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'order_received_text' ), 10, 2 );
 		}
+
+		add_filter( 'woocommerce_settings_api_form_fields_paypal', array( $this, 'maybe_remove_fields' ), 15 );
 	}
 
 	/**
@@ -346,12 +348,22 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = include __DIR__ . '/includes/settings-paypal.php';
+		$this->form_fields = apply_filters( 'woocommerce_settings_api_form_fields_paypal', $this->form_fields );
+	}
 
+	/**
+	 * Filter to remove fields for Orders v2.
+	 *
+	 * @param array $form_fields Form fields.
+	 * @return array
+	 */
+	public function maybe_remove_fields( $form_fields ) {
 		// Additional details are added to the receiver email when subscriptions are enabled.
 		// We don't need this for Orders v2.
 		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
-			unset( $this->form_fields['receiver_email'] );
+			unset( $form_fields['receiver_email'] );
 		}
+		return $form_fields;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -348,6 +348,12 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = include __DIR__ . '/includes/settings-paypal.php';
+		/**
+		 * Filters the PayPal settings form fields to remove unsupported fields for Orders v2.
+		 *
+		 * @param array $form_fields The form fields.
+		 * @return array
+		 */
 		$this->form_fields = apply_filters( 'woocommerce_settings_api_form_fields_paypal', $this->form_fields );
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -415,13 +415,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = include __DIR__ . '/includes/settings-paypal.php';
-		/**
-		 * Filters the PayPal settings form fields to remove unsupported fields for Orders v2.
-		 *
-		 * @param array $form_fields The form fields.
-		 * @return array
-		 */
-		$this->form_fields = apply_filters( 'woocommerce_settings_api_form_fields_paypal', $this->form_fields );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -346,6 +346,12 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = include __DIR__ . '/includes/settings-paypal.php';
+
+		// Additional details are added to the receiver email when subscriptions are enabled.
+		// We don't need this for Orders v2.
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
+			unset( $this->form_fields['receiver_email'] );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -195,7 +195,7 @@ if ( ! $should_use_orders_v2 ) {
 			'placeholder' => __( 'Optional', 'woocommerce' ),
 		),
 	);
-	$settings = array_merge( $settings, $legacy_settings );
+	$settings        = array_merge( $settings, $legacy_settings );
 }
 
 return $settings;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -90,7 +90,7 @@ $settings = array(
 		'title'       => __( 'Address override', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Prevent buyers from changing the shipping address.', 'woocommerce' ),
-		'description' => __( 'When enabled, PayPal will use the address provided by your store and prevent the buyer from changing it during checkout. Disable this to let buyers choose a shipping address from their PayPal account. PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
+		'description' => __( 'When enabled, PayPal will use the address provided by the checkout form, and prevent the buyer from changing it inside the PayPal payment page. Disable this to let buyers choose a shipping address from their PayPal account. PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
 		'default'     => 'no',
 	),
 	'debug'            => array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -60,16 +60,16 @@ $settings = array(
 		/* translators: %s: URL */
 		'description' => sprintf( __( 'PayPal sandbox can be used to test payments. Sign up for a <a href="%s">developer account</a>.', 'woocommerce' ), 'https://developer.paypal.com/' ),
 	),
-	'debug'            => array(
-		'title'       => __( 'Debug log', 'woocommerce' ),
-		'type'        => 'checkbox',
-		'label'       => __( 'Enable logging', 'woocommerce' ),
-		'default'     => 'no',
-		/* translators: %s: URL */
-		'description' => sprintf(
-			// translators: %s is a placeholder for a URL.
-			__( 'Log PayPal events such as IPN requests and review them on the <a href="%s">Logs screen</a>. Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ),
-			esc_url( LoggingUtil::get_logs_tab_url() )
+	'paymentaction'    => array(
+		'title'       => __( 'Payment action', 'woocommerce' ),
+		'type'        => 'select',
+		'class'       => 'wc-enhanced-select',
+		'description' => __( 'Choose whether you wish to capture funds immediately or authorize payment only.', 'woocommerce' ),
+		'default'     => 'sale',
+		'desc_tip'    => true,
+		'options'     => array(
+			'sale'          => __( 'Capture', 'woocommerce' ),
+			'authorization' => __( 'Authorize', 'woocommerce' ),
 		),
 	),
 	'invoice_prefix'   => array(
@@ -93,16 +93,16 @@ $settings = array(
 		'description' => __( 'PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
 		'default'     => 'no',
 	),
-	'paymentaction'    => array(
-		'title'       => __( 'Payment action', 'woocommerce' ),
-		'type'        => 'select',
-		'class'       => 'wc-enhanced-select',
-		'description' => __( 'Choose whether you wish to capture funds immediately or authorize payment only.', 'woocommerce' ),
-		'default'     => 'sale',
-		'desc_tip'    => true,
-		'options'     => array(
-			'sale'          => __( 'Capture', 'woocommerce' ),
-			'authorization' => __( 'Authorize', 'woocommerce' ),
+	'debug'            => array(
+		'title'       => __( 'Debug log', 'woocommerce' ),
+		'type'        => 'checkbox',
+		'label'       => __( 'Enable logging', 'woocommerce' ),
+		'default'     => 'no',
+		/* translators: %s: URL */
+		'description' => sprintf(
+			// translators: %s is a placeholder for a URL.
+			__( 'Log PayPal events such as IPN requests and review them on the <a href="%s">Logs screen</a>. Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ),
+			esc_url( LoggingUtil::get_logs_tab_url() )
 		),
 	),
 	'image_url'        => array(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -109,7 +109,7 @@ $settings = array(
 
 if ( ! $should_use_orders_v2 ) {
 	$legacy_settings = array(
-		'image_url'        => array(
+		'image_url'           => array(
 			'title'       => __( 'Image url', 'woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Optionally enter the URL to a 150x50px image displayed as your logo in the upper left corner of the PayPal checkout pages.', 'woocommerce' ),
@@ -117,14 +117,14 @@ if ( ! $should_use_orders_v2 ) {
 			'desc_tip'    => true,
 			'placeholder' => __( 'Optional', 'woocommerce' ),
 		),
-		'ipn_notification' => array(
+		'ipn_notification'           => array(
 			'title'       => __( 'IPN email notifications', 'woocommerce' ),
 			'type'        => 'checkbox',
 			'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
 			'default'     => 'yes',
 			'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
 		),
-		'receiver_email'   => array(
+		'receiver_email'           => array(
 			'title'       => __( 'Receiver email', 'woocommerce' ),
 			'type'        => 'email',
 			'description' => __( 'If your main PayPal email differs from the PayPal email entered above, input your main receiver email for your PayPal account here. This is used to validate IPN requests.', 'woocommerce' ),
@@ -132,7 +132,7 @@ if ( ! $should_use_orders_v2 ) {
 			'desc_tip'    => true,
 			'placeholder' => 'you@youremail.com',
 		),
-		'identity_token'   => array(
+		'identity_token'           => array(
 			'title'       => __( 'PayPal identity token', 'woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Optionally enable "Payment Data Transfer" (Profile > Profile and Settings > My Selling Tools > Website Preferences) and then copy your identity token here. This will allow payments to be verified without the need for PayPal IPN.', 'woocommerce' ),
@@ -195,7 +195,7 @@ if ( ! $should_use_orders_v2 ) {
 			'placeholder' => __( 'Optional', 'woocommerce' ),
 		),
 	);
-	$settings     = array_merge( $settings, $legacy_settings );
+	$settings = array_merge( $settings, $legacy_settings );
 }
 
 return $settings;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -105,18 +105,18 @@ $settings = array(
 			esc_url( LoggingUtil::get_logs_tab_url() )
 		),
 	),
-	'image_url'        => array(
-		'title'       => __( 'Image url', 'woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Optionally enter the URL to a 150x50px image displayed as your logo in the upper left corner of the PayPal checkout pages.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
 );
 
 if ( ! $should_use_orders_v2 ) {
 	$legacy_settings = array(
+		'image_url'        => array(
+			'title'       => __( 'Image url', 'woocommerce' ),
+			'type'        => 'text',
+			'description' => __( 'Optionally enter the URL to a 150x50px image displayed as your logo in the upper left corner of the PayPal checkout pages.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => __( 'Optional', 'woocommerce' ),
+		),
 		'ipn_notification' => array(
 			'title'       => __( 'IPN email notifications', 'woocommerce' ),
 			'type'        => 'checkbox',

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -109,7 +109,7 @@ $settings = array(
 
 if ( ! $should_use_orders_v2 ) {
 	$legacy_settings = array(
-		'image_url'           => array(
+		'image_url'             => array(
 			'title'       => __( 'Image url', 'woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Optionally enter the URL to a 150x50px image displayed as your logo in the upper left corner of the PayPal checkout pages.', 'woocommerce' ),
@@ -117,14 +117,14 @@ if ( ! $should_use_orders_v2 ) {
 			'desc_tip'    => true,
 			'placeholder' => __( 'Optional', 'woocommerce' ),
 		),
-		'ipn_notification'           => array(
+		'ipn_notification'      => array(
 			'title'       => __( 'IPN email notifications', 'woocommerce' ),
 			'type'        => 'checkbox',
 			'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
 			'default'     => 'yes',
 			'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
 		),
-		'receiver_email'           => array(
+		'receiver_email'        => array(
 			'title'       => __( 'Receiver email', 'woocommerce' ),
 			'type'        => 'email',
 			'description' => __( 'If your main PayPal email differs from the PayPal email entered above, input your main receiver email for your PayPal account here. This is used to validate IPN requests.', 'woocommerce' ),
@@ -132,7 +132,7 @@ if ( ! $should_use_orders_v2 ) {
 			'desc_tip'    => true,
 			'placeholder' => 'you@youremail.com',
 		),
-		'identity_token'           => array(
+		'identity_token'        => array(
 			'title'       => __( 'PayPal identity token', 'woocommerce' ),
 			'type'        => 'text',
 			'description' => __( 'Optionally enable "Payment Data Transfer" (Profile > Profile and Settings > My Selling Tools > Website Preferences) and then copy your identity token here. This will allow payments to be verified without the need for PayPal IPN.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -16,6 +16,8 @@ if ( ! class_exists( 'WC_Gateway_PayPal_Helper' ) ) {
 	require_once __DIR__ . '/class-wc-gateway-paypal-helper.php';
 }
 
+$should_use_orders_v2 = WC_Gateway_Paypal_Helper::should_use_orders_v2();
+
 $settings = array(
 	'enabled'          => array(
 		'title'   => __( 'Enable/Disable', 'woocommerce' ),
@@ -70,29 +72,6 @@ $settings = array(
 			esc_url( LoggingUtil::get_logs_tab_url() )
 		),
 	),
-	'ipn_notification' => array(
-		'title'       => __( 'IPN email notifications', 'woocommerce' ),
-		'type'        => 'checkbox',
-		'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
-		'default'     => 'yes',
-		'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
-	),
-	'receiver_email'   => array(
-		'title'       => __( 'Receiver email', 'woocommerce' ),
-		'type'        => 'email',
-		'description' => __( 'If your main PayPal email differs from the PayPal email entered above, input your main receiver email for your PayPal account here. This is used to validate IPN requests.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => 'you@youremail.com',
-	),
-	'identity_token'   => array(
-		'title'       => __( 'PayPal identity token', 'woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Optionally enable "Payment Data Transfer" (Profile > Profile and Settings > My Selling Tools > Website Preferences) and then copy your identity token here. This will allow payments to be verified without the need for PayPal IPN.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => '',
-	),
 	'invoice_prefix'   => array(
 		'title'       => __( 'Invoice prefix', 'woocommerce' ),
 		'type'        => 'text',
@@ -136,8 +115,31 @@ $settings = array(
 	),
 );
 
-if ( ! WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
-	$api_settings = array(
+if ( ! $should_use_orders_v2 ) {
+	$legacy_settings = array(
+		'ipn_notification' => array(
+			'title'       => __( 'IPN email notifications', 'woocommerce' ),
+			'type'        => 'checkbox',
+			'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
+			'default'     => 'yes',
+			'description' => __( 'Send notifications when an IPN is received from PayPal indicating refunds, chargebacks and cancellations.', 'woocommerce' ),
+		),
+		'receiver_email'   => array(
+			'title'       => __( 'Receiver email', 'woocommerce' ),
+			'type'        => 'email',
+			'description' => __( 'If your main PayPal email differs from the PayPal email entered above, input your main receiver email for your PayPal account here. This is used to validate IPN requests.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => 'you@youremail.com',
+		),
+		'identity_token'   => array(
+			'title'       => __( 'PayPal identity token', 'woocommerce' ),
+			'type'        => 'text',
+			'description' => __( 'Optionally enable "Payment Data Transfer" (Profile > Profile and Settings > My Selling Tools > Website Preferences) and then copy your identity token here. This will allow payments to be verified without the need for PayPal IPN.', 'woocommerce' ),
+			'default'     => '',
+			'desc_tip'    => true,
+			'placeholder' => '',
+		),
 		'api_details'           => array(
 			'title'       => __( 'API credentials', 'woocommerce' ),
 			'type'        => 'title',
@@ -193,7 +195,7 @@ if ( ! WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
 			'placeholder' => __( 'Optional', 'woocommerce' ),
 		),
 	);
-	$settings     = array_merge( $settings, $api_settings );
+	$settings     = array_merge( $settings, $legacy_settings );
 }
 
 return $settings;

--- a/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/settings-paypal.php
@@ -89,8 +89,8 @@ $settings = array(
 	'address_override' => array(
 		'title'       => __( 'Address override', 'woocommerce' ),
 		'type'        => 'checkbox',
-		'label'       => __( 'Enable "address_override" to prevent address information from being changed.', 'woocommerce' ),
-		'description' => __( 'PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
+		'label'       => __( 'Prevent buyers from changing the shipping address.', 'woocommerce' ),
+		'description' => __( 'When enabled, PayPal will use the address provided by your store and prevent the buyer from changing it during checkout. Disable this to let buyers choose a shipping address from their PayPal account. PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled).', 'woocommerce' ),
 		'default'     => 'no',
 	),
 	'debug'            => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Re-arranged the fields. 
- Hiding a few more fields when orders v2 is enabled.
    - `ipn_notification`: related to IPN and not needed in v2 API
    - `receiver_email`: related to IPN and not needed in v2 API
    - `identity_token`: related to PDT and not needed in v2 API
    - `image_url`: not supported in v2 API 
- Additionally, introduced the `woocommerce_settings_api_form_fields_paypal` filter to hide the description pushed by the subscriptions plugin.

Final Changes for PAYPAL-46, PAYPAL-42

### How to test the changes in this Pull Request:
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Confirm that the API keys, IPN related settings and Image URL is not present. 
5. Check the label/description of address override to see if it makes sense.
6. Disable orders v2 flag
```
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
7. Confirm that all the fields are present.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
