### PR TITLE
Fix WordPress footer display on WooCommerce admin pages

### DIFF
--- a/.cursor/rules/generate-pr-description.mdc
+++ b/.cursor/rules/generate-pr-description.mdc
@@ -1,8 +1,7 @@
 ---
-description: When a PR description is asked for.
-globs: 
 alwaysApply: false
 ---
+
 # Generating a Pull Request Description
 
 This rule provides guidance for generating a pull request (PR) description in this repository.
@@ -13,13 +12,40 @@ The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/P
 
 ## Best Practices
 
-- **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
-- **Changelog Section:** The changelog section in the PR description must keep the markdown structure from the PR template exactly as-is, including all checkboxes, comments, and headings. Only the appropriate checkbox may be checked, and the changelog message must be placed under the `#### Comment` heading and before the closing `</details>` tag. Do not add, remove, or reformat any part of the changelog section except for checking the box and adding the message in the correct place.
-- **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
-- **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation. Do not remove any checkbox items.
-- **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
-- **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change, following these rules strictly.
+-   **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
+-   **Changelog Section:** The changelog section in the PR description must keep the markdown structure from the PR template exactly as-is, including all checkboxes, comments, and headings. Only the appropriate checkbox may be checked, and the changelog message must be placed under the `#### Message` heading and before the closing `</details>` tag. Do not add, remove, or reformat any part of the changelog section except for checking the box and adding the message in the correct place.
+
+If the PR does not require a changelog message a comment can be left after the `#### Comment` heading and before the closing `</details>` tag.
+
+-   **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
+-   **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation. Do not remove any checkbox items.
+-   **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
+-   **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change, following these rules strictly.
 
 ## Example
 
-See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility, and that the changelog message is placed under the `#### Comment` heading as specified above.
+See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility, and that the changelog message is placed under the appropriate heading as specified above.
+
+# Generating a Pull Request Description
+
+This rule provides guidance for generating a pull request (PR) description in this repository.
+
+## Where to Find the Template
+
+The PR template is located at [`.github/PULL_REQUEST_TEMPLATE.md`](mdc:.github/PULL_REQUEST_TEMPLATE.md). Always use this template as the basis for your PR descriptions.
+
+## Best Practices
+
+-   **Preserve Markdown Structure:** Do not remove or alter required markdown sections, especially those used by automation (e.g., changelog entry details and comments).
+-   **Changelog Section:** The changelog section in the PR description must keep the markdown structure from the PR template exactly as-is, including all checkboxes, comments, and headings. Only the appropriate checkbox may be checked, and the changelog message must be placed under the `#### Message` heading and before the closing `</details>` tag. Do not add, remove, or reformat any part of the changelog section except for checking the box and adding the message in the correct place.
+
+If the PR does not require a changelog message a comment can be left after the `#### Comment` heading and before the closing `</details>` tag.
+
+-   **Be Concise and Clear:** Summarize the changes, testing steps, and rationale in a way that is easy for reviewers to understand.
+-   **Remove Irrelevant Sections:** You may erase template sections that are not applicable to your PR, except for those required by automation. Do not remove any checkbox items.
+-   **Testing Instructions:** Provide clear, step-by-step instructions for how to test the changes.
+-   **Always Output Markdown:** When the user requests a PR description, always provide the output in markdown format, using the structure and sections from the PR template. The output should be copy-paste ready for a GitHub PR and must include all required sections unless the user specifies otherwise. Do not provide plain text or summary—always provide the markdown-formatted PR template filled out with the relevant details from the change, following these rules strictly.
+
+## Example
+
+See the PR template for the required structure and sections. When generating a PR description, ensure that all required checkboxes and markdown details are preserved for automation compatibility, and that the changelog message is placed under the appropriate heading as specified above.

--- a/plugins/woocommerce/changelog/60176-fix-wooplug-5072-wpfooter-is-being-set-to-hidden-on-woo-admin-pages
+++ b/plugins/woocommerce/changelog/60176-fix-wooplug-5072-wpfooter-is-being-set-to-hidden-on-woo-admin-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WordPress footer display on WooCommerce admin pages

--- a/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
+++ b/plugins/woocommerce/client/admin/client/blueprint/settings/style.scss
@@ -1,6 +1,6 @@
 .woocommerce_page_wc-settings-advanced-blueprint {
 	.blueprint-settings-slotfill {
-		min-height: 650px;
+		min-height: 100%;
 	}
 
 	.components-snackbar .components-snackbar__content-with-icon {

--- a/plugins/woocommerce/client/admin/client/marketplace/marketplace.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/marketplace.scss
@@ -19,6 +19,13 @@
 
 	.woocommerce-layout__main {
 		padding: 0;
+		/* Maintain space at the bottom in line with the overall visual hierarchy relative to the WC footer. */
+		margin-bottom: calc($content-spacing-xlarge + 30px); // 30px is the 40px height minus the 10px top padding of the WC footer.
+
+		/* The WC footer is hidden bellow this breakpoint so we need to remove the bottom margin. */
+		@include breakpoint("<782px") {
+			margin-bottom: 0;
+		}
 	}
 
 	/* On marketplace pages, reposition store alerts so they don't collide with other components */

--- a/plugins/woocommerce/client/admin/client/marketplace/marketplace.scss
+++ b/plugins/woocommerce/client/admin/client/marketplace/marketplace.scss
@@ -5,7 +5,7 @@
 
 	#wpcontent,
 	&.woocommerce_page_wc-admin #wpbody-content {
-		overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the faetures banner 'stick
+		overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the features banner stick.
 		position: relative;
 	}
 

--- a/plugins/woocommerce/client/admin/client/settings/settings.scss
+++ b/plugins/woocommerce/client/admin/client/settings/settings.scss
@@ -7,8 +7,7 @@ body.woocommerce_page_wc-settings {
 	}
 	#wpadminbar,
 	#adminmenumain,
-	#screen-meta-links,
-	#wpfooter {
+	#screen-meta-links {
 		display: none;
 	}
 

--- a/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
@@ -53,10 +53,6 @@
 	margin-top: $header-height;
 }
 
-#wpfooter {
-	display: none;
-}
-
 .woocommerce_page_wc-admin {
 	.woocommerce-filters-date__content:not(.is-mobile) {
 		z-index: 2; /* below of woocommerce-layout__header */

--- a/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
@@ -53,6 +53,13 @@
 	margin-top: $header-height;
 }
 
+// Hide wpfooter on customize store pages.
+body.woocommerce-customize-store {
+	#wpfooter {
+		display: none;
+	}
+}
+
 .woocommerce_page_wc-admin {
 	.woocommerce-filters-date__content:not(.is-mobile) {
 		z-index: 2; /* below of woocommerce-layout__header */

--- a/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
+++ b/plugins/woocommerce/client/admin/client/stylesheets/shared/_reset.scss
@@ -54,7 +54,9 @@
 }
 
 // Hide wpfooter on customize store pages.
-body.woocommerce-customize-store {
+body.woocommerce-customize-store,
+body.woocommerce-launch-your-store,
+body.woocommerce-admin-full-screen {
 	#wpfooter {
 		display: none;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9079,3 +9079,8 @@ body.woocommerce_page_wc-settings {
 	}
 }
 
+.woocommerce-admin-page__customers {
+	#wpfooter {
+		bottom: 20px;
+	}
+}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9106,7 +9106,8 @@ body.woocommerce_page_wc-settings-advanced-blueprint {
  * Hide screen meta links on Advanced Keys settings page.
  */ 
 body.woocommerce_page_wc-settings-advanced-keys,
-body.woocommerce_page_wc-settings-advanced-webhooks {
+body.woocommerce_page_wc-settings-advanced-webhooks,
+body.woocommerce-admin-page__extensions {
 	#screen-meta-links {
 		display:none;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9074,13 +9074,40 @@ body.woocommerce_page_wc-settings {
 		}
 	}
 
+	/**
+	 * Default for footer on WooCommerce settings pages.
+	 */ 
 	#wpfooter {
 		position: relative;
 	}
 }
 
-.woocommerce-admin-page__customers {
+/**
+ * Fix for footer on various settings pages.
+ */ 
+body.woocommerce-admin-page__customers,
+body.woocommerce-settings-payments-tab,
+body.woocommerce_page_wc-settings-shipping-options,
+body.woocommerce_page_wc-settings-shipping-classes,
+body.woocommerce_page_wc-settings-integration,
+body.woocommerce_page_wc-settings-site-visibility,
+body.woocommerce_page_wc-settings-point-of-sale,
+body.woocommerce_page_wc-settings-advanced-keys,
+body.woocommerce_page_wc-settings-advanced-webhooks,
+body.woocommerce_page_wc-settings-advanced-legacy_api,
+body.woocommerce_page_wc-settings-advanced-woocommerce_com,
+body.woocommerce_page_wc-settings-advanced-blueprint {
 	#wpfooter {
-		bottom: 20px;
+		position: absolute;
+	}
+}
+
+/**
+ * Hide screen meta links on Advanced Keys settings page.
+ */ 
+body.woocommerce_page_wc-settings-advanced-keys,
+body.woocommerce_page_wc-settings-advanced-webhooks {
+	#screen-meta-links {
+		display:none;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8975,11 +8975,11 @@ body.woocommerce_page_wc-settings {
 		nav {
 			margin: 0 -30px 24px -30px;
 		}
-		padding: 0 30px;
+		padding: 0 30px 40px;
 		background: #f0f0f1;
 
 		.subsubsub {
-			margin-bottom: 24px;
+			margin-bottom: 0;
 			li {
 				color: #2271b1;
 				&:first-child a{
@@ -9072,35 +9072,6 @@ body.woocommerce_page_wc-settings {
 		.woocommerce-dismissable-list {
 			margin-bottom: 0;
 		}
-	}
-
-	/**
-	 * Default for footer on WooCommerce settings pages.
-	 */ 
-	#wpfooter {
-		position: relative;
-	}
-}
-
-/**
- * Fix for footer on various settings pages.
- */ 
-body.woocommerce-admin-page__customers,
-body.woocommerce-settings-payments-tab,
-body.woocommerce_page_wc-settings-shipping-options,
-body.woocommerce_page_wc-settings-shipping-classes,
-body.woocommerce_page_wc-settings-integration,
-body.woocommerce_page_wc-settings-site-visibility,
-body.woocommerce_page_wc-settings-point-of-sale,
-body.woocommerce_page_wc-settings-advanced-keys,
-body.woocommerce_page_wc-settings-advanced-webhooks,
-body.woocommerce_page_wc-settings-advanced-legacy_api,
-body.woocommerce_page_wc-settings-advanced-woocommerce_com,
-body.woocommerce_page_wc-settings-advanced-blueprint,
-body.woocommerce_page_wc-settings-products-download_urls,
-body.woocommerce_page_wc-settings-products-advanced {
-	#wpfooter {
-		position: absolute;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9096,7 +9096,9 @@ body.woocommerce_page_wc-settings-advanced-keys,
 body.woocommerce_page_wc-settings-advanced-webhooks,
 body.woocommerce_page_wc-settings-advanced-legacy_api,
 body.woocommerce_page_wc-settings-advanced-woocommerce_com,
-body.woocommerce_page_wc-settings-advanced-blueprint {
+body.woocommerce_page_wc-settings-advanced-blueprint,
+body.woocommerce_page_wc-settings-products-download_urls,
+body.woocommerce_page_wc-settings-products-advanced {
 	#wpfooter {
 		position: absolute;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9080,7 +9080,9 @@ body.woocommerce_page_wc-settings {
  */ 
 body.woocommerce_page_wc-settings-advanced-keys,
 body.woocommerce_page_wc-settings-advanced-webhooks,
-body.woocommerce-admin-page__extensions {
+body.woocommerce-admin-page__extensions,
+body.woocommerce-admin-launch-your-store,
+body.woocommerce-admin-full-screen {
 	#screen-meta-links {
 		display:none;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -9073,5 +9073,9 @@ body.woocommerce_page_wc-settings {
 			margin-bottom: 0;
 		}
 	}
+
+	#wpfooter {
+		position: relative;
+	}
 }
 

--- a/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
+++ b/plugins/woocommerce/client/legacy/js/admin/marketplace-suggestions.js
@@ -318,7 +318,6 @@
 			// Streamline onboarding UI if we're in 'empty state' welcome mode.
 			if ( showingEmptyStateSuggestions ) {
 				$( '#screen-meta-links' ).hide();
-				$( '#wpfooter' ).hide();
 			}
 
 			// Hide the header & footer, they don't make sense without specific promotion content

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -352,7 +352,7 @@ class WC_Admin {
 			return $footer_text;
 		}
 		$current_screen = get_current_screen();
-		$wc_pages       = wc_get_screen_ids();
+		$wc_pages       = array_merge( wc_get_screen_ids(), array( 'woocommerce_page_wc-admin' ) );
 
 		// Set only WC pages.
 		$wc_pages = array_diff( $wc_pages, array( 'profile', 'user-edit' ) );
@@ -398,7 +398,7 @@ class WC_Admin {
 			return $version;
 		}
 		$current_screen = get_current_screen();
-		$wc_pages       = wc_get_screen_ids();
+		$wc_pages       = array_merge( wc_get_screen_ids(), array( 'woocommerce_page_wc-admin' ) );
 
 		// Set only WC pages.
 		$wc_pages = array_diff( $wc_pages, array( 'profile', 'user-edit' ) );

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -42,6 +42,7 @@ class WC_Admin {
 		add_action( 'admin_init', array( $this, 'admin_redirects' ) );
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
+		add_filter( 'update_footer', array( $this, 'update_footer_version' ), 20 );
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
@@ -341,8 +342,9 @@ class WC_Admin {
 	/**
 	 * Change the admin footer text on WooCommerce admin pages.
 	 *
-	 * @since  2.3
-	 * @param  string $footer_text text to be rendered in the footer.
+	 * @since 2.3
+	 *
+	 * @param string $footer_text Footer text to be rendered.
 	 * @return string
 	 */
 	public function admin_footer_text( $footer_text ) {
@@ -355,7 +357,6 @@ class WC_Admin {
 		// Set only WC pages.
 		$wc_pages = array_diff( $wc_pages, array( 'profile', 'user-edit' ) );
 
-		// Check to make sure we're on a WooCommerce admin page.
 		/**
 		 * Filter to determine if admin footer text should be displayed.
 		 *
@@ -381,7 +382,43 @@ class WC_Admin {
 			}
 		}
 
-		return $footer_text;
+		return '<span id="footer-thankyou">' . $footer_text . '</span>';
+	}
+
+	/**
+	 * Update the footer version text.
+	 *
+	 * @since $VID:$
+	 *
+	 * @param string $version The current version string.
+	 * @return string
+	 */
+	public function update_footer_version( $version ) {
+		if ( ! function_exists( 'wc_get_screen_ids' ) ) {
+			return $version;
+		}
+		$current_screen = get_current_screen();
+		$wc_pages       = wc_get_screen_ids();
+
+		// Set only WC pages.
+		$wc_pages = array_diff( $wc_pages, array( 'profile', 'user-edit' ) );
+
+		// Check to make sure we're on a WooCommerce admin page.
+		/**
+		 * Filter to determine if update footer text should be displayed.
+		 *
+		 * @since 2.3
+		 */
+		if ( isset( $current_screen->id ) && apply_filters( 'woocommerce_display_update_footer_text', in_array( $current_screen->id, $wc_pages, true ) ) ) {
+			// Replace WordPress version with WooCommerce version.
+			$version = sprintf(
+				/* translators: %s: WooCommerce version */
+				__( 'Version %s', 'woocommerce' ),
+				esc_html( WC()->version )
+			);
+		}
+
+		return $version;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -40,6 +40,7 @@ function wc_get_screen_ids() {
 		'shop_coupon',
 		'edit-product_cat',
 		'edit-product_tag',
+		'edit-product-brand',
 		'profile',
 		'user-edit',
 	);

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -28,6 +28,7 @@ function wc_get_screen_ids() {
 		$wc_screen_id . '_page_wc-settings',
 		$wc_screen_id . '_page_wc-status',
 		$wc_screen_id . '_page_wc-addons',
+		$wc_screen_id . '_page_wc-admin',
 		'toplevel_page_wc-reports',
 		'product_page_product_attributes',
 		'product_page_product_exporter',

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Get all WooCommerce screen ids.
+ * Note, among other things, this is used to conditionally load some assets. See class-wc-admin-assets.php.
  *
  * @return array
  */
@@ -28,7 +29,6 @@ function wc_get_screen_ids() {
 		$wc_screen_id . '_page_wc-settings',
 		$wc_screen_id . '_page_wc-status',
 		$wc_screen_id . '_page_wc-addons',
-		$wc_screen_id . '_page_wc-admin',
 		'toplevel_page_wc-reports',
 		'product_page_product_attributes',
 		'product_page_product_exporter',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes the issue where the WordPress footer (`wpfooter`) was being hidden on WooCommerce admin pages, causing inconsistent styling and missing version information. The changes ensure proper footer display across all WooCommerce admin pages including settings, products, customers, and other admin interfaces.

The main changes include:
- Updated CSS to properly display the footer on WooCommerce admin and settings pages. This included some spacing fixes on various pages.
- Hide `screen-meta links` for various admin pages where they were breaking the layout.

Closes #5072.

### Screenshots or screen recordings:

Expected footer output should contain the following:

| User hasn't clicked to rate WooCommerce | User has clicked to rate WooCommerce |
| ----- | ----- |
| <img width="2510" height="1076" alt="CleanShot 2025-08-03 at 20 02 04@2x" src="https://github.com/user-attachments/assets/dfddff03-a86e-4790-b5a6-4e8bd025e67b" /> |<img width="2500" height="1176" alt="CleanShot 2025-08-03 at 20 04 08@2x" src="https://github.com/user-attachments/assets/3fa11a56-c25f-4fe2-ad5d-37d8cd108339" /> |

### How to test the changes in this Pull Request:

1. Navigate to all WooCommerce Admin and Settings pages in the WordPress admin
2. Verify the footer is visible at the bottom of the page with proper spacing.
3. The WooCommerce footer is _not_ expected to be in the product editor.
4. The WooCommerce specific text and version should **only** be on WooCommerce settings and admin pages.

Test in Firefox, Chrome (chromium), and Safari browsers.

### Testing that has already taken place:

I've tested all the testing steps above.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.
-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix WordPress footer display on WooCommerce admin pages

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

</details>
