### PR TITLE
Fix an issue when a product is not an object

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-not-an-object
+++ b/plugins/woocommerce/changelog/fix-product-not-an-object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue when a product is not an object in html order item

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -104,7 +104,7 @@ $item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $i
 			?>
 		</div>
 		<?php
-			$step = $product->get_purchase_quantity_step();
+			$step = $product && $product->get_purchase_quantity_step();
 
 			/**
 			* Filter to change the product quantity stepping in the order editor of the admin area.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -104,7 +104,7 @@ $item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $i
 			?>
 		</div>
 		<?php
-			$step = $product && $product->get_purchase_quantity_step();
+			$step = $product ? $product->get_purchase_quantity_step() : 1;
 
 			/**
 			* Filter to change the product quantity stepping in the order editor of the admin area.


### PR DESCRIPTION
Our bots reported:

```
Uncaught exception 'Error' with message 'Call to a member function get_purchase_quantity_step() on false' in /var/www/wp-content/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php:107
```

### Changes proposed in this Pull Request:

Use `$product` when it really exists, as done in other places in the same file.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
