### PR TITLE
Fix encoded html entities for shipping rate names in cart and checkout blocks

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5235-double-encoded-html-entities-in-woocommerce-blocks-shipping
+++ b/plugins/woocommerce/changelog/wooplug-5235-double-encoded-html-entities-in-woocommerce-blocks-shipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Decode shipping rate names to correct display of special characters on Block Cart and Checkout

--- a/plugins/woocommerce/client/blocks/assets/js/types/type-defs/hooks.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/types/type-defs/hooks.ts
@@ -38,31 +38,31 @@ export interface StoreCartCoupon {
 }
 
 export interface StoreCart {
+	billingAddress: CartResponseBillingAddress;
+	/** @deprecated Use billingAddress instead */
+	billingData: CartResponseBillingAddress;
 	cartCoupons: CartResponseCoupons;
-	cartItems: CartResponseItem[];
-	crossSellsProducts: ProductResponseItem[];
+	cartErrors: ApiErrorResponse[];
 	cartFees: CartResponseFeeItem[];
+	cartHasCalculatedShipping: boolean;
+	cartIsLoading: boolean;
+	cartItemErrors: CartResponseErrorItem[];
+	cartItems: CartResponseItem[];
 	cartItemsCount: number;
 	cartItemsWeight: number;
 	cartNeedsPayment: boolean;
 	cartNeedsShipping: boolean;
-	cartItemErrors: CartResponseErrorItem[];
 	cartTotals: CartResponseTotals;
-	cartIsLoading: boolean;
-	cartErrors: ApiErrorResponse[];
-	/** @deprecated Use billingAddress instead */
-	billingData: CartResponseBillingAddress;
-	billingAddress: CartResponseBillingAddress;
-	shippingAddress: CartResponseShippingAddress;
-	shippingRates: CartResponseShippingRate[];
+	crossSellsProducts: ProductResponseItem[];
 	extensions: Record< string, unknown >;
+	hasPendingItemsOperations: boolean;
 	isLoadingRates: boolean;
-	cartHasCalculatedShipping: boolean;
 	paymentMethods: string[];
 	paymentRequirements: string[];
 	receiveCart: ( cart: CartResponse ) => void;
 	receiveCartContents: ( cart: CartResponse ) => void;
-	hasPendingItemsOperations: boolean;
+	shippingAddress: CartResponseShippingAddress;
+	shippingRates: CartResponseShippingRate[];
 }
 
 export type Query = {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shipping rate names from the API are encoded. Similar to how we've handled coupons and fees, rates need to be decoded. To this end, I've added a normalization function within `useStoreCart` so all consumers of that hook have decoded entities.

While in there, I standardised this approach for the other properties, and sorted the properties alphabetically for readability.

Closes #60139

(For Bug Fixes) Bug introduced in PR # .

### How to test the changes in this Pull Request:

1. Enable free shipping and re-label it as "Free Shipping - Dash". Disable other methods.
2. Enable Local Pickup and rename re-label it as "Local Pickup - Dash"
3. Add a dash to the name of some pickup locations
4. Add an item to cart and go to the cart page. Free shipping should be selected (if not, go to checkout and select it). Ensure the dash is an actual `-` and not an entity.
5. Go to checkout and see the shipping rate name in order summary. Check the dash is a `-`.
6. Select local pickup and a location. Check the dash is a `-`.
7. Place order. Check the shipping name uses a real `-` in the order confirmation.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
