### PR TITLE
Add Interactive Star Rating Selector to Product Review Form

### DIFF
--- a/plugins/woocommerce/changelog/60213-feat-product-form-rating-selector-iapi
+++ b/plugins/woocommerce/changelog/60213-feat-product-form-rating-selector-iapi
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Interactive Star Rating Selector to Product Review Form

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/block.json
@@ -13,6 +13,7 @@
 	},
 	"usesContext": [ "postId", "postType" ],
 	"supports": {
+		"interactivity": true,
 		"html": false,
 		"color": {
 			"gradients": true,
@@ -55,5 +56,8 @@
 		"attributes": {
 			"textAlign": "center"
 		}
-	}
+	},
+	"viewScriptModule": "woocommerce/product-review-form",
+	"style": "file:../woocommerce/product-review-form-style.css",
+	"editorStyle": "file:../woocommerce/product-review-form-editor.css"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/edit.tsx
@@ -16,7 +16,6 @@ import type { BlockEditProps } from '@wordpress/blocks';
  * Internal dependencies
  */
 import CommentsForm from './form';
-import './editor.scss';
 
 export default function PostCommentsFormEdit( {
 	attributes,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
@@ -49,7 +49,6 @@ const productReviewsFormStore = {
 			state.selectedStar = parseInt( starValue, 10 );
 		},
 		changeRatingWithKeyboard( event: KeyboardEvent ) {
-			event.preventDefault();
 			const { ref } = getElement();
 			if ( ! ref || ! ref.parentNode ) {
 				return;
@@ -57,18 +56,42 @@ const productReviewsFormStore = {
 
 			const { starValue } = getContext< StarContext >();
 			const starInt = parseInt( starValue, 10 );
+			let newRating = starInt;
+
+			let shouldPreventDefault = false;
 
 			if ( event.key === 'ArrowLeft' && starInt > 1 ) {
-				state.selectedStar = starInt - 1;
+				newRating = starInt - 1;
+				shouldPreventDefault = true;
 			} else if ( event.key === 'ArrowRight' && starInt < 5 ) {
-				state.selectedStar = starInt + 1;
+				newRating = starInt + 1;
+				shouldPreventDefault = true;
+			} else if ( event.key === 'Home' ) {
+				newRating = 1;
+				shouldPreventDefault = true;
+			} else if ( event.key === 'End' ) {
+				newRating = 5;
+				shouldPreventDefault = true;
+			} else if ( event.key === ' ' || event.key === 'Enter' ) {
+				// Activate current star.
+				event.preventDefault();
+				state.selectedStar = starInt;
+				return;
 			}
 
-			ref.parentNode
-				.querySelector< HTMLButtonElement >(
-					`button:nth-child(${ state.selectedStar })`
-				)
-				?.focus();
+			if ( shouldPreventDefault ) {
+				event.preventDefault();
+				state.selectedStar = newRating;
+
+				// Focus management - only move focus for navigation keys.
+				const nextButton =
+					ref.parentNode.querySelector< HTMLButtonElement >(
+						`button:nth-child(${ newRating })`
+					);
+				if ( nextButton ) {
+					nextButton.focus();
+				}
+			}
 		},
 		handleSubmit( event: HTMLElementEvent< HTMLFormElement > ) {
 			const formData = new FormData( event.target );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
@@ -109,6 +109,20 @@ const productReviewsFormStore = {
 			state.ratingError = '';
 		},
 	},
+	callbacks: {
+		showRatingStars() {
+			const { ref } = getElement();
+			if ( ref ) {
+				ref.hidden = false;
+			}
+		},
+		hideRatingSelector() {
+			const { ref } = getElement();
+			if ( ref ) {
+				ref.hidden = true;
+			}
+		},
+	},
 };
 
 const { state } = store< ServerState & typeof productReviewsFormStore >(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
@@ -14,7 +14,7 @@ type ServerState = {
 		hoveredStar: number;
 		selectedStar: number;
 		ratingError: string;
-		hasError: boolean;
+		hasRatingError: boolean;
 	};
 };
 
@@ -32,7 +32,7 @@ const productReviewsFormStore = {
 			const { starValue } = getContext< StarContext >();
 			return state.selectedStar >= parseInt( starValue, 10 );
 		},
-		get hasError(): boolean {
+		get hasRatingError(): boolean {
 			return state.ratingError.length > 0;
 		},
 	},
@@ -47,6 +47,7 @@ const productReviewsFormStore = {
 		selectStar() {
 			const { starValue } = getContext< StarContext >();
 			state.selectedStar = parseInt( starValue, 10 );
+			state.ratingError = '';
 		},
 		changeRatingWithKeyboard( event: KeyboardEvent ) {
 			const { ref } = getElement();
@@ -76,12 +77,14 @@ const productReviewsFormStore = {
 				// Activate current star.
 				event.preventDefault();
 				state.selectedStar = starInt;
+				state.ratingError = '';
 				return;
 			}
 
 			if ( shouldPreventDefault ) {
 				event.preventDefault();
 				state.selectedStar = newRating;
+				state.ratingError = '';
 
 				// Focus management - only move focus for navigation keys.
 				const nextButton =
@@ -94,15 +97,18 @@ const productReviewsFormStore = {
 			}
 		},
 		handleSubmit( event: HTMLElementEvent< HTMLFormElement > ) {
+			const config = getConfig( 'woocommerce/product-reviews' );
+			if ( ! config.reviewRatingEnabled ) {
+				return;
+			}
 			const formData = new FormData( event.target );
 			const rating = formData.get( 'rating' ) as string | null;
-			const config = getConfig( 'woocommerce/product-reviews' );
 			if (
-				config.review_rating_required &&
+				config.reviewRatingRequired &&
 				( ! rating || parseInt( rating, 10 ) === 0 )
 			) {
 				event.preventDefault();
-				state.ratingError = config.i18n_required_rating_text;
+				state.ratingError = config.i18nRequiredRatingText;
 				return;
 			}
 
@@ -120,6 +126,9 @@ const productReviewsFormStore = {
 			const { ref } = getElement();
 			if ( ref ) {
 				ref.hidden = true;
+				if ( 'required' in ref ) {
+					ref.required = false;
+				}
 			}
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { getConfig, getContext, store } from '@wordpress/interactivity';
+import {
+	getConfig,
+	getContext,
+	getElement,
+	store,
+} from '@wordpress/interactivity';
 import type { HTMLElementEvent } from '@woocommerce/types';
 
 type ServerState = {
@@ -42,6 +47,28 @@ const productReviewsFormStore = {
 		selectStar() {
 			const { starValue } = getContext< StarContext >();
 			state.selectedStar = parseInt( starValue, 10 );
+		},
+		changeRatingWithKeyboard( event: KeyboardEvent ) {
+			event.preventDefault();
+			const { ref } = getElement();
+			if ( ! ref || ! ref.parentNode ) {
+				return;
+			}
+
+			const { starValue } = getContext< StarContext >();
+			const starInt = parseInt( starValue, 10 );
+
+			if ( event.key === 'ArrowLeft' && starInt > 1 ) {
+				state.selectedStar = starInt - 1;
+			} else if ( event.key === 'ArrowRight' && starInt < 5 ) {
+				state.selectedStar = starInt + 1;
+			}
+
+			ref.parentNode
+				.querySelector< HTMLButtonElement >(
+					`button:nth-child(${ state.selectedStar })`
+				)
+				?.focus();
 		},
 		handleSubmit( event: HTMLElementEvent< HTMLFormElement > ) {
 			const formData = new FormData( event.target );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/frontend.ts
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { getConfig, getContext, store } from '@wordpress/interactivity';
+import type { HTMLElementEvent } from '@woocommerce/types';
+
+type ServerState = {
+	state: {
+		hoveredStar: number;
+		selectedStar: number;
+		ratingError: string;
+		hasError: boolean;
+	};
+};
+
+type StarContext = {
+	starValue: string;
+};
+
+const productReviewsFormStore = {
+	state: {
+		get isStarHovered(): boolean {
+			const { starValue } = getContext< StarContext >();
+			return state.hoveredStar >= parseInt( starValue, 10 );
+		},
+		get isStarSelected(): boolean {
+			const { starValue } = getContext< StarContext >();
+			return state.selectedStar >= parseInt( starValue, 10 );
+		},
+		get hasError(): boolean {
+			return state.ratingError.length > 0;
+		},
+	},
+	actions: {
+		hoverStar() {
+			const { starValue } = getContext< StarContext >();
+			state.hoveredStar = parseInt( starValue, 10 );
+		},
+		leaveStar() {
+			state.hoveredStar = 0;
+		},
+		selectStar() {
+			const { starValue } = getContext< StarContext >();
+			state.selectedStar = parseInt( starValue, 10 );
+		},
+		handleSubmit( event: HTMLElementEvent< HTMLFormElement > ) {
+			const formData = new FormData( event.target );
+			const rating = formData.get( 'rating' ) as string | null;
+			const config = getConfig( 'woocommerce/product-reviews' );
+			if (
+				config.review_rating_required &&
+				( ! rating || parseInt( rating, 10 ) === 0 )
+			) {
+				event.preventDefault();
+				state.ratingError = config.i18n_required_rating_text;
+				return;
+			}
+
+			state.ratingError = '';
+		},
+	},
+};
+
+const { state } = store< ServerState & typeof productReviewsFormStore >(
+	'woocommerce/product-reviews',
+	productReviewsFormStore,
+	{
+		lock: 'I acknowledge that using a private store means my plugin will inevitably break on the next store release.',
+	}
+);

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/index.tsx
@@ -9,7 +9,6 @@ import { postCommentsForm as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
-import './style.scss';
 
 // @ts-expect-error metadata is not typed.
 registerBlockType( metadata, {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
@@ -93,7 +93,7 @@
 			appearance: none;
 			border: none;
 			background: transparent;
-			padding: 0;
+			padding: 0 1px;
 			cursor: pointer;
 		}
 		.stars-wrapper:not([hidden]) {
@@ -104,7 +104,6 @@
 		.stars {
 			display: flex;
 			align-items: center;
-			gap: 2px;
 			svg {
 				display: block;
 			}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
@@ -94,6 +94,7 @@
 			border: none;
 			background: transparent;
 			padding: 0;
+			cursor: pointer;
 		}
 		.stars-wrapper {
 			display: flex;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
@@ -96,7 +96,7 @@
 			padding: 0;
 			cursor: pointer;
 		}
-		.stars-wrapper {
+		.stars-wrapper:not([hidden]) {
 			display: flex;
 			align-items: center;
 			gap: $gap;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
@@ -89,6 +89,9 @@
 	}
 
 	.comment-form-rating {
+		select {
+			margin-left: 0.5em;
+		}
 		button {
 			appearance: none;
 			border: none;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-reviews/inner-blocks/review-form/style.scss
@@ -13,6 +13,11 @@
 			0.667em + 2px
 		); // The extra 2px is added to match outline buttons.
 	}
+
+	:where(.comment-form-rating button.is-hovered path),
+	:where(.comment-form-rating button.is-selected path) {
+		fill: currentColor;
+	}
 }
 
 .wp-block-woocommerce-product-review-form {
@@ -81,5 +86,27 @@
 		font-size: var(--wp--preset--font-size--medium);
 		font-weight: 700;
 		margin-bottom: 0;
+	}
+
+	.comment-form-rating {
+		button {
+			appearance: none;
+			border: none;
+			background: transparent;
+			padding: 0;
+		}
+		.stars-wrapper {
+			display: flex;
+			align-items: center;
+			gap: $gap;
+		}
+		.stars {
+			display: flex;
+			align-items: center;
+			gap: 2px;
+			svg {
+				display: block;
+			}
+		}
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -179,9 +179,10 @@ class ProductReviewForm extends AbstractBlock {
 				type="button"
 				<?php /* translators: %d is the rating value from 1 to 5 */ ?>
 				aria-label='<?php echo esc_attr( sprintf( _n( '%d of 5 star', '%d of 5 stars', $i, 'woocommerce' ), $i ) ); ?>'
-				data-wp-on--mouseenter="actions.hoverStar"
-				data-wp-on--mouseleave="actions.leaveStar"
-				data-wp-on--click="actions.selectStar"
+				data-wp-on-async--mouseenter="actions.hoverStar"
+				data-wp-on-async--mouseleave="actions.leaveStar"
+				data-wp-on-async--click="actions.selectStar"
+				data-wp-on-async--keyup="actions.changeRatingWithKeyboard"
 				data-wp-class--is-hovered="state.isStarHovered"
 				data-wp-class--is-selected="state.isStarSelected"
 				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -32,7 +32,7 @@ class ProductReviewForm extends AbstractBlock {
 		}
 
 		if ( post_password_required( $block->context['postId'] ) ) {
-			return;
+			return '';
 		}
 
 		$product = wc_get_product( $block->context['postId'] );
@@ -182,7 +182,7 @@ class ProductReviewForm extends AbstractBlock {
 				data-wp-on-async--mouseenter="actions.hoverStar"
 				data-wp-on-async--mouseleave="actions.leaveStar"
 				data-wp-on-async--click="actions.selectStar"
-				data-wp-on-async--keyup="actions.changeRatingWithKeyboard"
+				data-wp-on-async--keydown="actions.changeRatingWithKeyboard"
 				data-wp-class--is-hovered="state.isStarHovered"
 				data-wp-class--is-selected="state.isStarSelected"
 				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -50,7 +50,7 @@ class ProductReviewForm extends AbstractBlock {
 			'reviewRatingEnabled' => wc_review_ratings_enabled(),
 		];
 
-		$classes = array( 'comment-respond' );
+		$classes = [ 'comment-respond' ];
 		if ( isset( $attributes['textAlign'] ) ) {
 			$classes[] = 'has-text-align-' . $attributes['textAlign'];
 		}
@@ -58,13 +58,13 @@ class ProductReviewForm extends AbstractBlock {
 			$classes[] = 'has-link-color';
 		}
 		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
+			[
 				'class' => implode( ' ', $classes ),
-			)
+			]
 		);
 
 		$commenter    = wp_get_current_commenter();
-		$comment_form = array(
+		$comment_form = [
 			/* translators: %s is product title */
 			'title_reply'         => have_comments() ? esc_html__( 'Add a review', 'woocommerce' ) : sprintf( esc_html__( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), get_the_title() ),
 			/* translators: %s is product title */
@@ -75,27 +75,27 @@ class ProductReviewForm extends AbstractBlock {
 			'label_submit'        => esc_html__( 'Submit', 'woocommerce' ),
 			'logged_in_as'        => '',
 			'comment_field'       => '',
-		);
+		];
 
 		$name_email_required = (bool) get_option( 'require_name_email', 1 );
-		$fields              = array(
-			'author' => array(
+		$fields              = [
+			'author' => [
 				'label'        => __( 'Name', 'woocommerce' ),
 				'type'         => 'text',
 				'value'        => $commenter['comment_author'],
 				'required'     => $name_email_required,
 				'autocomplete' => 'name',
-			),
-			'email'  => array(
+			],
+			'email'  => [
 				'label'        => __( 'Email', 'woocommerce' ),
 				'type'         => 'email',
 				'value'        => $commenter['comment_author_email'],
 				'required'     => $name_email_required,
 				'autocomplete' => 'email',
-			),
-		);
+			],
+		];
 
-		$comment_form['fields'] = array();
+		$comment_form['fields'] = [];
 
 		foreach ( $fields as $key => $field ) {
 			$field_html  = '<p class="comment-form-' . esc_attr( $key ) . '">';
@@ -196,7 +196,7 @@ class ProductReviewForm extends AbstractBlock {
 				data-wp-class--is-hovered="state.isStarHovered"
 				data-wp-class--is-selected="state.isStarSelected"
 				data-wp-bind--aria-checked="state.isStarSelected"
-				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo wp_interactivity_data_wp_context( [ 'starValue' => $i ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			>
 				<svg
 					width='24'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -129,10 +129,17 @@ class ProductReviewForm extends AbstractBlock {
 		}
 
 		if ( wc_review_ratings_enabled() ) {
-			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-input" id="comment-form-rating-label">' .
+			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-selector" id="comment-form-rating-label">' .
 				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
-				'</label><input type="hidden" name="rating" id="rating-input" data-wp-bind--value="state.selectedStar">' .
-				'<p role="radiogroup" aria-labelledby="comment-form-rating-label" class="stars-wrapper" data-wp-bind--aria-invalid="state.hasError"' . ( wc_review_ratings_required() ? ' aria-required="true"' : '' ) . ' aria-describedby="rating-error">' . $this->render_stars() .
+				'</label><select name="rating" id="rating-selector" data-wp-init="callbacks.hideRatingSelector" data-wp-bind--value="state.selectedStar" ' . ( wc_review_ratings_required() ? ' required' : '' ) . '>
+				<option value="">' . esc_html__( 'Rate&hellip;', 'woocommerce' ) . '</option>
+				<option value="5">' . esc_html__( 'Perfect', 'woocommerce' ) . '</option>
+				<option value="4">' . esc_html__( 'Good', 'woocommerce' ) . '</option>
+				<option value="3">' . esc_html__( 'Average', 'woocommerce' ) . '</option>
+				<option value="2">' . esc_html__( 'Not that bad', 'woocommerce' ) . '</option>
+				<option value="1">' . esc_html__( 'Very poor', 'woocommerce' ) . '</option>
+			</select>' .
+				'<p role="radiogroup" aria-labelledby="comment-form-rating-label" class="stars-wrapper" data-wp-init="callbacks.showRatingStars" hidden data-wp-bind--aria-invalid="state.hasError"' . ( wc_review_ratings_required() ? ' aria-required="true"' : '' ) . ' aria-describedby="rating-error">' . $this->render_stars() .
 				( wc_review_ratings_required() ? '<small id="rating-error" data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError" role="alert"></small>' : '' ) .
 				'</p></div>';
 		}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -184,7 +184,7 @@ class ProductReviewForm extends AbstractBlock {
 				data-wp-on--click="actions.selectStar"
 				data-wp-class--is-hovered="state.isStarHovered"
 				data-wp-class--is-selected="state.isStarSelected"
-				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); ?>
+				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			>
 				<svg
 					width='24'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -2,28 +2,21 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\Reviews;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+use Automattic\WooCommerce\Blocks\BlockTypes\EnableBlockJsonAssetsTrait;
 
 /**
  * ProductReviewForm class.
  */
 class ProductReviewForm extends AbstractBlock {
+
+	use EnableBlockJsonAssetsTrait;
+
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'product-review-form';
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @see $this->register_block_type()
-	 * @param string $key Data to get, or default to everything.
-	 * @return array|string|null
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
 
 	/**
 	 * Render the block.
@@ -52,6 +45,23 @@ class ProductReviewForm extends AbstractBlock {
 			return '<p class="woocommerce-verification-required">' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
 		}
 
+		wp_interactivity_state(
+			'woocommerce/product-reviews',
+			array(
+				'selectedStar' => '0',
+				'hoveredStar'  => '0',
+				'ratingError'  => '',
+				'hasError'     => false,
+			)
+		);
+		wp_interactivity_config(
+			'woocommerce/product-reviews',
+			array(
+				'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
+				'review_rating_required'    => wc_review_ratings_required(),
+			)
+		);
+
 		$classes = array( 'comment-respond' );
 		if ( isset( $attributes['textAlign'] ) ) {
 			$classes[] = 'has-text-align-' . $attributes['textAlign'];
@@ -59,7 +69,11 @@ class ProductReviewForm extends AbstractBlock {
 		if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 			$classes[] = 'has-link-color';
 		}
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class' => implode( ' ', $classes ),
+			)
+		);
 
 		$commenter    = wp_get_current_commenter();
 		$comment_form = array(
@@ -76,81 +90,113 @@ class ProductReviewForm extends AbstractBlock {
 		);
 
 		$name_email_required = (bool) get_option( 'require_name_email', 1 );
-				$fields      = array(
-					'author' => array(
-						'label'        => __( 'Name', 'woocommerce' ),
-						'type'         => 'text',
-						'value'        => $commenter['comment_author'],
-						'required'     => $name_email_required,
-						'autocomplete' => 'name',
-					),
-					'email'  => array(
-						'label'        => __( 'Email', 'woocommerce' ),
-						'type'         => 'email',
-						'value'        => $commenter['comment_author_email'],
-						'required'     => $name_email_required,
-						'autocomplete' => 'email',
-					),
-				);
+		$fields              = array(
+			'author' => array(
+				'label'        => __( 'Name', 'woocommerce' ),
+				'type'         => 'text',
+				'value'        => $commenter['comment_author'],
+				'required'     => $name_email_required,
+				'autocomplete' => 'name',
+			),
+			'email'  => array(
+				'label'        => __( 'Email', 'woocommerce' ),
+				'type'         => 'email',
+				'value'        => $commenter['comment_author_email'],
+				'required'     => $name_email_required,
+				'autocomplete' => 'email',
+			),
+		);
 
-				$comment_form['fields'] = array();
+		$comment_form['fields'] = array();
 
-				foreach ( $fields as $key => $field ) {
-					$field_html  = '<p class="comment-form-' . esc_attr( $key ) . '">';
-					$field_html .= '<label for="' . esc_attr( $key ) . '">' . esc_html( $field['label'] );
+		foreach ( $fields as $key => $field ) {
+			$field_html  = '<p class="comment-form-' . esc_attr( $key ) . '">';
+			$field_html .= '<label for="' . esc_attr( $key ) . '">' . esc_html( $field['label'] );
 
-					if ( $field['required'] ) {
-						$field_html .= '&nbsp;<span class="required">*</span>';
-					}
+			if ( $field['required'] ) {
+				$field_html .= '&nbsp;<span class="required">*</span>';
+			}
 
-					$field_html .= '</label><input id="' . esc_attr( $key ) . '" name="' . esc_attr( $key ) . '" type="' . esc_attr( $field['type'] ) . '" autocomplete="' . esc_attr( $field['autocomplete'] ) . '" value="' . esc_attr( $field['value'] ) . '" size="30" ' . ( $field['required'] ? 'required' : '' ) . ' /></p>';
+			$field_html .= '</label><input id="' . esc_attr( $key ) . '" name="' . esc_attr( $key ) . '" type="' . esc_attr( $field['type'] ) . '" autocomplete="' . esc_attr( $field['autocomplete'] ) . '" value="' . esc_attr( $field['value'] ) . '" size="30" ' . ( $field['required'] ? 'required' : '' ) . ' /></p>';
 
-					$comment_form['fields'][ $key ] = $field_html;
-				}
+			$comment_form['fields'][ $key ] = $field_html;
+		}
 
-				$account_page_url = wc_get_page_permalink( 'myaccount' );
-				if ( $account_page_url ) {
-					/* translators: %s opening and closing link tags respectively */
-					$comment_form['must_log_in'] = '<p class="must-log-in">' . sprintf( esc_html__( 'You must be %1$slogged in%2$s to post a review.', 'woocommerce' ), '<a href="' . esc_url( $account_page_url ) . '">', '</a>' ) . '</p>';
-				}
+		$account_page_url = wc_get_page_permalink( 'myaccount' );
+		if ( $account_page_url ) {
+			/* translators: %s opening and closing link tags respectively */
+			$comment_form['must_log_in'] = '<p class="must-log-in">' . sprintf( esc_html__( 'You must be %1$slogged in%2$s to post a review.', 'woocommerce' ), '<a href="' . esc_url( $account_page_url ) . '">', '</a>' ) . '</p>';
+		}
 
-				if ( wc_review_ratings_enabled() ) {
-					$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating" id="comment-form-rating-label">' .
-						esc_html__( 'Your rating', 'woocommerce' ) .
-						( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
-					'</label><select name="rating" id="rating" required>
-					<option value="">' . esc_html__( 'Rate&hellip;', 'woocommerce' ) . '</option>
-					<option value="5">' . esc_html__( 'Perfect', 'woocommerce' ) . '</option>
-					<option value="4">' . esc_html__( 'Good', 'woocommerce' ) . '</option>
-					<option value="3">' . esc_html__( 'Average', 'woocommerce' ) . '</option>
-					<option value="2">' . esc_html__( 'Not that bad', 'woocommerce' ) . '</option>
-					<option value="1">' . esc_html__( 'Very poor', 'woocommerce' ) . '</option>
-				</select></div>';
-				}
+		if ( wc_review_ratings_enabled() ) {
+			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-input" id="comment-form-rating-label">' .
+				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
+				'</label><input type="hidden" name="rating" id="rating-input" data-wp-bind--value="state.selectedStar">' .
+				'<p role="group" aria-labelledby="comment-form-rating-label" class="stars-wrapper">' . $this->render_stars() .
+				( wc_review_ratings_required() ? '<small data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError"></small>' : '' ) .
+				'</p></div>';
+		}
 
-				$comment_form['comment_field'] .= '<p class="comment-form-comment"><label for="comment">' . esc_html__( 'Your review', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label><textarea id="comment" name="comment" cols="45" rows="8" required></textarea></p>';
+		$comment_form['comment_field'] .= '<p class="comment-form-comment"><label for="comment">' . esc_html__( 'Your review', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label><textarea id="comment" name="comment" cols="45" rows="8" required></textarea></p>';
 
-				add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
+		add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
 
-				ob_start();
-				echo '<div id="review_form_wrapper"><div id="review_form">';
-				/**
-				 * Filters the comment form arguments.
-				 *
-				 * @since 9.9.0
-				 * @param array $comment_form The comment form arguments.
-				 * @param int   $post_id      The post ID.
-				 */
-				comment_form( apply_filters( 'woocommerce_product_review_comment_form_args', $comment_form ), $block->context['postId'] );
-				echo '</div></div>';
-				$form = ob_get_clean();
+		ob_start();
+		echo '<div id="review_form_wrapper" data-wp-interactive="woocommerce/product-reviews"><div id="review_form">';
+		/**
+			* Filters the comment form arguments.
+			*
+			* @since 9.9.0
+			* @param array $comment_form The comment form arguments.
+			* @param int   $post_id      The post ID.
+			*/
+		comment_form( apply_filters( 'woocommerce_product_review_comment_form_args', $comment_form ), $block->context['postId'] );
+		echo '</div></div>';
+		$form = ob_get_clean();
 
-				remove_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
+		remove_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );
 
-				$form = str_replace( 'class="comment-respond"', $wrapper_attributes, $form );
+		$form = str_replace( 'class="comment-respond"', $wrapper_attributes, $form );
 
-				wp_enqueue_script( 'comment-reply' );
+		$p = new \WP_HTML_Tag_Processor( $form );
 
-				return $form;
+		if ( $p->next_tag( 'form' ) ) {
+			$p->set_attribute( 'data-wp-on--submit', 'actions.handleSubmit' );
+		}
+
+		return $p->get_updated_html();
+	}
+
+	/**
+	 * Render stars for rating selector.
+	 */
+	private function render_stars() {
+		ob_start();
+		echo '<span class="stars">';
+		for ( $i = 1; $i < 6; $i++ ) {
+			?>
+			<button
+				type="button"
+				<?php /* translators: %d is the rating value from 1 to 5 */ ?>
+				aria-label='<?php echo esc_attr( sprintf( _n( '%d of 5 star', '%d of 5 stars', $i, 'woocommerce' ), $i ) ); ?>'
+				data-wp-on--mouseenter="actions.hoverStar"
+				data-wp-on--mouseleave="actions.leaveStar"
+				data-wp-on--click="actions.selectStar"
+				data-wp-class--is-hovered="state.isStarHovered"
+				data-wp-class--is-selected="state.isStarSelected"
+				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); ?>
+			>
+				<svg
+					width='24'
+					height='24'
+					viewBox='0 0 24 24'
+				>
+					<path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="none" stroke="currentColor" stroke-width="1.5"/>
+				</svg>
+			</button>
+			<?php
+		}
+		echo '</span>';
+		return ob_get_clean();
 	}
 }

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -133,7 +133,7 @@ class ProductReviewForm extends AbstractBlock {
 				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
 				'</label><input type="hidden" name="rating" id="rating-input" data-wp-bind--value="state.selectedStar">' .
 				'<p role="group" aria-labelledby="comment-form-rating-label" class="stars-wrapper">' . $this->render_stars() .
-				( wc_review_ratings_required() ? '<small data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError"></small>' : '' ) .
+				( wc_review_ratings_required() ? '<small data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError" aria-live="polite"></small>' : '' ) .
 				'</p></div>';
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -45,22 +45,10 @@ class ProductReviewForm extends AbstractBlock {
 			return '<p class="woocommerce-verification-required">' . esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) . '</p>';
 		}
 
-		wp_interactivity_state(
-			'woocommerce/product-reviews',
-			array(
-				'selectedStar' => '0',
-				'hoveredStar'  => '0',
-				'ratingError'  => '',
-				'hasError'     => false,
-			)
-		);
-		wp_interactivity_config(
-			'woocommerce/product-reviews',
-			array(
-				'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
-				'review_rating_required'    => wc_review_ratings_required(),
-			)
-		);
+		$interactivy_state  = [];
+		$interactivy_config = [
+			'reviewRatingEnabled' => wc_review_ratings_enabled(),
+		];
 
 		$classes = array( 'comment-respond' );
 		if ( isset( $attributes['textAlign'] ) ) {
@@ -129,6 +117,13 @@ class ProductReviewForm extends AbstractBlock {
 		}
 
 		if ( wc_review_ratings_enabled() ) {
+			$interactivy_state['selectedStar']            = '';
+			$interactivy_state['hoveredStar']             = '0';
+			$interactivy_state['ratingError']             = '';
+			$interactivy_state['hasRatingError']          = false;
+			$interactivy_config['i18nRequiredRatingText'] = esc_attr__( 'Please select a rating', 'woocommerce' );
+			$interactivy_config['reviewRatingRequired']   = wc_review_ratings_required();
+
 			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-selector" id="comment-form-rating-label">' .
 				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
 				'</label><select name="rating" id="rating-selector" data-wp-init="callbacks.hideRatingSelector" data-wp-bind--value="state.selectedStar" ' . ( wc_review_ratings_required() ? ' required' : '' ) . '>
@@ -139,8 +134,8 @@ class ProductReviewForm extends AbstractBlock {
 				<option value="2">' . esc_html__( 'Not that bad', 'woocommerce' ) . '</option>
 				<option value="1">' . esc_html__( 'Very poor', 'woocommerce' ) . '</option>
 			</select>' .
-				'<p role="radiogroup" aria-labelledby="comment-form-rating-label" class="stars-wrapper" data-wp-init="callbacks.showRatingStars" hidden data-wp-bind--aria-invalid="state.hasError"' . ( wc_review_ratings_required() ? ' aria-required="true"' : '' ) . ' aria-describedby="rating-error">' . $this->render_stars() .
-				( wc_review_ratings_required() ? '<small id="rating-error" data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError" role="alert"></small>' : '' ) .
+				'<p role="radiogroup" aria-labelledby="comment-form-rating-label" class="stars-wrapper" data-wp-init="callbacks.showRatingStars" hidden data-wp-bind--aria-invalid="state.hasRatingError"' . ( wc_review_ratings_required() ? ' aria-required="true"' : '' ) . ' aria-describedby="rating-error">' . $this->render_stars() .
+				( wc_review_ratings_required() ? '<small id="rating-error" data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasRatingError" role="alert"></small>' : '' ) .
 				'</p></div>';
 		}
 
@@ -169,6 +164,13 @@ class ProductReviewForm extends AbstractBlock {
 
 		if ( $p->next_tag( 'form' ) ) {
 			$p->set_attribute( 'data-wp-on--submit', 'actions.handleSubmit' );
+		}
+
+		if ( ! empty( $interactivy_state ) ) {
+			wp_interactivity_state( 'woocommerce/product-reviews', $interactivy_state );
+		}
+		if ( ! empty( $interactivy_config ) ) {
+			wp_interactivity_config( 'woocommerce/product-reviews', $interactivy_config );
 		}
 
 		return $p->get_updated_html();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/Reviews/ProductReviewForm.php
@@ -132,8 +132,8 @@ class ProductReviewForm extends AbstractBlock {
 			$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating-input" id="comment-form-rating-label">' .
 				esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) .
 				'</label><input type="hidden" name="rating" id="rating-input" data-wp-bind--value="state.selectedStar">' .
-				'<p role="group" aria-labelledby="comment-form-rating-label" class="stars-wrapper">' . $this->render_stars() .
-				( wc_review_ratings_required() ? '<small data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError" aria-live="polite"></small>' : '' ) .
+				'<p role="radiogroup" aria-labelledby="comment-form-rating-label" class="stars-wrapper" data-wp-bind--aria-invalid="state.hasError"' . ( wc_review_ratings_required() ? ' aria-required="true"' : '' ) . ' aria-describedby="rating-error">' . $this->render_stars() .
+				( wc_review_ratings_required() ? '<small id="rating-error" data-wp-text="state.ratingError" class="rating-error" data-wp-bind--hidden="!state.hasError" role="alert"></small>' : '' ) .
 				'</p></div>';
 		}
 
@@ -176,6 +176,7 @@ class ProductReviewForm extends AbstractBlock {
 		for ( $i = 1; $i < 6; $i++ ) {
 			?>
 			<button
+				role="radio"
 				type="button"
 				<?php /* translators: %d is the rating value from 1 to 5 */ ?>
 				aria-label='<?php echo esc_attr( sprintf( _n( '%d of 5 star', '%d of 5 stars', $i, 'woocommerce' ), $i ) ); ?>'
@@ -185,12 +186,15 @@ class ProductReviewForm extends AbstractBlock {
 				data-wp-on-async--keydown="actions.changeRatingWithKeyboard"
 				data-wp-class--is-hovered="state.isStarHovered"
 				data-wp-class--is-selected="state.isStarSelected"
+				data-wp-bind--aria-checked="state.isStarSelected"
 				<?php echo wp_interactivity_data_wp_context( array( 'starValue' => $i ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			>
 				<svg
 					width='24'
 					height='24'
 					viewBox='0 0 24 24'
+					aria-hidden="true"
+					focusable="false"
 				>
 					<path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="none" stroke="currentColor" stroke-width="1.5"/>
 				</svg>


### PR DESCRIPTION
### Submission Review Guidelines

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request

In an effort to reduce legacy scripts for block themes, this PR implements a rating selector powered by the Interactivity API. This removes the need for the legacy `single-product.js` file that transforms the dropdown selector into star ratings.

### Screenshots or screen recordings

| Before | After |
| ------ | ----- |
|    <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/bfc47b59-c0b5-4534-80f4-20eaa2d6247e" />    |    <img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/03359c74-b42b-4a5a-8ade-78ffc74a41dc" />   |

### How to test the changes in this Pull Request

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the Product Details block to the Single Product template.
2. On the frontend, hover over the star selector in the form and verify that stars fill from left to right. Move the cursor away from the selector and verify all stars become unfilled.
3. Select a rating star and verify that stars fill from left to right and remain filled when the cursor moves away from the selector.
4. Type a review and submit to verify the review is recorded with the correct rating.
5. Try submitting a review without selecting a rating and verify that an error message appears next to the stars. The message currently lacks style, I just wrap it inside a `<small>` tag.
6. Test keyboard navigation by using Tab to focus on stars and Space to select ratings.
7. Make the Review accordion open by default. Disable JS on the frontend. Reload the product detail page.
8. See the rating select box. See you can submit a review with rating without JS.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add Interactive Star Rating Selector to Product Review Form

</details>