### PR TITLE
Use WooCommerce generic store for product quantity constraints

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-quantity-constraints
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-quantity-constraints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Use WooCommerce generic store for product quantity constraints
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -42,7 +42,7 @@ export type ProductData = {
 	weight?: string;
 	dimensions?: string;
 	min?: number;
-	max?: number | null;
+	max?: number;
 	step?: number;
 	variations?: {
 		[ variationId: number ]: {

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -41,6 +41,9 @@ export type ProductData = {
 	sku?: string;
 	weight?: string;
 	dimensions?: string;
+	min?: number;
+	max?: number | null;
+	step?: number;
 	variations?: {
 		[ variationId: number ]: {
 			price_html?: string;
@@ -48,6 +51,9 @@ export type ProductData = {
 			sku?: string;
 			weight?: string;
 			dimensions?: string;
+			min?: number;
+			max?: number;
+			step?: number;
 		};
 	};
 };

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -343,7 +343,7 @@ const addToCartWithOptionsStore = store<
 
 				const newValue = currentValue + step;
 
-				if ( max === null || newValue <= max ) {
+				if ( newValue <= max ) {
 					const updatedValue = Math.max( min, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
 						updatedValue

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -96,7 +96,10 @@ const getProductData = (
 		typeof productData?.min === 'number'
 			? productData.min
 			: defaultMinValue;
-	const max = productData?.max || Infinity;
+	const max =
+		productData && productData?.max && productData?.max >= 1
+			? productData?.max
+			: Infinity;
 	const step = productData?.step || 1;
 
 	return {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -99,7 +99,9 @@ const getProductData = (
 	const min =
 		typeof productData.min === 'number' ? productData.min : defaultMinValue;
 	const max =
-		productData.max && productData.max >= 1 ? productData.max : Infinity;
+		typeof productData.max === 'number' && productData.max >= 1
+			? productData.max
+			: Infinity;
 	const step = productData.step || 1;
 
 	return {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -6,6 +6,7 @@ import { store, getContext } from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
 	SelectedAttributes,
+	ProductData,
 } from '@woocommerce/stores/woocommerce/cart';
 import '@woocommerce/stores/woocommerce/product-data';
 import type { Store as StoreNotices } from '@woocommerce/stores/store-notices';
@@ -29,10 +30,6 @@ export type Context = {
 	tempQuantity: number;
 	groupedProductIds: number[];
 	childProductId: number;
-	quantityConstraints: Record<
-		number,
-		{ min: number; max: number | null; step: number }
-	>;
 };
 
 interface GroupedCartItem {
@@ -52,15 +49,6 @@ const { state: wooState } = store< WooCommerce >(
 	{ lock: universalLock }
 );
 
-const getDefaultConstraints = (
-	productType: string,
-	childProductId?: number
-) => ( {
-	min: productType === 'grouped' && childProductId ? 0 : 1,
-	step: 1,
-	max: null,
-} );
-
 const getInputElementFromEvent = (
 	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
 ) => {
@@ -77,6 +65,49 @@ const getInputElementFromEvent = (
 	return inputElement;
 };
 
+const getProductData = (
+	id: number,
+	productType: string,
+	availableVariations: AvailableVariation[],
+	selectedAttributes: SelectedAttributes[]
+): ProductData & { id: number } => {
+	let productId = id;
+	let productData: ProductData | undefined;
+
+	if ( productType === 'variable' ) {
+		const matchedVariation = getMatchedVariation(
+			availableVariations,
+			selectedAttributes
+		);
+		if ( matchedVariation?.variation_id ) {
+			productId = matchedVariation.variation_id;
+			productData =
+				wooState?.products?.[ id ]?.variations?.[
+					matchedVariation?.variation_id
+				];
+		}
+	} else {
+		productData = wooState?.products?.[ productId ];
+	}
+
+	// Add default quantity constraint values.
+	const defaultMinValue = productType === 'grouped' ? 0 : 1;
+	const min =
+		typeof productData?.min === 'number'
+			? productData.min
+			: defaultMinValue;
+	const max = productData?.max || Infinity;
+	const step = productData?.step || 1;
+
+	return {
+		id: productId,
+		...productData,
+		min,
+		max,
+		step,
+	};
+};
+
 const getInputData = (
 	event: HTMLElementEvent< HTMLButtonElement, HTMLInputElement >
 ) => {
@@ -87,27 +118,15 @@ const getInputData = (
 	}
 
 	const parsedValue = parseInt( inputElement.value, 10 );
-	const { productType, productId, quantityConstraints } =
-		getContext< Context >();
 	const childProductId = parseInt(
 		inputElement.name.match( /\[(\d+)\]/ )?.[ 1 ] ?? '0',
 		10
 	);
-	const id = childProductId || productId;
-	const constraints =
-		quantityConstraints?.[ id ] ||
-		getDefaultConstraints( productType, childProductId );
-	const minValue = constraints.min;
-	const maxValue = constraints.max;
-	const step = constraints.step;
 
 	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
 
 	return {
 		currentValue,
-		minValue,
-		maxValue,
-		step,
 		childProductId,
 		inputElement,
 	};
@@ -206,56 +225,62 @@ const addToCartWithOptionsStore = store<
 					quantity,
 					childProductId,
 					productType,
-					quantityConstraints,
 					productId,
 					availableVariations,
 					selectedAttributes,
 				} = getContext< Context >();
 
-				const matchedVariation = getMatchedVariation(
+				const productObject = getProductData(
+					childProductId || productId,
+					productType,
 					availableVariations,
 					selectedAttributes
 				);
 
-				const id =
-					matchedVariation?.variation_id ||
-					childProductId ||
-					productId;
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { id, min, step } = productObject;
+
+				if ( typeof step !== 'number' || typeof min !== 'number' ) {
+					return true;
+				}
+
 				const currentQuantity = quantity[ id ] || 0;
-				const constraints =
-					quantityConstraints?.[ id ] ||
-					getDefaultConstraints( productType, childProductId );
-				const minValue = constraints.min;
-				const step = constraints.step;
-				return currentQuantity - step >= minValue;
+
+				return currentQuantity - step >= min;
 			},
 			get allowsIncrease() {
 				const {
 					quantity,
 					childProductId,
 					productType,
-					quantityConstraints,
 					productId,
 					availableVariations,
 					selectedAttributes,
 				} = getContext< Context >();
 
-				const matchedVariation = getMatchedVariation(
+				const productObject = getProductData(
+					childProductId || productId,
+					productType,
 					availableVariations,
 					selectedAttributes
 				);
 
-				const id =
-					matchedVariation?.variation_id ||
-					childProductId ||
-					productId;
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { id, max, step } = productObject;
+
+				if ( typeof step !== 'number' || typeof max !== 'number' ) {
+					return true;
+				}
+
 				const currentQuantity = quantity[ id ] || 0;
-				const constraints =
-					quantityConstraints?.[ id ] ||
-					getDefaultConstraints( productType, childProductId );
-				const maxValue = constraints.max;
-				const step = constraints.step;
-				return maxValue === null || currentQuantity + step <= maxValue;
+
+				return currentQuantity + step <= max;
 			},
 		},
 		actions: {
@@ -288,18 +313,41 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
+				const { currentValue, childProductId, inputElement } =
+					inputData;
+
 				const {
-					currentValue,
-					maxValue,
-					minValue,
-					step,
-					childProductId,
-					inputElement,
-				} = inputData;
+					productType,
+					productId,
+					availableVariations,
+					selectedAttributes,
+				} = getContext< Context >();
+
+				const productObject = getProductData(
+					childProductId || productId,
+					productType,
+					availableVariations,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { max, min, step } = productObject;
+
+				if (
+					typeof step !== 'number' ||
+					typeof min !== 'number' ||
+					typeof max !== 'number'
+				) {
+					return true;
+				}
+
 				const newValue = currentValue + step;
 
-				if ( maxValue === null || newValue <= maxValue ) {
-					const updatedValue = Math.max( minValue, newValue );
+				if ( max === null || newValue <= max ) {
+					const updatedValue = Math.max( min, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
 						updatedValue,
 						childProductId
@@ -315,21 +363,41 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
+				const { currentValue, childProductId, inputElement } =
+					inputData;
+
 				const {
-					currentValue,
-					maxValue,
-					minValue,
-					step,
-					childProductId,
-					inputElement,
-				} = inputData;
+					productType,
+					productId,
+					availableVariations,
+					selectedAttributes,
+				} = getContext< Context >();
+
+				const productObject = getProductData(
+					childProductId || productId,
+					productType,
+					availableVariations,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { min, max, step } = productObject;
+
+				if (
+					typeof step !== 'number' ||
+					typeof min !== 'number' ||
+					typeof max !== 'number'
+				) {
+					return true;
+				}
+
 				const newValue = currentValue - step;
 
-				if ( newValue >= minValue ) {
-					const updatedValue = Math.min(
-						maxValue ?? Infinity,
-						newValue
-					);
+				if ( newValue >= min ) {
+					const updatedValue = Math.min( max ?? Infinity, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
 						updatedValue,
 						childProductId
@@ -359,12 +427,40 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { childProductId, maxValue, minValue, currentValue } =
-					inputData;
+				const { childProductId, currentValue } = inputData;
+
+				const {
+					productType,
+					productId,
+					availableVariations,
+					selectedAttributes,
+				} = getContext< Context >();
+
+				const id = childProductId || productId;
+				const productObject = getProductData(
+					id,
+					productType,
+					availableVariations,
+					selectedAttributes
+				);
+
+				if ( ! productObject ) {
+					return true;
+				}
+
+				const { min, max, step } = productObject;
+
+				if (
+					typeof step !== 'number' ||
+					typeof min !== 'number' ||
+					typeof max !== 'number'
+				) {
+					return true;
+				}
 
 				const newValue = Math.min(
-					maxValue ?? Infinity,
-					Math.max( minValue, currentValue )
+					max ?? Infinity,
+					Math.max( min, currentValue )
 				);
 
 				if ( event.target.value !== newValue.toString() ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -70,7 +70,7 @@ const getProductData = (
 	productType: string,
 	availableVariations: AvailableVariation[],
 	selectedAttributes: SelectedAttributes[]
-): ProductData & { id: number } => {
+): ( ProductData & { id: number } ) | null => {
 	let productId = id;
 	let productData: ProductData | undefined;
 
@@ -90,17 +90,17 @@ const getProductData = (
 		productData = wooState?.products?.[ productId ];
 	}
 
+	if ( typeof productData !== 'object' || productData === null ) {
+		return null;
+	}
+
 	// Add default quantity constraint values.
 	const defaultMinValue = productType === 'grouped' ? 0 : 1;
 	const min =
-		typeof productData?.min === 'number'
-			? productData.min
-			: defaultMinValue;
+		typeof productData.min === 'number' ? productData.min : defaultMinValue;
 	const max =
-		productData && productData?.max && productData?.max >= 1
-			? productData?.max
-			: Infinity;
-	const step = productData?.step || 1;
+		productData.max && productData.max >= 1 ? productData.max : Infinity;
+	const step = productData.step || 1;
 
 	return {
 		id: productId,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -118,16 +118,10 @@ const getInputData = (
 	}
 
 	const parsedValue = parseInt( inputElement.value, 10 );
-	const childProductId = parseInt(
-		inputElement.name.match( /\[(\d+)\]/ )?.[ 1 ] ?? '0',
-		10
-	);
-
 	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
 
 	return {
 		currentValue,
-		childProductId,
 		inputElement,
 	};
 };
@@ -172,7 +166,7 @@ export type AddToCartWithOptionsStore = {
 		allowsIncrease: boolean;
 	};
 	actions: {
-		setQuantity: ( value: number, childProductId?: number ) => void;
+		setQuantity: ( value: number ) => void;
 		increaseQuantity: (
 			event: HTMLElementEvent< HTMLButtonElement >
 		) => void;
@@ -284,7 +278,7 @@ const addToCartWithOptionsStore = store<
 			},
 		},
 		actions: {
-			setQuantity( value: number, childProductId?: number ) {
+			setQuantity( value: number ) {
 				const context = getContext< Context >();
 
 				if ( context.productType === 'variable' ) {
@@ -298,7 +292,7 @@ const addToCartWithOptionsStore = store<
 						context.quantity[ id ] = value;
 					} );
 				} else {
-					const id = childProductId || context.productId;
+					const id = context.childProductId || context.productId;
 
 					context.quantity = {
 						...context.quantity,
@@ -313,10 +307,10 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { currentValue, childProductId, inputElement } =
-					inputData;
+				const { currentValue, inputElement } = inputData;
 
 				const {
+					childProductId,
 					productType,
 					productId,
 					availableVariations,
@@ -349,8 +343,7 @@ const addToCartWithOptionsStore = store<
 				if ( max === null || newValue <= max ) {
 					const updatedValue = Math.max( min, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
-						updatedValue,
-						childProductId
+						updatedValue
 					);
 					inputElement.value = updatedValue.toString();
 					dispatchChangeEvent( inputElement );
@@ -363,10 +356,10 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { currentValue, childProductId, inputElement } =
-					inputData;
+				const { currentValue, inputElement } = inputData;
 
 				const {
+					childProductId,
 					productType,
 					productId,
 					availableVariations,
@@ -399,8 +392,7 @@ const addToCartWithOptionsStore = store<
 				if ( newValue >= min ) {
 					const updatedValue = Math.min( max ?? Infinity, newValue );
 					addToCartWithOptionsStore.actions.setQuantity(
-						updatedValue,
-						childProductId
+						updatedValue
 					);
 					inputElement.value = updatedValue.toString();
 					dispatchChangeEvent( inputElement );
@@ -413,12 +405,9 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { childProductId, currentValue } = inputData;
+				const { currentValue } = inputData;
 
-				addToCartWithOptionsStore.actions.setQuantity(
-					currentValue,
-					childProductId
-				);
+				addToCartWithOptionsStore.actions.setQuantity( currentValue );
 			},
 			handleQuantityChange: (
 				event: HTMLElementEvent< HTMLInputElement >
@@ -427,7 +416,9 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { childProductId, currentValue } = inputData;
+
+				const { childProductId } = getContext< Context >();
+				const { currentValue } = inputData;
 
 				const {
 					productType,
@@ -464,10 +455,7 @@ const addToCartWithOptionsStore = store<
 				);
 
 				if ( event.target.value !== newValue.toString() ) {
-					addToCartWithOptionsStore.actions.setQuantity(
-						newValue,
-						childProductId
-					);
+					addToCartWithOptionsStore.actions.setQuantity( newValue );
 					event.target.value = newValue.toString();
 					dispatchChangeEvent( event.target );
 				}
@@ -479,11 +467,10 @@ const addToCartWithOptionsStore = store<
 				if ( ! inputData ) {
 					return;
 				}
-				const { inputElement, childProductId } = inputData;
+				const { inputElement } = inputData;
 
 				addToCartWithOptionsStore.actions.setQuantity(
-					inputElement.checked ? 1 : 0,
-					childProductId
+					inputElement.checked ? 1 : 0
 				);
 			},
 			*handleSubmit( event: FormEvent< HTMLFormElement > ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -328,7 +328,7 @@ const addToCartWithOptionsStore = store<
 				);
 
 				if ( ! productObject ) {
-					return true;
+					return;
 				}
 
 				const { max, min, step } = productObject;
@@ -338,7 +338,7 @@ const addToCartWithOptionsStore = store<
 					typeof min !== 'number' ||
 					typeof max !== 'number'
 				) {
-					return true;
+					return;
 				}
 
 				const newValue = currentValue + step;
@@ -377,7 +377,7 @@ const addToCartWithOptionsStore = store<
 				);
 
 				if ( ! productObject ) {
-					return true;
+					return;
 				}
 
 				const { min, max, step } = productObject;
@@ -387,7 +387,7 @@ const addToCartWithOptionsStore = store<
 					typeof min !== 'number' ||
 					typeof max !== 'number'
 				) {
-					return true;
+					return;
 				}
 
 				const newValue = currentValue - step;
@@ -439,7 +439,7 @@ const addToCartWithOptionsStore = store<
 				);
 
 				if ( ! productObject ) {
-					return true;
+					return;
 				}
 
 				const { min, max, step } = productObject;
@@ -449,7 +449,7 @@ const addToCartWithOptionsStore = store<
 					typeof min !== 'number' ||
 					typeof max !== 'number'
 				) {
-					return true;
+					return;
 				}
 
 				const newValue = Math.min(

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-contraints.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-contraints.php
@@ -8,6 +8,8 @@
  * @package woocommerce-blocks-test-quantity-constraints
  */
 
+declare(strict_types=1);
+
 add_action(
 	'woocommerce_init',
 	function () {

--- a/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-contraints.php
+++ b/plugins/woocommerce/client/blocks/tests/e2e/plugins/quantity-contraints.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Blocks Test Quantity Constraints
+ * Description: Used to modify quantity constraints for products.
+ * Plugin URI: https://github.com/woocommerce/woocommerce
+ * Author: WooCommerce
+ *
+ * @package woocommerce-blocks-test-quantity-constraints
+ */
+
+add_action(
+	'woocommerce_init',
+	function () {
+		// Get ID of the T-Shirt product.
+		$tshirt_id      = wc_get_product_id_by_sku( 'woo-tshirt' );
+		$blue_hoodie_id = wc_get_product_id_by_sku( 'woo-blue-hoodie' );
+
+		add_filter(
+			'woocommerce_quantity_input_min',
+			function ( $min, $product ) use ( $tshirt_id, $blue_hoodie_id ) {
+				if ( $product->get_id() === $tshirt_id || $product->get_id() === $blue_hoodie_id ) {
+					return 4;
+				}
+				return $min;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_quantity_input_step',
+			function ( $step, $product ) use ( $tshirt_id, $blue_hoodie_id ) {
+				if ( $product->get_id() === $tshirt_id || $product->get_id() === $blue_hoodie_id ) {
+					return 2;
+				}
+				return $step;
+			},
+			10,
+			2
+		);
+
+		add_filter(
+			'woocommerce_quantity_input_max',
+			function ( $max, $product ) use ( $tshirt_id, $blue_hoodie_id ) {
+				if ( $product->get_id() === $tshirt_id || $product->get_id() === $blue_hoodie_id ) {
+					return 8;
+				}
+				return $max;
+			},
+			10,
+			2
+		);
+	}
+);

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -302,7 +302,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await expect( colorGreenOption ).toBeDisabled();
 	} );
 
-	test.only( 'respects quantity constraints', async ( {
+	test( 'respects quantity constraints', async ( {
 		page,
 		pageObject,
 		editor,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -106,7 +106,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
-		await page.goto( '/hoodie' );
+		await page.goto( '/product/hoodie/' );
 
 		// The radio input is visually hidden and, thus, not clickable. That's
 		// why we need to select the <label> instead.
@@ -236,7 +236,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			isOnlyCurrentEntityDirty: true,
 		} );
 
-		await page.goto( '/hoodie' );
+		await page.goto( '/product/hoodie/' );
 
 		// The radio input is visually hidden and, thus, not clickable. That's
 		// why we need to select the <label> instead.
@@ -279,7 +279,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await editor.saveSiteEditorEntities();
 
-		await page.goto( '/hoodie' );
+		await page.goto( '/product/hoodie/' );
 
 		let colorGreenOption = page.getByRole( 'option', {
 			name: 'Green',
@@ -300,6 +300,72 @@ test.describe( 'Add to Cart + Options Block', () => {
 		await page.getByLabel( 'Logo', { exact: true } ).selectOption( 'Yes' );
 
 		await expect( colorGreenOption ).toBeDisabled();
+	} );
+
+	test.only( 'respects quantity constraints', async ( {
+		page,
+		pageObject,
+		editor,
+		requestUtils,
+	} ) => {
+		await requestUtils.activatePlugin(
+			'woocommerce-blocks-test-quantity-constraints'
+		);
+		await pageObject.updateSingleProductTemplate();
+
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		await test.step( 'in simple products', async () => {
+			await page.goto( '/product/t-shirt/' );
+
+			const quantityInput = page.getByLabel( 'Product quantity' );
+
+			await expect( quantityInput ).toHaveValue( '4' );
+
+			const reduceQuantityButton = page.getByLabel(
+				'Reduce quantity of T-Shirt'
+			);
+			await expect( reduceQuantityButton ).toBeDisabled();
+
+			const increaseQuantityButton = page.getByLabel(
+				'Increase quantity of T-Shirt'
+			);
+			await increaseQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '6' );
+
+			await quantityInput.fill( '8' );
+
+			await expect( increaseQuantityButton ).toBeDisabled();
+		} );
+
+		await test.step( 'in grouped products', async () => {
+			await page.goto( '/product/logo-collection/' );
+
+			const quantityInput = page.getByRole( 'spinbutton', {
+				name: 'T-Shirt',
+			} );
+
+			await expect( quantityInput ).toHaveValue( '' );
+			const increaseQuantityButton = page.getByLabel(
+				'Increase quantity of T-Shirt'
+			);
+			await increaseQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '4' );
+
+			const reduceQuantityButton = page.getByLabel(
+				'Reduce quantity of T-Shirt'
+			);
+			await expect( reduceQuantityButton ).toBeDisabled();
+			await increaseQuantityButton.click();
+
+			await quantityInput.fill( '8' );
+
+			await expect( increaseQuantityButton ).toBeDisabled();
+		} );
 	} );
 
 	test( "allows adding products to cart when the 'Enable AJAX add to cart buttons' setting is disabled", async ( {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -249,22 +249,35 @@ class AddToCartWithOptions extends AbstractBlock {
 
 			if ( $product->is_type( 'grouped' ) ) {
 				// Add context for purchasable child products.
-				$context['groupedProductIds'] = array();
+				$children_product_data = array();
 				foreach ( $product->get_children() as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
 					if ( $child_product && $this->is_child_product_purchasable( $child_product ) ) {
-						$context['groupedProductIds'][] = $child_product_id;
+						/**
+						 * Filter the minimum quantity value allowed for the product.
+						 *
+						 * @since 10.2.0
+						 * @param int        $min_value Minimum quantity value.
+						 * @param WC_Product $product   Product object.
+						 */
+						$min = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
+						/**
+						 * Filter the maximum quantity value allowed for the product.
+						 *
+						 * @since 10.2.0
+						 * @param int        $max_value Maximum quantity value.
+						 * @param WC_Product $product   Product object.
+						 */
+						$max = apply_filters( 'woocommerce_quantity_input_max', $child_product->get_max_purchase_quantity(), $child_product );
+						/**
+						 * Filter the step quantity value allowed for the product.
+						 *
+						 * @since 10.2.0
+						 * @param int        $max_value Maximum quantity value.
+						 * @param WC_Product $product   Product object.
+						 */
+						$step = apply_filters( 'woocommerce_quantity_input_step', 1, $child_product );
 
-						$args = Utils::get_quantity_input_args( $child_product );
-						$min  = isset( $args['min_value'] ) ? (int) $args['min_value'] : 0;
-						// For grouped children, if min is 1 (the default), set to 0 unless a filter sets otherwise.
-						if ( 1 === $min ) {
-							$min = 0;
-						}
-						$max                                        = ( isset( $args['max_value'] ) && '' !== $args['max_value'] && -1 !== $args['max_value'] )
-							? (int) $args['max_value']
-							: null;
-						$step                                       = isset( $args['step'] ) ? (int) $args['step'] : 1;
 						$children_product_data[ $child_product_id ] = array(
 							'min'  => $min,
 							'max'  => $max,
@@ -273,6 +286,7 @@ class AddToCartWithOptions extends AbstractBlock {
 					}
 				}
 
+				$context['groupedProductIds'] = array_keys( $children_product_data );
 				wp_interactivity_state(
 					'woocommerce',
 					array(
@@ -302,13 +316,30 @@ class AddToCartWithOptions extends AbstractBlock {
 					}
 				}
 			} else {
-				// Not grouped: just add constraints for the main product.
-				$args = Utils::get_quantity_input_args( $product );
-				$min  = isset( $args['min_value'] ) ? (int) $args['min_value'] : 1;
-				$max  = ( isset( $args['max_value'] ) && '' !== $args['max_value'] && -1 !== $args['max_value'] )
-				? (int) $args['max_value']
-				: null;
-				$step = isset( $args['step'] ) ? (int) $args['step'] : 1;
+				/**
+				 * Filter the minimum quantity value allowed for the product.
+				 *
+				 * @since 10.2.0
+				 * @param int        $min_value Minimum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				$min = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+				/**
+				 * Filter the maximum quantity value allowed for the product.
+				 *
+				 * @since 10.2.0
+				 * @param int        $max_value Maximum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				$max = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
+				/**
+				 * Filter the step quantity value allowed for the product.
+				 *
+				 * @since 10.2.0
+				 * @param int        $max_value Maximum quantity value.
+				 * @param WC_Product $product   Product object.
+				 */
+				$step = apply_filters( 'woocommerce_quantity_input_step', 1, $product );
 
 				wp_interactivity_state(
 					'woocommerce',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -273,8 +273,8 @@ class AddToCartWithOptions extends AbstractBlock {
 						 * Filter the step quantity value allowed for the product.
 						 *
 						 * @since 10.2.0
-						 * @param int        $max_value Maximum quantity value.
-						 * @param WC_Product $product   Product object.
+						 * @param int        $step_value Step quantity value.
+						 * @param WC_Product $product     Product object.
 						 */
 						$step = apply_filters( 'woocommerce_quantity_input_step', 1, $child_product );
 
@@ -336,8 +336,8 @@ class AddToCartWithOptions extends AbstractBlock {
 				 * Filter the step quantity value allowed for the product.
 				 *
 				 * @since 10.2.0
-				 * @param int        $max_value Maximum quantity value.
-				 * @param WC_Product $product   Product object.
+				 * @param int        $step_value Step quantity value.
+				 * @param WC_Product $product    Product object.
 				 */
 				$step = apply_filters( 'woocommerce_quantity_input_step', 1, $product );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -221,10 +221,9 @@ class AddToCartWithOptions extends AbstractBlock {
 			);
 
 			$context = array(
-				'productId'           => $product->get_id(),
-				'productType'         => $product->get_type(),
-				'quantity'            => array( $product->get_id() => $default_quantity ),
-				'quantityConstraints' => array(),
+				'productId'   => $product->get_id(),
+				'productType' => $product->get_type(),
+				'quantity'    => array( $product->get_id() => $default_quantity ),
 			);
 
 			if ( $product->is_type( 'variable' ) ) {
@@ -262,17 +261,24 @@ class AddToCartWithOptions extends AbstractBlock {
 						if ( 1 === $min ) {
 							$min = 0;
 						}
-						$max  = ( isset( $args['max_value'] ) && '' !== $args['max_value'] && -1 !== $args['max_value'] )
+						$max                                        = ( isset( $args['max_value'] ) && '' !== $args['max_value'] && -1 !== $args['max_value'] )
 							? (int) $args['max_value']
 							: null;
-						$step = isset( $args['step'] ) ? (int) $args['step'] : 1;
-						$context['quantityConstraints'][ $child_product_id ] = array(
+						$step                                       = isset( $args['step'] ) ? (int) $args['step'] : 1;
+						$children_product_data[ $child_product_id ] = array(
 							'min'  => $min,
 							'max'  => $max,
 							'step' => $step,
 						);
 					}
 				}
+
+				wp_interactivity_state(
+					'woocommerce',
+					array(
+						'products' => $children_product_data,
+					)
+				);
 
 				// Add quantity context for purchasable child products.
 				$context['quantity'] = array_fill_keys(
@@ -304,10 +310,17 @@ class AddToCartWithOptions extends AbstractBlock {
 				: null;
 				$step = isset( $args['step'] ) ? (int) $args['step'] : 1;
 
-				$context['quantityConstraints'][ $product->get_id() ] = array(
-					'min'  => $min,
-					'max'  => $max,
-					'step' => $step,
+				wp_interactivity_state(
+					'woocommerce',
+					array(
+						'products' => array(
+							$product->get_id() => array(
+								'min'  => $min,
+								'max'  => $max,
+								'step' => $step,
+							),
+						),
+					)
 				);
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -253,35 +253,12 @@ class AddToCartWithOptions extends AbstractBlock {
 				foreach ( $product->get_children() as $child_product_id ) {
 					$child_product = wc_get_product( $child_product_id );
 					if ( $child_product && $this->is_child_product_purchasable( $child_product ) ) {
-						/**
-						 * Filter the minimum quantity value allowed for the product.
-						 *
-						 * @since 10.2.0
-						 * @param int        $min_value Minimum quantity value.
-						 * @param WC_Product $product   Product object.
-						 */
-						$min = apply_filters( 'woocommerce_quantity_input_min', $child_product->get_min_purchase_quantity(), $child_product );
-						/**
-						 * Filter the maximum quantity value allowed for the product.
-						 *
-						 * @since 10.2.0
-						 * @param int        $max_value Maximum quantity value.
-						 * @param WC_Product $product   Product object.
-						 */
-						$max = apply_filters( 'woocommerce_quantity_input_max', $child_product->get_max_purchase_quantity(), $child_product );
-						/**
-						 * Filter the step quantity value allowed for the product.
-						 *
-						 * @since 10.2.0
-						 * @param int        $step_value Step quantity value.
-						 * @param WC_Product $product     Product object.
-						 */
-						$step = apply_filters( 'woocommerce_quantity_input_step', 1, $child_product );
+						$child_product_quantity_constraints = Utils::get_product_quantity_constraints( $child_product );
 
 						$children_product_data[ $child_product_id ] = array(
-							'min'  => $min,
-							'max'  => $max,
-							'step' => $step,
+							'min'  => $child_product_quantity_constraints['min'],
+							'max'  => $child_product_quantity_constraints['max'],
+							'step' => $child_product_quantity_constraints['step'],
 						);
 					}
 				}
@@ -316,39 +293,16 @@ class AddToCartWithOptions extends AbstractBlock {
 					}
 				}
 			} else {
-				/**
-				 * Filter the minimum quantity value allowed for the product.
-				 *
-				 * @since 10.2.0
-				 * @param int        $min_value Minimum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				$min = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
-				/**
-				 * Filter the maximum quantity value allowed for the product.
-				 *
-				 * @since 10.2.0
-				 * @param int        $max_value Maximum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				$max = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
-				/**
-				 * Filter the step quantity value allowed for the product.
-				 *
-				 * @since 10.2.0
-				 * @param int        $step_value Step quantity value.
-				 * @param WC_Product $product    Product object.
-				 */
-				$step = apply_filters( 'woocommerce_quantity_input_step', 1, $product );
+				$product_quantity_constraints = Utils::get_product_quantity_constraints( $product );
 
 				wp_interactivity_state(
 					'woocommerce',
 					array(
 						'products' => array(
 							$product->get_id() => array(
-								'min'  => $min,
-								'max'  => $max,
-								'step' => $step,
+								'min'  => $product_quantity_constraints['min'],
+								'max'  => $product_quantity_constraints['max'],
+								'step' => $product_quantity_constraints['step'],
 							),
 						),
 					)

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -55,34 +55,6 @@ class Utils {
 	}
 
 	/**
-	 * Get standardized quantity input arguments for WooCommerce quantity input.
-	 *
-	 * @param \WC_Product $product The product object.
-	 * @return array Arguments for woocommerce_quantity_input().
-	 */
-	public static function get_quantity_input_args( $product ) {
-		return array(
-			/**
-			 * Filter the minimum quantity value allowed for the product.
-			 *
-			 * @since 10.1.0
-			 * @param int        $min_value Minimum quantity value.
-			 * @param WC_Product $product   Product object.
-			 */
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			/**
-			 * Filter the maximum quantity value allowed for the product.
-			 *
-			 * @since 10.1.0
-			 * @param int        $max_value Maximum quantity value.
-			 * @param WC_Product $product   Product object.
-			 */
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		);
-	}
-
-	/**
 	 * Make the quantity input interactive by wrapping it with the necessary data attribute and adding an input event listener.
 	 *
 	 * @param string   $quantity_html The quantity HTML.

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -180,4 +180,22 @@ class Utils {
 		$max_purchase_quantity = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
 		return $min_purchase_quantity === $max_purchase_quantity;
 	}
+
+	/**
+	 * Get the quantity constraints for a product.
+	 *
+	 * @param \WC_Product $product The product to get the quantity constraints for.
+	 * @return array The quantity constraints.
+	 */
+	public static function get_product_quantity_constraints( $product ) {
+		$min  = is_numeric( $product->get_min_purchase_quantity() ) ? $product->get_min_purchase_quantity() : 1;
+		$max  = is_numeric( $product->get_max_purchase_quantity() ) ? $product->get_max_purchase_quantity() : -1;
+		$step = is_numeric( $product->get_purchase_quantity_step() ) ? $product->get_purchase_quantity_step() : 1;
+
+		return array(
+			'min'  => $min,
+			'max'  => $max,
+			'step' => $step,
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR refactors how we save product quantity constraints. Until now, they were in the _Add to Cart + Options_ store, but this PR moves it to the generic WooCommerce store, in the `products` object, which contains product data. This is in preparation of https://github.com/woocommerce/woocommerce/issues/59443.

In addition to that, this PR:

* Includes automated testing to make sure there are no regressions in the quantity constraints.
* Refactors where we read `childProductId` from. Until now we were reading it either from the context or from the `<input>` markup. With this PR, we always read it from the context, making it easier to understand.

### How to test the changes in this Pull Request:

Testing this PR means making sure there are no regressions.

1. Add this code snippet, changing `125` for the product ID of a simple product that is also a child of a grouped product:

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 4;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_step', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 2;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 8;
	}
	return $default;
}, 10, 2 );
```

2. In the frontend, visit that simple product and verify the Quantity Selector default value is 4 and the minus icon is disabled. Verify pressing on the plus icon increases the quantity by 2 and, when you reach 8, the plus icon becomes disabled.

https://github.com/user-attachments/assets/afb38511-73e2-4d8e-8d4a-faf718075f4a

3. Now go to the grouped product and verify the product default value is empty (with `0` as the placeholder). Press on the plus icon and verify it jumps directly to 4. Verify the minus button is disabled. Keep pressing until you reach 8. Verify the plus icon becomes disabled.

https://github.com/user-attachments/assets/23668ead-d964-4333-97ba-eff8f24a3628