### PR TITLE
WPS Migration: Fix capture failure

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -248,7 +248,7 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		// Skip if the payment is already captured.
-		if ( 'COMPLETED' === $order->get_meta( '_paypal_status', true ) ) {
+		if ( 'completed' === $order->get_meta( '_paypal_status', true ) ) {
 			WC_Gateway_Paypal::log( 'PayPal payment is already captured. Skipping capture. Order ID: ' . $order->get_id() );
 			return;
 		}
@@ -280,7 +280,7 @@ class WC_Gateway_Paypal_Request {
 			WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 		}
 
-		$order->update_meta_data( '_paypal_status', $response_data['status'] );
+		$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
 		$order->save();
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -272,12 +272,16 @@ class WC_Gateway_Paypal_Request {
 			return;
 		}
 
-		$http_code = wp_remote_retrieve_response_code( $response );
-		$body      = wp_remote_retrieve_body( $response );
+		$http_code     = wp_remote_retrieve_response_code( $response );
+		$body          = wp_remote_retrieve_body( $response );
+		$response_data = json_decode( $body, true );
 
 		if ( 200 !== $http_code ) {
 			WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 		}
+
+		$order->update_meta_data( '_paypal_status', $response_data['status'] );
+		$order->save();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -280,8 +280,10 @@ class WC_Gateway_Paypal_Request {
 			WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 		}
 
-		$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
-		$order->save();
+		if ( isset( $response_data['status'] ) ) {
+			$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
+			$order->save();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -65,7 +65,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$paypal_order_id = $event['resource']['id'] ?? null;
 		if ( 'APPROVED' === $status ) {
 			WC_Gateway_Paypal::log( 'PayPal payment approved. Order ID: ' . $order->get_id() );
-			$order->update_meta_data( '_paypal_status', $status );
+			$order->update_meta_data( '_paypal_status', strtolower( $status ) );
 			$order->add_order_note(
 				sprintf(
 					/* translators: %1$s: PayPal order ID */
@@ -106,7 +106,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		}
 
 		$order->set_transaction_id( $event['resource']['id'] );
-		$order->update_meta_data( '_paypal_status', $event['resource']['status'] );
+		$order->update_meta_data( '_paypal_status', strtolower( $event['resource']['status'] ) );
 		$order->payment_complete();
 		$order->add_order_note(
 			sprintf(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -73,6 +73,7 @@ class WC_Gateway_Paypal_Webhook_Handler {
 					$paypal_order_id
 				)
 			);
+			$order->save();
 
 			// Authorize or capture the payment after approval.
 			$action = 'CAPTURE' === $event['resource']['intent'] ? 'capture' : 'authorize';

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -179,7 +179,6 @@ class WC_Gateway_Paypal_Webhook_Handler {
 	 * @return void
 	 */
 	private function authorize_or_capture_payment( $order, $links, $action ) {
-		wc_get_logger()->info( 'called from webhook handler: ' . $action );
 		$action_url = null;
 		foreach ( $links as $link ) {
 			if ( $action === $link['rel'] && 'POST' === $link['method'] && filter_var( $link['href'], FILTER_VALIDATE_URL ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-paypal-proxy-controller.php
@@ -324,9 +324,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		$authorization_id = $request->get_param( 'authorization_id' );
 		$request_data     = $request->get_json_params();
 
-		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
-		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment request received for request data: ' . wc_print_r( $request_data, true ) );
-
 		error_log( '(Proxy) PayPal capture authorized payment request received for auth ID: ' . $authorization_id );
 
 		if ( empty( $authorization_id ) || ! isset( $request_data['testmode'] ) ) {
@@ -340,12 +337,15 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 			);
 		}
 
-		if ( ! isset( $request_data['testmode'] ) ) {
-			error_log( '(Proxy) PayPal authorize payment request missing required param: ' . $param . '.' );
-			return new WP_REST_Response(
-				array( 'error' => 'PayPal capture authorized payment request missing required param: ' . $param . '.' ),
-				400
-			);
+		$required_params = array( 'testmode' );
+		foreach ( $required_params as $param ) {
+			if ( ! isset( $request_data[ $param ] ) ) {
+				error_log( '(Proxy) PayPal capture authorized payment request missing required param: ' . $param . '.' );
+				return new WP_REST_Response(
+					array( 'error' => 'PayPal capture authorized payment request missing required param: ' . $param . '.' ),
+					400
+				);
+			}
 		}
 
 		$access_token = $this->get_paypal_access_token( $request_data['testmode'] );
@@ -373,8 +373,6 @@ class WC_REST_Paypal_Proxy_Controller extends WC_REST_Controller {
 		$body          = wp_remote_retrieve_body( $response );
 		$response_data = json_decode( $body, true );
 		error_log( '(Proxy) PayPal capture authorized payment response: ' . wc_print_r( $response_data, true ) );
-
-		wc_get_logger()->info( '(Proxy) PayPal capture authorized payment response: ' . wc_print_r( $response_data, true ) );
 
 		if ( in_array( $http_code, array( 200, 201 ), true ) ) {
 			return new WP_REST_Response(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes the issue reported in https://github.com/woocommerce/woocommerce/pull/60044#pullrequestreview-3064637559

If you change the order status to `processing`, there are two API requests to capture the payment. We have a status check before sending the request. As we were setting the status during webhook processing, the status was not set by the time the 2nd request was made. In this PR, I have set the status when the order capture request is successful.

### How to test the changes in this Pull Request:
1. You will need a Business sandbox account (merchant) and a Personal sandbox account (shopper).
2. Set the deprecated PayPal gateway feature flag, and set the Orders v2 migration flag:
```
wp option patch update woocommerce_paypal_settings _should_load 'yes'
wp option patch update woocommerce_paypal_settings use_orders_v2 'yes'
```
3. Go to WooCommerce > Settings > Payments > and enable PayPal Standard.
4. Configure PayPal Standard's settings:
- For PayPal email, enter your merchant sandbox account email.
- Check Enable PayPal sandbox
- Check Enable logging (optional, for logging)
- **For Payment action, select Authorize**
5. To enable end-to-end testing, add the PayPal API client and secret (used by the feature branch's test proxy):
```
wp option update wc_paypal_api_client_id <YOUR-PAYPAL-CLIENT>
wp option update wc_paypal_api_client_secret <YOUR-PAYPAL-CLIENT-SECRET>
```
6. As a shopper, add a product to cart and go to checkout.
7. You should see PayPal as a payment option.
8. Click "Proceed to PayPal".
9. Use your Personal sandbox account credentials to log in and approve the purchase.
10. You should get redirected to the "Order Confirmation" page.
11. Wait a few seconds, and go to the wp-admin order page.
12. There should be an order note about payment authorization and the order status should be `on-hold`.
13. In the order details section, the transaction ID should be linked. 
15. Click the transaction ID. It should take you to the PayPal transaction page. Confirm that the transaction status is `Authorized`.
16. Go back to the order edit page and change the order status to `processing`.
17. Wait a few seconds and refresh the page.
18. There should be an order note about payment capture.
19. Go to the PayPal transaction page. Confirm that the transaction status is `Authorized`.
20. Confirm that there is no `Authorization has already been captured.` error in the logs.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
