### PR TITLE
[Do not merge] WPS Migration: POC webhook validation

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -233,7 +233,7 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 	 * @param bool $testmode Whether to use the sandbox environment.
 	 * @return string|null The access token.
 	 */
-	private function get_paypal_access_token( $testmode ) {
+	public function get_paypal_access_token( $testmode ) {
 		$paypal_client_id     = get_option( 'wc_paypal_api_client_id' );
 		$paypal_client_secret = get_option( 'wc_paypal_api_client_secret' );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
@@ -86,8 +86,12 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response The response object.
 	 */
 	public function process_webhook( WP_REST_Request $request ) {
-		// TODO: Validate the webhook signature.
-		// https://developer.paypal.com/api/rest/webhooks/rest/#link-messageverification.
+		// Validate the webhook signature first.
+		$validation_result = $this->validate_webhook_signature_with_postback( $request );
+		if ( is_wp_error( $validation_result ) ) {
+			error_log( 'PayPal webhook signature validation failed: ' . $validation_result->get_error_message() );
+			return new WP_REST_Response( 'Webhook signature validation failed', 401 );
+		}
 
 		$data = $request->get_json_params();
 		error_log( '(Proxy) PayPal webhook received: ' . wc_print_r( $data, true ) );
@@ -130,6 +134,102 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 		}
 
 		return new WP_REST_Response( 'Webhook processed', 200 );
+	}
+
+	/**
+	 * Validate the PayPal webhook signature.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 */
+	private function validate_webhook_signature_with_postback( WP_REST_Request $request ) {
+		// Extract required headers for signature validation.
+		$headers = $request->get_headers();
+		$data    = $request->get_json_params();
+		
+		$auth_algo        = $headers['paypal_auth_algo'][0] ?? '';
+		$cert_url         = $headers['paypal_cert_url'][0] ?? '';
+		$transmission_id  = $headers['paypal_transmission_id'][0] ?? '';
+		$transmission_sig = $headers['paypal_transmission_sig'][0] ?? '';
+		$transmission_time = $headers['paypal_transmission_time'][0] ?? '';
+
+		// Validate that all required headers are present.
+		if ( empty( $auth_algo ) || empty( $cert_url ) || empty( $transmission_id ) || 
+			 empty( $transmission_sig ) || empty( $transmission_time ) ) {
+			return new WP_Error( 'missing_headers', 'Required PayPal webhook headers are missing' );
+		}
+
+		// Get webhook ID from PayPal settings.
+		$webhook_id = get_option( 'wc_paypal_webhook_id' );
+		if ( empty( $webhook_id ) ) {
+			return new WP_Error( 'missing_webhook_id', 'PayPal webhook ID is not configured' );
+		}
+
+		// Prepare the verification request payload.
+		$verification_data = array(
+			'auth_algo'         => $auth_algo,
+			'cert_url'          => $cert_url,
+			'transmission_id'   => $transmission_id,
+			'transmission_sig'  => $transmission_sig,
+			'transmission_time' => $transmission_time,
+			'webhook_id'        => $webhook_id,
+			'webhook_event'     => $request->get_json_params(),
+		);
+
+
+		$testmode = strpos( $data['resource']['links'][0]['href'], 'sandbox' ) !== false;
+
+		// Make API call to PayPal to verify the signature.
+		$paypal_api_url = $this->get_paypal_api_base_url( $testmode ) . '/v1/notifications/verify-webhook-signature';
+		$proxy_controller = new WC_REST_Paypal_Proxy_Controller();
+		$access_token     = $proxy_controller->get_paypal_access_token( $testmode );
+
+		if ( empty( $access_token ) ) {
+			return new WP_Error( 'missing_access_token', 'PayPal access token is not available' );
+		}
+
+		$response = wp_remote_post(
+			$paypal_api_url,
+			array(
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $access_token,
+				),
+				'body'    => wp_json_encode( $verification_data ),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'verification_request_failed', 'Failed to make verification request to PayPal: ' . $response->get_error_message() );
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( 200 !== $response_code ) {
+			return new WP_Error( 'verification_failed', 'PayPal signature verification failed with status: ' . $response_code );
+		}
+
+		$verification_result = json_decode( $response_body, true );
+		
+		if ( ! isset( $verification_result['verification_status'] ) || 
+			 'SUCCESS' !== $verification_result['verification_status'] ) {
+			return new WP_Error( 'signature_invalid', 'PayPal signature verification returned failure status' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the PayPal API base URL based on environment.
+	 *
+	 * @return string The API base URL.
+	 */
+	private function get_paypal_api_base_url( $testmode ) {		
+		return $testmode 
+			? 'https://api-m.sandbox.paypal.com'
+			: 'https://api-m.paypal.com';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
@@ -89,6 +89,7 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 		// Validate the webhook signature first.
 		// $validation_result = $this->validate_webhook_signature_with_postback( $request );
 		$validation_result = $this->validate_webhook_signature_by_self_check( $request );
+		wc_get_logger()->info( 'PayPal webhook signature validation result: ' . wc_print_r( $validation_result, true ) );
 		if ( is_wp_error( $validation_result ) ) {
 			error_log( 'PayPal webhook signature validation failed: ' . $validation_result->get_error_message() );
 			return new WP_REST_Response( 'Webhook signature validation failed', 401 );
@@ -264,7 +265,7 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 		// Calculate CRC32 of raw event data
 		$crc = sprintf( '%u', crc32( $data ) );
 		
-		$message = "{$transmission_id}|{$time_stamp}|{$webhook_id}|{$crc}";
+		$message = "{$transmission_id}|{$time_stamp}|{$webhook_id}|{$crc}|{$webhook_id}";
 		
 		// Download and cache the certificate
 		$cert_pem = $this->get_paypal_cert( $headers['paypal_cert_url'][0] );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php
@@ -87,7 +87,8 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 	 */
 	public function process_webhook( WP_REST_Request $request ) {
 		// Validate the webhook signature first.
-		$validation_result = $this->validate_webhook_signature_with_postback( $request );
+		// $validation_result = $this->validate_webhook_signature_with_postback( $request );
+		$validation_result = $this->validate_webhook_signature_by_self_check( $request );
 		if ( is_wp_error( $validation_result ) ) {
 			error_log( 'PayPal webhook signature validation failed: ' . $validation_result->get_error_message() );
 			return new WP_REST_Response( 'Webhook signature validation failed', 401 );
@@ -230,6 +231,94 @@ class WC_REST_Paypal_Webhooks_Proxy_Controller extends WC_REST_Controller {
 		return $testmode 
 			? 'https://api-m.sandbox.paypal.com'
 			: 'https://api-m.paypal.com';
+	}
+
+	/**
+	 * Validate the PayPal webhook signature by self check.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 */
+	function validate_webhook_signature_by_self_check( $request ) {
+		$headers = $request->get_headers();
+		$data    = $request->get_body();
+
+		// Validate required headers
+		$required_headers = array(
+			'paypal_transmission_id',
+			'paypal_transmission_time', 
+			'paypal_cert_url',
+			'paypal_transmission_sig'
+		);
+		
+		foreach ( $required_headers as $header ) {
+			if ( empty( $headers[ $header ][0] ?? '' ) ) {
+				return new WP_Error( 'missing_header', "Missing required header: {$header}" );
+			}
+		}
+		
+		$transmission_id = $headers['paypal_transmission_id'][0];
+		$time_stamp     = $headers['paypal_transmission_time'][0];
+		$webhook_id     = get_option( 'wc_paypal_webhook_id' );
+		
+		// Calculate CRC32 of raw event data
+		$crc = sprintf( '%u', crc32( $data ) );
+		
+		$message = "{$transmission_id}|{$time_stamp}|{$webhook_id}|{$crc}";
+		
+		// Download and cache the certificate
+		$cert_pem = $this->get_paypal_cert( $headers['paypal_cert_url'][0] );
+		
+		if ( is_wp_error( $cert_pem ) ) {
+			wc_get_logger()->error( 'Failed to download certificate: ' . $cert_pem->get_error_message(), array( 'source' => 'paypal-webhook-proxy' ) );
+			return $cert_pem;
+		}
+		
+		// Decode the base64-encoded signature
+		$signature = base64_decode( $headers['paypal_transmission_sig'][0] );
+		
+		if ( $signature === false ) {
+			return new WP_Error( 'invalid_signature', 'Could not decode base64 signature' );
+		}
+		
+		// Verify the signature using OpenSSL
+		$result = openssl_verify( $message, $signature, $cert_pem, OPENSSL_ALGO_SHA256 );
+		
+		if ( $result !== 1 ) {
+			$openssl_error = '';
+			while ( $error = openssl_error_string() ) {
+				$openssl_error .= $error . ' ';
+			}
+			return new WP_Error( 'signature_invalid', 'OpenSSL verification error: ' . trim( $openssl_error ) );
+		}
+				
+		return true;
+	}
+
+	/**
+	 * Get the PayPal certificate.
+	 *
+	 * @param string $cert_url The certificate URL.
+	 * @return string|WP_Error The certificate.
+	 */
+	function get_paypal_cert( $cert_url ) {
+		$cert = get_transient( 'paypal_cert_' . md5( $cert_url ) );
+		if ( ! $cert ) {
+			$response = wp_remote_get( $cert_url, array( 'timeout' => 30 ) );
+			
+			if ( is_wp_error( $response ) ) {
+				return new WP_Error( 'cert_fetch_failed', 'Unable to fetch certificate: ' . $response->get_error_message() );
+			}
+			
+			$cert = wp_remote_retrieve_body( $response );
+			if ( empty( $cert ) ) {
+				return new WP_Error( 'cert_empty', 'Certificate is empty' );
+			}
+			
+			set_transient( 'paypal_cert_' . md5( $cert_url ), $cert, HOUR_IN_SECONDS ); // cache for 1 hour
+		}
+		
+		return $cert;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PayPal has 2 ways for [webhook signature validation](https://developer.paypal.com/api/rest/webhooks/rest/#link-messageverification). 
- Post Back method: Send the received webhook back to PayPal using `notifications/verify-webhook-signature` endpoint.
- Self check: Implement the signature comparison locally.
This PR is a basic POC for both.

Closes PAYPAL-57

### How to test the changes in this Pull Request:
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. You will need to configure the webhook to send the events to the proxy webhook endpoint.
3. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
4. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
5. Configure PayPal Standard's setting:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- For Payment action, select Capture
6. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
wp option update wc_paypal_webhook_id <YOUR-PAYPAL-WEBHOOK-ID>
```
7. As a shopper, add a product to cart and go to checkout.
8. You should see PayPal as a payment option.
9. Click "Proceed to PayPal".
10. Use your Personal sandbox account credentials to log in and approve the purchase.
11. You should get redirected to the "Order Confirmation" page.
12. Wait a few seconds, and go to the wp-admin order page.
13. The order status should be `Processing`.
14. In `plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-webhooks-proxy-controller.php`, uncomment line 90 and comment out line 91 to test `validate_webhook_signature_with_postback`.
15. Change one or more params in both of the methods and check if validation fails (expected).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
