### PR TITLE
When applying and removing coupons, leave address data alone in checkout

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5216-block-checkout-old-customer-data-getting-loaded-back-into
+++ b/plugins/woocommerce/changelog/wooplug-5216-block-checkout-old-customer-data-getting-loaded-back-into
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When applying and removing coupons, leave address data alone in checkout to prevent invalid values being replaced with values from server.

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/thunks.ts
@@ -292,7 +292,7 @@ export const applyCoupon =
 				},
 				cache: 'no-store',
 			} );
-			dispatch.receiveCart( response );
+			dispatch.receiveCartContents( response );
 			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );
@@ -324,7 +324,7 @@ export const removeCoupon =
 				},
 				cache: 'no-store',
 			} );
-			dispatch.receiveCart( response );
+			dispatch.receiveCartContents( response );
 			return response;
 		} catch ( error ) {
 			dispatch.receiveError( isApiErrorResponse( error ) ? error : null );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents address data (which may be in a stale/edited state on checkout) being overridden from the server when applying coupons. Switches out `dispatch.receiveCart` with `dispatch.receiveCartContents` which excludes shipping and billing address.

Closes #60096

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to checkout as any user
2. Enter first name OLDFIRSTNAME and surname OLDSURNAME and complete all other address fields. Everything should be valid.
3. Remove the address line 1 field. You'll see inline validation error.
4. Change OLDFIRSTNAME to NEWFIRSTNAME
5. Change OLDSURNAME to NEWSURNAME
6. In the checkout sidebar apply a valid coupon.
7. After the coupon has applied, ensure you still have NEWFIRSTNAME and NEWSURNAME
8. Remove the coupon. Ensure you still have NEWFIRSTNAME and NEWSURNAME
9. Refresh checkout. OLDFIRSTNAME and OLDSURNAME are back. They were never pushed.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
