### PR TITLE
Show animation in Add to Cart + Options button when adding grouped products to cart

### DIFF
--- a/plugins/woocommerce/changelog/fix-59419-add-to-cart-button-animation
+++ b/plugins/woocommerce/changelog/fix-59419-add-to-cart-button-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Show animation in Add to Cart + Options button when adding grouped products to cart

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -143,6 +143,8 @@ const productButtonStore = {
 	},
 	actions: {
 		*addCartItem(): Generator< unknown, void > {
+			productButtonStore.actions.handlePressedState();
+
 			const context = getContext< Context >();
 
 			// Todo: Use the module exports instead of `store()` once the
@@ -197,6 +199,7 @@ const productButtonStore = {
 				addToCartWithOptionsState?.isFormValid
 			) {
 				context.hasPressedButton = true;
+				context.animationStatus = AnimationStatus.SLIDE_OUT;
 			}
 		},
 	},
@@ -212,19 +215,6 @@ const productButtonStore = {
 				context.tempQuantity = state.quantity;
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
-		},
-		startAnimation() {
-			const context = getContext< Context >();
-			// We start the animation if the temporary quantity is out of
-			// sync with the quantity in the cart and the animation hasn't
-			// started yet.
-			// We skip the animation altogether if the Add to Cart + Options form is invalid.
-			if (
-				context.tempQuantity !== state.quantity &&
-				context.animationStatus === AnimationStatus.IDLE
-			) {
-				context.animationStatus = AnimationStatus.SLIDE_OUT;
-			}
 		},
 	},
 };

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts
@@ -143,8 +143,6 @@ const productButtonStore = {
 	},
 	actions: {
 		*addCartItem(): Generator< unknown, void > {
-			productButtonStore.actions.handlePressedState();
-
 			const context = getContext< Context >();
 
 			// Todo: Use the module exports instead of `store()` once the
@@ -215,6 +213,19 @@ const productButtonStore = {
 				context.tempQuantity = state.quantity;
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
+		},
+		startAnimation() {
+			const context = getContext< Context >();
+			// We start the animation if the temporary quantity is out of
+			// sync with the quantity in the cart and the animation hasn't
+			// started yet.
+			// We skip the animation altogether if the Add to Cart + Options form is invalid.
+			if (
+				context.tempQuantity !== state.quantity &&
+				context.animationStatus === AnimationStatus.IDLE
+			) {
+				context.animationStatus = AnimationStatus.SLIDE_OUT;
+			}
 		},
 	},
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -228,7 +228,6 @@ class ProductButton extends AbstractBlock {
 			data-wp-class--wc-block-slide-in="state.slideInAnimation"
 			data-wp-class--wc-block-slide-out="state.slideOutAnimation"
 			data-wp-on--animationend="actions.handleAnimationEnd"
-			data-wp-watch="callbacks.startAnimation"
 			data-wp-run="callbacks.syncTempQuantityOnLoad"
 		';
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductButton.php
@@ -228,6 +228,7 @@ class ProductButton extends AbstractBlock {
 			data-wp-class--wc-block-slide-in="state.slideInAnimation"
 			data-wp-class--wc-block-slide-out="state.slideOutAnimation"
 			data-wp-on--animationend="actions.handleAnimationEnd"
+			data-wp-watch="callbacks.startAnimation"
 			data-wp-run="callbacks.syncTempQuantityOnLoad"
 		';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59419.

This PR makes it so adding a child of a grouped product to cart using the _Add to Cart + Options_ block shows an animation. I used the `handlePressedState()` action to start the animation, because parent grouped products are never in the cart, we can't use their product quantity to decide when to start the animation.

### How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Templates > Single Product and update to the blockified _Add to Cart + Options_ block if not yet in the template.
2. Go to the frontend of a grouped product.
3. Add one of the child products to cart.
4. Verify the button changes from 'Add to cart'  to 'Added to cart' with an animation.
5. If you keep adding products to cart, the animation repeats.

Before:

https://github.com/user-attachments/assets/cdc2bf89-5925-48de-86b1-5b461014d725

After:

https://github.com/user-attachments/assets/f957a082-441f-47ea-95de-7d217abf81f1