### PR TITLE
Preserve manual discount when manually editing an order

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5271-wc-101-rc12-item-price-edit-is-broken-when-manually-editing
+++ b/plugins/woocommerce/changelog/wooplug-5271-wc-101-rc12-item-price-edit-is-broken-when-manually-editing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preserve manual discount when manually editing an order

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -457,7 +457,7 @@ function wc_save_order_items( $order_id, $items ) {
 
 	// Only recalculate when a coupon is applied.
 	// This allows manual discounts to be preserved when order items are saved.
-	$order_coupons = $order->get_items( 'coupon' );
+	$order_coupons = $order->get_coupons();
 	if ( ! empty( $order_coupons ) ) {
 		$order->recalculate_coupons();
 	}

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -454,7 +454,14 @@ function wc_save_order_items( $order_id, $items ) {
 	}
 
 	$order->update_taxes();
-	$order->recalculate_coupons();
+
+	// Only recalculate when a coupon is applied.
+	// This allows manual discounts to be preserved when order items are saved.
+	$order_coupons = $order->get_items( 'coupon' );
+	if ( ! empty( $order_coupons ) ) {
+		$order->recalculate_coupons();
+	}
+
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.

--- a/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/order/create-order.spec.js
@@ -414,7 +414,7 @@ test.describe(
 				)
 			).toBeVisible();
 			await expect(
-				page.locator( 'table' ).filter( { hasText: 'Paid: $220.00' } )
+				page.locator( 'table' ).filter( { hasText: 'Paid: $200.00' } )
 			).toBeVisible();
 		} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Note: this is targeting 10.1 milestone, to be included in next week's 10.1 release.** 

In https://github.com/woocommerce/woocommerce/pull/59606 we added a fix, that when manually editing an order with a coupon code, increasing item quantity wouldn't cause the discount to be greater than the coupon's value. This was done by calling `$order->recalculate_coupons();` on order items save. 

However, this introduced an issue when manually adding a discount to the order without using any coupon code:
<img width="338" height="211" alt="Screenshot 2025-08-07 at 08 20 59" src="https://github.com/user-attachments/assets/fae065de-f748-42d7-ba28-ee3982f498dc" />

In this case, calling `$order->recalculate_coupons();` removes the discount, because there is no coupon associated so the order items totals are recalculated to remove the discount (i.e., so the discount is not greater than $0). 

The fix is to only call `$order->recalculate_coupons();` when a coupon code is associated with the order. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60235, closes WOOPLUG-5271.

(For Bug Fixes) Bug introduced in PR #59606.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="292" height="244" alt="Screenshot 2025-08-07 at 08 20 25" src="https://github.com/user-attachments/assets/2bbcb891-e2c1-44cd-8cf6-c85c0691f196" />   |    <img width="343" height="270" alt="Screenshot 2025-08-07 at 08 20 45" src="https://github.com/user-attachments/assets/0461a00e-a9f6-49d2-b83e-3f7426b9ce9b" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Orders > Add orde**.
2. Add any product. 
3. Edit order item (the pencil icon).
4. Update prices so `Before discount` is greater than `Total`.
5. Click `Save` and check, that the discount is applied. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
