### PR TITLE
Add `role="status"` to `woocommerce-info` type notices

### DIFF
--- a/plugins/woocommerce/changelog/60253-wooplug-4876-accessibility-key-notices-not-being-read-by-screen-readers
+++ b/plugins/woocommerce/changelog/60253-wooplug-4876-accessibility-key-notices-not-being-read-by-screen-readers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed accessibility for all classic store notices added by the `wc_add_notice` function.

--- a/plugins/woocommerce/templates/notices/notice.php
+++ b/plugins/woocommerce/templates/notices/notice.php
@@ -26,7 +26,7 @@ if ( ! $notices ) {
 ?>
 
 <?php foreach ( $notices as $notice ) : ?>
-	<div class="woocommerce-info"<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> role="alert">
+	<div class="woocommerce-info"<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> role="status">
 		<?php echo wc_kses_notice( $notice['notice'] ); ?>
 	</div>
 <?php endforeach; ?>

--- a/plugins/woocommerce/templates/notices/notice.php
+++ b/plugins/woocommerce/templates/notices/notice.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.6.0
+ * @version 10.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,7 +26,7 @@ if ( ! $notices ) {
 ?>
 
 <?php foreach ( $notices as $notice ) : ?>
-	<div class="woocommerce-info"<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<div class="woocommerce-info"<?php echo wc_get_notice_data_attr( $notice ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> role="alert">
 		<?php echo wc_kses_notice( $notice['notice'] ); ?>
 	</div>
 <?php endforeach; ?>

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
@@ -131,7 +131,7 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 	 * when first parameter is set to true.
 	 */
 	public function test_wc_print_notices_should_return_notices() {
-		$expected_return = "\n	<div class=\"woocommerce-info\">\n		One True Notice	</div>\n";
+		$expected_return = "\n	<div class=\"woocommerce-info\" role=\"status\">\n		One True Notice	</div>\n";
 
 		wc_add_notice( 'One True Notice', 'notice' );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/notice-functions.php
@@ -119,7 +119,7 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 		wc_add_notice( 'One True Notice', 'notice' );
 		wc_add_notice( 'Second True Notice', 'notice', array( 'id' => 'second_notice' ) );
 
-		$this->expectOutputString( '<div class="woocommerce-info">One True Notice</div><div class="woocommerce-info" data-id="second_notice">Second True Notice</div>' );
+		$this->expectOutputString( '<div class="woocommerce-info" role="status">One True Notice</div><div class="woocommerce-info" data-id="second_notice" role="status">Second True Notice</div>' );
 
 		wc_print_notices();
 
@@ -161,7 +161,7 @@ class WC_Tests_Notice_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_print_info_notice() {
 
-		$this->expectOutputString( '<div class="woocommerce-info">Info!</div>' );
+		$this->expectOutputString( '<div class="woocommerce-info" role="status">Info!</div>' );
 
 		wc_print_notice( 'Info!', 'notice' );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #44283, when moving new notice styles to display in block themes only, there was an oversight in removing the `role="alert"` for the classic info notices.

The other notices, `success` and `error`, already have `role="alert"` applied to them, so that was inconsistent and meant that `info` notices were not read by screen readers. This affected all extensions that used `wc_add_notice` to display info notices.


Closes #59383.

Bug introduced in PR #44283.


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable Back in Stock Notifications.
2. Set a product as out of stock.
3. Turn on a screen reader like VoiceOver or NVDA.
4. On the shop page, find the out-of-stock product and click the Join the waitlist link.
5. Listen as the product single loads and the notice is not read out.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixed accessibility for all classic store notices added by the `wc_add_notice` function.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
