### PR TITLE
Preview cart updates

### DIFF
--- a/plugins/woocommerce/changelog/fix-editor-cart-preview
+++ b/plugins/woocommerce/changelog/fix-editor-cart-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing cart preview data in the site editor

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/test/editor-integration.tsx
@@ -6,6 +6,9 @@ import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
 import { type BlockAttributes } from '@wordpress/blocks';
 import { getAllByRole, getByLabelText } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
+import { previewCart } from '@woocommerce/resource-previews';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -41,6 +44,17 @@ describe( 'Cart block editor integration', () => {
 				}
 				return value;
 			},
+		} );
+	} );
+
+	beforeEach( () => {
+		act( () => {
+			// need to clear the store resolution state between tests.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( dispatch( storeKey ) as any ).invalidateResolutionForStore();
+			// Set up cart data with preview cart items
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( dispatch( storeKey ) as any ).receiveCart( previewCart );
 		} );
 	} );
 
@@ -126,12 +140,43 @@ describe( 'Cart block editor integration', () => {
 		expect( filledCartAudioOption ).not.toBeInTheDocument();
 	} );
 
+	it( 'shows the cart preview in the editor', async () => {
+		await setup( {} );
+
+		// Verify Cart block is properly initialized in the editor.
+		await waitFor( () => {
+			expect( screen.getByLabelText( /^Block: Cart$/i ) ).toBeVisible();
+			// Test Order Summary block - should have both Table and Audio options (specific filter applied).
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getByLabelText( /Block: Filled Cart$/i )
+			).toBeVisible();
+		} );
+
+		await selectBlock( /Block: Filled Cart/i );
+		await selectBlock( /Block: Cart Line Items/i );
+
+		const cartItems = previewCart.items;
+		// Now the product links should be rendered
+		cartItems.forEach( ( item ) => {
+			const productNameElement = screen.getByRole( 'link', {
+				name: item.name,
+			} );
+			expect( productNameElement ).toBeVisible();
+			expect( productNameElement ).toHaveTextContent( item.name );
+		} );
+	} );
+
 	it( 'can convert to Empty Cart block', async () => {
 		// Setup the cart block with default attributes (filled cart view)
 		await setup( {} );
 
 		// Verify Cart block is properly initialized in the editor
 		expect( screen.getByLabelText( /^Block: Cart$/i ) ).toBeVisible();
+
+		await selectBlock( /Block: Filled Cart/i );
 
 		const filledCartBlock = screen.getByLabelText( /Block: Filled Cart/i );
 		const emptyCartBlock = screen.getByLabelText( /Block: Empty Cart/i );
@@ -146,8 +191,6 @@ describe( 'Cart block editor integration', () => {
 				screen.getByLabelText( /Block: Filled Cart$/i )
 			).toBeVisible();
 		} );
-
-		await selectBlock( /Block: Filled Cart/i );
 
 		const selectParentBlockButton = screen.getByRole( 'button', {
 			name: /Select parent block: Cart/i,

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
@@ -9,6 +9,8 @@ import {
 	select,
 } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
+import { isEditor } from '../utils';
+import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -65,10 +67,14 @@ window.addEventListener( 'load', () => {
 
 	if (
 		( ! hasCartSession() || hasItemsInCachedCart ) &&
-		! isAddingToCart()
+		! isAddingToCart() &&
+		! isEditor() // Don't finish resolution in editor,but only for real carts
 	) {
-		// Prevent the API request from being made.
 		wpDispatch( store ).finishResolution( 'getCartData' );
+	}
+
+	if ( isEditor() ) {
+		wpDispatch( store ).receiveCart( previewCart );
 	}
 } );
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
@@ -9,7 +9,6 @@ import {
 	select,
 } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
-import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -70,11 +69,8 @@ window.addEventListener( 'load', () => {
 		! isAddingToCart() &&
 		! isEditor() // Don't finish resolution in editor,but only for real carts
 	) {
+		// Prevent the API request from being made.
 		wpDispatch( store ).finishResolution( 'getCartData' );
-	}
-
-	if ( isEditor() ) {
-		wpDispatch( store ).receiveCart( previewCart );
 	}
 } );
 

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/index.ts
@@ -9,7 +9,6 @@ import {
 	select,
 } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
-import { isEditor } from '../utils';
 import { previewCart } from '@woocommerce/resource-previews';
 
 /**
@@ -33,6 +32,7 @@ import {
 import { defaultCartState } from './default-state';
 import { getTriggerStoreSyncEvent } from './utils';
 import type { QuantityChanges } from './notify-quantity-changes';
+import { isEditor } from '../utils';
 
 export const config = {
 	reducer,

--- a/plugins/woocommerce/client/blocks/assets/js/data/cart/reducers.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/data/cart/reducers.ts
@@ -11,6 +11,7 @@ import { defaultCartState, CartState } from './default-state';
 import { EMPTY_CART_ERRORS } from '../constants';
 import { setIsCustomerDataDirty } from './utils';
 import { persistenceLayer } from './persistence-layer';
+import { isEditor } from '../utils';
 
 /**
  * Reducer for receiving items related to the cart.
@@ -215,7 +216,7 @@ function withPersistenceLayer( cartReducer: Reducer< CartState > ) {
 	return ( state: CartState | undefined, action: AnyAction ): CartState => {
 		const nextState = cartReducer( state, action );
 
-		if ( nextState.cartData ) {
+		if ( nextState.cartData && ! isEditor() ) {
 			persistenceLayer.set( nextState.cartData );
 		}
 


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using the store to get the `previewCart` data in the Editor, we don't finish resolutions for `getCartData` and we don't save the `previewCart` to the persistence layer.

This bug happened because there was some overlap at the cart store and cart persistence level, between preview cart data (Editor) and real carts.

Some context: 
Before [this change](https://github.com/woocommerce/woocommerce/pull/58782/files#r2143193550) the cart call was made everywhere and `finishResolution('getCartData')` was never called. So in the editor, we would[ be here](https://github.com/woocommerce/woocommerce/blob/912a59181b894d2029e00b6909c05acacac11de2/plugins/woocommerce/client/blocks/assets/js/data/cart/resolvers.ts#L22-L24), dispatching the same `receiveCart` after getting a `previewCart` 
 [my 2nd chage](https://github.com/woocommerce/woocommerce/pull/59920/files#diff-d8b0e5af5b93537eb599d6e53651c3be94f2765556df3bbe47780c86d3067b19L62) made sense in a storefront. But in the editor, not so much, now that we don’t have the cart call. We still need that cart preview data, which previously we were getting via the call.

While debugging, I found another issue. We are saving the `previewCart` in localStorage. Not an issue before, because the `/cart` call was mostly done everywhere. So we were getting the right cart.


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes  https://github.com/woocommerce/woocommerce/issues/60150 \
Closes https://linear.app/a8c/issue/WOOPLUG-5239/the-editor-is-not-showing-previewcart-data-for-the-checkout-blocks

(For Bug Fixes) Bug introduced in PR  https://github.com/woocommerce/woocommerce/pull/58782/files#r2143193550


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Log in as an admin in incognito. Make sure you have no cart in the storefront, or a cached cart in LocalStorage
2. Go to the Site Editor > Templates > WooCommerce > Page: Cart or Page: Checkout
3. Notice the cart preview data is shown (Beanie & Cap)

4. Go to the store. Notice the Mini-Cart is empty; click it to confirm 
5. Add a product to the cart; 
6. Go to the Editor cart page and notice the preview data

7. Go back to the store, and notice you have the product you previously added
8. Log out
9. Log back in again and notice the Mini-Cart is showing the product you added
10. Go to checkout and place the order


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
