### PR TITLE
WPS Migration: Hide 'Pay' button on order received page

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -127,7 +127,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_processing', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
-		
+
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
 		} else {

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -127,9 +127,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_processing', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
-
-		// Hide action buttons for pending orders as they take a while to be captured with orders v2.
-		add_filter( 'woocommerce_my_account_my_orders_actions', [ $this, 'filter_my_account_my_orders_actions' ], 10, 2 );
 		
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
@@ -146,6 +143,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		if ( 'yes' === $this->enabled ) {
 			add_filter( 'woocommerce_thankyou_order_received_text', array( $this, 'order_received_text' ), 10, 2 );
+			// Hide action buttons for pending orders as they take a while to be captured with orders v2.
+			add_filter( 'woocommerce_my_account_my_orders_actions', array( $this, 'hide_action_buttons' ), 10, 2 );
 		}
 
 		$this->maybe_register_site_with_wpcom();
@@ -206,20 +205,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			self::log( 'Jetpack registration failed: ' . $result->get_error_message(), 'error' );
 			return;
 		}
-	}
-
-	/**
-	 * Hide "Pay" and "Cancel" action buttons for pending orders as orders v2 takes a while to be captured.
-	 *
-	 * @param $actions array An array with the default actions.
-	 * @param $order WC_Order The order.
-	 * @return array
-	 */
-	public function filter_my_account_my_orders_actions( $actions, $order ) {
-		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
-			unset( $actions['pay'], $actions['cancel'] );
-		}
-		return $actions;
 	}
 
 	/**
@@ -626,6 +611,20 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		return $text;
+	}
+
+	/**
+	 * Hide "Pay" and "Cancel" action buttons for pending orders as orders v2 takes a while to be captured.
+	 *
+	 * @param array    $actions An array with the default actions.
+	 * @param WC_Order $order The order.
+	 * @return array
+	 */
+	public function hide_action_buttons( $actions, $order ) {
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() && $this->id === $order->get_payment_method() ) {
+			unset( $actions['pay'], $actions['cancel'] );
+		}
+		return $actions;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -128,6 +128,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 
+		// Hide action buttons for pending orders as they take a while to be captured with orders v2.
+		add_filter( 'woocommerce_my_account_my_orders_actions', [ $this, 'filter_my_account_my_orders_actions' ], 10, 2 );
+		
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';
 		} else {
@@ -203,6 +206,20 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			self::log( 'Jetpack registration failed: ' . $result->get_error_message(), 'error' );
 			return;
 		}
+	}
+
+	/**
+	 * Hide "Pay" and "Cancel" action buttons for pending orders as orders v2 takes a while to be captured.
+	 *
+	 * @param $actions array An array with the default actions.
+	 * @param $order WC_Order The order.
+	 * @return array
+	 */
+	public function filter_my_account_my_orders_actions( $actions, $order ) {
+		if ( WC_Gateway_Paypal_Helper::should_use_orders_v2() ) {
+			unset( $actions['pay'], $actions['cancel'] );
+		}
+		return $actions;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
After payment approval, when the user is redirected to the order received page, there is a `Pay` button in the order received section. This is because the order is currently in the `pending payment` status. User can click on the `Pay` button and pay for the same order again from the pay for order page. 
This PR prevents this flow by hiding the `Pay` button from the order received page. (similar to Stripe)

Closes PAYPAL-39

### How to test the changes in this Pull Request:
1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Configure PayPal Standard's setting:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- For Payment action, select Capture
5. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
```
6. As a shopper, add a product to cart and go to checkout.
7. You should see PayPal as a payment option.
8. Click "Proceed to PayPal".
9. Use your Personal sandbox account credentials to log in and approve the purchase.
10. You should get redirected to the "Order Confirmation" page.
11. In `trunk` notice that there is a `Pay` and `Cancel` button in the order details section. If you click the `Pay` button, you will be redirected to the pay for order page and can pay for the order again.
12. In this branch, the `Pay` and `Cancel` buttons should be absent from the order recieved page.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
