### PR TITLE
Announce Product Collection and Add to Cart + Options error notices to screen readers

### DIFF
--- a/plugins/woocommerce/changelog/fix-accessible-error-notices
+++ b/plugins/woocommerce/changelog/fix-accessible-error-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Announce Product Collection and Add to Cart + Options error notices to screen readers

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -638,7 +638,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						<path data-wp-bind--d="state.iconPath"></path>
 					</svg>
 					<div class="wc-block-components-notice-banner__content">
-						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive"></span>
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive" aria-atomic="true"></span>
 					</div>
 					<button
 						data-wp-bind--hidden="!context.notice.dismissible"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -638,7 +638,7 @@ class AddToCartWithOptions extends AbstractBlock {
 						<path data-wp-bind--d="state.iconPath"></path>
 					</svg>
 					<div class="wc-block-components-notice-banner__content">
-						<span data-wp-init="callbacks.renderNoticeContent"></span>
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive"></span>
 					</div>
 					<button
 						data-wp-bind--hidden="!context.notice.dismissible"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -205,7 +205,7 @@ class Renderer {
 						<path data-wp-bind--d="state.iconPath"></path>
 					</svg>
 					<div class="wc-block-components-notice-banner__content">
-						<span data-wp-init="callbacks.renderNoticeContent"></span>
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive"></span>
 					</div>
 					<button
 						data-wp-bind--hidden="!context.notice.dismissible"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection/Renderer.php
@@ -205,7 +205,7 @@ class Renderer {
 						<path data-wp-bind--d="state.iconPath"></path>
 					</svg>
 					<div class="wc-block-components-notice-banner__content">
-						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive"></span>
+						<span data-wp-init="callbacks.renderNoticeContent" aria-live="assertive" aria-atomic="true"></span>
 					</div>
 					<button
 						data-wp-bind--hidden="!context.notice.dismissible"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `aria-live="assertive"` to error notices in the _Product Collection_ and _Add to Cart + Options_ block. This way, when an error happens when adding to cart, it's announced to screen readers.

Part of https://github.com/woocommerce/woocommerce/issues/59438.

### How to test the changes in this Pull Request:

0. Test this PR using a screen reader.
1. In the _Shop_ page (assuming it uses the _Product Collection_ block), try to add to cart an individually-sold product twice.
2. Verify the error that appears on the screen is read by your screen reader.
3. In the _Single Product_ page of a variable product (assuming it uses the _Add to Cart + Options_ block), try to add the product to cart without selecting all the attributes.
4. Verify the error that appears on the screen is read by your screen reader.
