### PR TITLE
Remove check for aria-haspopup in 'Save' button in Add to Cart + Options e2e test

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-e2e-test-remove-aria-haspopup-check
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-e2e-test-remove-aria-haspopup-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove check for aria-haspopup in 'Save' button in Add to Cart + Options e2e test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -263,15 +263,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await page.getByRole( 'radio', { name: 'Dropdown' } ).click();
 
-		// We need to make sure the block updated before saving.
-		// @see https://github.com/woocommerce/woocommerce/issues/57718
-		// Verify that `.editor-post-publish-button__button` has an attribute
-		// `aria-haspopup="dialog"`. When https://github.com/woocommerce/woocommerce/issues/48936
-		// is fixed, we can simply check that the Save button becomes enabled.
-		await expect(
-			page.getByRole( 'button', { name: 'Save', exact: true } )
-		).toHaveAttribute( 'aria-haspopup', 'dialog' );
-
 		await editor.saveSiteEditorEntities();
 
 		await page.goto( '/hoodie' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A couple of weeks ago, I added a check to ensure the _Save_ button had the attribute `aria-haspopup` in a _Add to Cart + Options_ e2e test. That was to make sure the template part was being saved alongside the template (see https://github.com/woocommerce/woocommerce/pull/59631).

That was with the hope of decreasing the test flakiness. Unfortunately, the test is still flaky (https://github.com/woocommerce/woocommerce/issues/57718). In addition to that, the test is failing with WP latest-1:

https://github.com/woocommerce/woocommerce/actions/runs/16586007199/job/46911185407#step:9:143

So this PR removes that check in order to fix tests with WP latest-1.

### How to test the changes in this Pull Request:

1. Verify e2e tests pass.