### PR TITLE
Label PRs merged after Feature Freeze

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -68,7 +68,7 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
               run: |
                   gh pr edit ${{ github.event.pull_request.number }} \
-                      --add-label "metric: post feature freeze" \
+                      --add-label "metric: feature freeze exception" \
                       --repo ${{ github.repository }}
 
     process-pull-request-after-close:

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -57,6 +57,20 @@ jobs:
                   PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    process-feature-freeze-exception:
+        name: Log the merge of a Feature Freeze exception
+        if: ${{ github.event.pull_request.merged && startsWith( github.event.pull_request.base.ref, 'release/' ) }}
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh pr edit ${{ github.event.pull_request.number }} \
+                      --add-label "metric: post feature freeze" \
+                      --repo ${{ github.repository }}
+
     process-pull-request-after-close:
         name: "Process a pull request after it's been closed"
         runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -59,7 +59,7 @@ jobs:
 
     process-feature-freeze-exception:
         name: Log the merge of a Feature Freeze exception
-        if: ${{ github.event.pull_request.merged && startsWith( github.event.pull_request.base.ref, 'release/' ) }}
+        if: ${{ github.event.pull_request.merged && startsWith( github.event.pull_request.base.ref, 'release/' ) && ! contains( github.event.pull_request.labels.*.name, 'Release' ) }}
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -170,7 +170,8 @@ jobs:
             --title 'Bump WooCommerce version to ${{ steps.compute-new-version.outputs.nextVersion }}' \
             --body 'This PR updates the versions in ${{ inputs.branch }} to ${{ steps.compute-new-version.outputs.nextVersion }}.' \
             --base ${{ inputs.branch }} \
-            --head ${branch_name}
+            --head ${branch_name} \
+            --label Release
 
       - name: Ensure milestone for dev version exists
         if: ${{ inputs.bump-type == 'dev' }}

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+            ref: trunk
 
       - name: Check the necessary branch exists
         id: check-branch
@@ -123,7 +123,8 @@ jobs:
           VERSION: ${{ steps.validate-version.outputs.version }}
           SELECTED_BRANCH: ${{ steps.check-branch.outputs.selected_branch }}
         run: |
-          git checkout $SELECTED_BRANCH
+          git fetch origin ${SELECTED_BRANCH}
+          git checkout ${SELECTED_BRANCH}
           current_version=$( cat plugins/woocommerce/woocommerce.php | grep -oP '(?<=Version: )(.+)' | head -n1 )
 
           echo "Current version from woocommerce.php: '$current_version'"
@@ -135,6 +136,9 @@ jobs:
           fi
 
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
+
+          # Go back to trunk.
+          git checkout trunk
 
       - name: Setup PNPM
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

--- a/.github/workflows/release-trends-analysis.yml
+++ b/.github/workflows/release-trends-analysis.yml
@@ -15,7 +15,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: post feature freeze\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
+          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: feature freeze exception\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
           issue=$( gh issue create --title "[Release] trend analysis for ${{ inputs.milestone }} milestone (CFEs)" --assignee "${{ github.actor }}" --body "Generated automatically via release-trends-analysis.yml." | grep '/issues/' | sed -E 's/[^0-9]*//' )
 
           gh issue comment ${issue} --body "
@@ -63,7 +63,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: post feature freeze\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
+          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: feature freeze exception\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
           prrs=$( gh issue list --search "is:issue milestone:${{ inputs.milestone }} state:closed label:\"point release request\"" --json url | jq --compact-output '.[]' | jq --raw-output '( "- " + .url )' )
           issue=$( gh issue create --title "[Release] quality trend analysis for ${{ inputs.milestone }} milestone (CFEs and PRRs)" --assignee "${{ github.actor }}" --body "Generated automatically via release-trends-analysis.yml." | grep '/issues/' | sed -E 's/[^0-9]*//' )
 

--- a/.github/workflows/release-trends-analysis.yml
+++ b/.github/workflows/release-trends-analysis.yml
@@ -15,15 +15,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: code freeze exception\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
+          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: post feature freeze\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
           issue=$( gh issue create --title "[Release] trend analysis for ${{ inputs.milestone }} milestone (CFEs)" --assignee "${{ github.actor }}" --body "Generated automatically via release-trends-analysis.yml." | grep '/issues/' | sed -E 's/[^0-9]*//' )
-          
+
           gh issue comment ${issue} --body "
           @coderabbitai: for the following GitHub PRs:
           ${cfes}
-          
+
           please analyze the similarity and trends. When reporting results, please provide a separate comment on the criteria used for classification and grouping.
-          
+
           Additional instructions:
           - If processing any of the PRs takes more than 5 minutes, please skip it and report the list of skipped PRs in the full/final summary.
           - When starting to process this request, please estimate and memorize how much time it can take to complete the request processing.
@@ -41,13 +41,13 @@ jobs:
         run: |
           prrs=$( gh issue list --search "is:issue milestone:${{ inputs.milestone }} state:closed label:\"point release request\"" --json url | jq --compact-output '.[]' | jq --raw-output '( "- " + .url )' )
           issue=$( gh issue create --title "[Release] trend analysis for ${{ inputs.milestone }} milestone (PRRs)" --assignee "${{ github.actor }}" --body "Generated automatically via release-trends-analysis.yml." | grep '/issues/' | sed -E 's/[^0-9]*//' )
-          
+
           gh issue comment ${issue} --body "
           @coderabbitai: for the following GitHub issues and their comments:
           ${prrs}
-          
+
           please analyze the similarity and trends. When reporting results, please provide a separate comment on the criteria used for classification and grouping.
-        
+
           Additional instructions:
           - If processing any of the issues takes more than 5 minutes, please skip it and report the list of skipped issues in the full/final summary.
           - When starting to process this request, please estimate and memorize how much time it can take to complete the request processing.
@@ -63,24 +63,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: code freeze exception\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
+          cfes=$( gh pr list --search "is:pr milestone:${{ inputs.milestone }} is:closed label:\"metric: post feature freeze\"" --json url | jq --compact-output '.[]' |  jq --raw-output '( "- " + .url )' )
           prrs=$( gh issue list --search "is:issue milestone:${{ inputs.milestone }} state:closed label:\"point release request\"" --json url | jq --compact-output '.[]' | jq --raw-output '( "- " + .url )' )
           issue=$( gh issue create --title "[Release] quality trend analysis for ${{ inputs.milestone }} milestone (CFEs and PRRs)" --assignee "${{ github.actor }}" --body "Generated automatically via release-trends-analysis.yml." | grep '/issues/' | sed -E 's/[^0-9]*//' )
 
           gh issue comment ${issue} --body "
           @coderabbitai: for the following GitHub issues and their comments:
           ${prrs}
-          
+
           and the following GitHub PRs:
           ${cfes}
-          
+
           please answer the following questions (full report):
           - What are the changes types (one of the following options: bug fix, performance fix, enhancement, configuration changes, maintenance, other)?
           - What are the root causes (one of the following options: backward compatibility break, strict types issue, loose types issue, error/exception handling issue, validation issue, business logic issue, configuration issue, environment issue, other)?
           - Replace the 'other' option from above with one of your choice, which is fit to the PR context.
           - Which PRs, in your opinion, address issues caused by the technical debt?
           - Explain your definitions for the options listed above.
-        
+
           Additional instructions:
           - If processing any of the issues/PRs takes more than 5 minutes, please skip it and report the list of skipped issues/PRs in the full/final summary.
           - When starting to process this request, please estimate and memorize how much time it can take to complete the request processing.

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -12,7 +12,7 @@ import { readFileSync } from 'fs';
  */
 import { Logger } from '../../../../core/logger';
 import { checkoutRemoteBranch } from '../../../../core/git';
-import { createPullRequest } from '../../../../core/github/repo';
+import { addLabelsToIssue, createPullRequest } from '../../../../core/github/repo';
 import { Options } from '../types';
 import { getToday } from '../../get-version/lib';
 
@@ -179,6 +179,13 @@ export const updateReleaseBranchChangelogs = async (
 			base: releaseBranch,
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
+
+		try {
+			addLabelsToIssue( options, pullRequest.number, ["Release"] );
+		} catch {
+			// Not a critical error.
+		}
+
 		return {
 			deletionCommitHash: deletionCommitHash.trim(),
 			prNumber: pullRequest.number,
@@ -197,13 +204,14 @@ export const updateReleaseBranchChangelogs = async (
  * @param {Object} releaseBranchChanges                    update data from updateReleaseBranchChangelogs
  * @param {Object} releaseBranchChanges.deletionCommitHash commit from the changelog deletions in updateReleaseBranchChangelogs
  * @param {Object} releaseBranchChanges.prNumber           pr number created in updateReleaseBranchChangelogs
+ * @return {number} Update PR number.
  */
 export const updateBranchChangelog = async (
 	options: Options,
 	tmpRepoPath: string,
 	releaseBranch: string,
 	releaseBranchChanges: { deletionCommitHash: string; prNumber: number }
-): Promise< void > => {
+): Promise< number > => {
 	const { owner, name, version } = options;
 	const { deletionCommitHash, prNumber } = releaseBranchChanges;
 	Logger.notice( `Deleting changelogs from trunk ${ tmpRepoPath }` );
@@ -251,6 +259,14 @@ export const updateBranchChangelog = async (
 			base: releaseBranch,
 		} );
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
+
+		try {
+			addLabelsToIssue( options, pullRequest.number, ["Release"] );
+		} catch {
+			// Not a critical error.
+		}
+
+		return pullRequest.number;
 	} catch ( e ) {
 		if ( e.message.includes( `No commits between ${ releaseBranch }` ) ) {
 			Logger.notice(
@@ -281,7 +297,7 @@ export const updateTrunkChangelog = async (
 	options: Options,
 	tmpRepoPath: string,
 	releaseBranchChanges: { deletionCommitHash: string; prNumber: number }
-): Promise< void > => {
+): Promise< number > => {
 	return await updateBranchChangelog(
 		options,
 		tmpRepoPath,

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -12,7 +12,10 @@ import { readFileSync } from 'fs';
  */
 import { Logger } from '../../../../core/logger';
 import { checkoutRemoteBranch } from '../../../../core/git';
-import { addLabelsToIssue, createPullRequest } from '../../../../core/github/repo';
+import {
+	addLabelsToIssue,
+	createPullRequest,
+} from '../../../../core/github/repo';
 import { Options } from '../types';
 import { getToday } from '../../get-version/lib';
 
@@ -181,7 +184,7 @@ export const updateReleaseBranchChangelogs = async (
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
 		try {
-			addLabelsToIssue( options, pullRequest.number, ["Release"] );
+			addLabelsToIssue( options, pullRequest.number, [ 'Release' ] );
 		} catch {
 			// Not a critical error.
 		}
@@ -261,7 +264,7 @@ export const updateBranchChangelog = async (
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
 		try {
-			addLabelsToIssue( options, pullRequest.number, ["Release"] );
+			addLabelsToIssue( options, pullRequest.number, [ 'Release' ] );
 		} catch {
 			// Not a critical error.
 		}

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -184,9 +184,13 @@ export const updateReleaseBranchChangelogs = async (
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
 		try {
-			addLabelsToIssue( options, pullRequest.number, [ 'Release' ] );
+			await addLabelsToIssue( options, pullRequest.number, [
+				'Release',
+			] );
 		} catch {
-			// Not a critical error.
+			Logger.warn(
+				`Could not add label "Release" to PR ${ pullRequest.number }`
+			);
 		}
 
 		return {
@@ -264,9 +268,13 @@ export const updateBranchChangelog = async (
 		Logger.notice( `Pull request created: ${ pullRequest.html_url }` );
 
 		try {
-			addLabelsToIssue( options, pullRequest.number, [ 'Release' ] );
+			await addLabelsToIssue( options, pullRequest.number, [
+				'Release',
+			] );
 		} catch {
-			// Not a critical error.
+			Logger.warn(
+				`Could not add label "Release" to PR ${ pullRequest.number }`
+			);
 		}
 
 		return pullRequest.number;

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -229,6 +229,27 @@ export const deleteGithubBranch = async (
 	);
 };
 
+export const addLabelsToIssue = async (
+	options: {
+		owner?: string;
+		name?: string;
+	},
+	issueNumber: number,
+	labels: string[]
+): Promise< void > => {
+	const { owner, name } = options;
+	await octokitWithAuth().request(
+		'POST /repos/{owner}/{repo}/issues/{issue_number}/labels',
+		{
+			owner,
+			repo: name,
+			issue_number: issueNumber,
+			labels
+		}
+	);
+};
+
+
 /**
  * Create a pull request from branches on Github.
  *

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -244,11 +244,10 @@ export const addLabelsToIssue = async (
 			owner,
 			repo: name,
 			issue_number: issueNumber,
-			labels
+			labels,
 		}
 	);
 };
-
 
 /**
  * Create a pull request from branches on Github.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR introduces changes to workflows and changelog utils in order to ensure that any PRs automatically generated by release workflows are tagged with the `Release` label, and also that any non-release PRs merged into the release branch (that is, after the feature freeze) are tagged as `metric: feature freeze exception`.

This will allow us to better monitor and quantify what gets merged after the feature freeze, whether it is a backport or a direct PR against the release branch.

> [!WARNING]
> - Label `metric: feature freeze exception` must be created prior or after merging this PR.

Closes #60180.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repository, including the `release/10.1` branch.
1. Go to **Issues > Labels** in your fork and create labels `Release` and `metric: feature freeze exception`.
1. Run **Actions > Release: Bump version number** using `release/10.1` as release branch and `stable` as bump type.
1. Wait until the workflow finishes and ensure that the generated PR has label `Release`.
1. Merge this PR and confirm that (after the associated _Pull request post-merge processing_ job finishes) it doesn't get any new labels.
1. Run **Actions > Release: Compile changelog** with `10.1` as argument. Ensure that the generated PRs have label `Release`.
1. Merge the PRs and confirm that (after the associated _Pull request post-merge processing_ job finishes) they don't get any new labels.
1. Use the GitHub UI to make any change to `plugins/woocommerce/woocommerce.php` **inside** the `release/10.1` branch and open a PR with this change in your fork.
1. Merge the PR.
1. Confirm that after a little while (once the associated _Pull request post-merge processing_ job finishes) this PR has been labeled as `metric: feature freeze exception`.

<!-- End testing instructions -->