### PR TITLE
get_product_variation_image_ids: fetch image ids directly from meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ changes.json
 
 # Docusaurus
 .docusaurus
+.lnvim/

--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,3 @@ changes.json
 
 # Docusaurus
 .docusaurus
-.lnvim/

--- a/plugins/woocommerce/changelog/update-get-product-variation-image-ids
+++ b/plugins/woocommerce/changelog/update-get-product-variation-image-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+get_product_variation_image_ids: fetch image ids directly from meta

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -124,6 +124,7 @@ class ProductGalleryUtils {
 					if ( ! $variation_image_id ) {
 						$variation_image_id = $parent_image_id;
 					}
+					$variation_image_id = apply_filters( 'woocommerce_product_variation_get_image_id', $variation_image_id ); // Works, but doesn't pass the fully initialized product object as the second parameter - but is anything using this?
 					if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
 						$variation_image_ids[] = strval( $variation_image_id );
 					}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -117,7 +117,7 @@ class ProductGalleryUtils {
 
 		try {
 			if ( $product->is_type( 'variable' ) ) {
-				$variations = $product->get_children();
+				$variations      = $product->get_children();
 				$parent_image_id = $product->get_image_id();
 				foreach ( $variations as $variation_id ) {
 					$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -118,13 +118,14 @@ class ProductGalleryUtils {
 		try {
 			if ( $product->is_type( 'variable' ) ) {
 				$variations = $product->get_children();
+				$parent_image_id = $product->get_image_id();
 				foreach ( $variations as $variation_id ) {
-					$variation = wc_get_product( $variation_id );
-					if ( $variation ) {
-						$variation_image_id = $variation->get_image_id();
-						if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
-							$variation_image_ids[] = strval( $variation_image_id );
-						}
+					$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );
+					if ( ! $variation_image_id ) {
+						$variation_image_id = $parent_image_id;
+					}
+					if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
+						$variation_image_ids[] = strval( $variation_image_id );
 					}
 				}
 			}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -119,12 +119,22 @@ class ProductGalleryUtils {
 			if ( $product->is_type( 'variable' ) ) {
 				$variations      = $product->get_children();
 				$parent_image_id = $product->get_image_id();
+				$has_filter      = has_filter( 'woocommerce_product_variation_get_image_id' );
 				foreach ( $variations as $variation_id ) {
-					$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );
-					if ( ! $variation_image_id ) {
-						$variation_image_id = $parent_image_id;
+					if ( ! $has_filter ) {
+						// Quick path - skip object creation if no filter is active.
+						$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );
+						if ( ! $variation_image_id ) {
+							$variation_image_id = $parent_image_id;
+						}
+					} else {
+						$variation = wc_get_product( $variation_id );
+						if ( ! $variation ) {
+							continue;
+						}
+						$variation_image_id = $variation->get_image_id();
 					}
-					$variation_image_id = apply_filters( 'woocommerce_product_variation_get_image_id', $variation_image_id ); // Works, but doesn't pass the fully initialized product object as the second parameter - but is anything using this?
+
 					if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
 						$variation_image_ids[] = strval( $variation_image_id );
 					}

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -119,17 +119,10 @@ class ProductGalleryUtils {
 			if ( $product->is_type( 'variable' ) ) {
 				$variations      = $product->get_children();
 				$parent_image_id = $product->get_image_id();
-				$has_filter      = has_filter( 'woocommerce_product_variation_get_image_id' );
 				foreach ( $variations as $variation_id ) {
 					$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );
 					if ( ! $variation_image_id ) {
-						if ( $has_filter ) {
-							// Rare case: Instantiate only if filter hooked, to apply it.
-							$variation = wc_get_product( $variation_id );
-							$variation_image_id = $variation ? $variation->get_image_id() : $parent_image_id;
-						} else {
-							$variation_image_id = $parent_image_id;
-						}
+						$variation_image_id = $parent_image_id;
 					}
 					if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
 						$variation_image_ids[] = strval( $variation_image_id );

--- a/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/ProductGalleryUtils.php
@@ -119,10 +119,17 @@ class ProductGalleryUtils {
 			if ( $product->is_type( 'variable' ) ) {
 				$variations      = $product->get_children();
 				$parent_image_id = $product->get_image_id();
+				$has_filter      = has_filter( 'woocommerce_product_variation_get_image_id' );
 				foreach ( $variations as $variation_id ) {
 					$variation_image_id = get_post_meta( $variation_id, '_thumbnail_id', true );
 					if ( ! $variation_image_id ) {
-						$variation_image_id = $parent_image_id;
+						if ( $has_filter ) {
+							// Rare case: Instantiate only if filter hooked, to apply it.
+							$variation = wc_get_product( $variation_id );
+							$variation_image_id = $variation ? $variation->get_image_id() : $parent_image_id;
+						} else {
+							$variation_image_id = $parent_image_id;
+						}
 					}
 					if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
 						$variation_image_ids[] = strval( $variation_image_id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Refactor `get_product_variation_image_ids()` to directly query image IDs via `get_post_meta` instead of instantiating full `WC_Product_Variation` objects.

I was inspired after profiling showing this function being called multiple times per page (`/product-category/clothing-grocery-garden/`) and seeing a long loop/tail of function calls each time:
<img width="1110" height="281" alt="Screenshot 2025-08-05 at 3 49 01 PM" src="https://github.com/user-attachments/assets/e15b8126-fa2a-45e5-93b6-7eb13ed9a025" />

If we look at the bottom up view of this function, we can see a lot of time is spent in the chain of creating objects and data stores filling out information that isn't the image id:
<img width="546" height="227" alt="Screenshot 2025-08-05 at 3 50 35 PM" src="https://github.com/user-attachments/assets/b1017846-56bd-4f61-a7c4-b864e08e991c" />

Ultimately, the function is fetching one bit of meta:
```php
class WC_Product_Variation extends WC_Product_Simple {
	public function get_image_id( $context = 'view' ) {
		$image_id = $this->get_prop( 'image_id', $context );

		if ( 'view' === $context && ! $image_id ) {
			$image_id = apply_filters( $this->get_hook_prefix() . 'image_id', $this->parent_data['image_id'], $this );
		}

		return $image_id;
	}
}
```

And the data class it inherits from calls a filter when we `->get_prop( 'image_id'`

```php
abstract class WC_Data {
	protected function get_prop( $prop, $context = 'view' ) {
		$value = null;

		if ( array_key_exists( $prop, $this->data ) ) {
			$value = array_key_exists( $prop, $this->changes ) ? $this->changes[ $prop ] : $this->data[ $prop ];

			if ( 'view' === $context ) {
				$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
			}
		}

		return $value;
	}
}
```

There are two complexities:
* If there's not an image , it falls back to the parent's image
* It runs the `woocommerce_product_variation_get_image_id` filter on the ids
  * Crucially, this passes a fully filled out object (`$this`) as the second parameter
  * This means if I bypass the work of filling out the object, then I am now violating the filter contract

Therefore, we can apply this optimization, but only if there's nothing on the filter.  Note that since we're in a class that's designed as a helper for the product gallery block, we're always in "view" context.



### How to test the changes in this Pull Request:

**Goal 1: Seeing a gallery of variable products**

* Generate some global attributes and terms, then make some variable products that use these.
* You may use `wc-smooth-generator` (https://github.com/woocommerce/wc-smooth-generator)
  * (option 1) use `wp wc generate products 50 --type=variable`
  * (option 2) use [my branch](https://github.com/woocommerce/wc-smooth-generator/tree/reish20250805/generate-attributes), then `wp wc generate attributes 36 --terms=200` and `wp wc generate products 50 --type=variable --num-attributes=7 --max-terms=20 --max-variations=35 --use-existing-terms`
* You might have to make some extra variations on a product, so you can have a product with a lot of variations - maybe give some of the variations images 
* create a category and mass edit them to be in the category page
* Visit the category page on the frontend, like `/product-category/clothing-grocery-garden/`

**Goal 2: Observing the current results and timing on trunk**

Use something like:
```php
	public static function get_product_variation_image_ids( $product ) {
		$actual_link = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
		$t0 = microtime( true );

		$variation_image_ids = array();

		if ( ! $product instanceof \WC_Product ) {
			wc_doing_it_wrong( __FUNCTION__, __( 'Invalid product object.', 'woocommerce' ), '9.8.0' );
			return $variation_image_ids;
		}

		try {
			if ( $product->is_type( 'variable' ) ) {
				$variations = $product->get_children();
				foreach ( $variations as $variation_id ) {
					$variation = wc_get_product( $variation_id );
					if ( $variation ) {
						$variation_image_id = $variation->get_image_id();
						if ( ! empty( $variation_image_id ) && ! in_array( strval( $variation_image_id ), $variation_image_ids, true ) ) {
							$variation_image_ids[] = strval( $variation_image_id );
						}
					}
				}
			}
		} catch ( \Exception $e ) {
			// Log the error but continue execution.
			error_log( 'Error getting product variation image IDs: ' . $e->getMessage() );
		}

		$t1 = microtime( true );
		$execution_ms = ( $t1 - $t0 ) * 1000;
		error_log( "[$actual_link] get_product_variation_image_ids: {$execution_ms} ms | " . json_encode( $variation_image_ids ) );

		return $variation_image_ids;
	}
```

See some times over 10ms like:
```
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 29.88 ms | ["147","154","146","149","134","161","137","157","153","148","138","158","151","145","141","156","160","143","159","152","162","150","155","140"]
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 14.52 ms | ["148","153","156","154","157","151"]
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 8.16 ms | ["95","159","103","77","152","79","138","123","121","145","133"]
```

**Goal 2: Observing the propsed results and timing on this branch**

Like above. Add: 
```php
		$actual_link = "https://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
		$t0 = microtime( true );
```
To the top of the function and
```php
		$t1 = microtime( true );
		$execution_ms = ( $t1 - $t0 ) * 1000;
		$execution_ms = round( $execution_ms, 2 );
		error_log( "[$actual_link] get_product_variation_image_ids: {$execution_ms} ms | " . json_encode( $variation_image_ids ) );
```
to the bottom. You should see the same results, but faster.

For me, for example:
```
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 2.38 ms | ["147","154","146","149","134","161","137","157","153","148","138","158","151","145","141","156","160","143","159","152","162","150","155","140"]
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 0.45 ms | ["148","153","156","154","157","151"]
[https://localhost:8081/product-category/clothing-grocery-garden/] get_product_variation_image_ids: 0.55 ms | ["95","159","103","77","152","79","138","123","121","145","133"]
```

### Testing that has already taken place:



