### PR TITLE
Fix: Product Button state issue in the Product Collection

### DIFF
--- a/plugins/woocommerce/changelog/60149-fix-product-button-state
+++ b/plugins/woocommerce/changelog/60149-fix-product-button-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Product Button: Using `wp_interactivity_get_context` insdie state callback to ensure the serverside directive processing work as expected.
+

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -172,14 +172,16 @@ class ProductButton extends AbstractBlock {
 		wp_interactivity_state(
 			'woocommerce/product-button',
 			array(
-				'addToCartText' => function () use ( $add_to_cart_text, $number_of_items_in_cart ) {
-					return $number_of_items_in_cart > 0
-					? sprintf(
-						/* translators: %s: product quantity. */
+				'addToCartText' => function () {
+					$context = wp_interactivity_get_context();
+					$quantity = $context['tempQuantity'];
+					$add_to_cart_text = $context['addToCartText'];
+
+					return $quantity > 0 ? sprintf(
+						/* translators: %s: product number. */
 						__( '%s in cart', 'woocommerce' ),
-						$number_of_items_in_cart
-					)
-					: $add_to_cart_text;
+						$quantity
+					) : $add_to_cart_text;
 				},
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In https://github.com/woocommerce/woocommerce/pull/59037, we update the `addToCartText` state to use the `$number_of_items_in_cart` and `$add_to_cart_text` variables directly. This doesn't work with the Interactivity API; the state of all Product Buttons gets overridden by the last one in the loop. This PR fixes that issue by reverting the callback to its previous state, utilizing `wp_interactivity_get_context()` for server directive processing to work as expected.

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59037

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With trunk, go to the Shop page, add the first product in the loop the the cart.
2. Reload the page, see the flashing issue of the first product, changing from Add to cart to 1 in cart.
3. Checkout and build this PR. See the issue resolved.

<!-- End testing instructions -->


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Product Button: Using `wp_interactivity_get_context` insdie state callback to ensure the serverside directive processing work as expected.
</details>
