### PR TITLE
[Experimental] Support hierarchical data structure in Product Filters

### DIFF
--- a/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
+++ b/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add hierarchical data structure support to filter options of the Product Filters block, starting with Chips and Taxonomy filter options.

--- a/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
+++ b/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add hierarchical data structure support to filter options of the Product Filters block, starting with List and Taxonomy filter options.
+Add hierarchical data structure support to filter options of the Product Filters block, starting with Chips and Taxonomy filter options.

--- a/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
+++ b/plugins/woocommerce/changelog/60142-wooplug-5207-support-hierarchy-in-filter-options-data-structure
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add hierarchical data structure support to filter options of the Product Filters block, starting with Chips and Taxonomy filter options.
+Add hierarchical data structure support to filter options of the Product Filters block, starting with List and Taxonomy filter options.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -52,6 +52,8 @@ type FilterItem = {
 	count: number;
 	type: string;
 	attributeQueryType?: 'and' | 'or' | undefined;
+	parent?: string;
+	depth?: number;
 };
 
 export type ActiveFilterItem = Pick<

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/frontend.ts
@@ -52,7 +52,8 @@ type FilterItem = {
 	count: number;
 	type: string;
 	attributeQueryType?: 'and' | 'or' | undefined;
-	parent?: string;
+	id?: number;
+	parent?: number;
 	depth?: number;
 };
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -71,12 +71,12 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 				<?php if ( ! empty( $block_context['groupLabel'] ) ) : ?>
 					<legend class="screen-reader-text"><?php echo esc_html( $block_context['groupLabel'] ); ?></legend>
 				<?php endif; ?>
-				<div class="wc-block-product-filter-checkbox-list__item">
+				<div class="wc-block-product-filter-checkbox-list__items">
 					<?php foreach ( $items as $item ) { ?>
 						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
 						<div
 							data-wp-key="<?php echo esc_attr( $item_id ); ?>"
-							class="wc-block-product-filter-checkbox-list__item"
+							class="wc-block-product-filter-checkbox-list__item <?php echo isset( $item['depth'] ) ? esc_attr( 'depth-' . $item['depth'] ) : ''; ?>"
 							<?php if ( ! $item['selected'] ) : ?>
 								<?php if ( $count >= $remaining_initial_unchecked ) : ?>
 									data-wp-bind--hidden="!context.showAll"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterCheckboxList.php
@@ -76,7 +76,7 @@ final class ProductFilterCheckboxList extends AbstractBlock {
 						<?php $item_id = $item['type'] . '-' . $item['value']; ?>
 						<div
 							data-wp-key="<?php echo esc_attr( $item_id ); ?>"
-							class="wc-block-product-filter-checkbox-list__item <?php echo isset( $item['depth'] ) ? esc_attr( 'depth-' . $item['depth'] ) : ''; ?>"
+							class="wc-block-product-filter-checkbox-list__item <?php echo isset( $item['depth'] ) ? esc_attr( 'has-depth-' . $item['depth'] ) : ''; ?>"
 							<?php if ( ! $item['selected'] ) : ?>
 								<?php if ( $count >= $remaining_initial_unchecked ) : ?>
 									data-wp-bind--hidden="!context.showAll"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -366,13 +366,38 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 *
 	 * @param array $terms  Hierarchical terms with children structure.
 	 * @param array $result Reference to result array being built.
+	 * @param array $visited_ids Reference to array tracking visited term IDs to prevent circular references.
+	 * @param int   $depth Current recursion depth for bounds checking.
 	 */
-	private function flatten_terms_list( $terms, &$result ) {
+	private function flatten_terms_list( $terms, &$result, &$visited_ids = array(), $depth = 0 ) {
+		// Prevent excessive recursion depth (taxonomies shouldn't be this deep).
+		if ( $depth > 10 ) {
+			return;
+		}
+
+		if ( ! is_array( $terms ) ) {
+			return;
+		}
+
 		foreach ( $terms as $term ) {
-			$result[ $term['term_id'] ] = $term;
-			if ( ! empty( $term['children'] ) ) {
-				$this->flatten_terms_list( $term['children'], $result );
-				unset( $result[ $term['term_id'] ]['children'] );
+			// Validate term structure.
+			if ( ! is_array( $term ) || ! isset( $term['term_id'] ) ) {
+				continue;
+			}
+
+			$term_id = $term['term_id'];
+
+			// Prevent circular references.
+			if ( isset( $visited_ids[ $term_id ] ) ) {
+				continue;
+			}
+
+			$visited_ids[ $term_id ] = true;
+			$result[ $term_id ]      = $term;
+
+			if ( ! empty( $term['children'] ) && is_array( $term['children'] ) ) {
+				$this->flatten_terms_list( $term['children'], $result, $visited_ids, $depth + 1 );
+				unset( $result[ $term_id ]['children'] );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -370,7 +370,13 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @param int   $depth Current recursion depth for bounds checking.
 	 */
 	private function flatten_terms_list( $terms, &$result, &$visited_ids = array(), $depth = 0 ) {
-		// Prevent excessive recursion depth (taxonomies shouldn't be this deep).
+		/**
+		 * This is the safeguard to prevent the memory limit issue. We choose 10 as it
+		 * should cover most of the cases. Typical e-commerce stores have two or three
+		 * levels of category. Extreme cases like Amazon has about 7 levels.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/pull/60142/files#r2250287050
+		 */
 		if ( $depth > 10 ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -183,10 +183,12 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 					);
 
 					if ( is_taxonomy_hierarchical( $taxonomy ) ) {
-						if ( isset( $term['depth'] ) ) {
+						$option['id'] = $term['term_id'];
+
+						if ( isset( $term['depth'] ) && $term['depth'] > 0 ) {
 							$option['depth'] = $term['depth'];
 						}
-						if ( isset( $term['parent'] ) ) {
+						if ( isset( $term['parent'] ) && $term['parent'] > 0 ) {
 							$option['parent'] = $term['parent'];
 						}
 					}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -182,13 +182,14 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 						'type'     => 'taxonomy/' . $taxonomy,
 					);
 
-					if ( isset( $term['depth'] ) ) {
-						$option['depth'] = $term['depth'];
+					if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+						if ( isset( $term['depth'] ) ) {
+							$option['depth'] = $term['depth'];
+						}
+						if ( isset( $term['parent'] ) ) {
+							$option['parent'] = $term['parent'];
+						}
 					}
-					if ( isset( $term['parent'] ) ) {
-						$option['parent'] = $term['parent'];
-					}
-
 					return $option;
 				},
 				$taxonomy_terms

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -143,45 +143,53 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			)
 		);
 
-		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
-		$hide_empty      = $block_attributes['hideEmpty'] ?? true;
-		$orderby         = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
-		$order           = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
-
-		$taxonomy_terms = $this->get_hierarchical_terms( $taxonomy, $taxonomy_counts, $hide_empty, $orderby, $order );
-
-		if ( is_wp_error( $taxonomy_terms ) ) {
-			return '';
-		}
-
-		// Get selected terms from filter params.
-		$filter_params  = $block->context['filterParams'] ?? array();
-		$selected_terms = array();
-		$param_key      = $taxonomy_params[ $taxonomy ];
-
-		if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
-			$selected_terms = array_filter( array_map( 'sanitize_title', explode( ',', $filter_params[ $param_key ] ) ) );
-		}
-
-		$filter_context = array(
+		$filter_context  = array(
 			'showCounts' => $block_attributes['showCounts'] ?? false,
 			'items'      => array(),
 			'groupLabel' => $taxonomy_object->labels->singular_name,
 		);
+		$taxonomy_counts = $this->get_taxonomy_term_counts( $block, $taxonomy );
 
 		if ( ! empty( $taxonomy_counts ) ) {
+			$hide_empty     = $block_attributes['hideEmpty'] ?? true;
+			$orderby        = $block_attributes['sortOrder'] ? explode( '-', $block_attributes['sortOrder'] )[0] : 'name';
+			$order          = $block_attributes['sortOrder'] ? strtoupper( explode( '-', $block_attributes['sortOrder'] )[1] ) : 'DESC';
+			$taxonomy_terms = $this->get_sorted_terms( $taxonomy, $taxonomy_counts, $hide_empty, $orderby, $order );
+
+			if ( is_wp_error( $taxonomy_terms ) ) {
+				return '';
+			}
+
+			// Get selected terms from filter params.
+			$filter_params  = $block->context['filterParams'] ?? array();
+			$selected_terms = array();
+			$param_key      = $taxonomy_params[ $taxonomy ];
+
+			if ( $filter_params && ! empty( $filter_params[ $param_key ] ) && is_string( $filter_params[ $param_key ] ) ) {
+				$selected_terms = array_filter( array_map( 'sanitize_title', explode( ',', $filter_params[ $param_key ] ) ) );
+			}
+
 			$taxonomy_options = array_map(
 				function ( $term ) use ( $taxonomy_counts, $selected_terms, $taxonomy ) {
 					$term          = (array) $term;
 					$term['count'] = $taxonomy_counts[ $term['term_id'] ] ?? 0;
 
-					return array(
+					$option = array(
 						'label'    => $term['name'],
 						'value'    => $term['slug'],
 						'selected' => in_array( $term['slug'], $selected_terms, true ),
 						'count'    => $term['count'],
 						'type'     => 'taxonomy/' . $taxonomy,
 					);
+
+					if ( isset( $term['depth'] ) ) {
+						$option['depth'] = $term['depth'];
+					}
+					if ( isset( $term['parent'] ) ) {
+						$option['parent'] = $term['parent'];
+					}
+
+					return $option;
 				},
 				$taxonomy_terms
 			);
@@ -218,6 +226,39 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 				''
 			)
 		);
+	}
+
+	/**
+	 * Get terms sorted based on taxonomy type (hierarchical vs flat).
+	 *
+	 * @param string $taxonomy        Taxonomy slug.
+	 * @param array  $taxonomy_counts Term counts with term_id as key.
+	 * @param bool   $hide_empty      Whether to hide empty terms.
+	 * @param string $orderby         Sort field (name, count, menu_order).
+	 * @param string $order           Sort direction (ASC, DESC).
+	 * @return array Sorted terms array.
+	 */
+	private function get_sorted_terms( $taxonomy, $taxonomy_counts, $hide_empty, $orderby, $order ) {
+		if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
+			$args = array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+			);
+
+			if ( $hide_empty ) {
+				$args['include'] = array_keys( $taxonomy_counts );
+			}
+
+			$terms = get_terms( $args );
+
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				return array();
+			}
+
+			return $this->sort_terms_by_criteria( $terms, $orderby, $order, $taxonomy_counts );
+		}
+
+		return $this->get_hierarchical_terms( $taxonomy, $taxonomy_counts, $hide_empty, $orderby, $order );
 	}
 
 	/**
@@ -299,6 +340,41 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	}
 
 	/**
+	 * Sort hierarchical terms recursively maintaining parent-child relationships.
+	 *
+	 * @param array  $terms           Hierarchical terms array with children.
+	 * @param string $orderby         Sort field (name, count, menu_order).
+	 * @param string $order           Sort direction (ASC, DESC).
+	 * @param array  $taxonomy_counts Context-aware term counts.
+	 * @return array Sorted hierarchical terms.
+	 */
+	private function sort_hierarchy_terms( $terms, $orderby, $order, $taxonomy_counts ) {
+		foreach ( $terms as $term ) {
+			if ( ! empty( $term['children'] ) ) {
+				$term['children'] = $this->sort_terms_by_criteria( $term['children'], $orderby, $order, $taxonomy_counts );
+			}
+		}
+		$sorted = $this->sort_terms_by_criteria( $terms, $orderby, $order, $taxonomy_counts );
+		return $sorted;
+	}
+
+	/**
+	 * Flatten hierarchical term tree into flat array maintaining depth-first order.
+	 *
+	 * @param array $terms  Hierarchical terms with children structure.
+	 * @param array $result Reference to result array being built.
+	 */
+	private function flatten_terms_list( $terms, &$result ) {
+		foreach ( $terms as $term ) {
+			$result[ $term['term_id'] ] = $term;
+			if ( ! empty( $term['children'] ) ) {
+				$this->flatten_terms_list( $term['children'], $result );
+				unset( $result[ $term['term_id'] ]['children'] );
+			}
+		}
+	}
+
+	/**
 	 * Get taxonomy terms ordered hierarchically.
 	 *
 	 * @param string $taxonomy        Taxonomy slug.
@@ -309,53 +385,25 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	 * @return array|\WP_Error Hierarchically ordered terms or error.
 	 */
 	private function get_hierarchical_terms( string $taxonomy, array $taxonomy_counts, bool $hide_empty, string $orderby, string $order ) {
-		$args = array(
-			'taxonomy'   => $taxonomy,
-			'hide_empty' => false,
-		);
-
-		if ( $hide_empty ) {
-			$args['include'] = array_keys( $taxonomy_counts );
-		}
-
-		$terms = get_terms( $args );
-
-		if ( is_wp_error( $terms ) || empty( $terms ) ) {
-			return array();
-		}
-
-		if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
-			return $this->sort_terms_by_criteria( $terms, $orderby, $order, $taxonomy_counts );
-		}
-
 		// Use TaxonomyHierarchyData for hierarchy operations.
 		$container      = wc_get_container();
-		$hierarchy_data = $container->get( TaxonomyHierarchyData::class );
+		$hierarchy_data = $container->get( TaxonomyHierarchyData::class )->get_hierarchy_map( $taxonomy );
 
-		// Group terms by parent for hierarchy building.
-		$terms_by_id     = array();
-		$terms_by_parent = array();
+		$sorted_term = $this->sort_hierarchy_terms( $hierarchy_data['tree'], $orderby, $order, $taxonomy_counts );
 
-		foreach ( $terms as $term ) {
-			$terms_by_id[ $term->term_id ] = $term;
-			$parent_id                     = $hierarchy_data->get_parent( $term->term_id, $taxonomy );
+		$flat_list = array();
+		$this->flatten_terms_list( $sorted_term, $flat_list );
 
-			if ( ! isset( $terms_by_parent[ $parent_id ] ) ) {
-				$terms_by_parent[ $parent_id ] = array();
+		if ( ! $hide_empty ) {
+			return $flat_list;
+		}
+
+		return array_filter(
+			$flat_list,
+			function ( $term ) use ( $taxonomy_counts ) {
+				return ! empty( $taxonomy_counts[ $term['term_id'] ] );
 			}
-			$terms_by_parent[ $parent_id ][] = $term;
-		}
-
-		// Sort siblings at each hierarchy level.
-		foreach ( $terms_by_parent as $parent_id => $siblings ) {
-			$terms_by_parent[ $parent_id ] = $this->sort_terms_by_criteria( $siblings, $orderby, $order, $taxonomy_counts );
-		}
-
-		// Build hierarchical list with sorted siblings.
-		$hierarchical_terms = array();
-		$this->build_hierarchical_list( 0, $hierarchical_terms, $terms_by_parent );
-
-		return $hierarchical_terms;
+		);
 	}
 
 	/**
@@ -373,6 +421,8 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		usort(
 			$terms,
 			function ( $a, $b ) use ( $orderby, $sort_order, $taxonomy_counts ) {
+				$a = (object) $a;
+				$b = (object) $b;
 				switch ( $orderby ) {
 					case 'count':
 						$count_a    = $taxonomy_counts[ $a->term_id ] ?? 0;
@@ -391,26 +441,5 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		);
 
 		return $terms;
-	}
-
-	/**
-	 * Build hierarchical list in depth-first order with pre-sorted siblings.
-	 *
-	 * @param int   $parent_id        Current parent ID.
-	 * @param array &$result          Reference to result array.
-	 * @param array $terms_by_parent  Terms grouped and sorted by parent ID.
-	 */
-	private function build_hierarchical_list( int $parent_id, array &$result, array $terms_by_parent ): void {
-		if ( ! isset( $terms_by_parent[ $parent_id ] ) ) {
-			return;
-		}
-
-		foreach ( $terms_by_parent[ $parent_id ] as $term ) {
-			// Add current term.
-			$result[] = $term;
-
-			// Recursively add its children.
-			$this->build_hierarchical_list( $term->term_id, $result, $terms_by_parent );
-		}
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -21,33 +21,6 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 	protected $block_name = 'product-filter-taxonomy';
 
 	/**
-	 * Initialize this block type.
-	 *
-	 * - Hook into WP lifecycle.
-	 * - Register the block with WordPress.
-	 */
-	protected function initialize() {
-		parent::initialize();
-
-		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
-	}
-
-	/**
-	 * Extra data passed through from server to client for block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
-	 */
-	protected function enqueue_data( array $attributes = array() ) {
-		parent::enqueue_data( $attributes );
-
-		if ( is_admin() ) {
-			$this->asset_data_registry->add( 'filterableProductTaxonomies', $this->get_taxonomies() );
-		}
-	}
-
-	/**
 	 * Prepare the active filter items.
 	 *
 	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
@@ -103,6 +76,33 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'woocommerce_blocks_product_filters_selected_items', array( $this, 'prepare_selected_filters' ), 10, 2 );
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = array() ) {
+		parent::enqueue_data( $attributes );
+
+		if ( is_admin() ) {
+			$this->asset_data_registry->add( 'filterableProductTaxonomies', $this->get_taxonomies() );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -376,7 +376,7 @@ class FilterData {
 	 *
 	 * @param string $product_ids   Comma-separated list of product IDs.
 	 * @param string $taxonomy_name Original taxonomy name for hierarchy methods.
-	 * @return array Array of term_taxonomy_id => count pairs.
+	 * @return array Array of term_id => count pairs.
 	 */
 	private function get_hierarchical_taxonomy_counts( string $product_ids, string $taxonomy_name ) {
 		global $wpdb;
@@ -454,12 +454,12 @@ class FilterData {
 			return array();
 		}
 
-		// Parse results back to term_taxonomy_id => count format.
+		// Parse results back to term_id => count format.
 		$final_counts = array();
-		foreach ( $hierarchy_counts as $term_taxonomy_id => $term_ids ) {
-			$count_key = "count_{$term_taxonomy_id}";
+		foreach ( $hierarchy_counts as $term_id => $term_ids ) {
+			$count_key = "count_{$term_id}";
 			if ( isset( $count_result[ $count_key ] ) && $count_result[ $count_key ] > 0 ) {
-				$final_counts[ $term_taxonomy_id ] = absint( $count_result[ $count_key ] );
+				$final_counts[ $term_id ] = absint( $count_result[ $count_key ] );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -413,7 +413,7 @@ class FilterData {
 				$hierarchy_counts[ $term->term_taxonomy_id ] = $descendants;
 			}
 
-			// Get ancestors using optimized hierarchy data.
+			// Get ancestors using hierarchy data.
 			$current_id = $term_id;
 			while ( $current_id > 0 ) {
 				$parent_id = $this->taxonomy_hierarchy_data->get_parent( $current_id, $taxonomy_name );
@@ -426,15 +426,13 @@ class FilterData {
 					continue;
 				}
 
-				$ancestor_term_taxonomy_id = $this->get_term_taxonomy_id_from_term_id( $parent_id, $taxonomy_escaped );
-
 				// Get all descendants for this ancestor using optimized hierarchy data.
 				$descendants   = $this->taxonomy_hierarchy_data->get_descendants( $parent_id, $taxonomy_name );
 				$descendants[] = $parent_id; // Include the ancestor term itself.
 
-				$hierarchy_counts[ $ancestor_term_taxonomy_id ] = $descendants;
-				$processed_terms[]                              = $parent_id;
-				$current_id                                     = $parent_id;
+				$hierarchy_counts[ $parent_id ] = $descendants;
+				$processed_terms[]              = $parent_id;
+				$current_id                     = $parent_id;
 			}
 		}
 
@@ -474,28 +472,6 @@ class FilterData {
 		}
 
 		return $final_counts;
-	}
-
-	/**
-	 * Get term_taxonomy_id from term_id.
-	 *
-	 * @param int    $term_id  Term ID.
-	 * @param string $taxonomy Taxonomy name.
-	 * @return int Term taxonomy ID.
-	 */
-	private function get_term_taxonomy_id_from_term_id( int $term_id, string $taxonomy ) {
-		global $wpdb;
-
-		$cache_key        = WC_Cache_Helper::get_cache_prefix( CacheController::CACHE_GROUP ) . 'term_taxonomy_id_' . $term_id . '_' . $taxonomy;
-		$term_taxonomy_id = wp_cache_get( $cache_key );
-
-		if ( false === $term_taxonomy_id ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$term_taxonomy_id = $wpdb->get_var( $wpdb->prepare( "SELECT term_taxonomy_id FROM {$wpdb->term_taxonomy} WHERE term_id = %d AND taxonomy = %s", $term_id, $taxonomy ) );
-			wp_cache_set( $cache_key, $term_taxonomy_id, '', HOUR_IN_SECONDS );
-		}
-
-		return absint( $term_taxonomy_id );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/FilterData.php
@@ -407,32 +407,24 @@ class FilterData {
 			$term_id = (int) $term->term_id;
 
 			// Count for the term itself and all its descendants.
-			if ( ! isset( $hierarchy_counts[ $term->term_taxonomy_id ] ) ) {
-				$descendants                                 = $this->taxonomy_hierarchy_data->get_descendants( $term_id, $taxonomy_name );
-				$descendants[]                               = $term_id; // Include the term itself.
-				$hierarchy_counts[ $term->term_taxonomy_id ] = $descendants;
+			if ( ! isset( $hierarchy_counts[ $term_id ] ) ) {
+				$descendants                  = $this->taxonomy_hierarchy_data->get_descendants( $term_id, $taxonomy_name );
+				$descendants[]                = $term_id; // Include the term itself.
+				$hierarchy_counts[ $term_id ] = $descendants;
 			}
 
 			// Get ancestors using hierarchy data.
-			$current_id = $term_id;
-			while ( $current_id > 0 ) {
-				$parent_id = $this->taxonomy_hierarchy_data->get_parent( $current_id, $taxonomy_name );
-				if ( $parent_id <= 0 ) {
-					break;
-				}
-
-				if ( in_array( $parent_id, $processed_terms, true ) ) {
-					$current_id = $parent_id;
+			$ancestors = $this->taxonomy_hierarchy_data->get_ancestors( $term_id, $taxonomy_name );
+			foreach ( $ancestors as $ancestor_id ) {
+				if ( in_array( $ancestor_id, $processed_terms, true ) ) {
 					continue;
 				}
 
-				// Get all descendants for this ancestor using optimized hierarchy data.
-				$descendants   = $this->taxonomy_hierarchy_data->get_descendants( $parent_id, $taxonomy_name );
-				$descendants[] = $parent_id; // Include the ancestor term itself.
+				$descendants   = $this->taxonomy_hierarchy_data->get_descendants( $ancestor_id, $taxonomy_name );
+				$descendants[] = $ancestor_id; // Include the ancestor term itself.
 
-				$hierarchy_counts[ $parent_id ] = $descendants;
-				$processed_terms[]              = $parent_id;
-				$current_id                     = $parent_id;
+				$hierarchy_counts[ $ancestor_id ] = $descendants;
+				$processed_terms[]                = $ancestor_id;
 			}
 		}
 
@@ -442,9 +434,9 @@ class FilterData {
 
 		// Step 3: Execute batch counting using a single query with CASE statements.
 		$count_cases = array();
-		foreach ( $hierarchy_counts as $term_taxonomy_id => $term_ids ) {
+		foreach ( $hierarchy_counts as $term_id => $term_ids ) {
 			$term_ids_str  = implode( ',', array_map( 'absint', $term_ids ) );
-			$count_cases[] = "COUNT(DISTINCT CASE WHEN tt.term_id IN ({$term_ids_str}) THEN tr.object_id END) as count_{$term_taxonomy_id}";
+			$count_cases[] = "COUNT(DISTINCT CASE WHEN tt.term_id IN ({$term_ids_str}) THEN tr.object_id END) as count_{$term_id}";
 		}
 
 		$batch_count_sql = '

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -193,16 +193,15 @@ class TaxonomyHierarchyData {
 	 * @param int   $term_id    Current term ID.
 	 * @param array $children   Children relationships map (parent_id => [child_ids]).
 	 * @param array $temp_terms Term data indexed by term_id.
-	 * @param int   $parent_id  Current parent term ID.
 	 * @param int   $depth      Current depth level in hierarchy.
 	 */
-	private function build_term_tree( &$tree, $term_id, $children, $temp_terms, $parent_id = 0, $depth = 0 ) {
+	private function build_term_tree( &$tree, $term_id, $children, $temp_terms, $depth = 0 ) {
 		$tree[ $term_id ]          = $temp_terms[ $term_id ];
 		$tree[ $term_id ]['depth'] = $depth;
 
 		if ( ! empty( $children[ $term_id ] ) ) {
 			foreach ( $children[ $term_id ] as $child_id ) {
-				$this->build_term_tree( $tree[ $term_id ]['children'], $child_id, $children, $temp_terms, $term_id, $depth + 1 );
+				$this->build_term_tree( $tree[ $term_id ]['children'], $child_id, $children, $temp_terms, $depth + 1 );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -109,7 +109,7 @@ class TaxonomyHierarchyData {
 	/**
 	 * Check if the cache is valid.
 	 *
-	 * @param array $data Cache data
+	 * @param array $data Cache data.
 	 *
 	 * @return boolean
 	 */
@@ -142,12 +142,12 @@ class TaxonomyHierarchyData {
 		}
 
 		$map = array(
-			'descendants' => array(), // term_id => [descendant_ids]
-			'ancestors'   => array(), // term_id => [ancestor_ids]
+			'descendants' => array(), // term_id => [descendant_ids].
+			'ancestors'   => array(), // term_id => [ancestor_ids].
 			'tree'        => array(),
 		);
 
-		// Build core lookups and temporary structures
+		// Build core lookups and temporary structures.
 		$temp_children = array();
 		$temp_parents  = array();
 		$temp_terms    = array();
@@ -172,7 +172,7 @@ class TaxonomyHierarchyData {
 			);
 		}
 
-		// Pre-compute descendants and ancestors
+		// Pre-compute descendants and ancestors.
 		foreach ( array_keys( $temp_parents ) as $term_id ) {
 			$map['descendants'][ $term_id ] = $this->compute_descendants( $term_id, $temp_children );
 			$map['ancestors'][ $term_id ]   = $this->compute_ancestors( $term_id, $temp_parents );

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -186,7 +186,7 @@ class TaxonomyHierarchyData {
 	}
 
 	/**
-	 * Recursively build hierarchical term tree with depth and parent slug.
+	 * Recursively build hierarchical term tree with depth and parent.
 	 *
 	 * @param array $tree       Reference to tree array being built.
 	 * @param int   $term_id    Current term ID.
@@ -198,9 +198,7 @@ class TaxonomyHierarchyData {
 	private function build_term_tree( &$tree, $term_id, $children, $temp_terms, $parent_id = 0, $depth = 0 ) {
 		$tree[ $term_id ]          = $temp_terms[ $term_id ];
 		$tree[ $term_id ]['depth'] = $depth;
-		if ( isset( $temp_terms[ $parent_id ] ) ) {
-			$tree[ $term_id ]['parent'] = $temp_terms[ $parent_id ]['slug'];
-		}
+
 		if ( ! empty( $children[ $term_id ] ) ) {
 			foreach ( $children[ $term_id ] as $child_id ) {
 				$this->build_term_tree( $tree[ $term_id ]['children'], $child_id, $children, $temp_terms, $term_id, $depth + 1 );

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -81,7 +81,7 @@ class TaxonomyHierarchyData {
 	}
 
 	/**
-	 * Get ancestor chain for efficient batch processing.
+	 * Get ancestor chain for batch processing.
 	 *
 	 * @param int    $term_id  The term ID.
 	 * @param string $taxonomy The taxonomy name.
@@ -114,9 +114,10 @@ class TaxonomyHierarchyData {
 	 * @return boolean
 	 */
 	private function validate_cache( $data ) {
-		return array_key_exists( 'descendants', $data ) &&
-		array_key_exists( 'ancestors', $data ) &&
-		array_key_exists( 'tree', $data );
+		return is_array( $data ) &&
+			array_key_exists( 'descendants', $data ) &&
+			array_key_exists( 'ancestors', $data ) &&
+			array_key_exists( 'tree', $data );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -69,6 +69,44 @@ class TaxonomyHierarchyData {
 	}
 
 	/**
+	 * Get all descendants for a term.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy name.
+	 * @return array Array of all descendant term IDs.
+	 */
+	public function get_descendants( int $term_id, string $taxonomy ): array {
+		$map = $this->get_hierarchy_map( $taxonomy );
+		return $map['descendants'][ $term_id ] ?? array();
+	}
+
+	/**
+	 * Get ancestor chain for efficient batch processing.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy name.
+	 * @return array Array of ancestor term IDs (bottom-up).
+	 */
+	public function get_ancestors( int $term_id, string $taxonomy ): array {
+		$map = $this->get_hierarchy_map( $taxonomy );
+		return $map['ancestors'][ $term_id ] ?? array();
+	}
+
+	/**
+	 * Clear hierarchy cache for a taxonomy.
+	 *
+	 * @param string $taxonomy The taxonomy name.
+	 */
+	public function clear_cache( string $taxonomy ): void {
+		// Clear in-memory cache for this taxonomy.
+		unset( $this->hierarchy_data[ $taxonomy ] );
+
+		// Clear only the specific taxonomy's option cache.
+		$cache_key = self::CACHE_GROUP . '_' . $taxonomy;
+		delete_option( $cache_key );
+	}
+
+	/**
 	 * Check if the cache is valid.
 	 *
 	 * @param array $data Cache data
@@ -210,43 +248,5 @@ class TaxonomyHierarchyData {
 		}
 
 		return $ancestors;
-	}
-
-	/**
-	 * Get all descendants for a term.
-	 *
-	 * @param int    $term_id  The term ID.
-	 * @param string $taxonomy The taxonomy name.
-	 * @return array Array of all descendant term IDs.
-	 */
-	public function get_descendants( int $term_id, string $taxonomy ): array {
-		$map = $this->get_hierarchy_map( $taxonomy );
-		return $map['descendants'][ $term_id ] ?? array();
-	}
-
-	/**
-	 * Get ancestor chain for efficient batch processing.
-	 *
-	 * @param int    $term_id  The term ID.
-	 * @param string $taxonomy The taxonomy name.
-	 * @return array Array of ancestor term IDs (bottom-up).
-	 */
-	public function get_ancestors( int $term_id, string $taxonomy ): array {
-		$map = $this->get_hierarchy_map( $taxonomy );
-		return $map['ancestors'][ $term_id ] ?? array();
-	}
-
-	/**
-	 * Clear hierarchy cache for a taxonomy.
-	 *
-	 * @param string $taxonomy The taxonomy name.
-	 */
-	public function clear_cache( string $taxonomy ): void {
-		// Clear in-memory cache for this taxonomy.
-		unset( $this->hierarchy_data[ $taxonomy ] );
-
-		// Clear only the specific taxonomy's option cache.
-		$cache_key = self::CACHE_GROUP . '_' . $taxonomy;
-		delete_option( $cache_key );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -49,7 +49,7 @@ class TaxonomyHierarchyData {
 			$cached_map = get_option( $cache_key );
 		}
 
-		if ( ! empty( $cached_map ) ) {
+		if ( ! empty( $cached_map ) && $this->validate_cache( $cached_map ) ) {
 			// Cache in memory and return.
 			$this->hierarchy_data[ $taxonomy ] = $cached_map;
 			return $cached_map;
@@ -68,6 +68,18 @@ class TaxonomyHierarchyData {
 		return $map;
 	}
 
+	/**
+	 * Check if the cache is valid.
+	 *
+	 * @param array $data Cache data
+	 *
+	 * @return boolean
+	 */
+	private function validate_cache( $data ) {
+		return array_key_exists( 'descendants', $data ) &&
+		array_key_exists( 'ancestors', $data ) &&
+		array_key_exists( 'tree', $data );
+	}
 
 	/**
 	 * Build hierarchy map for FilterData and ProductFilterTaxonomy.
@@ -82,7 +94,8 @@ class TaxonomyHierarchyData {
 			array(
 				'taxonomy'   => $taxonomy,
 				'hide_empty' => false,
-				'fields'     => 'id=>parent',
+				'orderby'    => 'name',
+				'order'      => 'ASC',
 			)
 		);
 
@@ -93,19 +106,32 @@ class TaxonomyHierarchyData {
 		$map = array(
 			'descendants' => array(), // term_id => [descendant_ids]
 			'ancestors'   => array(), // term_id => [ancestor_ids]
+			'tree'        => array(),
 		);
 
 		// Build core lookups and temporary structures
 		$temp_children = array();
 		$temp_parents  = array();
+		$temp_terms    = array();
 
-		foreach ( $terms as $term_id => $parent_id ) {
+		foreach ( $terms as $term ) {
+			$term_id   = $term->term_id;
+			$parent_id = $term->parent;
+
 			$temp_parents[ $term_id ] = $parent_id;
 
 			if ( ! isset( $temp_children[ $parent_id ] ) ) {
 				$temp_children[ $parent_id ] = array();
 			}
+
 			$temp_children[ $parent_id ][] = $term_id;
+
+			$temp_terms[ $term_id ] = array(
+				'slug'    => $term->slug,
+				'name'    => $term->name,
+				'parent'  => $parent_id,
+				'term_id' => $term->term_id,
+			);
 		}
 
 		// Pre-compute descendants and ancestors
@@ -114,9 +140,35 @@ class TaxonomyHierarchyData {
 			$map['ancestors'][ $term_id ]   = $this->compute_ancestors( $term_id, $temp_parents );
 		}
 
+		foreach ( $temp_children[0] as $term_id ) {
+			$this->build_term_tree( $map['tree'], $term_id, $temp_children, $temp_terms );
+		}
+
 		return $map;
 	}
 
+	/**
+	 * Recursively build hierarchical term tree with depth and parent slug.
+	 *
+	 * @param array $tree       Reference to tree array being built.
+	 * @param int   $term_id    Current term ID.
+	 * @param array $children   Children relationships map (parent_id => [child_ids]).
+	 * @param array $temp_terms Term data indexed by term_id.
+	 * @param int   $parent_id  Current parent term ID.
+	 * @param int   $depth      Current depth level in hierarchy.
+	 */
+	private function build_term_tree( &$tree, $term_id, $children, $temp_terms, $parent_id = 0, $depth = 0 ) {
+		$tree[ $term_id ]          = $temp_terms[ $term_id ];
+		$tree[ $term_id ]['depth'] = $depth;
+		if ( isset( $temp_terms[ $parent_id ] ) ) {
+			$tree[ $term_id ]['parent'] = $temp_terms[ $parent_id ]['slug'];
+		}
+		if ( ! empty( $children[ $term_id ] ) ) {
+			foreach ( $children[ $term_id ] as $child_id ) {
+				$this->build_term_tree( $tree[ $term_id ]['children'], $child_id, $children, $temp_terms, $term_id, $depth + 1 );
+			}
+		}
+	}
 
 	/**
 	 * Compute all descendants of a term.
@@ -183,7 +235,6 @@ class TaxonomyHierarchyData {
 		$map = $this->get_hierarchy_map( $taxonomy );
 		return $map['ancestors'][ $term_id ] ?? array();
 	}
-
 
 	/**
 	 * Clear hierarchy cache for a taxonomy.

--- a/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
+++ b/plugins/woocommerce/src/Internal/ProductFilters/TaxonomyHierarchyData.php
@@ -70,14 +70,12 @@ class TaxonomyHierarchyData {
 
 
 	/**
-	 * Build complete hierarchy map with all relationships pre-computed.
+	 * Build hierarchy map for FilterData and ProductFilterTaxonomy.
 	 *
-	 * Pre-computes all descendants for maximum query speed, which is essential
-	 * for product filtering where parent category filters must include all
-	 * subcategory products regardless of hierarchy depth.
+	 * Pre-computes descendants and ancestor chains for maximum query speed.
 	 *
 	 * @param string $taxonomy The taxonomy name.
-	 * @return array Complete hierarchy map with parents, children, and descendants.
+	 * @return array Complete hierarchy map with descendants and ancestor chains.
 	 */
 	private function build_full_hierarchy_map( string $taxonomy ): array {
 		$terms = get_terms(
@@ -93,24 +91,27 @@ class TaxonomyHierarchyData {
 		}
 
 		$map = array(
-			'parents'     => array(),
-			'children'    => array(),
-			'descendants' => array(),
+			'descendants' => array(), // term_id => [descendant_ids]
+			'ancestors'   => array(), // term_id => [ancestor_ids]
 		);
 
-		// Build basic parent-child relationships.
-		foreach ( $terms as $term_id => $parent_id ) {
-			$map['parents'][ $term_id ] = $parent_id;
+		// Build core lookups and temporary structures
+		$temp_children = array();
+		$temp_parents  = array();
 
-			if ( ! isset( $map['children'][ $parent_id ] ) ) {
-				$map['children'][ $parent_id ] = array();
+		foreach ( $terms as $term_id => $parent_id ) {
+			$temp_parents[ $term_id ] = $parent_id;
+
+			if ( ! isset( $temp_children[ $parent_id ] ) ) {
+				$temp_children[ $parent_id ] = array();
 			}
-			$map['children'][ $parent_id ][] = $term_id;
+			$temp_children[ $parent_id ][] = $term_id;
 		}
 
-		// Pre-compute all descendants for each term.
-		foreach ( array_keys( $map['parents'] ) as $term_id ) {
-			$map['descendants'][ $term_id ] = $this->compute_descendants( $term_id, $map['children'] );
+		// Pre-compute descendants and ancestors
+		foreach ( array_keys( $temp_parents ) as $term_id ) {
+			$map['descendants'][ $term_id ] = $this->compute_descendants( $term_id, $temp_children );
+			$map['ancestors'][ $term_id ]   = $this->compute_ancestors( $term_id, $temp_parents );
 		}
 
 		return $map;
@@ -140,15 +141,23 @@ class TaxonomyHierarchyData {
 	}
 
 	/**
-	 * Get parent term ID for a given term.
+	 * Compute ancestor chain for a term.
 	 *
-	 * @param int    $term_id  The term ID.
-	 * @param string $taxonomy The taxonomy name.
-	 * @return int The parent term ID (0 if root level).
+	 * @param int   $term_id The term ID.
+	 * @param array $parent_lookup Parent relationships.
+	 * @return array Array of ancestor term IDs (bottom-up).
 	 */
-	public function get_parent( int $term_id, string $taxonomy ): int {
-		$map = $this->get_hierarchy_map( $taxonomy );
-		return $map['parents'][ $term_id ] ?? 0;
+	private function compute_ancestors( int $term_id, array $parent_lookup ): array {
+		$ancestors  = array();
+		$current_id = $term_id;
+
+		while ( isset( $parent_lookup[ $current_id ] ) && $parent_lookup[ $current_id ] > 0 ) {
+			$parent_id   = $parent_lookup[ $current_id ];
+			$ancestors[] = $parent_id;
+			$current_id  = $parent_id;
+		}
+
+		return $ancestors;
 	}
 
 	/**
@@ -162,6 +171,19 @@ class TaxonomyHierarchyData {
 		$map = $this->get_hierarchy_map( $taxonomy );
 		return $map['descendants'][ $term_id ] ?? array();
 	}
+
+	/**
+	 * Get ancestor chain for efficient batch processing.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy name.
+	 * @return array Array of ancestor term IDs (bottom-up).
+	 */
+	public function get_ancestors( int $term_id, string $taxonomy ): array {
+		$map = $this->get_hierarchy_map( $taxonomy );
+		return $map['ancestors'][ $term_id ] ?? array();
+	}
+
 
 	/**
 	 * Clear hierarchy cache for a taxonomy.

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
@@ -242,4 +242,3 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 		$this->assertEquals( $laptops_id, $gaming_tree['parent'] );
 	}
 }
-

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
@@ -49,7 +49,7 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 	 * Clean up test environment.
 	 */
 	public function tearDown(): void {
-		// Clean up. test terms.
+		// Clean up test terms.
 		foreach ( $this->test_term_ids as $term_id ) {
 			wp_delete_term( $term_id, $this->taxonomy );
 		}
@@ -98,43 +98,28 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 
 		$map = $this->sut->get_hierarchy_map( $this->taxonomy );
 
-		// Should have full map structure.
-		$this->assertArrayHasKey( 'parents', $map );
-		$this->assertArrayHasKey( 'children', $map );
+		// Should have new map structure.
 		$this->assertArrayHasKey( 'descendants', $map );
-
-		// Verify parents mapping.
-		$this->assertEquals( 0, $map['parents'][ $electronics_id ] );
-		$this->assertEquals( $electronics_id, $map['parents'][ $laptops_id ] );
-		$this->assertEquals( $laptops_id, $map['parents'][ $gaming_id ] );
-
-		// Verify children mapping.
-		$this->assertContains( $electronics_id, $map['children'][0] );
-		$this->assertContains( $laptops_id, $map['children'][ $electronics_id ] );
-		$this->assertContains( $gaming_id, $map['children'][ $laptops_id ] );
+		$this->assertArrayHasKey( 'ancestors', $map );
+		$this->assertArrayHasKey( 'tree', $map );
 
 		// Verify descendants are pre-computed.
 		$this->assertContains( $laptops_id, $map['descendants'][ $electronics_id ] );
 		$this->assertContains( $gaming_id, $map['descendants'][ $electronics_id ] );
 		$this->assertContains( $gaming_id, $map['descendants'][ $laptops_id ] );
+
+		// Verify ancestors are pre-computed.
+		$this->assertContains( $electronics_id, $map['ancestors'][ $laptops_id ] );
+		$this->assertContains( $electronics_id, $map['ancestors'][ $gaming_id ] );
+		$this->assertContains( $laptops_id, $map['ancestors'][ $gaming_id ] );
+
+		// Verify tree structure.
+		$this->assertArrayHasKey( $electronics_id, $map['tree'] );
+		$this->assertEquals( 'Electronics', $map['tree'][ $electronics_id ]['name'] );
+		$this->assertEquals( 0, $map['tree'][ $electronics_id ]['depth'] );
+		$this->assertArrayHasKey( 'children', $map['tree'][ $electronics_id ] );
+		$this->assertArrayHasKey( $laptops_id, $map['tree'][ $electronics_id ]['children'] );
 	}
-
-	/**
-	 * Test get_parent method.
-	 */
-	public function test_get_parent(): void {
-		$electronics_id = $this->create_test_term( 'Electronics' );
-		$laptops_id     = $this->create_test_term( 'Laptops', $electronics_id );
-		$gaming_id      = $this->create_test_term( 'Gaming Laptops', $laptops_id );
-
-		$this->assertEquals( 0, $this->sut->get_parent( $electronics_id, $this->taxonomy ) );
-		$this->assertEquals( $electronics_id, $this->sut->get_parent( $laptops_id, $this->taxonomy ) );
-		$this->assertEquals( $laptops_id, $this->sut->get_parent( $gaming_id, $this->taxonomy ) );
-
-		// Non-existent term should return 0.
-		$this->assertEquals( 0, $this->sut->get_parent( 99999, $this->taxonomy ) );
-	}
-
 
 	/**
 	 * Test get_descendants method.
@@ -162,6 +147,32 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 
 		// Non-existent term should return empty array.
 		$this->assertEmpty( $this->sut->get_descendants( 99999, $this->taxonomy ) );
+	}
+
+	/**
+	 * Test get_ancestors method.
+	 */
+	public function test_get_ancestors(): void {
+		$electronics_id = $this->create_test_term( 'Electronics' );
+		$laptops_id     = $this->create_test_term( 'Laptops', $electronics_id );
+		$gaming_id      = $this->create_test_term( 'Gaming Laptops', $laptops_id );
+
+		// Root term should have no ancestors.
+		$this->assertEmpty( $this->sut->get_ancestors( $electronics_id, $this->taxonomy ) );
+
+		// Second level should have one ancestor.
+		$laptops_ancestors = $this->sut->get_ancestors( $laptops_id, $this->taxonomy );
+		$this->assertContains( $electronics_id, $laptops_ancestors );
+		$this->assertCount( 1, $laptops_ancestors );
+
+		// Third level should have two ancestors.
+		$gaming_ancestors = $this->sut->get_ancestors( $gaming_id, $this->taxonomy );
+		$this->assertContains( $laptops_id, $gaming_ancestors );
+		$this->assertContains( $electronics_id, $gaming_ancestors );
+		$this->assertCount( 2, $gaming_ancestors );
+
+		// Non-existent term should return empty array.
+		$this->assertEmpty( $this->sut->get_ancestors( 99999, $this->taxonomy ) );
 	}
 
 	/**
@@ -200,9 +211,35 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 
 		// Should return empty arrays for all methods.
 		$this->assertEmpty( $this->sut->get_descendants( 1, $empty_taxonomy ) );
-		$this->assertEquals( 0, $this->sut->get_parent( 1, $empty_taxonomy ) );
+		$this->assertEmpty( $this->sut->get_ancestors( 1, $empty_taxonomy ) );
 
 		// Clean up.
 		unregister_taxonomy( $empty_taxonomy );
 	}
+
+	/**
+	 * Test tree structure includes depth and parent information.
+	 */
+	public function test_tree_structure_includes_depth_and_parent(): void {
+		$electronics_id = $this->create_test_term( 'Electronics' );
+		$laptops_id     = $this->create_test_term( 'Laptops', $electronics_id );
+		$gaming_id      = $this->create_test_term( 'Gaming Laptops', $laptops_id );
+
+		$map = $this->sut->get_hierarchy_map( $this->taxonomy );
+
+		// Check root level term.
+		$this->assertEquals( 0, $map['tree'][ $electronics_id ]['depth'] );
+		$this->assertEquals( 0, $map['tree'][ $electronics_id ]['parent'] );
+
+		// Check second level term.
+		$laptops_tree = $map['tree'][ $electronics_id ]['children'][ $laptops_id ];
+		$this->assertEquals( 1, $laptops_tree['depth'] );
+		$this->assertEquals( $map['tree'][ $electronics_id ]['slug'], $laptops_tree['parent'] );
+
+		// Check third level term.
+		$gaming_tree = $laptops_tree['children'][ $gaming_id ];
+		$this->assertEquals( 2, $gaming_tree['depth'] );
+		$this->assertEquals( $laptops_tree['slug'], $gaming_tree['parent'] );
+	}
 }
+

--- a/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductFilters/TaxonomyHierarchyDataTest.php
@@ -234,12 +234,12 @@ class TaxonomyHierarchyDataTest extends WP_UnitTestCase {
 		// Check second level term.
 		$laptops_tree = $map['tree'][ $electronics_id ]['children'][ $laptops_id ];
 		$this->assertEquals( 1, $laptops_tree['depth'] );
-		$this->assertEquals( $map['tree'][ $electronics_id ]['slug'], $laptops_tree['parent'] );
+		$this->assertEquals( $electronics_id, $laptops_tree['parent'] );
 
 		// Check third level term.
 		$gaming_tree = $laptops_tree['children'][ $gaming_id ];
 		$this->assertEquals( 2, $gaming_tree['depth'] );
-		$this->assertEquals( $laptops_tree['slug'], $gaming_tree['parent'] );
+		$this->assertEquals( $laptops_id, $gaming_tree['parent'] );
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR adds depth information to the filter options of hierarchical taxonomies, such as product category or product brand. For now, we only add a class that displays the depth information to the checkbox list item (`depth-<number>`). Developers can utilize this class to style the list, the hierarchical list. 

I also took this opportunity to refactor the hierarchical data cache we are using. The cache now includes a pre-computed hierarchy tree with all necessary term data. This eliminates the need for `get_terms` calls to retrieve hierarchical terms. With the tree, the performance of building the list of filter options on the front end is also improved. 

The hierarchy data also has another improvement: we are now using the ancestor chains. With this, we can replace the parent walking loop when calculating the hierarchical taxonomy count at FilterData.php.

Closes WOOPLUG-5207

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Experimental blocks using WooCommerce Beta tester.
2. Add the "Product Filters" block and then the "Product Categories Filter" block to the "Product Catalog" template.
4. On the front end, open the inspector and focus on the list item. See the depth class. 
5. Ensure there is no regression, the filter count is still accrurate and match the current results.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Enhancement - Improvement to existing functionality

#### Message

Add hierarchical data structure support to filter options of the Product Filters block, starting with List and Taxonomy filter options.

</details>