### PR TITLE
Skip` test_json_search_customers` for now

### DIFF
--- a/plugins/woocommerce/changelog/skip-test_json_search_customers
+++ b/plugins/woocommerce/changelog/skip-test_json_search_customers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skip skip/test_json_search_customers test for now

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -203,6 +203,8 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 	 * @throws Automattic\WooCommerce\Internal\DependencyManagement\ContainerException If the LegacyProxy cannot be retrieved.
 	 */
 	public function test_json_search_customers(): void {
+		$this->markTestSkipped( 'Skipping this test temporarily due to intermittent failures. Needs proper investigation.' );
+
 		// This class does not inherit from WC_Unit_Test_Case, so we're handling the legacy proxy mechanics ourselves.
 		$legacy_proxy = wc_get_container()->get( LegacyProxy::class );
 		$legacy_proxy->reset();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`test_json_search_customers` keeps failing intermittently, skipping it for now, to have a proper investigation later.

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment Doesn't need changelog.
</details>
