### PR TITLE
Fix #23802: prevent double tax removal on coupon discounts when prices include tax

### DIFF
--- a/plugins/woocommerce/changelog/60117-fix-issue-23802-coupon-discount-tax-inclusive
+++ b/plugins/woocommerce/changelog/60117-fix-issue-23802-coupon-discount-tax-inclusive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix coupon discount calculation with tax-inclusive pricing in admin orders

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1557,10 +1557,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					}
 
 					$discount_tax += $taxes;
-
-					if ( $this->get_prices_include_tax() ) {
-						$amount = $amount - $taxes;
-					}
 				}
 
 				$coupon_item->set_discount( $amount );

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -653,15 +653,13 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test for issue #23802: Validate that the fix prevents double tax subtraction.
+	 * Test that coupon discounts are calculated correctly for admin orders with tax-inclusive pricing.
 	 * 
-	 * This test validates that our fix in set_coupon_discount_amounts() prevents
-	 * the double tax subtraction that was causing incorrect coupon calculations
-	 * when prices include tax.
-	 * 
-	 * @see https://github.com/woocommerce/woocommerce/issues/23802
+	 * When creating orders manually in the admin with tax-inclusive pricing enabled,
+	 * coupon discounts should be calculated based on the tax-exclusive amount without
+	 * double-subtracting the tax amount.
 	 */
-	public function test_issue_23802_fix_prevents_double_tax_subtraction() {
+	public function test_admin_order_coupon_discount_with_tax_inclusive_pricing() {
 		// Set up WooCommerce settings
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
@@ -689,28 +687,29 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$product->set_regular_price( 39.00 );
 		$product->save();
 
-		// Create admin order
+		// Create admin order (manual order creation, not frontend checkout)
 		$order = wc_create_order();
 		$order->add_product( $product, 1 );
 		$order->apply_coupon( 'test_coupon' );
 
 		// Get the coupon items to validate the discount amounts directly
 		$coupon_items = $order->get_items( 'coupon' );
-		$this->assertCount( 1, $coupon_items, 'Coupon should be applied to order' );
+		$this->assertCount( 1, $coupon_items, 'Coupon should be applied to admin order' );
 		
 		$coupon_item = current( $coupon_items );
 		$coupon_discount = $coupon_item->get_discount();
 		
-		// Before the fix, this would be ~2.53 due to double tax subtraction
-		// After the fix, this should be higher (the correct discount amount)
-		// The exact value may vary due to WooCommerce's complex calculation flow,
-		// but it should be significantly higher than the broken value
-		$this->assertGreaterThan( 2.8, $coupon_discount, 
-			'Fix validation: Coupon discount should be greater than broken value, indicating fix prevents double tax subtraction' );
+		// For a 39€ product with 24% tax included and a 10% coupon:
+		// Tax-exclusive price: 39 / 1.24 ≈ 31.45
+		// Expected discount: 31.45 * 0.10 ≈ 3.14
+		// The discount should be calculated on the tax-exclusive amount
+		$expected_min_discount = 3.0; // Allow for rounding
+		$expected_max_discount = 3.3; // Allow for calculation variations
+		
+		$this->assertGreaterThan( $expected_min_discount, $coupon_discount, 
+			'Admin order coupon discount should be calculated on tax-exclusive price' );
 			
-		// Also verify it's reasonable (should be around 10% of tax-exclusive price)
-		// Tax-exclusive price: 39 / 1.24 ≈ 31.45, so 10% ≈ 3.14
-		$this->assertLessThan( 3.5, $coupon_discount, 
-			'Coupon discount should be reasonable (close to 10% of tax-exclusive price)' );
+		$this->assertLessThan( $expected_max_discount, $coupon_discount, 
+			'Admin order coupon discount should not exceed reasonable bounds' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -651,4 +651,66 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		remove_action( 'woocommerce_before_order_item_object_save', $callback );
 		remove_action( 'woocommerce_order_status_' . $refunded_status, $should_not_be_called_callback );
 	}
+
+	/**
+	 * Test for issue #23802: Validate that the fix prevents double tax subtraction.
+	 * 
+	 * This test validates that our fix in set_coupon_discount_amounts() prevents
+	 * the double tax subtraction that was causing incorrect coupon calculations
+	 * when prices include tax.
+	 * 
+	 * @see https://github.com/woocommerce/woocommerce/issues/23802
+	 */
+	public function test_issue_23802_fix_prevents_double_tax_subtraction() {
+		// Set up WooCommerce settings
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+
+		// Create 24% tax rate
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '24.0000',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => '1',
+			'tax_rate_order'    => '1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		// Create 10% percentage discount coupon
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'test_coupon' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Create product with 39€ price (inclusive of tax)
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 39.00 );
+		$product->save();
+
+		// Create admin order
+		$order = wc_create_order();
+		$order->add_product( $product, 1 );
+		$order->apply_coupon( 'test_coupon' );
+
+		// Get the coupon items to validate the discount amounts directly
+		$coupon_items = $order->get_items( 'coupon' );
+		$this->assertCount( 1, $coupon_items, 'Coupon should be applied to order' );
+		
+		$coupon_item = current( $coupon_items );
+		$coupon_discount = $coupon_item->get_discount();
+		
+		// Before the fix, this would be ~2.53 due to double tax subtraction
+		// After the fix, this should be higher (the correct discount amount)
+		// The exact value may vary due to WooCommerce's complex calculation flow,
+		// but it should be significantly higher than the broken value
+		$this->assertGreaterThan( 2.8, $coupon_discount, 
+			'Fix validation: Coupon discount should be greater than broken value, indicating fix prevents double tax subtraction' );
+			
+		// Also verify it's reasonable (should be around 10% of tax-exclusive price)
+		// Tax-exclusive price: 39 / 1.24 ≈ 31.45, so 10% ≈ 3.14
+		$this->assertLessThan( 3.5, $coupon_discount, 
+			'Coupon discount should be reasonable (close to 10% of tax-exclusive price)' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a bug where coupon discounts were calculated incorrectly when prices are set to be inclusive of tax in the admin order creation interface. The issue caused double tax removal from coupon discount amounts, resulting in incorrect discount calculations that didn't match customer expectations.

The bug manifested when:
- Tax calculations are enabled
- Prices are set to be inclusive of tax  
- Percentage discount coupons are applied to admin-created orders
- The discount amount was being reduced by tax twice, once when calculating the base discount and again in the `set_coupon_discount_amounts()` method

**Technical Fix:**
Removed redundant tax subtraction logic in the `set_coupon_discount_amounts()` method in `abstract-wc-order.php`. The tax adjustment was already being handled correctly in the discount calculation flow, so the additional subtraction in the coupon discount setting was causing the double tax removal.

Closes #23802.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Configure WooCommerce settings:**
   - Enable tax rates and calculations (General settings)
   - Enable the use of coupon codes (General settings)
   - Set currency to Euro (€) or any currency with tax
   - Under Tax settings: Enable "Yes, I will enter prices inclusive of tax"
   - Add a standard tax rate of 24% (or any percentage)

2. **Create test coupon and product:**
   - Create a "Percentage discount" coupon with 10% discount value
   - Create a product with price of €39.00 (or equivalent in your currency)

3. **Test Case 1 - Add product first, then coupon:**
   - In WP Admin, go to WooCommerce > Orders > Add Order
   - Add the test product (quantity 1)
   - Apply the 10% discount coupon
   - Verify the discount calculation is correct: €39.00 ÷ 1.24 × 0.10 = €3.15 (not the incorrect ~€2.54)
   - Verify total shows: €39.00 - €3.15 = €35.85

4. **Test Case 2 - Add coupon first, then product:**
   - In WP Admin, create a new order
   - Apply the 10% discount coupon first (before adding products)
   - Add the test product (quantity 1)
   - Verify the coupon discount is applied correctly to the product
   - Click "Recalculate" to ensure amounts remain correct

5. **Test Case 3 - Remove and reapply coupon:**
   - With an order containing a product and coupon, remove the coupon
   - Reapply the same coupon
   - Verify the discount amount remains consistent and correct

### Testing that has already taken place:

- Tests added to confirm issue before and after fix, see comment below.

Environment: WordPress 6.x, WooCommerce 9.x, Storefront theme, no additional plugins

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix coupon discount calculation with tax-inclusive pricing in admin orders

</details>