### PR TITLE
Add log level threshold for Email Editor

### DIFF
--- a/docs/features/email/email-editor-logging.md
+++ b/docs/features/email/email-editor-logging.md
@@ -15,4 +15,4 @@ add_filter( 'woocommerce_email_editor_logging_threshold', function() {
 
 This will enable logging for all email editor operations, such as email editor initialization, personalization tag registration, etc.
 
-For available log levels and their priority, see the [Logging in WooCommerce](/docs/best-practices/data-management/logging.md/#level) documentation.
+For available log levels and their priority, see the [Logging in WooCommerce](/docs/best-practices/data-management/logging/#level) documentation.

--- a/docs/features/email/email-editor-logging.md
+++ b/docs/features/email/email-editor-logging.md
@@ -15,4 +15,4 @@ add_filter( 'woocommerce_email_editor_logging_threshold', function() {
 
 This will enable logging for all email editor operations, such as email editor initialization, personalization tag registration, etc.
 
-For available log levels and their priority, see the [Logging in WooCommerce](/docs/best-practices/data-management/logging/#level) documentation.
+For available log levels and their priority, see the [Logging in WooCommerce](/docs/best-practices/data-management/logging.md/#level) documentation.

--- a/docs/features/email/email-editor-logging.md
+++ b/docs/features/email/email-editor-logging.md
@@ -1,0 +1,18 @@
+---
+post_title: Email editor logging
+sidebar_label: Email editor logging
+---
+
+# Email Editor Logging
+
+Email editor logging uses a severity threshold to reduce noise during normal operation. By default, only warnings and above are logged. To change the logging level, use the `woocommerce_email_editor_logging_threshold` filter:
+
+```php
+add_filter( 'woocommerce_email_editor_logging_threshold', function() {
+    return WC_Log_Levels::DEBUG;
+} );
+```
+
+This will enable logging for all email editor operations, such as email editor initialization, personalization tag registration, etc.
+
+For available log levels and their priority, see the [Logging in WooCommerce](/best-practices/data-management/logging/#level) documentation.

--- a/docs/features/email/email-editor-logging.md
+++ b/docs/features/email/email-editor-logging.md
@@ -15,4 +15,4 @@ add_filter( 'woocommerce_email_editor_logging_threshold', function() {
 
 This will enable logging for all email editor operations, such as email editor initialization, personalization tag registration, etc.
 
-For available log levels and their priority, see the [Logging in WooCommerce](/best-practices/data-management/logging/#level) documentation.
+For available log levels and their priority, see the [Logging in WooCommerce](/docs/best-practices/data-management/logging/#level) documentation.

--- a/packages/php/email-editor/README.md
+++ b/packages/php/email-editor/README.md
@@ -126,7 +126,11 @@ The following log levels are supported:
 
 ### Log Locations
 
-By default, logs are written to the WordPress debug log if `WP_DEBUG_LOG` is enabled. The location is `wp-content/debug.log`.
+By default, logs are written to the WordPress debug log if `WP_DEBUG_LOG` is enabled. The behavior depends on how `WP_DEBUG_LOG` is configured:
+
+- If `WP_DEBUG_LOG` is set to `true`, logs are written to `wp-content/debug.log`
+- If `WP_DEBUG_LOG` is set to a string path (e.g., `/path/to/custom/debug.log`), logs are written to that custom location
+- If `WP_DEBUG_LOG` is not defined or set to `false`, logging is disabled
 
 ### Example Log Messages
 
@@ -148,7 +152,7 @@ Example log entry:
 
 You can customize the logging behavior by:
 
-1. Setting a delegate logger using `set_delegate_logger()` method to use another logging system (e.g., WooCommerce's logger)
+1. Setting a delegate logger using `set_logger()` method to use another logging system (e.g., WooCommerce's logger)
 2. Configuring WordPress debug logging through `WP_DEBUG_LOG` constant in wp-config.php to enable/disable logging to wp-content/debug.log
 
 ### Best Practices

--- a/packages/php/email-editor/changelog/wooplug-5003-review-and-refine-logging-in-the-email-editor
+++ b/packages/php/email-editor/changelog/wooplug-5003-review-and-refine-logging-in-the-email-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use custom log filepath defined in WP_DEBUG_LOG when specified.

--- a/packages/php/email-editor/src/Engine/Logger/class-default-email-editor-logger.php
+++ b/packages/php/email-editor/src/Engine/Logger/class-default-email-editor-logger.php
@@ -36,7 +36,17 @@ class Default_Email_Editor_Logger implements Email_Editor_Logger_Interface {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->log_file = defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ? WP_CONTENT_DIR . '/debug.log' : '';
+		if ( defined( 'WP_DEBUG_LOG' ) ) {
+			if ( true === WP_DEBUG_LOG ) {
+				$this->log_file = WP_CONTENT_DIR . '/debug.log';
+			} elseif ( is_string( WP_DEBUG_LOG ) && ! empty( WP_DEBUG_LOG ) ) {
+				$this->log_file = WP_DEBUG_LOG;
+			} else {
+				$this->log_file = '';
+			}
+		} else {
+			$this->log_file = '';
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/changelog/wooplug-5003-review-and-refine-logging-in-the-email-editor
+++ b/plugins/woocommerce/changelog/wooplug-5003-review-and-refine-logging-in-the-email-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add custom log level threshold for Email Editor logging set to `WC_Log_Levels::WARNING` as default.

--- a/plugins/woocommerce/src/Internal/EmailEditor/Logger.php
+++ b/plugins/woocommerce/src/Internal/EmailEditor/Logger.php
@@ -10,6 +10,7 @@ declare(strict_types = 1);
 namespace Automattic\WooCommerce\Internal\EmailEditor;
 
 use Automattic\WooCommerce\EmailEditor\Engine\Logger\Email_Editor_Logger_Interface;
+use WC_Log_Levels;
 
 /**
  * WooCommerce logger adapter for the email editor.
@@ -34,6 +35,25 @@ class Logger implements Email_Editor_Logger_Interface {
 	}
 
 	/**
+	 * Checks if the log level should be handled.
+	 *
+	 * @param string $level The log level.
+	 * @return bool Whether the log level should be handled.
+	 */
+	private function should_handle( string $level ): bool {
+		/**
+		 * Controls the logging threshold for the email editor.
+		 *
+		 * @param string $threshold The log level threshold.
+		 *
+		 * @since 10.2.0
+		 */
+		$logging_threshold = apply_filters( 'woocommerce_email_editor_logging_threshold', WC_Log_Levels::WARNING );
+
+		return WC_Log_Levels::get_level_severity( $logging_threshold ) <= WC_Log_Levels::get_level_severity( $level );
+	}
+
+	/**
 	 * Adds emergency level log message.
 	 *
 	 * @param string $message The log message.
@@ -41,7 +61,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function emergency( string $message, array $context = array() ): void {
-		$this->wc_logger->emergency( $message, $context );
+		$this->log( WC_Log_Levels::EMERGENCY, $message, $context );
 	}
 
 	/**
@@ -52,7 +72,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function alert( string $message, array $context = array() ): void {
-		$this->wc_logger->alert( $message, $context );
+		$this->log( WC_Log_Levels::ALERT, $message, $context );
 	}
 
 	/**
@@ -63,7 +83,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function critical( string $message, array $context = array() ): void {
-		$this->wc_logger->critical( $message, $context );
+		$this->log( WC_Log_Levels::CRITICAL, $message, $context );
 	}
 
 	/**
@@ -74,7 +94,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function error( string $message, array $context = array() ): void {
-		$this->wc_logger->error( $message, $context );
+		$this->log( WC_Log_Levels::ERROR, $message, $context );
 	}
 
 	/**
@@ -85,7 +105,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function warning( string $message, array $context = array() ): void {
-		$this->wc_logger->warning( $message, $context );
+		$this->log( WC_Log_Levels::WARNING, $message, $context );
 	}
 
 	/**
@@ -96,7 +116,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function notice( string $message, array $context = array() ): void {
-		$this->wc_logger->notice( $message, $context );
+		$this->log( WC_Log_Levels::NOTICE, $message, $context );
 	}
 
 	/**
@@ -107,7 +127,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function info( string $message, array $context = array() ): void {
-		$this->wc_logger->info( $message, $context );
+		$this->log( WC_Log_Levels::INFO, $message, $context );
 	}
 
 	/**
@@ -118,7 +138,7 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function debug( string $message, array $context = array() ): void {
-		$this->wc_logger->debug( $message, $context );
+		$this->log( WC_Log_Levels::DEBUG, $message, $context );
 	}
 
 	/**
@@ -130,6 +150,8 @@ class Logger implements Email_Editor_Logger_Interface {
 	 * @return void
 	 */
 	public function log( string $level, string $message, array $context = array() ): void {
-		$this->wc_logger->log( $level, $message, $context );
+		if ( $this->should_handle( $level ) ) {
+			$this->wc_logger->log( $level, $message, $context );
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Add custom log level threshold for Email Editor logging set to `WC_Log_Levels::WARNING` as default.
* Add WooCommerce docs for the email editor logging.
* Fix email editor package logger to use custom log filepath defined in `WP_DEBUG_LOG` when specified.
* Fix email editor documentation errors for logging.

Closes [WOOPLUG-5003: Review and Refine Logging in the Email Editor](https://linear.app/a8c/issue/WOOPLUG-5003/review-and-refine-logging-in-the-email-editor).

### Screenshots or screen recordings:

N/A

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
2. Make sure **Logger** is enabled in WooCommerce → Status → Logs → **Settings**
3. Inspect the **plugin-woocommerce** log in WooCommerce → Status → Logs → **Browse**
4. It is expected that nothing from the Email Editor below `WC_Log_Levels::WARNING` is logged.
5. Modify the log level threshold for the email editor using the `woocommerce_email_editor_logging_threshold` filter, e.g.:
```php
add_filter( 'woocommerce_email_editor_logging_threshold', function() {
    return WC_Log_Levels::DEBUG;
} );
```
6. Refresh the website a few times and open the **plugin-woocommerce** log again.
7. It should have logged `Debug` and `Info` (since it's higher level compare to `WC_Log_Levels::WARNING`) entries from the email editor.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Add custom log level threshold for Email Editor logging set to `WC_Log_Levels::WARNING` as default.

</details>
