### PR TITLE
Update additional fields schema definition docs

### DIFF
--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -790,7 +790,7 @@ It's full schema is this one:
 				},
 				"additional_fields": {
 					"type": "object",
-					"description": "Additional checkout fields, limited to the order location.",
+					"description": "Additional checkout fields with 'order' location. These fields are rendered in the order information section.",
 					"additionalProperties": {
 						"type": "string"
 					},
@@ -826,7 +826,7 @@ It's full schema is this one:
 				},
 				"additional_fields": {
 					"type": "object",
-					"description": "Additional checkout fields, limited to the contact location.",
+					"description": "Additional checkout fields with 'contact' location. These fields are rendered in the contact information section.",
 					"additionalProperties": {
 						"type": "string"
 					}
@@ -893,12 +893,12 @@ It's full schema is this one:
 			},
 			"additionalProperties": {
 				"type": "string",
-				"description": "Custom fields with namespace identifiers"
+				"description": "Additional fields with 'address' location appear here as properties within the address objects"
 			},
 			"patternProperties": {
 				"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$": {
 					"type": "string",
-					"description": "Custom fields with namespace identifiers"
+					"description": "Additional fields with 'address' location using namespace identifiers (e.g., 'namespace/field-name')"
 				}
 			}
 		}

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -833,6 +833,12 @@ It's full schema is this one:
 					"description": "Additional checkout fields with 'contact' location. These fields are rendered in the contact information section.",
 					"additionalProperties": {
 						"type": "string"
+					},
+					"patternProperties": {
+						"^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$": {
+							"type": "string",
+							"description": "Custom fields with namespace identifiers"
+						}
 					}
 				},
 				"address": {

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -625,8 +625,8 @@ When you're writing your rules, you're writing a partial schema for the document
 		"needs_shipping": true,
 		"prefers_collection": false,
 		"totals": {
-			"totalPrice": 6600,
-			"totalTax": 600
+			"total_price": 6600,
+			"total_tax": 600
 		},
 		"extensions": {}
 	},

--- a/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
+++ b/docs/block-development/extensible-blocks/cart-and-checkout-blocks/additional-checkout-fields.md
@@ -596,7 +596,11 @@ If you're not familiar with JSON Schema, you can get a quick introduction to it 
 
 ### Document object
 
-When you're writing your rules, you're writing a partial schema for the document object, essentially describing the ideal state you want for your field to be required or hidden. An example of the document object looks like this:
+When you're writing your rules, you're writing a partial schema for the document object, essentially describing the ideal state you want for your field to be required or hidden. 
+
+**Important:** All properties in the document object use snake_case naming convention (e.g., `total_price`, `shipping_rates`, `customer_note`), not camelCase.
+
+An example of the document object looks like this:
 
 <!-- markdownlint-disable MD033 -->
 <details>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Update the docs to include clearer descriptions of the  additional field areas, and update camel case properties to use correct snake case.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60092

(For Bug Fixes) Bug introduced in PR # .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Read the doc changes and ensure they make sense.
2. For developers, you can compare the defined schema in the docs to the real schema, by console logging `data` [here](https://github.com/woocommerce/woocommerce/blob/568d9bfdd61843d901721f2d5c3be22f64c6b64f/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/form/use-form-fields.ts#L65)

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
