### PR TITLE
[Release] CI: change automation PRs author (batch 1)

### DIFF
--- a/.github/workflows/cherry-pick-milestoned-prs.yml
+++ b/.github/workflows/cherry-pick-milestoned-prs.yml
@@ -9,10 +9,10 @@ on:
     branches: [trunk]
 
 env:
-  GIT_COMMITTER_NAME: 'WooCommerce Bot'
-  GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-  GIT_AUTHOR_NAME: 'WooCommerce Bot'
-  GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+  GIT_COMMITTER_NAME: 'woocommercebot'
+  GIT_COMMITTER_EMAIL: 'woocommercebot@users.noreply.github.com'
+  GIT_AUTHOR_NAME: 'woocommercebot'
+  GIT_AUTHOR_EMAIL: 'woocommercebot@users.noreply.github.com'
 
 jobs:
   prepare:
@@ -102,6 +102,7 @@ jobs:
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
       target_branch: ${{ needs.prepare.outputs.milestoned_branch }}
+    secrets: inherit
 
   # Cherry-pick to next branch
   cherry-pick-next:
@@ -111,6 +112,7 @@ jobs:
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
       target_branch: ${{ needs.prepare.outputs.next_branch }}
+    secrets: inherit
 
   # Handle successful cherry-pick to milestoned branch
   handle-success-milestoned:

--- a/.github/workflows/cherry-pick-milestoned-prs.yml
+++ b/.github/workflows/cherry-pick-milestoned-prs.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Add milestone
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
               owner: context.repo.owner,
@@ -141,6 +142,7 @@ jobs:
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick-milestoned.outputs.cherry_pick_pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const cherryPickPrNumber = process.env.CHERRY_PICK_PR_NUMBER;
             const targetBranch = process.env.TARGET_BRANCH;
@@ -192,6 +194,7 @@ jobs:
       - name: Add milestone
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
               owner: context.repo.owner,
@@ -209,6 +212,7 @@ jobs:
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick-next.outputs.cherry_pick_pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const cherryPickPrNumber = process.env.CHERRY_PICK_PR_NUMBER;
             const targetBranch = process.env.TARGET_BRANCH;
@@ -264,6 +268,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -281,6 +286,7 @@ jobs:
           TARGET_BRANCH: ${{ needs.prepare.outputs.milestoned_branch }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pr = (await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -342,6 +348,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -359,6 +366,7 @@ jobs:
           TARGET_BRANCH: ${{ needs.prepare.outputs.next_branch }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pr = (await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/cherry-pick-milestoned-prs.yml
+++ b/.github/workflows/cherry-pick-milestoned-prs.yml
@@ -52,7 +52,7 @@ jobs:
       # Identify release branches to cherry-pick to
       - name: Get release branches
         id: get-branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           BASE_VERSION: ${{ steps.extract-version.outputs.base_version }}
         with:
@@ -122,7 +122,7 @@ jobs:
     steps:
       # Add original milestone to new PR
       - name: Add milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -136,7 +136,7 @@ jobs:
       # Comment on original PR about cherry-pick success
       - name: Comment on original PR about cherry-pick success
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.milestoned_branch }}
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick-milestoned.outputs.cherry_pick_pr_number }}
@@ -192,7 +192,7 @@ jobs:
     steps:
       # Add original milestone to new PR
       - name: Add milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -206,7 +206,7 @@ jobs:
       # Comment on original PR about cherry-pick success
       - name: Comment on original PR about cherry-pick success
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.next_branch }}
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick-next.outputs.cherry_pick_pr_number }}
@@ -266,7 +266,7 @@ jobs:
       # Label original PR with failure tag
       - name: Add "cherry pick failed" label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -280,7 +280,7 @@ jobs:
       # Comment on original PR about failure
       - name: Comment on original PR about cherry-pick failure
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           ERROR_MESSAGE: ${{ needs.cherry-pick-milestoned.outputs.error_message || 'Unknown error' }}
           TARGET_BRANCH: ${{ needs.prepare.outputs.milestoned_branch }}
@@ -346,7 +346,7 @@ jobs:
       # Label original PR with failure tag
       - name: Add "cherry pick failed" label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -360,7 +360,7 @@ jobs:
       # Comment on original PR about failure
       - name: Comment on original PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           ERROR_MESSAGE: ${{ needs.cherry-pick-next.outputs.error_message || 'Unknown error' }}
           TARGET_BRANCH: ${{ needs.prepare.outputs.next_branch }}

--- a/.github/workflows/cherry-pick-to-frozen.yml
+++ b/.github/workflows/cherry-pick-to-frozen.yml
@@ -126,6 +126,7 @@ jobs:
         if: github.event.pull_request.milestone.number != null
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
               owner: context.repo.owner,
@@ -143,6 +144,7 @@ jobs:
           ADD_CP_TO_TRUNK_NAG: ${{ needs.cherry-pick-to-trunk-check.outputs.add_cp_to_trunk_nag }}
           NEXT_BRANCH: ${{ needs.prepare.outputs.next_branch }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const cherryPickPrNumber = process.env.CHERRY_PICK_PR_NUMBER;
             const targetBranch = process.env.NEXT_BRANCH;
@@ -205,6 +207,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -222,6 +225,7 @@ jobs:
           ADD_CP_TO_TRUNK_NAG: ${{ needs.cherry-pick-to-trunk-check.outputs.add_cp_to_trunk_nag }}
           NEXT_BRANCH: ${{ needs.prepare.outputs.next_branch }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pr = (await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/cherry-pick-to-frozen.yml
+++ b/.github/workflows/cherry-pick-to-frozen.yml
@@ -10,10 +10,10 @@ on:
       - 'release/*'
 
 env:
-  GIT_COMMITTER_NAME: 'WooCommerce Bot'
-  GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-  GIT_AUTHOR_NAME: 'WooCommerce Bot'
-  GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+  GIT_COMMITTER_NAME: 'woocommercebot'
+  GIT_COMMITTER_EMAIL: 'woocommercebot@users.noreply.github.com'
+  GIT_AUTHOR_NAME: 'woocommercebot'
+  GIT_AUTHOR_EMAIL: 'woocommercebot@users.noreply.github.com'
 
 jobs:
 
@@ -86,6 +86,7 @@ jobs:
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
       target_branch: ${{ needs.prepare.outputs.next_branch }}
+    secrets: inherit
 
   # Check if the original PR has been labeled to cherry pick to trunk and add a reminder to the output if not.  
   cherry-pick-to-trunk-check:

--- a/.github/workflows/cherry-pick-to-frozen.yml
+++ b/.github/workflows/cherry-pick-to-frozen.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Check frozen release conditions
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           BASE_BRANCH: ${{ needs.prepare.outputs.base_branch }}
         with:
@@ -124,7 +124,7 @@ jobs:
       # We set the milestone of the new PR to the milestone of the source PR since they should all be merged in preperation for the same release.
       - name: Add milestone
         if: github.event.pull_request.milestone.number != null
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -137,7 +137,7 @@ jobs:
 
       - name: Comment on original PR about cherry-pick success
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick.outputs.cherry_pick_pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -205,7 +205,7 @@ jobs:
     steps:
       - name: Add "cherry pick failed" label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -218,7 +218,7 @@ jobs:
 
       - name: Comment on original PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           ERROR_MESSAGE: ${{ needs.cherry-pick.outputs.error_message || 'Unknown error' }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/cherry-pick-to-trunk.yml
+++ b/.github/workflows/cherry-pick-to-trunk.yml
@@ -115,6 +115,7 @@ jobs:
         if: github.event.pull_request.milestone.number != null
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
               owner: context.repo.owner,
@@ -132,6 +133,7 @@ jobs:
           ADD_CP_TO_FROZEN_NAG: ${{ needs.frozen-release-check.outputs.add_cp_to_frozen_nag }}
           NEXT_BRANCH: ${{ needs.frozen-release-check.outputs.next_branch }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const cherryPickPrNumber = process.env.CHERRY_PICK_PR_NUMBER;
             const targetBranch = 'trunk';
@@ -194,6 +196,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -211,6 +214,7 @@ jobs:
           ADD_CP_TO_FROZEN_NAG: ${{ needs.frozen-release-check.outputs.add_cp_to_frozen_nag }}
           NEXT_BRANCH: ${{ needs.frozen-release-check.outputs.next_branch }}
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pr = (await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/cherry-pick-to-trunk.yml
+++ b/.github/workflows/cherry-pick-to-trunk.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Check frozen release conditions
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           BASE_BRANCH: ${{ needs.prepare.outputs.base_branch }}
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
@@ -113,7 +113,7 @@ jobs:
       # We set the milestone of the new PR to the milestone of the source PR since they should all be merged in preparation for the same release.
       - name: Add milestone
         if: github.event.pull_request.milestone.number != null
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -126,7 +126,7 @@ jobs:
 
       - name: Comment on original PR about cherry-pick success
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           CHERRY_PICK_PR_NUMBER: ${{ needs.cherry-pick.outputs.cherry_pick_pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -194,7 +194,7 @@ jobs:
     steps:
       - name: Add "cherry pick failed" label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -207,7 +207,7 @@ jobs:
 
       - name: Comment on original PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         env:
           ERROR_MESSAGE: ${{ needs.cherry-pick.outputs.error_message || 'Unknown error' }}
           GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/cherry-pick-to-trunk.yml
+++ b/.github/workflows/cherry-pick-to-trunk.yml
@@ -7,10 +7,10 @@ on:
       - 'release/*'
 
 env:
-  GIT_COMMITTER_NAME: 'WooCommerce Bot'
-  GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-  GIT_AUTHOR_NAME: 'WooCommerce Bot'
-  GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+  GIT_COMMITTER_NAME: 'woocommercebot'
+  GIT_COMMITTER_EMAIL: 'woocommercebot@users.noreply.github.com'
+  GIT_AUTHOR_NAME: 'woocommercebot'
+  GIT_AUTHOR_EMAIL: 'woocommercebot@users.noreply.github.com'
 
 jobs:
   prepare:
@@ -38,6 +38,7 @@ jobs:
     with:
       pr_number: ${{ needs.prepare.outputs.pr_number }}
       target_branch: 'trunk'
+    secrets: inherit
 
   # Check if the original PR has been labeled to cherry pick to frozen and add a reminder to the output if not.  
   frozen-release-check:

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Validate PR and get merge commit
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const prNumber = parseInt('${{ inputs.pr_number }}', 10);
@@ -102,7 +102,7 @@ jobs:
       - name: Verify target branch and cherry-pick branch
         id: verify-branches
         if: steps.check-pr.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const targetBranch = '${{ inputs.target_branch }}';
@@ -244,7 +244,7 @@ jobs:
 
       - name: Create cherry-pick pull request
         id: create-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -293,7 +293,7 @@ jobs:
 
       - name: Assign PR
         if: steps.create-pr.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -246,7 +246,7 @@ jobs:
         id: create-pr
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PR_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.PR_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = '${{ inputs.pr_number }}';
             const targetBranch = '${{ inputs.target_branch }}';

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -178,7 +178,7 @@ jobs:
       cherry_pick_pr_number: ${{ steps.aggregate-status.outputs.cherry_pick_pr_number }}
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: ${{ inputs.target_branch }}
 

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -246,6 +246,7 @@ jobs:
         id: create-pr
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PR_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = '${{ inputs.pr_number }}';
             const targetBranch = '${{ inputs.target_branch }}';

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -246,7 +246,7 @@ jobs:
         id: create-pr
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.PR_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = '${{ inputs.pr_number }}';
             const targetBranch = '${{ inputs.target_branch }}';

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -37,10 +37,10 @@ on:
         type: string
 
 env:
-  GIT_COMMITTER_NAME: 'WooCommerce Bot'
-  GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-  GIT_AUTHOR_NAME: 'WooCommerce Bot'
-  GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+  GIT_COMMITTER_NAME: 'woocommercebot'
+  GIT_COMMITTER_EMAIL: 'woocommercebot@users.noreply.github.com'
+  GIT_AUTHOR_NAME: 'woocommercebot'
+  GIT_AUTHOR_EMAIL: 'woocommercebot@users.noreply.github.com'
 
 jobs:
   verify:

--- a/.github/workflows/shared-cherry-pick.yml
+++ b/.github/workflows/shared-cherry-pick.yml
@@ -295,6 +295,7 @@ jobs:
         if: steps.create-pr.outcome == 'success'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.WC_BOT_PR_CREATE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = '${{ steps.create-pr.outputs.pr_number }}';
             const originalAuthor = '${{ steps.create-pr.outputs.original_author }}';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Related to: #60245, WOOPLUG-5274

> Do not merge: I'll create a new token in the repository before I merge the PR.

To trigger CI for PRs created by our automation, we are switching the auth token starting with the cherry-picking automation.
Along the way, we fix resolving `woocommercebot` as a committer.

The new token has a fallback to the GH actions token to simplify testing any future changes in the forks.

For the [example PR](https://github.com/kalessil/woocommerce/pull/5) note: GH action bot is not referenced, woocommercebot is correctly recognized as a committer.

<img width="920" height="555" alt="Screenshot from 2025-08-07 12-26-30" src="https://github.com/user-attachments/assets/b396dee2-cfd0-464c-a89c-04d4c469dcec" />

### How to test the changes in this Pull Request:

Follow test instructions from https://github.com/woocommerce/woocommerce/pull/59048, with additional setup steps:

- Navigate to developer settings under your GitHub account and create a custom token limited to the fork-repo and PRs write permission
- add a new fork-repo secret: WC_BOT_PR_CREATE_TOKEN for the new token (in the monorepo, we'll use the woocommercebot token)
- as per the shared screenshot, expect your profile to be referenced instead of mine
