### PR TITLE
Email editor: Suppress HTML5 warnings during conversion

### DIFF
--- a/packages/php/email-editor/changelog/60137-fix-email-editor-convert-warnings
+++ b/packages/php/email-editor/changelog/60137-fix-email-editor-convert-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+Comment: Email Editor: Suppress HTML5 warnings when converting content using html2text class.
+

--- a/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
+++ b/packages/php/email-editor/src/Engine/Renderer/class-renderer.php
@@ -172,7 +172,7 @@ class Renderer {
 		// Preserve personalization tags by temporarily replacing them with unique placeholders.
 		$template = $this->preserve_personalization_tags( $template );
 
-		$result = Html2Text::convert( (string) $template );
+		$result = Html2Text::convert( (string) $template, array( 'ignore_errors' => true ) );
 		if ( ! $result ) {
 			return '';
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

* Suppress HTML5 warnings when using html2text. The HTML parsing is working correctly, but `DOMDocument::loadHTML()` which uses `libxml` doesn't recognize HTML5 semantic tags.

### Warnings without this change

```
[30-Jul-2025 21:08:29 UTC] Warning: DOMDocument::loadHTML(): Tag figure invalid in Entity, line: 166 in /home/wpcom/public_html/wp-content/lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php on line 270 [public-api.wordpress.com/wpcom/v2/sites/246979225/email-preview/?_envelope=1&post_id=7&access=subscribers&_gutenberg_nonce=e746819e36&_locale=user] [/lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php:270 loadHTML(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php:87 get_document(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-renderer.php:175 convert(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-renderer.php:144 render_text_version(), /mu-plugins/email-subscriptions/subscription-mailer.php:3197 render(), /mu-plugins/email-subscriptions/subscription-mailer.php:2907 convert_view_html(), wp-includes/plugin.php:205 apply_filters(''), /mu-plugins/jetpack-plugin/sun/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php:145 apply_filters('jetpack_generate_email_preview_html'), wp-includes/rest-api/class-wp-rest-server.php:1292 email_preview(), wp-includes/rest-api/class-wp-rest-server.php:1125 respond_to_request(), wp-includes/rest-api/class-wp-rest-server.php:439 dispatch(), wp-includes/rest-api.php:464 serve_request(), wp-includes/class-wp-hook.php:324 rest_api_loaded(), wp-includes/class-wp-hook.php:348 apply_filters(''), wp-includes/plugin.php:565 do_action(Array), wp-includes/class-wp.php:418 do_action_ref_array(), wp-includes/class-wp.php:818 parse_request(), wp-includes/functions.php:1446 main(), public.api/wp-json/index.php:46 wp(), public.api/wp-json/index.php:49 wpcom_wp_api_run()] log-json:{"request_id":"42b40b46a14993091d9c53af9f674089","php_ver":"8.4.10"}
[30-Jul-2025 21:08:29 UTC] Warning: DOMDocument::loadHTML(): Tag figcaption invalid in Entity, line: 166 in /home/wpcom/public_html/wp-content/lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php on line 270 [public-api.wordpress.com/wpcom/v2/sites/246979225/email-preview/?_envelope=1&post_id=7&access=subscribers&_gutenberg_nonce=e746819e36&_locale=user] [/lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php:270 loadHTML(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-html2text.php:87 get_document(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-renderer.php:175 convert(), /lib/woocommerce-email-editor/vendor/woocommerce/email-editor/src/Engine/Renderer/class-renderer.php:144 render_text_version(), /mu-plugins/email-subscriptions/subscription-mailer.php:3197 render(), /mu-plugins/email-subscriptions/subscription-mailer.php:2907 convert_html_to_email(), /mu-plugins/email-subscriptions/subscription-mailer.php:1002 get_post_as_html(), /rest-api-plugins/jetpack-endpoints/email-preview-v2.php:88 get_posts(), wp-includes/class-wp-hook.php:324 jetpack_generate_email_preview_html(), wp-includes/plugin.php:205 apply_filters(''), /mu-plugins/jetpack-plugin/sun/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php:145 apply_filters('jetpack_generate_email_preview_html'), wp-includes/rest-api/class-wp-rest-server.php:1292 email_preview(), wp-includes/rest-api/class-wp-rest-server.php:1125 respond_to_request(), wp-includes/rest-api/class-wp-rest-server.php:439 dispatch(), wp-includes/rest-api.php:464 serve_request(), wp-includes/class-wp-hook.php:324 rest_api_loaded(), wp-includes/class-wp-hook.php:348 apply_filters(''), wp-includes/plugin.php:565 do_action(Array), wp-includes/class-wp.php:418 do_action_ref_array(), wp-includes/class-wp.php:818 parse_request(), wp-includes/functions.php:1446 main(), public.api/wp-json/index.php:46 wp(), public.api/wp-json/index.php:49 wpcom_wp_api_run()] log-json:{"request_id":"42b40b46a14993091d9c53af9f674089","php_ver":"8.4.10"}html_to_email(), /mu-plugins/email-subscriptions/subscription-mailer.php:1002 get_post_as_html(), /rest-api-plugins/jetpack-endpoints/email-preview-v2.php:88 get_posts(), wp-includes/class-wp-hook.php:324 jetpack_generate_email_pre
```


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

I tested by applying this change to WPCOM and sending an email using the package.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Email Editor: Suppress HTML5 warnings when converting content using html2text class.

</details>
