### PR TITLE
Use the WordPress core template registration API to register WooCommerce templates

### DIFF
--- a/plugins/woocommerce/changelog/fix-update-tests-theme-template-slug
+++ b/plugins/woocommerce/changelog/fix-update-tests-theme-template-slug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update e2e tests to use the theme template slug instead of the woocommerce slug
+
+

--- a/plugins/woocommerce/changelog/update-simplify-has_block_template
+++ b/plugins/woocommerce/changelog/update-simplify-has_block_template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Simplify has_block_template function
+
+

--- a/plugins/woocommerce/changelog/update-use-template-registration-api
+++ b/plugins/woocommerce/changelog/update-use-template-registration-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use the WordPress core template registration API to register WooCommerce templates

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
@@ -17,7 +17,7 @@ const NewsletterPanel = () => {
 	);
 
 	// Restrict the panel to only show on the coming soon page tempalte
-	if ( postId !== 'woocommerce/woocommerce//coming-soon' ) {
+	if ( ! postId?.endsWith( '//coming-soon' ) ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -67,9 +67,9 @@ export function setQueryAttribute(
 
 const isInProductArchive = () => {
 	const ARCHIVE_PRODUCT_TEMPLATES = [
-		'woocommerce/woocommerce//archive-product',
-		'woocommerce/woocommerce//taxonomy-product_attribute',
-		'woocommerce/woocommerce//product-search-results',
+		'//archive-product',
+		'//taxonomy-product_attribute',
+		'//product-search-results',
 		// Custom taxonomy templates have structure:
 		// <<THEME>>//taxonomy-product_cat-<<CATEGORY>>
 		// hence we're checking if template ID includes the middle part.
@@ -79,6 +79,7 @@ const isInProductArchive = () => {
 		// - woocommerce/woocommerce//taxonomy-product_tag
 		'//taxonomy-product_cat',
 		'//taxonomy-product_tag',
+		'//taxonomy-product_brand',
 	];
 
 	const currentTemplateId = select(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -29,11 +29,12 @@ import {
 } from '../constants';
 
 const ARCHIVE_PRODUCT_TEMPLATES = [
-	'woocommerce/woocommerce//archive-product',
-	'woocommerce/woocommerce//taxonomy-product_cat',
-	'woocommerce/woocommerce//taxonomy-product_tag',
-	'woocommerce/woocommerce//taxonomy-product_attribute',
-	'woocommerce/woocommerce//product-search-results',
+	'//archive-product',
+	'//taxonomy-product_cat',
+	'//taxonomy-product_tag',
+	'//taxonomy-product_brand',
+	'//taxonomy-product_attribute',
+	'//product-search-results',
 ];
 
 const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
@@ -77,7 +78,9 @@ subscribe( () => {
 	}
 
 	if ( isSiteEditorPage( store ) ) {
-		const inherit = ARCHIVE_PRODUCT_TEMPLATES.includes( currentTemplateId );
+		const inherit = ARCHIVE_PRODUCT_TEMPLATES.some( ( template ) =>
+			currentTemplateId?.endsWith( template )
+		);
 
 		const inheritQuery: Partial< ProductQueryBlockQuery > = {
 			inherit,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
@@ -35,7 +35,7 @@ test.describe( `Add to Cart + Options Block (block theme with templates)`, () =>
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { Editor, Admin } from '@woocommerce/e2e-utils';
+import { Editor, Admin, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 class AddToCartWithOptionsPage {
 	private page: Page;
@@ -68,7 +68,7 @@ class AddToCartWithOptionsPage {
 
 	async updateSingleProductTemplate() {
 		await this.admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	wpCLI,
 	TemplateCompiler,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -109,7 +110,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test as base, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -47,7 +52,7 @@ test.describe( 'Merchant → Checkout', () => {
 
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -158,7 +163,7 @@ test.describe( 'Merchant → Checkout', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -201,7 +206,7 @@ test.describe( 'Merchant → Checkout', () => {
 		).toBeVisible();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -7,6 +7,7 @@ import {
 	customerFile,
 	guestFile,
 	BlockData,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -348,7 +349,7 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 
 	test.beforeEach( async ( { admin, editor, page } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -654,7 +655,7 @@ test.describe( 'Billing Address Form', () => {
 
 	test( 'Enable company field', async ( { page, admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test as base, expect, guestFile } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	guestFile,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -30,7 +35,7 @@ test.describe( 'Shopper (logged-in) → Order Confirmation', () => {
 		await localPickupUtils.disableLocalPickup();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { test, expect, wpCLI, BlockData, Editor } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	wpCLI,
+	BlockData,
+	Editor,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -27,31 +34,37 @@ const templates = [
 		title: 'Single Product',
 		slug: 'single-product',
 		path: '/product/hoodie',
+		needsCreation: false,
 	},
 	{
-		title: 'Product Attribute',
+		title: 'Products by Attribute',
 		slug: 'taxonomy-product_attribute',
 		path: '/color/blue',
+		needsCreation: false,
 	},
 	{
-		title: 'Product Category',
+		title: 'Products by Category',
 		slug: 'taxonomy-product_cat',
 		path: '/product-category/clothing',
+		needsCreation: true,
 	},
 	{
-		title: 'Product Tag',
+		title: 'Products by Tag',
 		slug: 'taxonomy-product_tag',
 		path: '/product-tag/recommended/',
+		needsCreation: true,
 	},
 	{
 		title: 'Product Catalog',
 		slug: 'archive-product',
 		path: '/shop/',
+		needsCreation: false,
 	},
 	{
 		title: 'Product Search Results',
 		slug: 'product-search-results',
 		path: '/?s=shirt&post_type=product',
+		needsCreation: false,
 	},
 ];
 
@@ -145,7 +158,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -182,7 +195,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -233,7 +246,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		wpCoreVersion,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -295,17 +308,32 @@ test.describe( `${ blockData.name } Block `, () => {
 			editor,
 			page,
 		} ) => {
-			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.slug }`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+			if ( template.needsCreation ) {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: template.title,
+				} );
+			} else {
+				await admin.visitSiteEditor( {
+					postId: `${ BLOCK_THEME_SLUG }//${ template.slug }`,
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+			}
 
 			const block = editor.canvas.locator(
 				`[data-type="${ blockData.name }"]`
 			);
 
 			await expect( block ).toBeVisible();
+
+			if ( template.needsCreation ) {
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
+			}
 
 			await page.goto( template.path );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 const blockData: BlockData = {
 	name: 'Mini-Cart',
@@ -20,7 +25,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 	test.describe( 'in FSE editor', () => {
 		test( 'can be inserted in FSE area', async ( { editor, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -35,7 +40,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 
 		test( 'can only be inserted once', async ( { editor, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	Editor,
 	FrontendUtils,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -92,7 +93,7 @@ test.describe( `${ blockData.name }`, () => {
 	test.describe( `On the Single Product Template`, () => {
 		test.beforeEach( async ( { admin, editor } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ blockData.slug }`,
+				postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -7,6 +7,7 @@ import {
 	TemplateCompiler,
 	BASE_URL,
 	wpCLI,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -271,7 +272,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -152,7 +152,7 @@ test.describe( 'Product Collection: Collections', () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -393,11 +393,9 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 		} );
 
 		[
-			'woocommerce/woocommerce//archive-product',
-			'woocommerce/woocommerce//taxonomy-product_cat',
-			'woocommerce/woocommerce//taxonomy-product_tag',
-			'woocommerce/woocommerce//taxonomy-product_attribute',
-			'woocommerce/woocommerce//product-search-results',
+			`${ BLOCK_THEME_SLUG }//archive-product`,
+			`${ BLOCK_THEME_SLUG }//taxonomy-product_attribute`,
+			`${ BLOCK_THEME_SLUG }//product-search-results`,
 		].forEach( ( slug ) => {
 			test( `should be visible in archive template: ${ slug }`, async ( {
 				pageObject,
@@ -418,9 +416,47 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 		} );
 
 		[
-			'woocommerce/woocommerce//single-product',
-			'twentytwentyfour//home',
-			'twentytwentyfour//index',
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
+				title: 'Products by Category',
+			},
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
+				title: 'Products by Tag',
+			},
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
+				title: 'Products by Brand',
+			},
+		].forEach( ( template ) => {
+			test( `should be visible in archive template: ${ template.slug }`, async ( {
+				admin,
+				pageObject,
+				editor,
+			} ) => {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: template.title,
+				} );
+				await pageObject.insertProductCollection();
+				await pageObject.chooseCollectionInTemplate();
+				await pageObject.focusProductCollection();
+				await editor.openDocumentSettingsSidebar();
+
+				await expect(
+					pageObject
+						.locateSidebarSettings()
+						.getByLabel( SELECTORS.usePageContextControl )
+				).toBeVisible();
+			} );
+		} );
+
+		[
+			`${ BLOCK_THEME_SLUG }//single-product`,
+			`${ BLOCK_THEME_SLUG }//home`,
+			`${ BLOCK_THEME_SLUG }//index`,
 		].forEach( ( slug ) => {
 			test( `should be visible in non-archive template: ${ slug }`, async ( {
 				pageObject,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { Request } from '@playwright/test';
-import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	wpCLI,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -484,9 +489,10 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_cat`,
 				postType: 'wp_template',
-				canvas: 'edit',
+			} );
+			await editor.createTemplate( {
+				templateName: 'Products by Category',
 			} );
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
@@ -513,9 +519,10 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_tag`,
 				postType: 'wp_template',
-				canvas: 'edit',
+			} );
+			await editor.createTemplate( {
+				templateName: 'Products by Tag',
 			} );
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
@@ -601,21 +608,36 @@ test.describe( 'Product Collection', () => {
 		const genericArchiveTemplates = [
 			{
 				name: 'Products by Tag',
-				path: 'woocommerce/woocommerce//taxonomy-product_tag',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
+				needsCreation: true,
 			},
 			{
 				name: 'Products by Category',
-				path: 'woocommerce/woocommerce//taxonomy-product_cat',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
+				needsCreation: true,
 			},
 			{
 				name: 'Products by Attribute',
-				path: 'woocommerce/woocommerce//taxonomy-product_attribute',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_attribute`,
 			},
 		];
 
-		genericArchiveTemplates.forEach( ( { name, path } ) => {
-			test( `${ name } template`, async ( { editor, pageObject } ) => {
-				await pageObject.goToEditorTemplate( path );
+		genericArchiveTemplates.forEach( ( { name, path, needsCreation } ) => {
+			test( `${ name } template`, async ( {
+				admin,
+				editor,
+				pageObject,
+			} ) => {
+				if ( needsCreation ) {
+					await admin.visitSiteEditor( {
+						postType: 'wp_template',
+					} );
+					await editor.createTemplate( {
+						templateName: name,
+					} );
+				} else {
+					await pageObject.goToEditorTemplate( path );
+				}
 				await pageObject.focusProductCollection();
 
 				const previewButtonLocator = editor.canvas.getByTestId(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -2,13 +2,8 @@
  * External dependencies
  */
 import { FrameLocator, Locator, Page } from '@playwright/test';
-import { Editor, Admin } from '@woocommerce/e2e-utils';
+import { Editor, Admin, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
-
-/**
- * Internal dependencies
- */
-import { BLOCK_THEME_SLUG } from '../../utils/constants';
 
 export const BLOCK_LABELS = {
 	productTemplate: 'Block: Product Template',
@@ -336,7 +331,7 @@ class ProductCollectionPage {
 
 	// Going to Product Catalog by default
 	async goToEditorTemplate(
-		template = 'woocommerce/woocommerce//archive-product'
+		template = `${ BLOCK_THEME_SLUG }//archive-product`
 	) {
 		await this.admin.visitSiteEditor( {
 			postId: template,
@@ -348,7 +343,7 @@ class ProductCollectionPage {
 
 	async goToProductCatalogAndInsertCollection( collection: Collections ) {
 		await this.goToTemplateAndInsertCollection(
-			'woocommerce/woocommerce//archive-product',
+			`${ BLOCK_THEME_SLUG }//archive-product`,
 			collection
 		);
 	}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-picker.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-picker.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -145,7 +145,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 			editor,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -168,7 +168,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//page-cart`,
+			postId: `${ BLOCK_THEME_SLUG }//page-cart`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -190,7 +190,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//order-confirmation`,
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -329,20 +329,20 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			id: 'myCustomCollectionWithProductContext',
 			name: 'My Custom Collection - Product Context',
 			label: 'Block: My Custom Collection - Product Context',
-			previewLabelTemplate: [ 'woocommerce/woocommerce//single-product' ],
+			previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//single-product` ],
 		},
 		{
 			id: 'myCustomCollectionWithCartContext',
 			name: 'My Custom Collection - Cart Context',
 			label: 'Block: My Custom Collection - Cart Context',
-			previewLabelTemplate: [ 'woocommerce/woocommerce//page-cart' ],
+			previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//page-cart` ],
 		},
 		{
 			id: 'myCustomCollectionWithOrderContext',
 			name: 'My Custom Collection - Order Context',
 			label: 'Block: My Custom Collection - Order Context',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//order-confirmation',
+				`${ BLOCK_THEME_SLUG }//order-confirmation`,
 			],
 		},
 		{
@@ -350,7 +350,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			name: 'My Custom Collection - Archive Context',
 			label: 'Block: My Custom Collection - Archive Context',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//taxonomy-product_cat',
+				`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 			],
 		},
 		{
@@ -358,17 +358,29 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			name: 'My Custom Collection - Multiple Contexts',
 			label: 'Block: My Custom Collection - Multiple Contexts',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//single-product',
-				'woocommerce/woocommerce//order-confirmation',
+				`${ BLOCK_THEME_SLUG }//single-product`,
+				`${ BLOCK_THEME_SLUG }//order-confirmation`,
 			],
 		},
 	].forEach( ( collection ) => {
 		collection.previewLabelTemplate.forEach( ( template ) => {
 			test( `Collection "${ collection.name }" should show preview label in "${ template }"`, async ( {
+				admin,
 				pageObject,
 				editor,
 			} ) => {
-				await pageObject.goToEditorTemplate( template );
+				if (
+					template === `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`
+				) {
+					await admin.visitSiteEditor( {
+						postType: 'wp_template',
+					} );
+					await editor.createTemplate( {
+						templateName: 'Products by Category',
+					} );
+				} else {
+					await pageObject.goToEditorTemplate( template );
+				}
 				await pageObject.insertProductCollection();
 				await pageObject.chooseCollectionInTemplate(
 					collection.id as Collections
@@ -511,7 +523,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Product Context',
 				label: 'Block: My Custom Collection - Product Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//single-product',
+					`${ BLOCK_THEME_SLUG }//single-product`,
 				],
 				shouldShowProductPicker: true,
 			},
@@ -519,7 +531,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				id: 'myCustomCollectionWithCartContext',
 				name: 'My Custom Collection - Cart Context',
 				label: 'Block: My Custom Collection - Cart Context',
-				previewLabelTemplate: [ 'woocommerce/woocommerce//page-cart' ],
+				previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//page-cart` ],
 				shouldShowProductPicker: false,
 			},
 			{
@@ -527,7 +539,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Order Context',
 				label: 'Block: My Custom Collection - Order Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//order-confirmation',
+					`${ BLOCK_THEME_SLUG }//order-confirmation`,
 				],
 				shouldShowProductPicker: false,
 			},
@@ -536,7 +548,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Archive Context',
 				label: 'Block: My Custom Collection - Archive Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//taxonomy-product_cat',
+					`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 				],
 				shouldShowProductPicker: false,
 			},
@@ -545,18 +557,31 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Multiple Contexts',
 				label: 'Block: My Custom Collection - Multiple Contexts',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//single-product',
-					'woocommerce/woocommerce//order-confirmation',
+					`${ BLOCK_THEME_SLUG }//single-product`,
+					`${ BLOCK_THEME_SLUG }//order-confirmation`,
 				],
 				shouldShowProductPicker: true,
 			},
 		].forEach( ( collection ) => {
 			collection.previewLabelTemplate.forEach( ( template ) => {
 				test( `Collection "${ collection.name }" should show preview label in "${ template }"`, async ( {
+					admin,
 					pageObject,
 					editor,
 				} ) => {
-					await pageObject.goToEditorTemplate( template );
+					if (
+						template ===
+						`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`
+					) {
+						await admin.visitSiteEditor( {
+							postType: 'wp_template',
+						} );
+						await editor.createTemplate( {
+							templateName: 'Products by Category',
+						} );
+					} else {
+						await pageObject.goToEditorTemplate( template );
+					}
 					await pageObject.insertProductCollection();
 					await pageObject.chooseCollectionInTemplate(
 						collection.id as Collections

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/price-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/price-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/rating-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/rating-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/removable-chips-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/removable-chips-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -29,30 +34,35 @@ const templates = {
 	//	slug: 'taxonomy-product_attribute',
 	//	frontendPage: '/product-attribute/color/',
 	//	legacyBlockName: 'woocommerce/legacy-template',
+	//	needsCreation: false,
 	//},
 	'taxonomy-product_cat': {
 		templateTitle: 'Product Category',
 		slug: 'taxonomy-product_cat',
 		frontendPage: '/product-category/music/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: true,
 	},
 	'taxonomy-product_tag': {
 		templateTitle: 'Product Tag',
 		slug: 'taxonomy-product_tag',
 		frontendPage: '/product-tag/recommended/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: true,
 	},
 	'archive-product': {
 		templateTitle: 'Product Catalog',
 		slug: 'archive-product',
 		frontendPage: '/shop/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: false,
 	},
 	'product-search-results': {
 		templateTitle: 'Product Search Results',
 		slug: 'product-search-results',
 		frontendPage: '/?s=shirt&post_type=product',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: false,
 	},
 };
 
@@ -63,7 +73,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		page,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -94,6 +104,7 @@ for ( const {
 	slug,
 	frontendPage,
 	legacyBlockName,
+	needsCreation,
 } of Object.values( templates ) ) {
 	test.describe( `${ templateTitle } template`, () => {
 		test( 'Products block matches with classic template block', async ( {
@@ -101,11 +112,20 @@ for ( const {
 			editor,
 			page,
 		} ) => {
-			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ slug }`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+			if ( needsCreation ) {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: 'Products by Category',
+				} );
+			} else {
+				await admin.visitSiteEditor( {
+					postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+			}
 			await editor.setContent( '' );
 			await insertProductsQuery( editor );
 			await editor.insertBlock( { name: legacyBlockName } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	wpCLI,
 	TemplateCompiler,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -107,7 +108,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 // Block is soft-depreacted meaning that it's hidden from the inserter.
 const blockData: BlockData = {
@@ -34,7 +39,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -57,7 +62,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -179,7 +179,7 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 	} ) => {
 		/* Switch to the blockified Add to Cart + Options block to be able to test all hooks */
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	TemplateCompiler,
 	wpCLI,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 export const blockData = {
@@ -121,7 +122,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await page.reload();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect, test } from '@woocommerce/e2e-utils';
+import { expect, test, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
-const templatePath = 'woocommerce/woocommerce//page-cart';
+const templatePath = `${ BLOCK_THEME_SLUG }//page-cart`;
 const templateType = 'wp_template';
 
 test.describe( 'Test the cart template', () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
-const templatePath = 'woocommerce/woocommerce//page-checkout';
+const templatePath = `${ BLOCK_THEME_SLUG }//page-checkout`;
 const templateType = 'wp_template';
 
 test.describe( 'Test the checkout template', () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 test.describe( 'Test the order confirmation template', () => {
 	test( 'Template can be opened in the site editor', async ( {
@@ -9,7 +9,7 @@ test.describe( 'Test the order confirmation template', () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 test.describe( 'Product Search Results template', () => {
 	// This is a test to verify there are no regressions on
@@ -12,7 +12,7 @@ test.describe( 'Product Search Results template', () => {
 	} ) => {
 		await admin.visitSiteEditor( {
 			canvas: 'edit',
-			postId: 'woocommerce/woocommerce//product-search-results',
+			postId: `${ BLOCK_THEME_SLUG }//product-search-results`,
 			postType: 'wp_template',
 		} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -8,11 +8,6 @@ import {
 	BLOCK_THEME_WITH_TEMPLATES_SLUG,
 } from '@woocommerce/e2e-utils';
 
-/**
- * Internal dependencies
- */
-import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
-
 test.describe( 'Template priority', () => {
 	// Templates might come from different sources, and they should have this order of priority:
 	// 1. Template from the database with the theme slug.
@@ -46,7 +41,6 @@ test.describe( 'Template priority', () => {
 	templatesToTest.forEach( ( testData ) => {
 		test( `priorities are applied correctly in the ${ testData.templateName } template`, async ( {
 			admin,
-			frontendUtils,
 			editor,
 			page,
 			requestUtils,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -158,24 +158,9 @@ test.describe( 'Template priority', () => {
 				} );
 
 				if ( testData.fallbackTemplate ) {
-					await page.getByLabel( 'Add Template' ).click();
-
-					const dialog = page.getByRole( 'dialog' );
-					await dialog
-						.getByRole( 'button', { name: testData.templateName } )
-						.click();
-					// There is the chance that the Add template dialog is opened before
-					// product taxonomies could load. In that case, the screen to select
-					// whether to create a template for a specific taxonomy or for all of
-					// them won't be shown. That's why we click the 'All Categories' /
-					// 'All Tags' button only if visible.
-					const allButton = dialog.getByRole( 'button', {
-						name: 'All',
+					await editor.createTemplate( {
+						templateName: testData.templateName,
 					} );
-					if ( await allButton.isVisible() ) {
-						await allButton.click();
-					}
-					await page.getByLabel( 'Fallback content' ).click();
 
 					// Verify we are editing the correct template.
 					await page

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -2,18 +2,33 @@
  * External dependencies
  */
 import {
-	test,
+	test as base,
 	expect,
 	BLOCK_THEME_SLUG,
 	BLOCK_THEME_WITH_TEMPLATES_SLUG,
 } from '@woocommerce/e2e-utils';
 
+/**
+ * Internal dependencies
+ */
+import TemplatesPage from './templates.page';
+
+const test = base.extend< { pageObject: TemplatesPage } >( {
+	pageObject: async ( { admin, editor }, use ) => {
+		const pageObject = new TemplatesPage( {
+			admin,
+			editor,
+		} );
+		await use( pageObject );
+	},
+} );
+
 test.describe( 'Template priority', () => {
 	// Templates might come from different sources, and they should have this order of priority:
 	// 1. Template from the database with the theme slug.
 	// 2. Template from the database with the WooCommerce slug.
-	// 3. Fallback template from the database with the theme BLOCK_THEME_SLUG.
-	// 4. Fallback template from the database with the WooCommerce BLOCK_THEME_SLUG.
+	// 3. Fallback template from the database with the theme slug.
+	// 4. Fallback template from the database with the WooCommerce slug.
 	// 5. Template from the theme.
 	// 6. Fallback template from the theme.
 	// 7. Template from WooCommerce.
@@ -44,29 +59,8 @@ test.describe( 'Template priority', () => {
 			editor,
 			page,
 			requestUtils,
+			pageObject,
 		} ) => {
-			const addParagraphToTemplate = async (
-				templateSlug: string,
-				content: string
-			) => {
-				await admin.visitSiteEditor( {
-					postId: templateSlug,
-					postType: 'wp_template',
-					canvas: 'edit',
-				} );
-
-				await editor.insertBlock( {
-					name: 'core/paragraph',
-					attributes: {
-						content,
-					},
-				} );
-
-				await editor.saveSiteEditorEntities( {
-					isOnlyCurrentEntityDirty: true,
-				} );
-			};
-
 			await test.step( 'WooCommerce template', async () => {
 				await page.goto( testData.path );
 
@@ -95,7 +89,7 @@ test.describe( 'Template priority', () => {
 
 			if ( testData.fallbackTemplate ) {
 				await test.step( 'custom fallback template with WooCommerce slug', async () => {
-					await addParagraphToTemplate(
+					await pageObject.addParagraphToTemplate(
 						`woocommerce/woocommerce//${ testData.fallbackTemplate.templatePath }`,
 						'Custom fallback template with WooCommerce slug'
 					);
@@ -113,7 +107,7 @@ test.describe( 'Template priority', () => {
 				} );
 
 				await test.step( 'custom fallback template with theme slug', async () => {
-					await addParagraphToTemplate(
+					await pageObject.addParagraphToTemplate(
 						`${ BLOCK_THEME_SLUG }//${ testData.fallbackTemplate.templatePath }`,
 						'Custom fallback template with theme slug'
 					);
@@ -137,7 +131,7 @@ test.describe( 'Template priority', () => {
 			}
 
 			await test.step( 'custom template with WooCommerce slug', async () => {
-				await addParagraphToTemplate(
+				await pageObject.addParagraphToTemplate(
 					`woocommerce/woocommerce//${ testData.templatePath }`,
 					'Custom template with WooCommerce slug'
 				);
@@ -202,7 +196,7 @@ test.describe( 'Template priority', () => {
 						isOnlyCurrentEntityDirty: true,
 					} );
 				} else {
-					await addParagraphToTemplate(
+					await pageObject.addParagraphToTemplate(
 						`${ BLOCK_THEME_SLUG }//${ testData.templatePath }`,
 						'Custom template with theme slug'
 					);

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import {
+	test,
+	expect,
+	BLOCK_THEME_SLUG,
+	BLOCK_THEME_WITH_TEMPLATES_SLUG,
+} from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { CUSTOMIZABLE_WC_TEMPLATES } from './constants';
+
+test.describe( 'Template priority', () => {
+	// Templates might come from different sources, and they should have this order of priority:
+	// 1. Template from the database with the theme slug.
+	// 2. Template from the database with the WooCommerce slug.
+	// 3. Fallback template from the database with the theme BLOCK_THEME_SLUG.
+	// 4. Fallback template from the database with the WooCommerce BLOCK_THEME_SLUG.
+	// 5. Template from the theme.
+	// 6. Fallback template from the theme.
+	// 7. Template from WooCommerce.
+
+	// We test a regular template and a taxonomy template with fallback, as they follow slightly different flow.
+	const templatesToTest = [
+		{
+			path: '/product/hoodie',
+			templateName: 'Single Product',
+			templatePath: 'single-product',
+			identificableText: 'Related products',
+		},
+		{
+			path: '/product-category/clothing',
+			templateName: 'Products by Category',
+			templatePath: 'taxonomy-product_cat',
+			fallbackTemplate: {
+				templateName: 'Product Catalog',
+				templatePath: 'archive-product',
+			},
+			identificableText: 'Showing all 9 results',
+		},
+	];
+
+	templatesToTest.forEach( ( testData ) => {
+		test( `priorities are applied correctly in the ${ testData.templateName } template`, async ( {
+			admin,
+			frontendUtils,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			const addParagraphToTemplate = async (
+				templateSlug: string,
+				content: string
+			) => {
+				await admin.visitSiteEditor( {
+					postId: templateSlug,
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content,
+					},
+				} );
+
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
+			};
+
+			await test.step( 'WooCommerce template', async () => {
+				await page.goto( testData.path );
+
+				// Verify it loaded correctly but has no custom text.
+				await expect(
+					page.getByText( testData.identificableText )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Custom template' )
+				).toBeHidden();
+			} );
+
+			await test.step( 'theme template', async () => {
+				await requestUtils.activateTheme(
+					BLOCK_THEME_WITH_TEMPLATES_SLUG
+				);
+
+				await expect(
+					page.getByText( testData.identificableText )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Custom template' )
+				).toBeHidden();
+				await requestUtils.activateTheme( BLOCK_THEME_SLUG );
+			} );
+
+			if ( testData.fallbackTemplate ) {
+				await test.step( 'custom fallback template with WooCommerce slug', async () => {
+					await addParagraphToTemplate(
+						`woocommerce/woocommerce//${ testData.fallbackTemplate.templatePath }`,
+						'Custom fallback template with WooCommerce slug'
+					);
+
+					await page.goto( testData.path );
+
+					await expect(
+						page.getByText( testData.identificableText )
+					).toBeVisible();
+					await expect(
+						page.getByText(
+							'Custom fallback template with WooCommerce slug'
+						)
+					).toBeVisible();
+				} );
+
+				await test.step( 'custom fallback template with theme slug', async () => {
+					await addParagraphToTemplate(
+						`${ BLOCK_THEME_SLUG }//${ testData.fallbackTemplate.templatePath }`,
+						'Custom fallback template with theme slug'
+					);
+
+					await page.goto( testData.path );
+
+					await expect(
+						page.getByText( testData.identificableText )
+					).toBeVisible();
+					await expect(
+						page.getByText(
+							'Custom fallback template with theme slug'
+						)
+					).toBeVisible();
+					await expect(
+						page.getByText(
+							'Custom fallback template with WooCommerce slug'
+						)
+					).toBeHidden();
+				} );
+			}
+
+			await test.step( 'custom template with WooCommerce slug', async () => {
+				await addParagraphToTemplate(
+					`woocommerce/woocommerce//${ testData.templatePath }`,
+					'Custom template with WooCommerce slug'
+				);
+
+				await page.goto( testData.path );
+
+				await expect(
+					page.getByText( testData.identificableText )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Custom fallback template with theme slug' )
+				).toBeHidden();
+				await expect(
+					page.getByText( 'Custom template with WooCommerce slug' )
+				).toBeVisible();
+			} );
+
+			await test.step( 'custom template with theme slug', async () => {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.revertTemplate( {
+					templateName: testData.templateName,
+				} );
+
+				if ( testData.fallbackTemplate ) {
+					await page.getByLabel( 'Add Template' ).click();
+
+					const dialog = page.getByRole( 'dialog' );
+					await dialog
+						.getByRole( 'button', { name: testData.templateName } )
+						.click();
+					// There is the chance that the Add template dialog is opened before
+					// product taxonomies could load. In that case, the screen to select
+					// whether to create a template for a specific taxonomy or for all of
+					// them won't be shown. That's why we click the 'All Categories' /
+					// 'All Tags' button only if visible.
+					const allButton = dialog.getByRole( 'button', {
+						name: 'All',
+					} );
+					if ( await allButton.isVisible() ) {
+						await allButton.click();
+					}
+					await page.getByLabel( 'Fallback content' ).click();
+
+					// Verify we are editing the correct template.
+					await page
+						.getByRole( 'heading', {
+							name: `${ testData.templateName } · Template`,
+							level: 1,
+						} )
+						.waitFor();
+
+					await editor.insertBlock( {
+						name: 'core/paragraph',
+						attributes: {
+							content: 'Custom template with theme slug',
+						},
+					} );
+
+					await editor.saveSiteEditorEntities( {
+						isOnlyCurrentEntityDirty: true,
+					} );
+				} else {
+					await addParagraphToTemplate(
+						`${ BLOCK_THEME_SLUG }//${ testData.templatePath }`,
+						'Custom template with theme slug'
+					);
+				}
+
+				await page.goto( testData.path );
+
+				await expect(
+					page.getByText( testData.identificableText )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Custom template with theme slug' )
+				).toBeVisible();
+				await expect(
+					page.getByText( 'Custom template with WooCommerce slug' )
+				).toBeHidden();
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/templates.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/templates.page.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { Editor, Admin } from '@woocommerce/e2e-utils';
+
+class TemplatesPage {
+	private admin: Admin;
+	private editor: Editor;
+
+	constructor( { admin, editor }: { admin: Admin; editor: Editor } ) {
+		this.admin = admin;
+		this.editor = editor;
+	}
+
+	async addParagraphToTemplate( templateSlug: string, content: string ) {
+		await this.admin.visitSiteEditor( {
+			postId: templateSlug,
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
+
+		await this.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content,
+			},
+		} );
+
+		await this.editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+	}
+}
+
+export default TemplatesPage;

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect, Editor } from '@woocommerce/e2e-utils';
+import { test, expect, Editor, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 const insertSingleProductBlock = async (
 	blockName: string,
@@ -24,7 +24,7 @@ const insertInSingleProductTemplate = async (
 	admin: Admin
 ) => {
 	await admin.visitSiteEditor( {
-		postId: `woocommerce/woocommerce//single-product`,
+		postId: `${ BLOCK_THEME_SLUG }//single-product`,
 		postType: 'wp_template',
 		canvas: 'edit',
 	} );
@@ -80,7 +80,7 @@ test.describe( 'registerProductBlockType registers', () => {
 		await test.step( 'Blocks not available in non-product template', async () => {
 			// Visit site editor with a non-product template
 			await admin.visitSiteEditor( {
-				postId: 'woocommerce/woocommerce//coming-soon',
+				postId: `${ BLOCK_THEME_SLUG }//coming-soon`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -126,6 +126,25 @@ export class Editor extends CoreEditor {
 			.waitFor();
 	}
 
+	async createTemplate( { templateName }: { templateName: string } ) {
+		await this.page.getByLabel( 'Add Template' ).click();
+
+		const dialog = this.page.getByRole( 'dialog' );
+		await dialog.getByRole( 'button', { name: templateName } ).click();
+		// There is the chance that the Add template dialog is opened before
+		// product taxonomies could load. In that case, the screen to select
+		// whether to create a template for a specific taxonomy or for all of
+		// them won't be shown. That's why we click the 'All Categories' /
+		// 'All Tags' button only if visible.
+		const allButton = dialog.getByRole( 'button', {
+			name: 'For all items',
+		} );
+		if ( await allButton.isVisible() ) {
+			await allButton.click();
+		}
+		await this.page.getByLabel( 'Fallback content' ).click();
+	}
+
 	async publishAndVisitPost() {
 		const postId = await this.publishPost();
 		await this.page.goto( `/?p=${ postId }` );

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -134,36 +134,12 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template      = false;
-		$template_filename = $template_name . '.html';
-		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
-		// we should check both these possible directories for backwards-compatibility.
-		$possible_templates_dirs = array( 'templates', 'block-templates' );
-
-		// Combine the possible root directory names with either the template directory
-		// or the stylesheet directory for child themes, getting all possible block templates
-		// locations combinations.
-		$filepath        = DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$legacy_filepath = DIRECTORY_SEPARATOR . 'block-templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$possible_paths  = array(
-			get_stylesheet_directory() . $filepath,
-			get_stylesheet_directory() . $legacy_filepath,
-			get_template_directory() . $filepath,
-			get_template_directory() . $legacy_filepath,
-		);
-
-		// Check the first matching one.
-		foreach ( $possible_paths as $path ) {
-			if ( is_readable( $path ) ) {
-				$has_template = true;
-				break;
-			}
-		}
+		$has_template = WP_Block_Templates_Registry::get_instance()->is_registered( 'woocommerce//' . $template_name );
 
 		/**
 		 * Filters the value of the result of the block template check.
 		 *
-		 * @since x.x.x
+		 * @since 10.2.0
 		 *
 		 * @param boolean $has_template value to be filtered.
 		 * @param string $template_name The name of the template.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -232,7 +232,7 @@ class BlockTemplatesController {
 				)
 			) {
 				array_unshift( $query_result, $template_file );
-				return $query_result;
+				continue;
 			}
 
 			// If the template has a fallback, we should not include it in the list of templates, unless it has been modified.
@@ -267,9 +267,10 @@ class BlockTemplatesController {
 			}
 		}
 
-		// We need to remove theme (i.e. filesystem) templates that have the same slug as a customised one.
-		// This only affects saved templates that were saved BEFORE a theme template with the same slug was added.
-		$query_result = BlockTemplateUtils::remove_theme_templates_with_custom_alternative( $query_result );
+		// If there are certain templates that have been customised with the `woocommerce/woocommerce` slug,
+		// We prioritize them over the theme and WC templates. That is, we remove the theme and WC templates
+		// from the results and only keep the customised ones.
+		$query_result = BlockTemplateUtils::remove_templates_with_custom_alternative( $query_result );
 
 		// There is the chance that the user customized the default template, installed a theme with a custom template
 		// and customized that one as well. When that happens, duplicates might appear in the list.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -24,6 +24,7 @@ class BlockTemplatesController {
 	 */
 	public function init() {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
+		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
@@ -184,6 +185,18 @@ class BlockTemplatesController {
 	}
 
 	/**
+	 * Add the template title and description to WooCommerce templates.
+	 *
+	 * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
+	 * @param string                 $id             Template unique identifier (example: 'theme_slug//template_slug').
+	 * @param array                  $template_type  Template type: 'wp_template' or 'wp_template_part'.
+	 * @return WP_Block_Template|null
+	 */
+	public function add_block_template_details( $block_template, $id, $template_type ) {
+		return BlockTemplateUtils::update_template_data( $block_template, $template_type );
+	}
+
+	/**
 	 * Add the block template objects to be used.
 	 *
 	 * @param array  $query_result Array of template objects.
@@ -276,6 +289,18 @@ class BlockTemplatesController {
 		// and customized that one as well. When that happens, duplicates might appear in the list.
 		// See: https://github.com/woocommerce/woocommerce/issues/42220.
 		$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result, $theme_slug );
+
+		/**
+		 * WC templates from theme aren't included in `$this->get_block_templates()` but are handled by Gutenberg.
+		 * We need to do additional search through all templates file to update title and description for WC
+		 * templates that aren't listed in theme.json.
+		 */
+		$query_result = array_map(
+			function ( $template ) use ( $template_type ) {
+				return BlockTemplateUtils::update_template_data( $template, $template_type );
+			},
+			$query_result
+		);
 
 		return $query_result;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -207,6 +207,7 @@ class BlockTemplatesController {
 	public function run_hooks_on_block_templates( $templates ) {
 		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
 		// via the Template Registration API. Because of this, we run them manually.
+		// https://github.com/WordPress/gutenberg/issues/71139
 		foreach ( $templates as $template ) {
 			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
 				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -207,7 +207,7 @@ class BlockTemplatesController {
 	public function run_hooks_on_block_templates( $templates ) {
 		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
 		// via the Template Registration API. Because of this, we run them manually.
-		// https://github.com/WordPress/gutenberg/issues/71139
+		// https://github.com/WordPress/gutenberg/issues/71139.
 		foreach ( $templates as $template ) {
 			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
 				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -220,7 +220,7 @@ class BlockTemplatesController {
 	/**
 	 * Add the block template objects currently saved in the database with the WooCommerce slug.
 	 * That is, templates that have been customised before WooCommerce started to use the
-	 * Tempalte Registration API.
+	 * Template Registration API.
 	 *
 	 * @param array  $query_result Array of template objects.
 	 * @param array  $query Optional. Arguments to retrieve templates.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -26,9 +26,28 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'hide_template_selector_in_cart_checkout_pages' ), 10 );
+	}
+
+	/**
+	 * Run hooks on block templates.
+	 *
+	 * @param array $templates The block templates.
+	 * @return array The block templates.
+	 */
+	public function run_hooks_on_block_templates( $templates ) {
+		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
+		// via the Template Registration API. Because of this, we run them manually.
+		foreach ( $templates as $template ) {
+			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
+				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+			}
+		}
+
+		return $templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -26,6 +26,7 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_filter( 'rest_pre_insert_wp_template', array( $this, 'dont_load_templates_for_suggestions' ), 10, 1 );
 		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
@@ -322,6 +323,20 @@ class BlockTemplatesController {
 		);
 
 		return $query_result;
+	}
+
+	/**
+	 * When creating a template from the WP suggestion, don't load the templates with the WooCommerce slug.
+	 * Otherwise they take precedence and the new template can't be created.
+	 *
+	 * @param stdClass $prepared_post An object representing a single post prepared
+	 *                                for inserting or updating the database.
+	 */
+	public function dont_load_templates_for_suggestions( $prepared_post ) {
+		if ( isset( $prepared_post->meta_input['is_wp_suggestion'] ) ) {
+			remove_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		}
+		return $prepared_post;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -24,7 +24,6 @@ class BlockTemplatesController {
 	 */
 	public function init() {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
-		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
@@ -185,18 +184,6 @@ class BlockTemplatesController {
 	}
 
 	/**
-	 * Add the template title and description to WooCommerce templates.
-	 *
-	 * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
-	 * @param string                 $id             Template unique identifier (example: 'theme_slug//template_slug').
-	 * @param array                  $template_type  Template type: 'wp_template' or 'wp_template_part'.
-	 * @return WP_Block_Template|null
-	 */
-	public function add_block_template_details( $block_template, $id, $template_type ) {
-		return BlockTemplateUtils::update_template_data( $block_template, $template_type );
-	}
-
-	/**
 	 * Add the block template objects to be used.
 	 *
 	 * @param array  $query_result Array of template objects.
@@ -288,18 +275,6 @@ class BlockTemplatesController {
 		// and customized that one as well. When that happens, duplicates might appear in the list.
 		// See: https://github.com/woocommerce/woocommerce/issues/42220.
 		$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result, $theme_slug );
-
-		/**
-		 * WC templates from theme aren't included in `$this->get_block_templates()` but are handled by Gutenberg.
-		 * We need to do additional search through all templates file to update title and description for WC
-		 * templates that aren't listed in theme.json.
-		 */
-		$query_result = array_map(
-			function ( $template ) use ( $template_type ) {
-				return BlockTemplateUtils::update_template_data( $template, $template_type );
-			},
-			$query_result
-		);
 
 		return $query_result;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -238,24 +238,6 @@ class BlockTemplatesController {
 		$theme_slug = get_stylesheet();
 
 		foreach ( $template_files as $template_file ) {
-
-			// If we have a template which is eligible for a fallback, we need to explicitly tell Gutenberg that
-			// it has a theme file (because it is using the fallback template file). And then `continue` to avoid
-			// adding duplicates.
-			if ( BlockTemplateUtils::is_template_in_query_result( $query_result, $template_file ) ) {
-				continue;
-			}
-
-			// If the current $post_type is set (e.g. on an Edit Post screen), and isn't included in the available post_types
-			// on the template file, then lets skip it so that it doesn't get added. This is typically used to hide templates
-			// in the template dropdown on the Edit Post page.
-			if ( $post_type &&
-				isset( $template_file->post_types ) &&
-				! in_array( $post_type, $template_file->post_types, true )
-			) {
-				continue;
-			}
-
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
 			if (
@@ -278,18 +260,6 @@ class BlockTemplatesController {
 		// and customized that one as well. When that happens, duplicates might appear in the list.
 		// See: https://github.com/woocommerce/woocommerce/issues/42220.
 		$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result, $theme_slug );
-
-		/**
-		 * WC templates from theme aren't included in `$this->get_block_templates()` but are handled by Gutenberg.
-		 * We need to do additional search through all templates file to update title and description for WC
-		 * templates that aren't listed in theme.json.
-		 */
-		$query_result = array_map(
-			function ( $template ) use ( $template_type ) {
-				return BlockTemplateUtils::update_template_data( $template, $template_type );
-			},
-			$query_result
-		);
 
 		return $query_result;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -26,7 +26,7 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
-		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_filter( 'get_block_templates', array( $this, 'add_db_templates_with_woo_slug' ), 10, 3 );
 		add_filter( 'rest_pre_insert_wp_template', array( $this, 'dont_load_templates_for_suggestions' ), 10, 1 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
@@ -218,24 +218,24 @@ class BlockTemplatesController {
 	}
 
 	/**
-	 * Add the block template objects to be used.
+	 * Add the block template objects currently saved in the database with the WooCommerce slug.
+	 * That is, templates that have been customised before WooCommerce started to use the
+	 * Tempalte Registration API.
 	 *
 	 * @param array  $query_result Array of template objects.
 	 * @param array  $query Optional. Arguments to retrieve templates.
 	 * @param string $template_type wp_template or wp_template_part.
 	 * @return array
 	 */
-	public function add_block_templates( $query_result, $query, $template_type ) {
+	public function add_db_templates_with_woo_slug( $query_result, $query, $template_type ) {
 		$slugs = isset( $query['slug__in'] ) ? $query['slug__in'] : array();
 
 		if ( ! BlockTemplateUtils::supports_block_templates( $template_type ) && ! in_array( ComingSoonTemplate::SLUG, $slugs, true ) ) {
 			return $query_result;
 		}
 
-		$post_type      = isset( $query['post_type'] ) ? $query['post_type'] : '';
-		$template_files = $this->get_block_templates( $slugs, $template_type );
-
-		$theme_slug = get_stylesheet();
+		$template_files = BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
+		$new_templates  = array();
 
 		foreach ( $template_files as $template_file ) {
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
@@ -247,19 +247,23 @@ class BlockTemplatesController {
 					BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === $template_file->theme
 				)
 			) {
-				array_unshift( $query_result, $template_file );
+				array_unshift( $new_templates, $template_file );
 			}
 		}
 
-		// If there are certain templates that have been customised with the `woocommerce/woocommerce` slug,
-		// We prioritize them over the theme and WC templates. That is, we remove the theme and WC templates
-		// from the results and only keep the customised ones.
-		$query_result = BlockTemplateUtils::remove_templates_with_custom_alternative( $query_result );
+		$query_result = array_merge( $new_templates, $query_result );
 
-		// There is the chance that the user customized the default template, installed a theme with a custom template
-		// and customized that one as well. When that happens, duplicates might appear in the list.
-		// See: https://github.com/woocommerce/woocommerce/issues/42220.
-		$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result, $theme_slug );
+		if ( count( $new_templates ) > 0 ) {
+			// If there are certain templates that have been customised with the `woocommerce/woocommerce` slug,
+			// We prioritize them over the theme and WC templates. That is, we remove the theme and WC templates
+			// from the results and only keep the customised ones.
+			$query_result = BlockTemplateUtils::remove_templates_with_custom_alternative( $query_result );
+
+			// There is the chance that the user customized the default template, installed a theme with a custom template
+			// and customized that one as well. When that happens, duplicates might appear in the list.
+			// See: https://github.com/woocommerce/woocommerce/issues/42220.
+			$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result );
+		}
 
 		return $query_result;
 	}
@@ -273,7 +277,7 @@ class BlockTemplatesController {
 	 */
 	public function dont_load_templates_for_suggestions( $prepared_post ) {
 		if ( isset( $prepared_post->meta_input['is_wp_suggestion'] ) ) {
-			remove_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+			remove_filter( 'get_block_templates', array( $this, 'add_db_templates_with_woo_slug' ), 10, 3 );
 		}
 		return $prepared_post;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -237,9 +237,15 @@ class BlockTemplatesController {
 
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
-			if ( 'custom' === $template_file->source ) {
-				$query_result[] = $template_file;
-				continue;
+			if (
+				'custom' === $template_file->source &&
+				(
+					BlockTemplateUtils::PLUGIN_SLUG === $template_file->theme ||
+					BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG === $template_file->theme
+				)
+			) {
+				array_unshift( $query_result, $template_file );
+				return $query_result;
 			}
 
 			// If the template has a fallback, we should not include it in the list of templates, unless it has been modified.

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -25,30 +25,12 @@ class BlockTemplatesController {
 	public function init() {
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
 		add_filter( 'get_block_template', array( $this, 'add_block_template_details' ), 10, 3 );
+		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'rest_pre_insert_wp_template', array( $this, 'dont_load_templates_for_suggestions' ), 10, 1 );
-		add_filter( 'get_block_templates', array( $this, 'run_hooks_on_block_templates' ), 10, 3 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'add_plugin_templates_parts_support' ), 10, 2 );
 		add_filter( 'block_type_metadata_settings', array( $this, 'prevent_shortcodes_html_breakage' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'hide_template_selector_in_cart_checkout_pages' ), 10 );
-	}
-
-	/**
-	 * Run hooks on block templates.
-	 *
-	 * @param array $templates The block templates.
-	 * @return array The block templates.
-	 */
-	public function run_hooks_on_block_templates( $templates ) {
-		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
-		// via the Template Registration API. Because of this, we run them manually.
-		foreach ( $templates as $template ) {
-			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
-				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
-			}
-		}
-
-		return $templates;
 	}
 
 	/**
@@ -214,6 +196,24 @@ class BlockTemplatesController {
 	 */
 	public function add_block_template_details( $block_template, $id, $template_type ) {
 		return BlockTemplateUtils::update_template_data( $block_template, $template_type );
+	}
+
+	/**
+	 * Run hooks on block templates.
+	 *
+	 * @param array $templates The block templates.
+	 * @return array The block templates.
+	 */
+	public function run_hooks_on_block_templates( $templates ) {
+		// There is a bug in the WordPress implementation that causes block hooks not to run in templates registered
+		// via the Template Registration API. Because of this, we run them manually.
+		foreach ( $templates as $template ) {
+			if ( 'plugin' === $template->source && 'woocommerce' === $template->plugin ) {
+				$template->content = apply_block_hooks_to_content( $template->content, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+			}
+		}
+
+		return $templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -265,38 +265,6 @@ class BlockTemplatesController {
 				)
 			) {
 				array_unshift( $query_result, $template_file );
-				continue;
-			}
-
-			// If the template has a fallback, we should not include it in the list of templates, unless it has been modified.
-			$template_data = BlockTemplateUtils::get_template( $template_file->slug );
-			if ( $template_data && isset( $template_data->fallback_template ) ) {
-				continue;
-			}
-
-			$possible_template_ids = [
-				$theme_slug . '//' . $template_file->slug,
-				$theme_slug . '//' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $template_file->slug,
-				$theme_slug . '//' . BlockTemplateUtils::DIRECTORY_NAMES['DEPRECATED_TEMPLATE_PARTS'] . '/' . $template_file->slug,
-			];
-
-			$is_custom                 = false;
-			$query_result_template_ids = array_column( $query_result, 'id' );
-
-			foreach ( $possible_template_ids as $template_id ) {
-				if ( in_array( $template_id, $query_result_template_ids, true ) ) {
-					$is_custom = true;
-					break;
-				}
-			}
-			$fits_slug_query =
-				! isset( $query['slug__in'] ) || in_array( $template_file->slug, $query['slug__in'], true );
-			$fits_area_query =
-				! isset( $query['area'] ) || ( property_exists( $template_file, 'area' ) && $template_file->area === $query['area'] );
-			$should_include  = ! $is_custom && $fits_slug_query && $fits_area_query;
-			if ( $should_include ) {
-				$template       = BlockTemplateUtils::build_template_result_from_file( $template_file, $template_type );
-				$query_result[] = $template;
 			}
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -88,12 +88,32 @@ class BlockTemplatesRegistry {
 		} else {
 			$template_parts = array();
 		}
-		$this->templates = array_merge( $templates, $template_parts );
 
 		// Init all templates.
-		foreach ( $this->templates as $template ) {
+		foreach ( $templates as $template ) {
 			$template->init();
+
+			// Taxonomy templates are registered automatically by WordPress and
+			// are made available through the Add Template menu.
+			if ( ! $template->is_taxonomy_template ) {
+				$directory          = BlockTemplateUtils::get_templates_directory( 'wp_template' );
+				$template_file_path = $directory . '/' . $template::SLUG . '.html';
+				register_block_template(
+					'woocommerce//' . $template::SLUG,
+					array(
+						'title'       => $template->get_template_title(),
+						'description' => $template->get_template_description(),
+						'content'     => file_get_contents( $template_file_path ),
+					)
+				);
+			}
 		}
+
+		foreach ( $template_parts as $template_part ) {
+			$template_part->init();
+		}
+
+		$this->templates = array_merge( $templates, $template_parts );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesRegistry.php
@@ -103,6 +103,7 @@ class BlockTemplatesRegistry {
 					array(
 						'title'       => $template->get_template_title(),
 						'description' => $template->get_template_description(),
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 						'content'     => file_get_contents( $template_file_path ),
 					)
 				);

--- a/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/OrderConfirmation/CreateAccount.php
@@ -35,7 +35,7 @@ class CreateAccount extends AbstractOrderConfirmationBlock {
 	 */
 	protected function initialize_hooks() {
 		// This does not use the Block Hooks Trait used in mini cart. The implementation is simpler because we support
-		// versions higher than WP 6.5 when hooks were introduced. They should be consolodated in the future.
+		// versions higher than WP 6.5 when hooks were introduced. They should be consolidated in the future.
 		add_filter(
 			'hooked_block_types',
 			function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {

--- a/plugins/woocommerce/src/Blocks/Templates/AbstractTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/AbstractTemplate.php
@@ -19,6 +19,13 @@ abstract class AbstractTemplate {
 	const SLUG = '';
 
 	/**
+	 * Whether this is a taxonomy template.
+	 *
+	 * @var bool
+	 */
+	public bool $is_taxonomy_template = false;
+
+	/**
 	 * Initialization method.
 	 */
 	abstract public function init();

--- a/plugins/woocommerce/src/Blocks/Templates/CartTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/CartTemplate.php
@@ -16,15 +16,6 @@ class CartTemplate extends AbstractPageTemplate {
 	const SLUG = 'page-cart';
 
 	/**
-	 * Initialization method.
-	 */
-	public function init() {
-		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
-
-		parent::init();
-	}
-
-	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string
@@ -40,17 +31,6 @@ class CartTemplate extends AbstractPageTemplate {
 	 */
 	public function get_template_description() {
 		return __( 'The Cart template displays the items selected by the user for purchase, including quantities, prices, and discounts. It allows users to review their choices before proceeding to checkout.', 'woocommerce' );
-	}
-
-	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
-	 */
-	public function render_block_template() {
-		if (
-			! is_embed() && is_cart()
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Templates/CheckoutTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/CheckoutTemplate.php
@@ -16,15 +16,6 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	const SLUG = 'page-checkout';
 
 	/**
-	 * Initialization method.
-	 */
-	public function init() {
-		parent::init();
-
-		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
-	}
-
-	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string
@@ -40,17 +31,6 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	 */
 	public function get_template_description() {
 		return __( 'The Checkout template guides users through the final steps of the purchase process. It enables users to enter shipping and billing information, select a payment method, and review order details.', 'woocommerce' );
-	}
-
-	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
-	 */
-	public function render_block_template() {
-		if (
-			! is_embed() && is_checkout()
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -74,8 +74,22 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 	 */
 	public function template_hierarchy( $templates ) {
 		$queried_object = get_queried_object();
+
 		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wp_is_block_theme() ) {
-			array_splice( $templates, count( $templates ) - 1, 0, array( self::SLUG, $this->fallback_template ) );
+			// If Products by Attribute template has been customized or it's in the
+			// theme, we load it first, otherwise we only load the fallback template.
+			// If we don't do that, the WC core template would also have priority
+			// over the fallback template.
+			$slugs = array( $this->fallback_template );
+
+			if (
+				BlockTemplateUtils::theme_has_template( self::SLUG ) ||
+				BlockTemplateUtils::get_block_templates_from_db( array( self::SLUG ) )
+			) {
+				$slugs = array( self::SLUG, $this->fallback_template );
+			}
+
+			array_splice( $templates, count( $templates ) - 1, 0, $slugs );
 		}
 
 		return $templates;

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -62,8 +62,6 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -78,7 +78,7 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wp_is_block_theme() ) {
 			// If Products by Attribute template has been customized or it's in the
 			// theme, we load it first, otherwise we only load the fallback template.
-			// If we don't do that, the WC core template would also have priority
+			// If we don't do that, the WC core template would always have priority
 			// over the fallback template.
 			$slugs = array( $this->fallback_template );
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductBrandTemplate.php
@@ -27,6 +27,13 @@ class ProductBrandTemplate extends AbstractTemplateWithFallback {
 	public string $fallback_template = ProductCatalogTemplate::SLUG;
 
 	/**
+	 * Whether this is a taxonomy template.
+	 *
+	 * @var bool
+	 */
+	public bool $is_taxonomy_template = true;
+
+	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -58,8 +58,6 @@ class ProductCatalogTemplate extends AbstractTemplate {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCategoryTemplate.php
@@ -27,6 +27,13 @@ class ProductCategoryTemplate extends AbstractTemplateWithFallback {
 	public string $fallback_template = ProductCatalogTemplate::SLUG;
 
 	/**
+	 * Whether this is a taxonomy template.
+	 *
+	 * @var bool
+	 */
+	public bool $is_taxonomy_template = true;
+
+	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -57,8 +57,6 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductTagTemplate.php
@@ -27,6 +27,13 @@ class ProductTagTemplate extends AbstractTemplateWithFallback {
 	public string $fallback_template = ProductCatalogTemplate::SLUG;
 
 	/**
+	 * Whether this is a taxonomy template.
+	 *
+	 * @var bool
+	 */
+	public bool $is_taxonomy_template = true;
+
+	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -69,7 +69,7 @@ class SingleProductTemplate extends AbstractTemplate {
 			}
 
 			// Use the first template by default.
-			$template = $templates[0];
+			$template = reset( $templates );
 
 			// Check if there is a template matching the slug `single-product-{post_name}`.
 			if ( count( $valid_slugs ) > 1 && count( $templates ) > 1 ) {

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -144,6 +144,10 @@ class SingleProductTemplate extends AbstractTemplate {
 			},
 			$query_result
 		);
+
+		// Let's make sure we only run the filter once.
+		remove_filter( 'get_block_templates', array( $this, 'update_single_product_content' ), 11 );
+
 		return $query_result;
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -97,8 +97,6 @@ class SingleProductTemplate extends AbstractTemplate {
 					)
 				);
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -692,6 +692,37 @@ class BlockTemplateUtils {
 	}
 
 	/**
+	 * Updates the title, description and area of a template to the correct values and to make them more user-friendly.
+	 * For example, instead of:
+	 * - Title: `Tag (product_tag)`
+	 * - Description: `Displays taxonomy: Tag.`
+	 * we display:
+	 * - Title: `Products by Tag`
+	 * - Description: `Displays products filtered by a tag.`.
+	 *
+	 * @param WP_Block_Template $template The template object.
+	 * @param string            $template_type wp_template or wp_template_part.
+	 *
+	 * @return WP_Block_Template
+	 */
+	public static function update_template_data( $template, $template_type ) {
+		if ( ! $template ) {
+			return $template;
+		}
+		if ( empty( $template->title ) || $template->title === $template->slug ) {
+			$template->title = self::get_block_template_title( $template->slug );
+		}
+		if ( empty( $template->description ) ) {
+			$template->description = self::get_block_template_description( $template->slug );
+		}
+		if ( empty( $template->area ) || 'uncategorized' === $template->area ) {
+			$template->area = self::get_block_template_area( $template->slug, $template_type );
+		}
+
+		return $template;
+	}
+
+	/**
 	 * Gets the templates saved in the database.
 	 *
 	 * @param array  $slugs An array of slugs to retrieve templates for.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -691,37 +691,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Updates the title, description and area of a template to the correct values and to make them more user-friendly.
-	 * For example, instead of:
-	 * - Title: `Tag (product_tag)`
-	 * - Description: `Displays taxonomy: Tag.`
-	 * we display:
-	 * - Title: `Products by Tag`
-	 * - Description: `Displays products filtered by a tag.`.
-	 *
-	 * @param WP_Block_Template $template The template object.
-	 * @param string            $template_type wp_template or wp_template_part.
-	 *
-	 * @return WP_Block_Template
-	 */
-	public static function update_template_data( $template, $template_type ) {
-		if ( ! $template ) {
-			return $template;
-		}
-		if ( empty( $template->title ) || $template->title === $template->slug ) {
-			$template->title = self::get_block_template_title( $template->slug );
-		}
-		if ( empty( $template->description ) ) {
-			$template->description = self::get_block_template_description( $template->slug );
-		}
-		if ( empty( $template->area ) || 'uncategorized' === $template->area ) {
-			$template->area = self::get_block_template_area( $template->slug, $template_type );
-		}
-
-		return $template;
-	}
-
-	/**
 	 * Gets the templates saved in the database.
 	 *
 	 * @param array  $slugs An array of slugs to retrieve templates for.

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -535,26 +535,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Returns `true` if the $template has been found in the $query_result.
-	 *
-	 * @param array  $query_result Array of template objects.
-	 * @param object $template A specific template object.
-	 *
-	 * @return boolean
-	 */
-	public static function is_template_in_query_result( $query_result, $template ) {
-		foreach ( $query_result as &$query_result_template ) {
-			if (
-				$query_result_template->slug === $template->slug
-				&& $query_result_template->theme === $template->theme
-			) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * Removes templates from the theme or WooCommerce which have the same slug
 	 * as template saved in the database with the `woocommerce/woocommerce` theme.
 	 * Before WC migrated to the Template Registration API from WordPress, templates

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -555,13 +555,17 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Removes templates that were added to a theme's block-templates directory, but already had a customised version saved in the database.
+	 * Removes templates from the theme or WooCommerce which have the same slug
+	 * as template saved in the database with the `woocommerce/woocommerce` theme.
+	 * Before WC migrated to the Template Registration API from WordPress, templates
+	 * were saved in the database with the `woocommerce/woocommerce` theme instead
+	 * of the theme's slug.
 	 *
 	 * @param \WP_Block_Template[]|\stdClass[] $templates List of templates to run the filter on.
 	 *
 	 * @return array List of templates with duplicates removed. The customised alternative is preferred over the theme default.
 	 */
-	public static function remove_theme_templates_with_custom_alternative( $templates ) {
+	public static function remove_templates_with_custom_alternative( $templates ) {
 
 		// Get the slugs of all templates that have been customised and saved in the database.
 		$customised_template_slugs = array_column(
@@ -569,22 +573,19 @@ class BlockTemplateUtils {
 				$templates,
 				function ( $template ) {
 					// This template has been customised and saved as a post.
-					return 'custom' === $template->source;
+					return 'custom' === $template->source && 'woocommerce/woocommerce' === $template->theme;
 				}
 			),
 			'slug'
 		);
 
-		// Remove theme (i.e. filesystem) templates that have the same slug as a customised one. We don't need to check
-		// for `woocommerce` in $template->source here because woocommerce templates won't have been added to $templates
-		// if a saved version was found in the db. This only affects saved templates that were saved BEFORE a theme
-		// template with the same slug was added.
+		// Remove theme and WC templates that have the same slug as a customised one.
 		return array_values(
 			array_filter(
 				$templates,
 				function ( $template ) use ( $customised_template_slugs ) {
 					// This template has been customised and saved as a post, so return it.
-					return ! ( 'theme' === $template->source && in_array( $template->slug, $customised_template_slugs, true ) );
+					return ! ( 'custom' !== $template->source && in_array( $template->slug, $customised_template_slugs, true ) );
 				}
 			)
 		);
@@ -612,7 +613,7 @@ class BlockTemplateUtils {
 				$is_there_a_customized_theme_template = array_filter(
 					$templates,
 					function ( $theme_template ) use ( $template, $theme_slug ) {
-						return $theme_template->slug === $template->slug && $theme_template->theme === $theme_slug;
+						return $theme_template->slug === $template->slug && $theme_template->theme === $theme_slug && 'custom' === $theme_template->source;
 					}
 				);
 				if ( $is_there_a_customized_theme_template ) {

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -564,19 +564,15 @@ class BlockTemplateUtils {
 	public static function remove_theme_templates_with_custom_alternative( $templates ) {
 
 		// Get the slugs of all templates that have been customised and saved in the database.
-		$customised_template_slugs = array_map(
-			function ( $template ) {
-				return $template->slug;
-			},
-			array_values(
-				array_filter(
-					$templates,
-					function ( $template ) {
-						// This template has been customised and saved as a post.
-						return 'custom' === $template->source;
-					}
-				)
-			)
+		$customised_template_slugs = array_column(
+			array_filter(
+				$templates,
+				function ( $template ) {
+					// This template has been customised and saved as a post.
+					return 'custom' === $template->source;
+				}
+			),
+			'slug'
 		);
 
 		// Remove theme (i.e. filesystem) templates that have the same slug as a customised one. We don't need to check

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -576,11 +576,12 @@ class BlockTemplateUtils {
 	 * WooCommerce default template when there is a customized template based on the theme template.
 	 *
 	 * @param \WP_Block_Template[]|\stdClass[] $templates  List of templates to run the filter on.
-	 * @param string                           $theme_slug Slug of the theme currently active.
 	 *
 	 * @return array Filtered list of templates with only relevant templates available.
 	 */
-	public static function remove_duplicate_customized_templates( $templates, $theme_slug ) {
+	public static function remove_duplicate_customized_templates( $templates ) {
+		$theme_slug = get_stylesheet();
+
 		$filtered_templates = array_filter(
 			$templates,
 			function ( $template ) use ( $templates, $theme_slug ) {

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -40,7 +40,6 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 				return new BlockTemplatesRegistry();
 			}
 		);
-		$this->container->get( BlockTemplatesRegistry::class )->init();
 		$this->container->register(
 			TemplateOptions::class,
 			function () {
@@ -171,7 +170,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			'theme'       => 'woocommerce/woocommerce',
 			'source'      => 'plugin',
 			'title'       => 'Single Product',
-			'description' => 'Displays a single product.',
+			'description' => '',
 			'post_types'  => array(),
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -192,18 +192,22 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			(object) array(
 				'slug'   => 'single-product',
 				'source' => 'theme',
+				'theme'  => 'my-theme',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_tag',
 				'source' => 'theme',
+				'theme'  => 'my-theme',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_cat',
 				'source' => 'theme',
+				'theme'  => 'my-theme',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_cat',
 				'source' => 'custom',
+				'theme'  => 'woocommerce/woocommerce',
 			),
 		);
 
@@ -211,14 +215,17 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			(object) array(
 				'slug'   => 'single-product',
 				'source' => 'theme',
+				'theme'  => 'my-theme',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_tag',
 				'source' => 'theme',
+				'theme'  => 'my-theme',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_cat',
 				'source' => 'custom',
+				'theme'  => 'woocommerce/woocommerce',
 			),
 		);
 

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -134,31 +134,6 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the is_template_in_query_result method.
-	 */
-	public function test_is_template_in_query_result() {
-		$query_result = array(
-			(object) array(
-				'slug'  => 'taxonomy-product_cat',
-				'theme' => 'twentytwentytwo',
-			),
-		);
-
-		$non_matching_template_file = (object) array(
-			'slug'  => 'archive-product',
-			'theme' => 'twentytwentytwo',
-		);
-
-		$matching_template_file = (object) array(
-			'slug'  => 'taxonomy-product_cat',
-			'theme' => 'twentytwentytwo',
-		);
-
-		$this->assertFalse( BlockTemplateUtils::is_template_in_query_result( $query_result, $non_matching_template_file ) );
-		$this->assertTrue( BlockTemplateUtils::is_template_in_query_result( $query_result, $matching_template_file ) );
-	}
-
-	/**
 	 * Test create_new_block_template_object.
 	 */
 	public function test_create_new_block_template_object() {

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -185,9 +185,9 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test remove_theme_templates_with_custom_alternative.
+	 * Test remove_templates_with_custom_alternative.
 	 */
-	public function test_remove_theme_templates_with_custom_alternative() {
+	public function test_remove_templates_with_custom_alternative() {
 		$templates = array(
 			(object) array(
 				'slug'   => 'single-product',
@@ -222,7 +222,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertEquals( $expected_templates, BlockTemplateUtils::remove_theme_templates_with_custom_alternative( $templates ) );
+		$this->assertEquals( $expected_templates, BlockTemplateUtils::remove_templates_with_custom_alternative( $templates ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Built on top of https://github.com/woocommerce/woocommerce/pull/60191.

Closes https://github.com/woocommerce/woocommerce/issues/47885.

This PR updates WooCommerce to use the [Template Registration API introduced in WP 6.7](https://make.wordpress.org/core/2024/10/20/new-plugin-template-registration-api-in-wordpress-6-7/). This brings a few benefits:

1. It allows us to simplify our codebase. The hooks we have in `get_block_templates` should be much simpler and easier to understand now. Unfortunately, we still need a lot of custom code to support templates that were saved in previous WC versions using the `woocommerce` slug.
2. It fixes some weird issues like #42181.
3. It will bring more reliability to the templating logic, as it will be handled by WP core. For now, I only introduced new tests, but if everything goes well, I expect we will be able to [remove the existing slow tests](https://github.com/woocommerce/woocommerce/blob/b45221c22987cae5b871139f58baff5fcf1b103b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-customization.block_theme.spec.ts) that test each specific template individually. Some other tests should ideally be updated too so they use the theme slug when editing templates instead of the WC slug, but I will handle that in a separate PR.

This PR also closes https://github.com/woocommerce/woocommerce/issues/42181. But there is a small note to make:

1. If a template has been customized (saved with the `woocommerce` slug), it will persist after updating. Editing it again will keep it under the `woocommerce` slug. That means #42181 won't be fixed for these templates until they are completely reset.
2. If a template has never been customized, any new customizations will be saved with the theme slug, this is how the upstream Template Registration API works. This means #42181 will be fixed for any new customized templates.

### How to test the changes in this Pull Request:

We need to do a broad testing to make sure there are no regressions in the way WooCommerce block templates work and, more specifically, that updating from an old version of WooCommerce doesn't cause any templates to be lost. I'm posting some testing steps below, but feel free to test differently and try to break as many things as possible.

1. In `trunk`, customize some templates, like _Product Catalog_, _Products by Category_ and _Products by Attribute_.
2. Update to this branch.
3. Verify the customizations you did before are still applied. Make sure also that _Products by Tag_ or _Products by Brand_ fall back to the customized _Product Catalog_ template.
4. In the editor, open _Product Catalog_, _Product by Category_ and _Products by Attribute_. Verify the templates you customized are loaded.
5. Now, create an _Products by Tag_ template (_Add Template_ > _Products by Tag_ > _All tags_) and chose the suggested pattern. Verify it is the customized _Product Catalog_ template.
6. Make edits to one of three templates you edited in step 1 and verify they are applied to the frontend as expected. Now, reset one of these templates and verify the edits are gone.
7. Now, reset the _Single Product_ template if you have any edits.
8. Make a new edit and verify the changes are applied in the frontend.
9. Switch to another theme.
10. Verify the _Single Product_ template went back to the default and the header is loading as expected.