### PR TITLE
Announce variation data when changing attributes in the Add to Cart + Options block

### DIFF
--- a/plugins/woocommerce/changelog/fix-59444-accessible-selected-variation-data
+++ b/plugins/woocommerce/changelog/fix-59444-accessible-selected-variation-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Announce variation data when changing attributes in the Add to Cart + Options block

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -123,7 +123,7 @@ class ProductPrice extends AbstractBlock {
 						'productElementKey' => 'price_html',
 					);
 					$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
-					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue" aria-live="assertive" aria-atomic="true"';
+					$interactive_attributes                    = 'data-wp-watch="callbacks.updateValue" aria-live="polite" aria-atomic="true"';
 				}
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -79,8 +79,8 @@ class ProductPrice extends AbstractBlock {
 			$is_descendant_of_grouped_product_selector = isset( $block->context['isDescendantOfGroupedProductSelector'] );
 			$is_interactive                            = ! $is_descendant_of_product_collection && ! $is_descendant_of_grouped_product_selector && $product->is_type( 'variable' );
 
-			$wrapper_attributes = array();
-			$watch_attribute    = '';
+			$wrapper_attributes     = array();
+			$interactive_attributes = '';
 
 			if ( $is_interactive ) {
 				$variations_data           = $product->get_available_variations();
@@ -123,7 +123,7 @@ class ProductPrice extends AbstractBlock {
 						'productElementKey' => 'price_html',
 					);
 					$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
-					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue"';
+					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue" aria-live="assertive"';
 				}
 			}
 
@@ -135,7 +135,7 @@ class ProductPrice extends AbstractBlock {
 				esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 				esc_attr( $styles_and_classes['classes'] ),
 				esc_attr( $styles_and_classes['styles'] ?? '' ),
-				$watch_attribute,
+				$interactive_attributes,
 				$product->get_price_html()
 			);
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -123,7 +123,7 @@ class ProductPrice extends AbstractBlock {
 						'productElementKey' => 'price_html',
 					);
 					$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
-					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue" aria-live="assertive"';
+					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue" aria-live="assertive" aria-atomic="true"';
 				}
 			}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -151,6 +151,7 @@ class ProductStockIndicator extends AbstractBlock {
 			wp_enqueue_script_module( 'woocommerce/product-elements' );
 			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
 			$wrapper_attributes['data-wp-text']        = 'state.productData.availability';
+			$wrapper_attributes['aria-live']           = 'assertive';
 		}
 
 		$output_text = $low_stock_text ?? $availability['availability'];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -152,6 +152,7 @@ class ProductStockIndicator extends AbstractBlock {
 			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
 			$wrapper_attributes['data-wp-text']        = 'state.productData.availability';
 			$wrapper_attributes['aria-live']           = 'assertive';
+			$wrapper_attributes['aria-atomic']         = 'true';
 		}
 
 		$output_text = $low_stock_text ?? $availability['availability'];

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductStockIndicator.php
@@ -151,7 +151,7 @@ class ProductStockIndicator extends AbstractBlock {
 			wp_enqueue_script_module( 'woocommerce/product-elements' );
 			$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
 			$wrapper_attributes['data-wp-text']        = 'state.productData.availability';
-			$wrapper_attributes['aria-live']           = 'assertive';
+			$wrapper_attributes['aria-live']           = 'polite';
 			$wrapper_attributes['aria-atomic']         = 'true';
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #59444.

This PR adds `aria-live="polite"` to the _Product Price_ and _Stock Indicator_ blocks when they are interactive. This way, when they are updated (ie, when selecting a specific variation), they are announced to screen readers.

In the future, the _Variation Description_ block will also have this behavior, matching the behavior in classic themes and templates.

### How to test the changes in this Pull Request:

0. Test this PR using a screen reader.
1. Make sure you have a variable product where different variations have different prices and stock statuses.
2. In the frontend, visit the page of that product.
3. Select attributes to match some of the variations.
4. Verify the stock status and price are announced to screen readers.
