### PR TITLE
Remove duplicate quantity filters applied on get_min_purchase_quantity and get_max_purchase_quantity

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-duplicate-quantity-filters
+++ b/plugins/woocommerce/changelog/fix-remove-duplicate-quantity-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove duplicate quantity filters applied on get_min_purchase_quantity and get_max_purchase_quantity

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -178,14 +178,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				$template_part_contents = file_get_contents( $template_part_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
 
-			/**
-			 * Filter the default quantity to add to cart.
-			 *
-			 * @since 10.0.0
-			 * @param number $default_quantity The default quantity.
-			 * @param \WC_Product $product The product object.
-			 */
-			$default_quantity = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+			$default_quantity = $product->get_min_purchase_quantity();
 
 			wp_interactivity_state(
 				'woocommerce/add-to-cart-with-options',
@@ -230,14 +223,7 @@ class AddToCartWithOptions extends AbstractBlock {
 				$context['selectedAttributes'] = array();
 				$available_variations          = $product->get_available_variations( 'objects' );
 				foreach ( $available_variations as $variation ) {
-					/**
-					 * Filter the default quantity to add to cart.
-					 *
-					 * @since 10.1.0
-					 * @param number $default_variation_quantity The default quantity.
-					 * @param WC_Variation_Product $variation The variation object.
-					 */
-					$default_variation_quantity                  = apply_filters( 'woocommerce_quantity_input_min', $variation->get_min_purchase_quantity(), $variation );
+					$default_variation_quantity                  = $variation->get_min_purchase_quantity();
 					$context['quantity'][ $variation->get_id() ] = $default_variation_quantity;
 					$context['availableVariations'][]            = array(
 						'variation_id' => $variation->get_id(),

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -42,14 +42,8 @@ class GroupedProductItemSelector extends AbstractBlock {
 	private function get_quantity_selector_markup( $product ) {
 		ob_start();
 
-		/**
-		 * Filter the minimum quantity value allowed for the product.
-		 *
-		 * @since 10.1.0
-		 * @param int        $min_value Minimum quantity value.
-		 * @param WC_Product $product   Product object.
-		 */
-		$min_value = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
+		$min_value = $product->get_min_purchase_quantity();
+		$max_value = $product->get_max_purchase_quantity();
 
 		// By default, products have a min value of 1. In that case, we can
 		// safely override it to 0 when they are a child of a grouped product.
@@ -59,15 +53,6 @@ class GroupedProductItemSelector extends AbstractBlock {
 		if ( 1 === $min_value ) {
 			$min_value = 0;
 		}
-
-		/**
-		 * Filter the maximum quantity value allowed for the product.
-		 *
-		 * @since 10.1.0
-		 * @param int        $max_value Maximum quantity value.
-		 * @param WC_Product $product   Product object.
-		 */
-		$max_value = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
 
 		if ( $min_value === $max_value && $min_value > 0 ) {
 			add_filter( 'woocommerce_quantity_input_type', array( $this, 'set_quantity_input_type' ) );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/QuantitySelector.php
@@ -76,22 +76,8 @@ class QuantitySelector extends AbstractBlock {
 
 		woocommerce_quantity_input(
 			array(
-				/**
-				 * Filter the minimum quantity value allowed for the product.
-				 *
-				 * @since 2.0.0
-				 * @param int        $min_value Minimum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-				/**
-				 * Filter the maximum quantity value allowed for the product.
-				 *
-				 * @since 2.0.0
-				 * @param int        $max_value Maximum quantity value.
-				 * @param WC_Product $product   Product object.
-				 */
-				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'min_value'   => $product->get_min_purchase_quantity(),
+				'max_value'   => $product->get_max_purchase_quantity(),
 				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			)
 		);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -160,24 +160,8 @@ class Utils {
 	 * @return bool True if min and max purchase quantity are the same, false otherwise.
 	 */
 	public static function is_min_max_quantity_same( $product ) {
-		/**
-		 * Filter the minimum quantity value allowed for the product.
-		 *
-		 * @since 2.0.0
-		 *
-		 * @param int        $min_purchase_quantity The minimum purchase quantity.
-		 * @param WC_Product $product               The product object.
-		 */
-		$min_purchase_quantity = apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product );
-		/**
-		 * Filter the maximum quantity value allowed for the product.
-		 *
-		 * @since 2.0.0
-		 *
-		 * @param int        $max_purchase_quantity The maximum purchase quantity.
-		 * @param WC_Product $product               The product object.
-		 */
-		$max_purchase_quantity = apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product );
+		$min_purchase_quantity = $product->get_min_purchase_quantity();
+		$max_purchase_quantity = $product->get_max_purchase_quantity();
 		return $min_purchase_quantity === $max_purchase_quantity;
 	}
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -91,7 +91,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 										'input_name'  => 'quantity[' . $grouped_product_child->get_id() . ']',
 										'input_value' => isset( $_POST['quantity'][ $grouped_product_child->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $grouped_product_child->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
 										'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $grouped_product_child ),
-										'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $grouped_product_child->get_max_purchase_quantity(), $grouped_product_child ),
+										'max_value'   => $grouped_product_child->get_max_purchase_quantity(),
 										'placeholder' => '0',
 									)
 								);

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.8.0
+ * @version 10.2.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 10.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -37,8 +37,8 @@ if ( $product->is_in_stock() ) : ?>
 
 		woocommerce_quantity_input(
 			array(
-				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'min_value'   => $product->get_min_purchase_quantity(),
+				'max_value'   => $product->get_max_purchase_quantity(),
 				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
 			)
 		);

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -4,7 +4,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 10.2.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -19,8 +19,8 @@ global $product;
 
 	woocommerce_quantity_input(
 		array(
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+			'min_value'   => $product->get_min_purchase_quantity(),
+			'max_value'   => $product->get_max_purchase_quantity(),
 			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
 		)
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In WC 10.1 (#58693), the `woocommerce_quantity_input_min` and `woocommerce_quantity_input_max` filters were moved inside the `get_min_purchase_quantity` and `get_max_purchase_quantity` methods. However, in several instances we were applying those filters on the result of those methods, causing the filter to run twice.

This PR fixes that in all cases. https://github.com/woocommerce/woocommerce/pull/60099 already fixed it in a few of them.

Kudos to @helgatheviking for reporting this issue.

cc @mikejolley for awareness as you worked on the initial PR.

### How to test the changes in this Pull Request:


1. Add this code snippet, changing `125` for the product ID of a simple product that is also a child of a grouped product:

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 4;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_step', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 2;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 125 ) {
		return 8;
	}
	return $default;
}, 10, 2 );
```
2. In a classic theme, visit that product's frontend and the frontend of the parent grouped product.
3. Verify the min, max and step values are applied correctly.
4. Repeat the process in a block theme with the _Add to Cart + Options_ block.