### PR TITLE
Add a tool to repair coupons lookup table with zero discount amounts

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4955-coupon-discount-totals-not-aggregated-in-analytics-when-code
+++ b/plugins/woocommerce/changelog/wooplug-4955-coupon-discount-totals-not-aggregated-in-analytics-when-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a tool to repair coupons lookup table with zero discount amounts

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -151,6 +151,11 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This tool will regenerate product lookup table data. This process may take a while.', 'woocommerce' ),
 			),
+			'repair_coupons_lookup_table'          => array(
+				'name'   => __( 'Coupons lookup table', 'woocommerce' ),
+				'button' => __( 'Repair', 'woocommerce' ),
+				'desc'   => __( 'This tool will repair the coupons lookup table data with missing discount amounts. This process may take a while.', 'woocommerce' ),
+			),
 			'recount_terms'                        => array(
 				'name'   => __( 'Term counts', 'woocommerce' ),
 				'button' => __( 'Recount terms', 'woocommerce' ),
@@ -523,6 +528,11 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					wc_update_product_lookup_tables();
 				}
 				$message = __( 'Lookup tables are regenerating', 'woocommerce' );
+				break;
+
+			case 'repair_coupons_lookup_table':
+				$result  = wc_repair_zero_discount_coupons_lookup_table();
+				$message = $result['message'];
 				break;
 			case 'reset_roles':
 				// Remove then re-add caps and roles.

--- a/plugins/woocommerce/includes/wc-coupon-functions.php
+++ b/plugins/woocommerce/includes/wc-coupon-functions.php
@@ -11,6 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Admin\API\Reports\Coupons\DataStore as CouponsDataStore;
 
 /**
  * Get coupon types.
@@ -128,4 +129,89 @@ function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {
 	$ids = array_diff( array_filter( array_map( 'absint', (array) $ids ) ), array( $exclude ) );
 
 	return apply_filters( 'woocommerce_get_coupon_id_from_code', absint( current( $ids ) ), $code, $exclude );
+}
+
+/**
+ * Repair coupon lookup entries with zero discount_amount. A bug in WC 9.9 (fixed in 10.0)
+ * caused discount_amount to be set to zero when a coupon code was used with
+ * different case (e.g. "10-off" vs "10-OFF").
+ *
+ * @since 10.1.0
+ * @return array Array with 'success' boolean and 'message' string.
+ */
+function wc_repair_zero_discount_coupons_lookup_table() {
+	global $wpdb;
+
+	$table_name = $wpdb->prefix . 'wc_order_coupon_lookup';
+
+	// Check if table exists.
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	if ( $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) !== $table_name ) {
+		return array(
+			'success' => false,
+			'message' => __( 'Coupons lookup table does not exist.', 'woocommerce' ),
+		);
+	}
+
+	// Get entries with zero discount_amount.
+	$zero_discount_entries = $wpdb->get_results(
+		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT order_id, coupon_id FROM $table_name WHERE discount_amount = %f",
+			0.0
+		),
+		ARRAY_A
+	);
+
+	if ( empty( $zero_discount_entries ) ) {
+		return array(
+			'success' => true,
+			'message' => __( 'No entries with zero discount amount found. Coupons lookup table is up to date.', 'woocommerce' ),
+		);
+	}
+
+	$processed_count = 0;
+	$error_count     = 0;
+
+	foreach ( $zero_discount_entries as $entry ) {
+		try {
+			$result = CouponsDataStore::sync_order_coupons( $entry['order_id'] );
+			if ( false !== $result ) {
+				++$processed_count;
+			} else {
+				++$error_count;
+			}
+		} catch ( Exception $e ) {
+			++$error_count;
+			$logger = wc_get_logger();
+			$logger->error(
+				sprintf(
+					'Error fixing coupon lookup entry for order %d: %s',
+					$entry['order_id'],
+					$e->getMessage()
+				),
+				array(
+					'source'   => 'coupons-lookup-fix',
+					'order_id' => $entry['order_id'],
+					'error'    => $e,
+				)
+			);
+		}
+	}
+
+	// Clear any related caches.
+	wp_cache_flush_group( 'coupons' );
+	WC_Cache_Helper::get_transient_version( 'woocommerce_reports', true );
+
+	$message = sprintf(
+		/* translators: %1$d: number of entries processed, %2$d: number of errors */
+		__( 'Coupons lookup table entries with zero discount amount repaired successfully. Processed %1$d entries with %2$d errors.', 'woocommerce' ),
+		$processed_count,
+		$error_count
+	);
+
+	return array(
+		'success' => true,
+		'message' => $message,
+	);
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a tool to repair `discount_amount` being `0` in coupon lookup table. The bug was introduced in WC 9.9 (https://github.com/woocommerce/woocommerce/pull/56319) and fixed in 10.0 (https://github.com/woocommerce/woocommerce/pull/58918), but the data remained corrupted in database. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4955, closes #59545.

(For Bug Fixes) Bug introduced in PR #56319.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This is already fixed in https://github.com/woocommerce/woocommerce/pull/58918 and this PR only 

1. Create a coupon code for $10 fixed amount.
2. Create 4 orders with this coupon and mark orders as completed.
3. Go to **Analytics > Coupon** and check that **Amount** discounted is $40.
4. Manually edit `{$prefix}_wc_order_coupon_lookup` table and set `discount_amount` to 0.
5. Go to **Analytics > Coupon** and check that **Amount** discounted is $20 (if you have any form of caching on the website, this might require clearing that cache first).
6. Go to **WooCommerce > Status > Tools** and click `Repair` on **Coupons lookup table**.
7. You should see `Coupons lookup table entries with zero discount amount repaired successfully. Processed 2 entries with 0 errors.`
8. Go to **Analytics > Coupon** and check that **Amount** discounted is $40.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
