### PR TITLE
Fix returning customer detection for guest orders with existing email

### DIFF
--- a/plugins/woocommerce/changelog/60141-wooplug-5075-woo-may-be-incorrectly-tagging-a-returning-customer
+++ b/plugins/woocommerce/changelog/60141-wooplug-5075-woo-may-be-incorrectly-tagging-a-returning-customer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix returning customer detection for guest orders with existing email addresses

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -652,7 +652,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	}
 
 	/**
-	 * Retrieve a customer ID by email address
+	 * Retrieve a customer ID by email address, regardless of user registration status.
+	 * Prioritizes registered customers over guest customers when both exist.
 	 *
 	 * @param string $email Email address.
 	 * @return false|int Customer ID if found, boolean false if not.
@@ -668,7 +669,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$customer_id = $wpdb->get_var(
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				"SELECT customer_id FROM {$table_name} WHERE email = %s LIMIT 1",
+				"SELECT customer_id FROM {$table_name} WHERE email = %s ORDER BY user_id IS NOT NULL DESC LIMIT 1",
 				$email
 			)
 		);

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -469,7 +469,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$email = $order->get_billing_email( 'edit' );
 
 			if ( $email ) {
-				return self::get_guest_id_by_email( $email );
+				return self::get_customer_id_by_email( $email );
 			} else {
 				return false;
 			}
@@ -644,6 +644,27 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$wpdb->prepare(
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"SELECT customer_id FROM {$table_name} WHERE email = %s AND user_id IS NULL LIMIT 1",
+				$email
+			)
+		);
+
+		return $customer_id ? (int) $customer_id : false;
+	}
+
+	/**
+	 * Retrieve a customer ID by email address
+	 *
+	 * @param string $email Email address.
+	 * @return false|int Customer ID if found, boolean false if not.
+	 */
+	public static function get_customer_id_by_email( $email ) {
+		global $wpdb;
+
+		$table_name  = self::get_db_table_name();
+		$customer_id = $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT customer_id FROM {$table_name} WHERE email = %s LIMIT 1",
 				$email
 			)
 		);

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -660,6 +660,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public static function get_customer_id_by_email( $email ) {
 		global $wpdb;
 
+		if ( empty( $email ) || ! is_email( $email ) ) {
+			return false;
+		}
+
 		$table_name  = self::get_db_table_name();
 		$customer_id = $wpdb->get_var(
 			$wpdb->prepare(


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes a bug where WooCommerce incorrectly identifies returning customers when they switch between logged-in and guest purchases using the same email address.

**Problem:** The `is_returning_customer` function calls `get_existing_customer_id_from_order` to find the customer. When the customer doesn't log in (customer ID not found in the order), it checks the email by calling `get_guest_id_by_email`. 

 At `/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php:646`, the query:

```sql
  SELECT customer_id FROM {table} WHERE email = %s AND user_id IS NULL
```

Only looks for guest customers, not registered customers who made guest purchases.

**Solution:**

- Added new `get_customer_id_by_email()` function that finds customers by email regardless of registration status
- Updated `get_existing_customer_id_from_order()` to use the new function for guest orders
- Preserved `get_guest_id_by_email()` unchanged for backward compatibility

Closes WOOPLUG-5075.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new customer account with an email 
2. While logged in, purchase the test product
3. Log out completely
4. Make another purchase as a guest using the same email 
5. Wait for the `admin_import_orders` action to be completed. `/wp-admin/admin.php?page=wc-status&tab=action-scheduler`.
6.  Check the `order_stats` table `SELECT * FROM `wp_wc_order_stats` ORDER BY `order_id` DESC `
7. `returning_customer` value should be `1` for the second order.
8. It shouldn't create a new customer with the same email in the `wp_wc_customer_lookup` table




### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message
Fix returning customer detection for guest orders with existing email addresses

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)