### PR TITLE
Reset quantity states when adding to cart a grouped product fails with the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-product-errors
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-product-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reset quantities when adding to cart a grouped product fails with the Add to Cart + Options block

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -425,25 +425,25 @@ const { state, actions } = store< Store >(
 
 					const json: BatchResponse = yield res.json();
 
-					// Checks if any of the responses contain an error.
-					json.responses?.forEach( ( response ) => {
-						if ( isApiErrorResponse( res, response ) )
-							throw generateError( response );
-					} );
+					const errorResponses = Array.isArray( json.responses )
+						? json.responses.filter(
+								( response ) =>
+									response.status < 200 ||
+									response.status >= 300
+						  )
+						: [];
+
+					if ( errorResponses.length > 0 ) {
+						throw generateError(
+							errorResponses[ 0 ].body as ApiErrorResponse
+						);
+					}
 
 					const successfulResponses = Array.isArray( json.responses )
 						? json.responses.filter(
 								( response ) =>
 									response.status >= 200 &&
 									response.status < 300
-						  )
-						: [];
-
-					const errorResponses = Array.isArray( json.responses )
-						? json.responses.filter(
-								( response ) =>
-									response.status < 200 ||
-									response.status >= 300
 						  )
 						: [];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Apparently, the code that throws an error when adding to cart fails wasn't working properly in grouped products, and it never threw. That caused quantities not to be reset, making the server and local state to not be in sync.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product and update to the blockified _Add to Cart + Options_ block if not yet in the template.
2. Add this code snippet, changing `125` for the product ID of a simple product that is also a child of a grouped product:

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 4;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 8;
	}
	return $default;
}, 10, 2 );
```

3. In the frontend, visit the grouped product containing the simple product you added the snippets for.
4. Add 4 items of the child product to cart.
5. Now, try to add 8 items. Verify an error is displayed.
6. Reduce the quantity back to 4 items and try to add to cart.

Before: The error would persist and new products wouldn't be added to cart.

https://github.com/user-attachments/assets/daf27c26-ebb5-4256-9b89-cd0f4da26daf

After: The error goes away and 4 items are added to cart, totalling 8 items in cart.

https://github.com/user-attachments/assets/329e61e1-9cd5-4dd2-8e75-af71ad50c756

