### PR TITLE
Add support for beta prereleases in workflows

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -249,7 +249,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          IS_PRERELEASE: ${{ contains(steps.get_version.outputs.version, '-rc') }}
+          IS_PRERELEASE: ${{ contains( steps.get_version.outputs.version, '-dev' ) || contains( steps.get_version.outputs.version, '-beta' ) || contains( steps.get_version.outputs.version, '-rc' ) }}
         run: |
           FLAGS=""
           if [ "$IS_PRERELEASE" = "true" ]; then

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - stable
+          - beta
           - rc
           - dev
   workflow_call:
@@ -60,23 +61,31 @@ jobs:
             const bumpType = `${{ inputs.bump-type }}`;
             const currentVersion = '${{ steps.get-current-version.outputs.version }}';
 
-            const m = currentVersion.match( /(?<base>\d+\.\d+)\.(?<patch>\d+)(-rc\.(?<rc>\d+))?/ );
+            const m = currentVersion.match( /(?<base>\d+\.\d+)\.(?<patch>\d+)(-(?<prerelease>rc|beta|dev)(\.(?<prerelease_number>\d+))?)?/ );
             if ( ! m ) {
               core.setFailed( `Current version (${ currentVersion }) does not have the expected format.` );
               return;
             }
 
-            const baseVersion = m.groups['base'];
-            const patch       = parseInt( m.groups['patch'] );
-            const rc          = m.groups['rc'] ? parseInt( m.groups['rc'] ) : null;
+            const baseVersion      = m.groups['base'];
+            const patch            = parseInt( m.groups['patch'] );
+            const prerelease       = m.groups['prerelease'] ?? '';
+            const prereleaseNumber = m.groups['prerelease_number'] ? parseInt( m.groups['prerelease_number'] ) : 0;
 
             // Validate current version against bumpType and/or branch.
-            if ( 0 !== patch && ( 'dev' === bumpType || 'rc' === bumpType || ( 'stable' === bumpType && rc ) ) ) {
+            const invalidBump =
+                ( prerelease && 0 !== patch ) ||
+                ( ! prerelease && 'stable' !== bumpType ) ||
+                ( 'dev' === prerelease && ! [ 'dev', 'beta' ].includes( bumpType ) ) ||
+                ( 'beta' === prerelease && ! [ 'beta', 'rc' ].includes( bumpType ) ) ||
+                ( 'rc' === prerelease && ! [ 'rc', 'stable' ].includes( bumpType ) );
+
+            if ( invalidBump ) {
               core.setFailed( `Bump type (${ bumpType }) does not apply to current version (${ currentVersion }).` );
               return;
             }
 
-            if ( ( 'trunk' === branch && ( rc || 'dev' !== bumpType ) ) || ( 'trunk' !== branch && 'dev' === bumpType ) ) {
+            if ( ( 'trunk' === branch && 'dev' !== bumpType ) || ( 'trunk' !== branch && 'dev' === bumpType ) ) {
               core.setFailed( `Bump type (${ bumpType }) does not apply to source branch (${ branch }).` );
               return;
             }
@@ -89,12 +98,13 @@ jobs:
                 newVersion = `${ ( Number( baseVersion ) + 0.1 ).toFixed( 1 ) }.0-dev`;
                 break;
 
+              case 'beta':
               case 'rc':
-                newVersion = `${ baseVersion }.${ patch }-rc.${ rc + 1 }`;
+                newVersion = `${ baseVersion }.${ patch }-${ bumpType }.${ bumpType === prerelease ? prereleaseNumber + 1 : 1 }`;
                 break;
 
               case 'stable':
-                newVersion = rc ? `${ baseVersion }.0` : `${ baseVersion }.${ patch + 1 }`;
+                newVersion = prerelease ? `${ baseVersion }.0` : `${ baseVersion }.${ patch + 1 }`;
                 break;
 
               default:
@@ -103,7 +113,7 @@ jobs:
             }
 
             core.setOutput( 'nextVersion', newVersion );
-            core.setOutput( 'nextStable', newVersion.replace( /-(dev|rc\.\d+)/, '' ) );
+            core.setOutput( 'nextStable', newVersion.replace( /-(dev|(beta|rc)\.\d+)/, '' ) );
 
       - name: Bump version in files
         env:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -114,11 +114,13 @@ jobs:
 
             core.setOutput( 'nextVersion', newVersion );
             core.setOutput( 'nextStable', newVersion.replace( /-(dev|(beta|rc)\.\d+)/, '' ) );
+            core.setOutput( 'clearChangelog', '' === prerelease );
 
       - name: Bump version in files
         env:
           NEXT_VERSION: ${{ steps.compute-new-version.outputs.nextVersion }}
           NEXT_STABLE: ${{ steps.compute-new-version.outputs.nextStable }}
+          CLEAR_CHANGELOG: ${{ steps.compute-new-version.outputs.clearChangelog }}
         run: |
           cd plugins/woocommerce
 
@@ -127,6 +129,10 @@ jobs:
 
           # Update changelog in readme.txt.
           sed -i -E "s/^= [0-9]+\.[0-9]+\.[0-9]+ (.*) =/= $NEXT_STABLE \1 =/" readme.txt
+
+          if [[ "$CLEAR_CHANGELOG" == "true" ]]; then
+            perl -i -p0e 's/(== Changelog ==.*= \d+\.\d+\.\d+.*=\n)(.*)(\n\[See changelog for all versions\].*)/$1$3/igs' readme.txt
+          fi
 
           # Update composer.json and package.json.
           for filename in {composer,package}.json; do

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -5,13 +5,13 @@ on:
       version:
         type: string
         required: true
-        description: 'The release version (in X.Y or X.Y.Z-rc.N formats) to generate the release summary for.'
+        description: 'The release version (in X.Y or X.Y.Z-beta.N formats) to generate the release summary for.'
   workflow_call:
     inputs:
       version:
         type: string
         required: true
-        description: 'The release version (in X.Y or X.Y.Z-rc.N formats) to generate the release summary for.'
+        description: 'The release version (in X.Y or X.Y.Z-beta.N formats) to generate the release summary for.'
 
 jobs:
   extract-versions:
@@ -36,9 +36,9 @@ jobs:
             const currentVersion = '${{ inputs.version }}';
             console.log(`Current version from input: ${currentVersion}`);
 
-            const versionMatch = currentVersion.match(/^(\d+)\.(\d+)(?:\.\d+)?(?:-(rc)\.(\d+))?$/);
+            const versionMatch = currentVersion.match(/^(\d+)\.(\d+)(?:\.\d+)?(?:-(beta)\.(\d+))?$/);
             if (!versionMatch) {
-              core.setFailed(`Version format must be 'x.y' or 'x.y.z-rc.N'. Provided: ${currentVersion}`);
+              core.setFailed(`Version format must be 'x.y' or 'x.y.z-beta.N'. Provided: ${currentVersion}`);
               process.exit(1);
             }
 

--- a/.github/workflows/release-new-release-published.yml
+++ b/.github/workflows/release-new-release-published.yml
@@ -11,7 +11,7 @@ jobs:
   # Jobs to run after a pre-release is published (triggered by the "prereleased" GH event).
   generate-release-commits-and-contributors:
     name: 'Call release commits and contributors workflow'
-    if: ${{ github.event.action == 'prereleased' }}
+    if: ${{ ( github.event.action == 'prereleased' || ( github.event.action == 'published' && github.event.release.prerelease ) ) &&  contains( inputs.release_tag_name, '-beta' ) }}
     uses: woocommerce/woocommerce/.github/workflows/release-commits-and-contributors.yml@trunk
     with:
       version: ${{ inputs.release_tag_name }}
@@ -21,7 +21,7 @@ jobs:
   notify-release-published:
     name: 'Notify in Slack when a new (pre)release is published'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'published' }}
+    if: ${{ github.event.action == 'published' && ! ( contains( inputs.release_tag_name, '-dev' ) || contains( inputs.release_tag_name, '-rc' ) ) }}
     steps:
       - name: 'Notify to release channel'
         uses: archive/github-actions-slack@a62d71a4ea93e68cbdc37581166b0298bea512e9 # v 2.10.0
@@ -36,7 +36,7 @@ jobs:
   update-global-changelog:
     name: 'Update changelog.txt after any stable release'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    if: ${{ github.event.action == 'published' && ! contains( inputs.release_tag_name, '-rc' ) }}
+    if: ${{ github.event.action == 'published' && ! ( contains( inputs.release_tag_name, '-dev' ) || contains( inputs.release_tag_name, '-beta' ) || contains( inputs.release_tag_name, '-rc' ) ) }}
     steps:
       - name: 'Fetch release readme.txt'
         env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
The new versioning scheme, bringing back beta 1 and beta 2 and using RCs for internal deployment only means we need to make some adjustments to our workflows.

This PR introduces those changes. In particular:

- Any version with `-dev`, `-beta` or `-rc` is now considered "prerelease" by the build workflow.
- The "bump version" workflow now supports bumping `-beta.N` versions and also between `-beta` and `-rc`. Checks to prevent invalid workflows were enhanced as well.
- The "Commits and Contributors" workflow is now triggered by a beta pre-release, and not RCs. Similarly, for Slack pings to DeAd about new releases.
- The global changelog is only updated for stable releases, ignoring any `-dev`, `-beta` or `-rc` release.

Related to #60029.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the WooCommerce repository and set the release-related secrets as indicated in https://github.com/woocommerce/woocommerce/pull/60001. Ensure that `release/10.1` is also included.
2. Use the GH UI or the tool of your choice and replace `woocommerce/woocommerce` for `<yourusername>/woocommerce` in both of these files:
   https://github.com/woocommerce/woocommerce/blob/c183a34c37682b3f7ab423b8649b90d444697ea8/.github/workflows/release-release-events-proxy.yml#L11

   https://github.com/woocommerce/woocommerce/blob/e4e047fe1d9ac3c8f7856f96a6f7ae1ccde8e41b/.github/workflows/release-new-release-published.yml#L15
3. Go to **Actions > _Release: Enforce Code Freeze_** and run the workflow. Confirm that after it finishes:
   - A PR has been created bumping versions in `trunk` to `10.3.0-dev`.
   - Branch `release/10.2` and milestone `10.3.0` have been created.
   - A `10.2.0-dev` pre-release has been created and published.
   - The only Slack notification sent is about the code freeze itself.
4. Go to **Actions > _Release: Bump version number_** and test the version bump logic (always using `release/10.2` as _Release branch_):
   1. Confirm that the workflow **fails** for bump types `dev`, `stable` and `rc`.
   2. Run the workflow with bump type `beta` and confirm that it creates a PR bumping versions to `10.2.0-beta.1`. Merge this PR.
   3. Confirm that the workflow **fails** for bump types `dev` and `stable`.
   4. Run the workflow with bump type `beta` and confirm that it creates a PR bumping version sto `10.2.0-beta.2`. Merge this PR.
   5. Run the workflow again with bump type `rc` and confirm that it creates a PR bumping versions to `10.2.0-rc.1`. Merge this PR.
   6. Confirm that the workflow **fails** for bump types `dev` or `beta`.
   7. Run the workflow again with bump type `stable` and confirm that it creates a PR bumping versions to `10.2.0`. Merge this PR.
5. Go to **Actions > _Release: Build ZIP file**:
   1. Run the workflow with `release/10.1` as _Release branch_ and make sure _Create a draft GitHub release_ is checked. I suggest to _Skip verification steps_ for testing purposes. Once the workflow completes, you should have a `10.1.0-rc.2` draft release in **Code > Releases**. Confirm that this is marked as pre-release by default.
   1. Run the workflow with `release/10.2` as _Release branch_ and _Create a draft GitHub release_ is checked. Same as above, I suggest to _Skip verification steps_. Once the workflow completes, you should have a `10.2.0` draft release in **Code > Releases**. Confirm that this is **not** marked as pre-release by default.
1. Go to **Code > Releases** and create **draft** releases with the following names: `10.3.0-dev`, `10.3.0-beta.1`, `10.3.0-rc.1` and `10.3.0`. There's no need to upload a ZIP. Confirm that:
   1. Publishing `10.3.0-dev` and `10.3.0-rc.1` don't trigger any Slack notification.
   2. Publishing `10.3.0-beta.1` triggers a Slack notification and runs the _Call release commits and contributors workflow_ job as part of its associated _Release: Release events proxy workfllow_ run.
   3. PUblishing `10.3.0` triggers a Slack notifications as well, and in its _Release: Release events proxy workfllow_ run it should not run the _Call release commits and contributors workflow_ but should run the _Update changelog.txt_ job.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->