### PR TITLE
Make button animation show up in the Add to Cart + Options even when 'Enable AJAX add to cart buttons' setting is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-59283-add-to-cart-with-options-button-animation-ajax-disabled
+++ b/plugins/woocommerce/changelog/fix-59283-add-to-cart-with-options-button-animation-ajax-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make button animation show up in the Add to Cart + Options even when 'Enable AJAX add to cart buttons' setting is disabled

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -257,5 +257,30 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await page.getByLabel( 'Logo', { exact: true } ).selectOption( 'Yes' );
 
 		await expect( colorGreenOption ).toBeDisabled();
+	} );
+
+	test( "allows adding products to cart when the 'Enable AJAX add to cart buttons' setting is disabled", async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		// Set `woocommerce_enable_ajax_add_to_cart` setting to "no".
+		await wpCLI( `option set woocommerce_enable_ajax_add_to_cart no` );
+
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/t-shirt' );
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect( addToCartButton ).toHaveText( '1 in cart' );
 	} );
 } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -264,7 +264,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 		pageObject,
 		editor,
 	} ) => {
-		// Set `woocommerce_enable_ajax_add_to_cart` setting to "no".
 		await wpCLI( `option set woocommerce_enable_ajax_add_to_cart no` );
 
 		await pageObject.updateSingleProductTemplate();
@@ -282,5 +281,94 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await addToCartButton.click();
 
 		await expect( addToCartButton ).toHaveText( '1 in cart' );
+	} );
+
+	test( "allows adding simple products to cart when the 'Redirect to cart after successful addition' setting is enabled", async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		await wpCLI( `option set woocommerce_cart_redirect_after_add yes` );
+
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/t-shirt' );
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect(
+			page.getByLabel( 'Quantity of T-Shirt in your cart.' )
+		).toHaveValue( '1' );
+	} );
+
+	test( "allows adding variable products to cart when the 'Redirect to cart after successful addition' setting is enabled", async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		await wpCLI( `option set woocommerce_cart_redirect_after_add yes` );
+
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/hoodie' );
+
+		const colorBlueOption = page.locator( 'label:has-text("Blue")' );
+		const logoYesOption = page.locator( 'label:has-text("Yes")' );
+
+		await colorBlueOption.click();
+		await logoYesOption.click();
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect(
+			page.getByLabel( 'Quantity of Hoodie in your cart.' )
+		).toHaveValue( '1' );
+	} );
+
+	test( "allows adding grouped products to cart when the 'Redirect to cart after successful addition' setting is enabled", async ( {
+		page,
+		pageObject,
+		editor,
+	} ) => {
+		await wpCLI( `option set woocommerce_cart_redirect_after_add yes` );
+
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await page.goto( '/product/logo-collection' );
+
+		const increaseQuantityButton = page.getByLabel(
+			'Increase quantity of T-Shirt'
+		);
+		await increaseQuantityButton.click();
+
+		const addToCartButton = page.getByRole( 'button', {
+			name: 'Add to cart',
+		} );
+
+		await addToCartButton.click();
+
+		await expect(
+			page.getByLabel( 'Quantity of T-Shirt in your cart.' )
+		).toHaveValue( '1' );
 	} );
 } );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -102,7 +102,7 @@ class ProductButton extends AbstractBlock {
 		$is_product_purchasable   = $this->is_product_purchasable( $product );
 		$cart_redirect_after_add  = get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes';
 		$ajax_add_to_cart_enabled = get_option( 'woocommerce_enable_ajax_add_to_cart' ) === 'yes';
-		$is_ajax_button           = $ajax_add_to_cart_enabled && ! $cart_redirect_after_add && ( $is_descendant_of_add_to_cart_form || $product->supports( 'ajax_add_to_cart' ) ) && $is_product_purchasable;
+		$is_ajax_button           = ( ( $ajax_add_to_cart_enabled && $product->supports( 'ajax_add_to_cart' ) ) || $is_descendant_of_add_to_cart_form ) && $is_product_purchasable && ! $cart_redirect_after_add;
 		$html_element             = $is_ajax_button || ( $is_descendant_of_add_to_cart_form && 'external' !== $product->get_type() ) ? 'button' : 'a';
 		$styles_and_classes       = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array(), array( 'extra_classes' ) );
 		$classname                = StyleAttributesUtils::get_classes_by_attributes( $attributes, array( 'extra_classes' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59283.

This PR fixes an issue where the _Add to Cart + Options_ block button text doesn't update dynamically (e.g., to "X in cart") after adding items to the cart when the 'Enable AJAX add to cart buttons on archives' setting is disabled.

As I added tests for the above, I took the opportunity to add tests for the 'Redirect to cart after successful addition' setting too. To make sure adding products to cart worked.

Note: for the 'Enable AJAX add to cart buttons on archives' I only added tests for simple products, as product type shouldn't impact how it works. For 'Redirect to cart after successful addition', I added different tests for each product type, as the form is completely different, so things might break in one product type and not another.

### How to test the changes in this Pull Request:

1. Go to *Appearance* > *Editor* > *Templates* > *Single Product*.
2. Click on the *Add to Cart with Options* block and update to the blockified version.
3. Go to *WooCommerce* > *Settings* > *Products*. Uncheck *Enable AJAX add to cart buttons on archives*.
4. In the frontend, go to a product page.
5. Click on *Add to cart*.
6. Verify the product was added to the cart and the button text updated to "X in cart".

https://github.com/user-attachments/assets/4a6b3e35-ac33-4030-a721-558c0f91a769
