### PR TITLE
[Expreimental] Show preview taxonomy filter options in hierarchy order

### DIFF
--- a/plugins/woocommerce/changelog/60144-wooplug-5236-editor-preview-filter-options-dont-show-in-hierarchical
+++ b/plugins/woocommerce/changelog/60144-wooplug-5236-editor-preview-filter-options-dont-show-in-hierarchical
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Experimental: Show preview taxonomy filter options in hierarchy order.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -99,7 +99,7 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 									className={ clsx(
 										'wc-block-product-filter-checkbox-list__item',
 										{
-											[ `depth-${ item?.depth }` ]:
+											[ `has-depth-${ item?.depth }` ]:
 												item?.depth,
 										}
 									) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/checkbox-list/edit.tsx
@@ -96,7 +96,13 @@ const CheckboxListEdit = ( props: EditProps ): JSX.Element => {
 							).map( ( item, index ) => (
 								<div
 									key={ index }
-									className="wc-block-product-filter-checkbox-list__item"
+									className={ clsx(
+										'wc-block-product-filter-checkbox-list__item',
+										{
+											[ `depth-${ item?.depth }` ]:
+												item?.depth,
+										}
+									) }
 								>
 									<label
 										htmlFor={ `interactive-checkbox-${ index }` }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -53,12 +53,12 @@ function createHierarchicalList(
 
 	// Last: build hierarchical list
 	const result: FilterOptionItem[] = [];
-	function addTermsRecursively( termList: FilterOptionItem[] ) {
+	function addTermsRecursively( termList: FilterOptionItem[], depth = 0 ) {
 		termList.forEach( ( term ) => {
+			term.depth = depth;
 			result.push( term );
 			const termChildren = children.get( term.id ) || [];
 			if ( termChildren.length > 0 ) {
-				addTermsRecursively( termChildren );
 				addTermsRecursively( termChildren, depth + 1 );
 			}
 		} );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -53,13 +53,23 @@ function createHierarchicalList(
 
 	// Last: build hierarchical list
 	const result: FilterOptionItem[] = [];
-	function addTermsRecursively( termList: FilterOptionItem[], depth = 0 ) {
+	function addTermsRecursively(
+		termList: FilterOptionItem[],
+		depth = 0,
+		visited = new Set< number >()
+	) {
+		if ( depth > 10 ) {
+			return;
+		}
 		termList.forEach( ( term ) => {
-			term.depth = depth;
-			result.push( term );
+			if ( ! term.id || visited.has( term.id ) ) {
+				return;
+			}
+			visited.add( term.id );
+			result.push( { ...term, depth } );
 			const termChildren = children.get( term.id ) || [];
 			if ( termChildren.length > 0 ) {
-				addTermsRecursively( termChildren, depth + 1 );
+				addTermsRecursively( termChildren, depth + 1, visited );
 			}
 		} );
 	}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -28,6 +28,46 @@ import { Notice } from '../../components/notice';
 import { getTaxonomyLabel } from './utils';
 import { sortFilterOptions } from '../../utils/sort-filter-options';
 
+// Create hierarchical structure: parents followed by their children
+function createHierarchicalList(
+	terms: FilterOptionItem[],
+	sortOrder: string
+) {
+	const children = new Map();
+
+	// First: categorize terms
+	terms.forEach( ( term ) => {
+		if ( ! children.has( term.parent ) ) {
+			children.set( term.parent, [] );
+		}
+		children.get( term.parent ).push( term );
+	} );
+
+	// Next: sort them
+	children.keys().forEach( ( key ) => {
+		children.set(
+			key,
+			sortFilterOptions( children.get( key ), sortOrder )
+		);
+	} );
+
+	// Last: build hierarchical list
+	const result: FilterOptionItem[] = [];
+	function addTermsRecursively( termList: FilterOptionItem[] ) {
+		termList.forEach( ( term ) => {
+			result.push( term );
+			const termChildren = children.get( term.id ) || [];
+			if ( termChildren.length > 0 ) {
+				addTermsRecursively( termChildren );
+				addTermsRecursively( termChildren, depth + 1 );
+			}
+		} );
+	}
+
+	addTermsRecursively( children.get( 0 ) );
+	return result;
+}
+
 const Edit = ( props: EditProps ) => {
 	const { attributes: blockAttributes } = props;
 
@@ -58,23 +98,21 @@ const Edit = ( props: EditProps ) => {
 
 			const { getEntityRecords, hasFinishedResolution } =
 				select( coreStore );
-			const selectorArgs = [
-				'taxonomy',
-				taxonomy,
-				{
-					per_page: 15,
-					hide_empty: hideEmpty,
-					orderby: 'name',
-					order: 'asc',
-				},
-			];
 
+			const selectArgs = {
+				per_page: 15,
+				hide_empty: hideEmpty,
+				orderby: 'name',
+				order: 'asc',
+			};
 			return {
-				taxonomyTerms: getEntityRecords( ...selectorArgs ) || [],
-				isTermsLoading: ! hasFinishedResolution(
-					'getEntityRecords',
-					selectorArgs
-				),
+				taxonomyTerms:
+					getEntityRecords( 'taxonomy', taxonomy, selectArgs ) || [],
+				isTermsLoading: ! hasFinishedResolution( 'getEntityRecords', [
+					'taxonomy',
+					taxonomy,
+					selectArgs,
+				] ),
 			};
 		},
 		[ taxonomy, hideEmpty, isPreview ]
@@ -132,6 +170,8 @@ const Edit = ( props: EditProps ) => {
 					value: term.slug,
 					selected: false,
 					count,
+					id: term.id,
+					parent: term.parent || 0,
 				} );
 
 				return acc;
@@ -139,8 +179,12 @@ const Edit = ( props: EditProps ) => {
 			[]
 		);
 
-		// Sort the processed terms
-		setTermOptions( sortFilterOptions( processedTerms, sortOrder ) );
+		// Create hierarchical structure then apply sorting
+		const hierarchicalTerms = createHierarchicalList(
+			processedTerms,
+			sortOrder
+		);
+		setTermOptions( hierarchicalTerms );
 		setIsOptionsLoading( false );
 	}, [
 		taxonomy,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/types.ts
@@ -24,6 +24,9 @@ export type FilterOptionItem = (
 	value: string;
 	selected?: boolean;
 	count: number;
+	id?: number;
+	parent?: number;
+	depth?: number;
 };
 
 export type FilterBlockContext = {


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

This PR updates the preview of hierarchical taxonomies, such as category or brand, by sorting the preview filter options in hierarchical order.

This also add the depth class to the editor preview of the Checkbox List block, to sync with the class added on the frontend in #60142.

Closes WOOPLUG-5236

### Screenshots or screen recordings

| Before | After |
| ------ | ----- |
|  <img width="1497" height="929" alt="image" src="https://github.com/user-attachments/assets/b3c85f5b-2d11-47c1-8566-6801c5fa03bf" />      |  <img width="1497" height="929" alt="image" src="https://github.com/user-attachments/assets/f30b7c36-25a9-4626-9444-3a172d2b927c" /> |

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Experimental blocks using WooCommerce Beta tester.
2. Add the "Product Filters" block and then the "Product Categories Filter" block to the "Product Catalog" template.
3. Try changing the short order of the broad category filter block. See the hierarchy order is always preserved. Only the siblings follow the selected short order. 

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Experimental: Show preview taxonomy filter options in hierarchy order.

</details>