### PR TITLE
Implement line_discount feature for orders

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -768,7 +768,7 @@ final class WC_Cart_Totals {
 
 		// Prices are not rounded here because they should already be rounded based on settings in `get_rounded_items_total` and in `round_line_tax` method calls.
 		$this->set_total( 'items_subtotal', $items_subtotal );
-		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ), 0 );
+		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ) );
 
 		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
 		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -685,9 +685,19 @@ final class WC_Cart_Totals {
 				}
 			}
 
-			$this->cart->cart_contents[ $item_key ]['line_tax_data']['total'] = wc_remove_number_precision_deep( $item->taxes );
-			$this->cart->cart_contents[ $item_key ]['line_total']             = wc_remove_number_precision( $item->total );
-			$this->cart->cart_contents[ $item_key ]['line_tax']               = wc_remove_number_precision( $item->total_tax );
+			   $this->cart->cart_contents[ $item_key ]['line_tax_data']['total'] = wc_remove_number_precision_deep( $item->taxes );
+			   $this->cart->cart_contents[ $item_key ]['line_total']             = wc_remove_number_precision( $item->total );
+			   $this->cart->cart_contents[ $item_key ]['line_tax']               = wc_remove_number_precision( $item->total_tax );
+			   
+			   if ( isset( $item->product ) ) {
+				   $regular_price = $item->product->get_regular_price();
+				   $quantity = $item->quantity;
+				   $regular_total = $regular_price * $quantity;
+				   $actual_total = wc_remove_number_precision( $item->total );
+				   
+				   $line_discount = $regular_total - $actual_total;
+				   $this->cart->cart_contents[ $item_key ]['line_discount'] = max( 0, $line_discount );
+			   }
 		}
 
 		$items_total = $this->get_rounded_items_total( $this->get_values_for_total( 'total' ) );
@@ -758,7 +768,7 @@ final class WC_Cart_Totals {
 
 		// Prices are not rounded here because they should already be rounded based on settings in `get_rounded_items_total` and in `round_line_tax` method calls.
 		$this->set_total( 'items_subtotal', $items_subtotal );
-		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ) );
+		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ), 0 );
 
 		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
 		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -547,7 +547,7 @@ class WC_Checkout {
 				   'subtotal_tax' => $values['line_subtotal_tax'],
 				   'total_tax'    => $values['line_tax'],
 				   'taxes'        => $values['line_tax_data'],
-				   'line_discount'=> isset($values['line_discount']) ? $values['line_discount'] : 0,
+				   'line_discount'=> isset($values['line_discount']) ? wc_format_decimal($values['line_discount']) : 0,
 			   )
 		   );
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -538,28 +538,29 @@ class WC_Checkout {
 			$product                    = $values['data'];
 			$item->legacy_values        = $values; // @deprecated 4.4.0 For legacy actions.
 			$item->legacy_cart_item_key = $cart_item_key; // @deprecated 4.4.0 For legacy actions.
-			$item->set_props(
-				array(
-					'quantity'     => $values['quantity'],
-					'variation'    => $values['variation'],
-					'subtotal'     => $values['line_subtotal'],
-					'total'        => $values['line_total'],
-					'subtotal_tax' => $values['line_subtotal_tax'],
-					'total_tax'    => $values['line_tax'],
-					'taxes'        => $values['line_tax_data'],
-				)
-			);
+		   $item->set_props(
+			   array(
+				   'quantity'     => $values['quantity'],
+				   'variation'    => $values['variation'],
+				   'subtotal'     => $values['line_subtotal'],
+				   'total'        => $values['line_total'],
+				   'subtotal_tax' => $values['line_subtotal_tax'],
+				   'total_tax'    => $values['line_tax'],
+				   'taxes'        => $values['line_tax_data'],
+				   'line_discount'=> isset($values['line_discount']) ? $values['line_discount'] : 0,
+			   )
+		   );
 
-			if ( $product ) {
-				$item->set_props(
-					array(
-						'name'         => $product->get_name(),
-						'tax_class'    => $product->get_tax_class(),
-						'product_id'   => $product->is_type( ProductType::VARIATION ) ? $product->get_parent_id() : $product->get_id(),
-						'variation_id' => $product->is_type( ProductType::VARIATION ) ? $product->get_id() : 0,
-					)
-				);
-			}
+		   if ( $product ) {
+			   $item->set_props(
+				   array(
+					   'name'         => $product->get_name(),
+					   'tax_class'    => $product->get_tax_class(),
+					   'product_id'   => $product->is_type( ProductType::VARIATION ) ? $product->get_parent_id() : $product->get_id(),
+					   'variation_id' => $product->is_type( ProductType::VARIATION ) ? $product->get_id() : 0,
+				   )
+			   );
+		   }
 
 			$item->set_backorder_meta();
 

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -50,6 +50,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 		'subtotal_tax' => 0,
 		'total'        => 0,
 		'total_tax'    => 0,
+		'line_discount' => 0,
 		'taxes'        => array(
 			'subtotal' => array(),
 			'total'    => array(),
@@ -158,6 +159,30 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 */
 	public function set_total_tax( $value ) {
 		$this->set_prop( 'total_tax', wc_format_decimal( $value ) );
+	}
+
+	 /**
+	 * Get line discount (total discount for this line item).
+	 *
+	 * @param string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return string
+	 */
+
+   public function get_line_discount( $context = 'view' ) {
+	   $discount = $this->get_prop( 'line_discount', $context );
+	   if ( $discount !== '' && $discount !== null ) {
+		   return wc_format_decimal( $discount );
+	   }
+	   return 0;
+   }
+
+	/**
+	 * Set line discount (total discount for this line item).
+	 *
+	 * @param string $value Line discount amount.
+	 */
+	public function set_line_discount( $value ) {
+		$this->set_prop( 'line_discount', wc_format_decimal( $value ) );
 	}
 
 	/**
@@ -500,6 +525,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			$offset = 'total_tax';
 		} elseif ( 'line_tax_data' === $offset ) {
 			$offset = 'taxes';
+		} elseif ( 'line_discount' === $offset ) {
+			$offset = 'line_discount';
 		} elseif ( 'qty' === $offset ) {
 			$offset = 'quantity';
 		}
@@ -526,6 +553,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			$offset = 'total_tax';
 		} elseif ( 'line_tax_data' === $offset ) {
 			$offset = 'taxes';
+		} elseif ( 'line_discount' === $offset ) {
+			$offset = 'line_discount';
 		} elseif ( 'qty' === $offset ) {
 			$offset = 'quantity';
 		}
@@ -540,7 +569,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 */
 	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
-		if ( in_array( $offset, array( 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'line_tax_data', 'item_meta_array', 'item_meta', 'qty' ), true ) ) {
+		if ( in_array( $offset, array( 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'line_tax_data', 'line_discount', 'item_meta_array', 'item_meta', 'qty' ), true ) ) {
 			return true;
 		}
 		return parent::offsetExists( $offset );

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-item-product-data-store.php
@@ -22,7 +22,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 	 * @since 3.0.0
 	 * @var array
 	 */
-	protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data' );
+protected $internal_meta_keys = array( '_product_id', '_variation_id', '_qty', '_tax_class', '_line_subtotal', '_line_subtotal_tax', '_line_total', '_line_tax', '_line_tax_data', '_line_discount' );
 
 	/**
 	 * Read/populate data properties specific to this order item.
@@ -35,13 +35,16 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 		$id = $item->get_id();
 		$item->set_props(
 			array(
-				'product_id'   => get_metadata( 'order_item', $id, '_product_id', true ),
-				'variation_id' => get_metadata( 'order_item', $id, '_variation_id', true ),
-				'quantity'     => get_metadata( 'order_item', $id, '_qty', true ),
-				'tax_class'    => get_metadata( 'order_item', $id, '_tax_class', true ),
-				'subtotal'     => get_metadata( 'order_item', $id, '_line_subtotal', true ),
-				'total'        => get_metadata( 'order_item', $id, '_line_total', true ),
-				'taxes'        => get_metadata( 'order_item', $id, '_line_tax_data', true ),
+				'product_id'    => get_metadata( 'order_item', $id, '_product_id', true ),
+				'variation_id'  => get_metadata( 'order_item', $id, '_variation_id', true ),
+				'quantity'      => get_metadata( 'order_item', $id, '_qty', true ),
+				'tax_class'     => get_metadata( 'order_item', $id, '_tax_class', true ),
+				'subtotal'      => get_metadata( 'order_item', $id, '_line_subtotal', true ),
+				'subtotal_tax'  => get_metadata( 'order_item', $id, '_line_subtotal_tax', true ),
+				'total'         => get_metadata( 'order_item', $id, '_line_total', true ),
+				'total_tax'     => get_metadata( 'order_item', $id, '_line_tax', true ),
+				'taxes'         => get_metadata( 'order_item', $id, '_line_tax_data', true ),
+				'line_discount' => get_metadata( 'order_item', $id, '_line_discount', true ),
 			)
 		);
 		$item->set_object_read( true );
@@ -67,6 +70,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 			'_line_total'        => 'total',
 			'_line_tax'          => 'total_tax',
 			'_line_tax_data'     => 'taxes',
+			'_line_discount'     => 'line_discount',
 		);
 		$props_to_update   = $this->get_props_to_update( $item, $meta_key_to_props, 'order_item' );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -435,6 +435,12 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 				),
 			),
 		);
+		$schema['properties']['line_items']['items']['properties']['line_discount'] = array(
+			'description' => __( 'Line discount (total discount for this line item).', 'woocommerce' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true
+		);
 
 		return $schema;
 	}
@@ -492,6 +498,12 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 						$line_item_data['cost_of_goods_sold']['value'] = $line_item_data['cogs_value'];
 					}
 					unset( $line_item_data['cogs_value'] );
+				}
+				if ( isset( $line_item_data['id'] ) ) {
+					$order_item = $order->get_item( $line_item_data['id'] );
+					if ( $order_item && method_exists( $order_item, 'get_line_discount' ) ) {
+						$line_item_data['line_discount'] = $order_item->get_line_discount();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Save the price difference between the sales and list price in new meta `_line_discount`
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30308

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. create a product with a regular and sales price
2. create a woocommerce order with that product
3. call the order rest api and check the new line item
4. or get the order object and check the new line item

<!-- End testing instructions -->

### Changelog entry
<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>
Add a 'line_discount' line item for all orders which saves the difference between the regular price and the sales price for products that are discounted and ordered. Visible in the Order Object and Order API. 
 
#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
