### PR TITLE
Fully normalize versions for use in compile changelog

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -162,7 +162,9 @@ jobs:
           echo "Using branch: $SELECTED_BRANCH"
           echo "Generating changelog for version: $VERSION"
 
-          # Normalize the version by removing .0 patch if present, as the changelog command does not support it
+          # Normalize version for use with changelog command.
+          VERSION=$(echo "$VERSION" | grep -oP '\d+\.\d+\.\d+')
+
           if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
             VERSION=${VERSION%.0}
           fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The changelogger command does not play well with prerelease versions such as `10.0.0-beta.1` or `10.0.0-rc.2`. We already have some logic to do some normalization, but this PR takes it a step further by ensuring the changelogger command only receives the stable version number.

This wasn't a problem before #60203 because the version number used as input was in the format `X.Y.0` and that was passed almost verbatim to the changelogger command. We now use the version number from the release branch, which can be a pre-release value.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repo including the `release/10.1` branch.
2. Before merging this PR into `trunk` in your fork, run the **Actions > Release: Compile changelog** workflow using `10.1` as version number. It should fail with an error similar to this:
   > Invalid --use-version: Version number "10.1.0-rc.2" is not in a recognized format.
3. Now merge this branch into `trunk` in your fork.
4. Run **Actions > Release: Compile changelog** workflow using `10.1` as version number.
5. Ensure the workflow completes successfully and creates the PR updating the changelog and removing changelog files from `trunk`. 

<!-- End testing instructions -->