### PR TITLE
Update OrderCountCache to return values for all previously saved statuses

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOSUBS-867-retrieve-previously-cached-order-counts
+++ b/plugins/woocommerce/changelog/fix-WOOSUBS-867-retrieve-previously-cached-order-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updated OrderCountCache to return values for all previously saved statuses, not just those registered.

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -230,7 +230,7 @@ class OrderCountCache {
 		$order_type = (string) $order_type;
 		$flush_saved_statuses = false;
 		if ( empty( $order_statuses ) ) {
-			$order_statuses = $this->get_saved_statuses_for_type( $order_type );
+			$order_statuses       = $this->get_saved_statuses_for_type( $order_type );
 			$flush_saved_statuses = true;
 		}
 

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -94,7 +94,14 @@ class OrderCountCache {
 		return $this->cache_prefix . '_' . $order_type . '_' . $order_status;
 	}
 
-	private function get_saved_statuses_cache_key( $order_type ) {
+	/**
+	 * Get the cache key saved statuses of the given order type.
+	 *
+	 * @param string $order_type
+	 *
+	 * @return string
+	 */
+	private function get_saved_statuses_cache_key( string $order_type ) {
 		return $this->cache_prefix . '_' . $order_type . 'statuses';
 	}
 
@@ -220,6 +227,7 @@ class OrderCountCache {
 	 * @return void
 	 */
 	public function flush( $order_type = 'shop_order', $order_statuses = array() ) {
+		$order_type = (string) $order_type;
 		$flush_saved_statuses = false;
 		if ( empty( $order_statuses ) ) {
 			$order_statuses = $this->get_saved_statuses_for_type( $order_type );

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -15,6 +15,13 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 class OrderCountCache {
 
 	/**
+	 * Cache prefix.
+	 *
+	 * @var string
+	 */
+	private $cache_prefix = 'order-count';
+
+	/**
 	 * Default value for the duration of the objects in the cache, in seconds
 	 * (may not be used depending on the cache engine used WordPress cache implementation).
 	 *
@@ -63,20 +70,12 @@ class OrderCountCache {
 		wp_cache_set( $this->get_saved_statuses_cache_key( $order_type ), $merged, '', $this->expiration );
 	}
 
-
-	/**
-	 * Cache prefix.
-	 *
-	 * @var string
-	 */
-	private $cache_prefix = 'order-count';
-
 	/**
 	 * Get the default statuses.
 	 *
 	 * @return string[]
 	 *
-	 * @deprecated 10.0.0 This method will be removed in the future.
+	 * @deprecated 10.1.0 This method will be removed in the future.
 	 */
 	public function get_default_statuses() {
 		return array_merge(

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -41,23 +41,6 @@ class OrderCountCache {
 	}
 
 	/**
-	 * Adds the given status to the cached statuses array for the order type to make sure it can be retrieved when all
-	 * statuses are requested.
-	 *
-	 * @param string $order_status The status to add.
-	 * @param string $order_type   The order type to save with.
-	 *
-	 * @return void
-	 */
-	private function ensure_status_for_type( string $order_status, string $order_type ) {
-		$statuses = $this->get_saved_statuses_for_type( $order_type );
-		if ( ! in_array( $order_status, $statuses, true ) ) {
-			$statuses[] = $order_status;
-			wp_cache_set( $this->get_saved_statuses_cache_key( $order_type ), $statuses, '', $this->expiration );
-		}
-	}
-
-	/**
 	 * Adds the given statuses to the cached statuses array for the order type if they are not already stored.
 	 *
 	 * @param string   $order_type     The order type to save with.
@@ -112,7 +95,7 @@ class OrderCountCache {
 	}
 
 	private function get_saved_statuses_cache_key( $order_type ) {
-		return $this->cache_prefix . '-statuses-' . $order_type;
+		return $this->cache_prefix . '_' . $order_type . 'statuses';
 	}
 
 	/**
@@ -136,7 +119,7 @@ class OrderCountCache {
 	 * @return bool True if the value was set, false otherwise.
 	 */
 	public function set( $order_type, $order_status, int $value ): bool {
-		$this->ensure_statuses_for_type( (string) $order_type, (string) $order_status );
+		$this->ensure_statuses_for_type( (string) $order_type, array( (string) $order_status ) );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_set( $cache_key, $value, '', $this->expiration );
 	}

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -227,7 +227,7 @@ class OrderCountCache {
 	 * @return void
 	 */
 	public function flush( $order_type = 'shop_order', $order_statuses = array() ) {
-		$order_type = (string) $order_type;
+		$order_type           = (string) $order_type;
 		$flush_saved_statuses = false;
 		if ( empty( $order_statuses ) ) {
 			$order_statuses       = $this->get_saved_statuses_for_type( $order_type );

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -97,9 +97,9 @@ class OrderCountCache {
 	/**
 	 * Get the cache key saved statuses of the given order type.
 	 *
-	 * @param string $order_type
+	 * @param string $order_type The type of order.
 	 *
-	 * @return string
+	 * @return string The cache key.
 	 */
 	private function get_saved_statuses_cache_key( string $order_type ) {
 		return $this->cache_prefix . '_' . $order_type . 'statuses';

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -102,7 +102,7 @@ class OrderCountCache {
 	 * @return string The cache key.
 	 */
 	private function get_saved_statuses_cache_key( string $order_type ) {
-		return $this->cache_prefix . '_' . $order_type . 'statuses';
+		return $this->cache_prefix . '_' . $order_type . '_statuses';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -23,23 +23,46 @@ class OrderCountCache {
 	protected $expiration = DAY_IN_SECONDS;
 
 	/**
+	 * Retrieves the list of known statuses by order type. A cached array of statuses is saved per order type for
+	 * improved backward compatibility with some of the extensions that don't register all statuses they use with
+	 * WooCommerce.
+	 *
+	 * @param string $order_type The type of order.
+	 *
+	 * @return string[]
+	 */
+	private function get_saved_statuses_for_type( string $order_type ) {
+		$statuses = wp_cache_get( $this->cache_prefix . '-statuses-' . $order_type );
+		if ( ! is_array( $statuses ) ) {
+			$statuses = $this->get_default_statuses();
+		}
+
+		return $statuses;
+	}
+
+	/**
+	 * Adds the given status to the cached statuses array for the order type to make sure it can be retrieved when all
+	 * statuses are requested.
+	 *
+	 * @param string $order_status The status to add.
+	 * @param string $order_type   The order type to save with.
+	 *
+	 * @return void
+	 */
+	private function ensure_status_for_type( string $order_status, string $order_type ) {
+		$statuses = $this->get_saved_statuses_for_type( $order_type );
+		if ( ! in_array( $order_status, $statuses ) ) {
+			$statuses[] = $order_status;
+			wp_cache_set( $this->cache_prefix . '-statuses-' . $order_type, $statuses, '', $this->expiration );
+		}
+	}
+
+	/**
 	 * Cache prefix.
 	 *
 	 * @var string
 	 */
 	private $cache_prefix = 'order-count';
-
-	/**
-	 * Get valid statuses.
-	 *
-	 * @return string[]
-	 */
-	private function get_valid_statuses() {
-		return array_merge(
-			array_keys( wc_get_order_statuses() ),
-			array_keys( get_post_stati() ),
-		);
-	}
 
 	/**
 	 * Get the default statuses.
@@ -85,12 +108,13 @@ class OrderCountCache {
 	 * @return bool True if the value was set, false otherwise.
 	 */
 	public function set( $order_type, $order_status, int $value ): bool {
+		$this->ensure_status_for_type( $order_status, $order_type );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_set( $cache_key, $value, '', $this->expiration );
 	}
 
 	/**
-	 * Get the cache value for a given order type and status.
+	 * Get the cache value for a given order type and set of statuses.
 	 *
 	 * @param string $order_type The type of order.
 	 * @param string[] $order_statuses The statuses of the order.
@@ -98,7 +122,10 @@ class OrderCountCache {
 	 */
 	public function get( $order_type, $order_statuses = array() ) {
 		if ( empty( $order_statuses ) ) {
-			$order_statuses = $this->get_default_statuses();
+			$order_statuses = $this->get_saved_statuses_for_type( $order_type );
+			if ( empty( $order_statuses ) ) {
+				return null;
+			}
 		}
 
 		$cache_keys = array_map( function( $order_statuses ) use ( $order_type ) {
@@ -109,7 +136,7 @@ class OrderCountCache {
 		$status_values = array();
 
 		foreach ( $cache_values as $key => $value ) {
-			// Return null for the entire cache if any of the requested statuses are not found.
+			// Return null for the entire cache if any of the requested statuses are not found because they fell out of cache.
 			if ( $value === false ) {
 				return null;
 			}
@@ -155,13 +182,20 @@ class OrderCountCache {
 	 * @return void
 	 */
 	public function flush( $order_type = 'shop_order', $order_statuses = array() ) {
+		$flush_saved_statuses = false;
 		if ( empty( $order_statuses ) ) {
-			$order_statuses = $this->get_default_statuses();
+			$order_statuses = $this->get_saved_statuses_for_type( $order_type );
+			$flush_saved_statuses = true;
 		}
 
 		$cache_keys = array_map( function( $order_statuses ) use ( $order_type ) {
 			return $this->get_cache_key( $order_type, $order_statuses );
 		}, $order_statuses );
+
+		if ( $flush_saved_statuses ) {
+			// If all statuses are being flushed, go ahead and flush the status list so any permanently removed statuses are cleared out.
+			$cache_keys[] = $this->cache_prefix . '-statuses-' . $order_type;
+		}
 
 		wp_cache_delete_multiple( $cache_keys );
 	}

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -32,9 +32,9 @@ class OrderCountCache {
 	 * @return string[]
 	 */
 	private function get_saved_statuses_for_type( string $order_type ) {
-		$statuses = wp_cache_get( $this->cache_prefix . '-statuses-' . $order_type );
+		$statuses = wp_cache_get( $this->get_saved_statuses_cache_key( $order_type ) );
 		if ( ! is_array( $statuses ) ) {
-			$statuses = $this->get_default_statuses();
+			$statuses = array();
 		}
 
 		return $statuses;
@@ -51,11 +51,35 @@ class OrderCountCache {
 	 */
 	private function ensure_status_for_type( string $order_status, string $order_type ) {
 		$statuses = $this->get_saved_statuses_for_type( $order_type );
-		if ( ! in_array( $order_status, $statuses ) ) {
+		if ( ! in_array( $order_status, $statuses, true ) ) {
 			$statuses[] = $order_status;
-			wp_cache_set( $this->cache_prefix . '-statuses-' . $order_type, $statuses, '', $this->expiration );
+			wp_cache_set( $this->get_saved_statuses_cache_key( $order_type ), $statuses, '', $this->expiration );
 		}
 	}
+
+	/**
+	 * Adds the given statuses to the cached statuses array for the order type if they are not already stored.
+	 *
+	 * @param string   $order_type     The order type to save with.
+	 * @param string[] $order_statuses One or more normalised statuses to add.
+	 *
+	 * @return void
+	 */
+	private function ensure_statuses_for_type( string $order_type, array $order_statuses ) {
+		if ( empty( $order_statuses ) ) {
+			return;
+		}
+
+		$existing     = $this->get_saved_statuses_for_type( $order_type );
+		$new_statuses = array_diff( $order_statuses, $existing );
+		if ( empty( $new_statuses ) ) {
+			return;
+		}
+		$merged = array_unique( array_merge( $existing, $new_statuses ) );
+
+		wp_cache_set( $this->get_saved_statuses_cache_key( $order_type ), $merged, '', $this->expiration );
+	}
+
 
 	/**
 	 * Cache prefix.
@@ -87,6 +111,10 @@ class OrderCountCache {
 		return $this->cache_prefix . '_' . $order_type . '_' . $order_status;
 	}
 
+	private function get_saved_statuses_cache_key( $order_type ) {
+		return $this->cache_prefix . '-statuses-' . $order_type;
+	}
+
 	/**
 	 * Check if the cache has a value for a given order type and status.
 	 *
@@ -103,15 +131,41 @@ class OrderCountCache {
 	 * Set the cache value for a given order type and status.
 	 *
 	 * @param string $order_type The type of order.
-	 * @param string $order_status The status of the order.
+	 * @param string $order_status The status slug of the order.
 	 * @param int $value The value to set.
 	 * @return bool True if the value was set, false otherwise.
 	 */
 	public function set( $order_type, $order_status, int $value ): bool {
-		$this->ensure_status_for_type( $order_status, $order_type );
+		$this->ensure_statuses_for_type( (string) $order_type, (string) $order_status );
 		$cache_key = $this->get_cache_key( $order_type, $order_status );
 		return wp_cache_set( $cache_key, $value, '', $this->expiration );
 	}
+
+
+	/**
+	 * Set the cache count value for multiple statuses at once.
+	 *
+	 * @param string $order_type The order type being set.
+	 * @param array  $counts     Normalized counts keyed by status slug
+	 *                           (e.g. [ 'wc-processing' => 10, 'wc-pending' => 5 ]).
+	 *
+	 * @return array|bool[]      Success map from wp_cache_set_multiple().
+	 */
+	public function set_multiple( string $order_type, array $counts ) {
+		if ( empty( $counts ) ) {
+			return array();
+		}
+
+		$this->ensure_statuses_for_type( $order_type, array_keys( $counts ) );
+
+		$mapped_counts = array();
+		foreach ( $counts as $status => $count ) {
+			$mapped_counts[ $this->get_cache_key( $order_type, $status ) ] = (int) $count;
+		}
+
+		return wp_cache_set_multiple( $mapped_counts, '', $this->expiration );
+	}
+
 
 	/**
 	 * Get the cache value for a given order type and set of statuses.
@@ -121,6 +175,7 @@ class OrderCountCache {
 	 * @return int[] The cache value.
 	 */
 	public function get( $order_type, $order_statuses = array() ) {
+		$order_type = (string) $order_type;
 		if ( empty( $order_statuses ) ) {
 			$order_statuses = $this->get_saved_statuses_for_type( $order_type );
 			if ( empty( $order_statuses ) ) {
@@ -194,7 +249,7 @@ class OrderCountCache {
 
 		if ( $flush_saved_statuses ) {
 			// If all statuses are being flushed, go ahead and flush the status list so any permanently removed statuses are cleared out.
-			$cache_keys[] = $this->cache_prefix . '-statuses-' . $order_type;
+			$cache_keys[] = $this->get_saved_statuses_cache_key( $order_type );
 		}
 
 		wp_cache_delete_multiple( $cache_keys );

--- a/plugins/woocommerce/src/Caches/OrderCountCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCountCache.php
@@ -75,6 +75,8 @@ class OrderCountCache {
 	 * Get the default statuses.
 	 *
 	 * @return string[]
+	 *
+	 * @deprecated 10.0.0 This method will be removed in the future.
 	 */
 	public function get_default_statuses() {
 		return array_merge(

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -206,6 +206,8 @@ final class OrderUtil {
 	public static function get_count_for_type( $order_type ) {
 		global $wpdb;
 
+		$order_type = (string) $order_type;
+
 		$order_count_cache = new OrderCountCache();
 		$count_per_status  = $order_count_cache->get( $order_type );
 

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -233,9 +233,7 @@ final class OrderUtil {
 				$count_per_status
 			);
 
-			foreach ( $count_per_status as $order_status => $count ) {
-				$order_count_cache->set( $order_type, $order_status, $count );
-			}
+			$order_count_cache->set_multiple( $order_type, $count_per_status );
 		}
 
 		return $count_per_status;

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -232,7 +232,7 @@ final class OrderUtil {
 
 			// Make sure all order statuses are included just in case.
 			$count_per_status = array_merge(
-				array_fill_keys( array_merge( array_keys( wc_get_order_statuses() ), [ OrderStatus::TRASH ] ), 0 ),
+				array_fill_keys( array_merge( array_keys( wc_get_order_statuses() ), array( OrderStatus::TRASH ) ), 0 ),
 				$count_per_status
 			);
 

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Utilities;
 
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Caches\OrderCountCache;
+use Automattic\WooCommerce\Enums\OrderStatus;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\Utilities\COTMigrationUtil;
@@ -231,7 +232,7 @@ final class OrderUtil {
 
 			// Make sure all order statuses are included just in case.
 			$count_per_status = array_merge(
-				array_fill_keys( $order_count_cache->get_default_statuses(), 0 ),
+				array_fill_keys( array_merge( array_keys( wc_get_order_statuses() ), [ OrderStatus::TRASH ] ), 0 ),
 				$count_per_status
 			);
 

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheServiceTest.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\Caches\OrderCountCache;
 use Automattic\WooCommerce\Caches\OrderCountCacheService;
 use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Enums\OrderStatus;
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
@@ -35,8 +35,8 @@ class OrderCountCacheTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_cache_order_counts() {
 		$counts = array(
-			OrderInternalStatus::PENDING   => 5,
-			OrderInternalStatus::COMPLETED => 10,
+			OrderInternalStatus::PENDING      => 5,
+			OrderInternalStatus::COMPLETED    => 10,
 			'third-party-unregistered-status' => 20,
 		);
 
@@ -50,7 +50,7 @@ class OrderCountCacheTest extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 5, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
 		$this->assertEquals( 10, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::COMPLETED ) )[ OrderInternalStatus::COMPLETED ] );
-		$this->assertEquals( 20, $this->order_cache->get( 'shop_order', array( 'third-party-unregistered-status' ) )[ 'third-party-unregistered-status' ] );
+		$this->assertEquals( 20, $this->order_cache->get( 'shop_order', array( 'third-party-unregistered-status' ) )['third-party-unregistered-status'] );
 
 		// verify when a specific set of statuses isn't requested.
 		$this->assertEquals( 5, $this->order_cache->get( 'shop_order' )[ OrderInternalStatus::PENDING ] );

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCountCacheTest.php
@@ -31,12 +31,13 @@ class OrderCountCacheTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that a valid status and order type can be cached.
+	 * Test that known and unknown, based on `wc_get_order_statuses()`, statuses and order type can be cached.
 	 */
 	public function test_cache_order_counts() {
 		$counts = array(
 			OrderInternalStatus::PENDING   => 5,
 			OrderInternalStatus::COMPLETED => 10,
+			'third-party-unregistered-status' => 20,
 		);
 
 		foreach ( $counts as $status => $count ) {
@@ -45,8 +46,16 @@ class OrderCountCacheTest extends \WC_Unit_Test_Case {
 
 		$this->assertTrue( $this->order_cache->is_cached( 'shop_order', OrderInternalStatus::PENDING ) );
 		$this->assertTrue( $this->order_cache->is_cached( 'shop_order', OrderInternalStatus::COMPLETED ) );
+		$this->assertTrue( $this->order_cache->is_cached( 'shop_order', 'third-party-unregistered-status' ) );
+
 		$this->assertEquals( 5, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::PENDING ) )[ OrderInternalStatus::PENDING ] );
 		$this->assertEquals( 10, $this->order_cache->get( 'shop_order', array( OrderInternalStatus::COMPLETED ) )[ OrderInternalStatus::COMPLETED ] );
+		$this->assertEquals( 20, $this->order_cache->get( 'shop_order', array( 'third-party-unregistered-status' ) )[ 'third-party-unregistered-status' ] );
+
+		// verify when a specific set of statuses isn't requested.
+		$this->assertEquals( 5, $this->order_cache->get( 'shop_order' )[ OrderInternalStatus::PENDING ] );
+		$this->assertEquals( 10, $this->order_cache->get( 'shop_order' )[ OrderInternalStatus::COMPLETED ] );
+		$this->assertEquals( 20, $this->order_cache->get( 'shop_order' )['third-party-unregistered-status'] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This updates the `OrderCountCache::get()` method so that it returns all previously stored values for a given order type.  

Previously, if $order_statuses were not passed in, the list of statuses that would be fetched from cache would be based on the default list of statuses retrieved from `wc_get_order_statuses()`.  This causes a backward compatibility issue with extensions like WooCommerce Subscriptions which doesn't register all of the statuses it uses to be returned by `wc_get_order_statuses()`.

This changes it so that the OrderCountCache will keep it's own list of saved statuses per order type allowing `OrderCountCache->get()` to return all previously saved counts for the order type.

Partial Fix for WOOSUBS-867.

This specifically fixes an issue with WooCommerce Subscriptions when running object cache.

(For Bug Fixes) Bug introduced in PR #54034.

To See Previous Bug:
1. Make sure you have at least 2 active subsccriptions.
2. Go to WP-Admin -> WooCommerce -> Subscriptions.
3. Set the screen options -> items per page to less than than the number of active subcriptions you have setup.
4. Choose to display only Active subscriptions.
5. Without this patch, the pagination for Active subscriptions will not show because the cached count is not currently being returned for that status.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have at least 2 active subsccriptions.
2. Go to WP-Admin -> WooCommerce -> Subscriptions.
3. Set the screen options -> items per page to less than than the number of active subcriptions you have setup.
4. Choose to display only Active subscriptions.
5. The pagination for Active subscriptions should correctly show as the cached count is now returned for that status.

Note - The cached count shown within pagination WooCommerce Subscriptions does not get properly updated when a subscription is transitioned from one status to another.  This is noted in https://github.com/woocommerce/woocommerce-subscriptions/pull/4973#issuecomment-3154877832.  Because Woo Subscriptions overrides the transition method of its extended order, it will need to integrate cache incrementing itself.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
