### PR TITLE
Improve PaymentInfo for better compatibility with WooPayments and improvement performance

### DIFF
--- a/plugins/woocommerce/changelog/60257-wooplug-5275-avoid-multiple-card-info-retrieval-calls-for-woopayments
+++ b/plugins/woocommerce/changelog/60257-wooplug-5275-avoid-multiple-card-info-retrieval-calls-for-woopayments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Cache data while preparing WooPayments card info, allow the `wc_order_payment_card_info` filter to take precedence over the built-in fallback.

--- a/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
+++ b/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
@@ -101,8 +101,11 @@ class PaymentInfo {
 
 		// This is a Woo-specific meta key, not used within WooPayments.
 		$cache_meta_key         = '_wcpay_raw_payment_method_details';
+		$payment_details        = null;
 		$stored_payment_details = $order->get_meta( $cache_meta_key );
-		$payment_details        = json_decode( $stored_payment_details, true );
+		if ( is_string( $stored_payment_details ) && strlen( $stored_payment_details ) > 0 ) {
+			$payment_details = json_decode( $stored_payment_details, true );
+		}
 
 		if ( ! $payment_details ) {
 			if ( ! class_exists( \WC_Payments::class ) ) {

--- a/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
+++ b/plugins/woocommerce/src/Internal/Orders/PaymentInfo.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Internal\Orders;
 
-use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use WC_Abstract_Order;
 
@@ -35,22 +34,22 @@ class PaymentInfo {
 	public static function get_card_info( WC_Abstract_Order $order ): array {
 		$method = $order->get_payment_method();
 
-		if ( 'woocommerce_payments' === $method ) {
-			$info = self::get_wcpay_card_info( $order );
-		} else {
-			/**
-			 * Filter to allow payment gateways to provide payment card info for an order.
-			 *
-			 * @since 9.5.0
-			 *
-			 * @param array|null        $info  The card info.
-			 * @param WC_Abstract_Order $order The order.
-			 */
-			$info = apply_filters( 'wc_order_payment_card_info', array(), $order );
+		/**
+		 * Filter to allow payment gateways to provide payment card info for an order.
+		 *
+		 * @since 9.5.0
+		 *
+		 * @param array|null        $info  The card info.
+		 * @param WC_Abstract_Order $order The order.
+		 */
+		$info = apply_filters( 'wc_order_payment_card_info', array(), $order );
+		if ( ! is_array( $info ) ) {
+			$info = array();
+		}
 
-			if ( ! is_array( $info ) ) {
-				$info = array();
-			}
+		// Fallback for WooPayments.
+		if ( empty( $info ) && 'woocommerce_payments' === $method ) {
+			$info = self::get_wcpay_card_info( $order );
 		}
 
 		$defaults = array(
@@ -100,11 +99,9 @@ class PaymentInfo {
 			return array();
 		}
 
-		// For testing purposes: if WooCommerce Payments development mode is enabled, an order meta item with
-		// key '_wcpay_payment_details' will be used if it exists as a replacement for the call to the Stripe
-		// API's 'get intent' endpoint. The value must be the JSON encoding of an array simulating the
-		// "payment_details" part of the response from the endpoint.
-		$stored_payment_details = Constants::get_constant( 'WCPAY_DEV_MODE' ) ? $order->get_meta( '_wcpay_payment_details' ) : '';
+		// This is a Woo-specific meta key, not used within WooPayments.
+		$cache_meta_key         = '_wcpay_raw_payment_method_details';
+		$stored_payment_details = $order->get_meta( $cache_meta_key );
 		$payment_details        = json_decode( $stored_payment_details, true );
 
 		if ( ! $payment_details ) {
@@ -137,6 +134,10 @@ class PaymentInfo {
 
 				return array();
 			}
+
+			// Cache payment method details.
+			$order->update_meta_data( $cache_meta_key, wp_json_encode( $payment_details ) );
+			$order->save_meta_data();
 		}
 
 		$card_info = array();

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/PaymentInfoTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/PaymentInfoTest.php
@@ -42,6 +42,9 @@ class PaymentInfoTest extends WC_Unit_Test_Case {
 		$this->assertEquals( '4242', $result['last4'] );
 	}
 
+	/**
+	 * @testdox The `get_card_info` method should prefer the filter result over the metadata.
+	 */
 	public function test_get_card_info_prefers_filter() {
 		$order = OrderHelper::create_order();
 
@@ -55,7 +58,7 @@ class PaymentInfoTest extends WC_Unit_Test_Case {
 		$order->save();
 
 		// Add a dummy callback to the filter. It should be prefered over metadata.
-		$filter_callback = fn() => [ 'payment_method' => 'foo' ];
+		$filter_callback = fn() => array( 'payment_method' => 'foo' );
 		add_filter( 'wc_order_payment_card_info', $filter_callback );
 
 		$result = $order->get_payment_card_info();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes WOOPLUG-5275

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/52173.

All changes relate to the `PaymentInfo` class.

#### Swapped order

Until now, for WooPayments, `get_wcpay_card_info()` was used without calling the `wc_order_payment_card_info` filter. This PR swaps the order, calling the filter first. That way, [WooPayments will be able to provide data first](https://github.com/Automattic/woocommerce-payments/pull/11001) in an upcoming version.

Until WooPayments gets updated for the merchant, `get_wcpay_card_info()` will still be used as a fallback.

#### Add cache

`get_wcpay_card_info()` was performing external requests without caching the results, effectively slowing down checkout by 4x the duration of the request. This PR caches the data in order meta, limiting external requests to a single one.

### Screenshots or screen recordings:

This PR includes no visual changes.

### How to test the changes in this Pull Request:

You need both Woo Core and WooPayments active and set up.

1. Perform a (not necessarily) simple checkout with WooPayments and a new card.
2. Monitor the number of outgoing requests to the WooPayments server. Based on the Core and WooPayments branch, you should see a similar number of requests to the one described in _Testing that has already taken place_ below.
    - The easiest way to do this locally is to add a breakpoint at the beginning of the WooPayments `WC_Payments_API_Client->request()` method ([ref](https://github.com/Automattic/woocommerce-payments/blob/trunk/includes/wc-payment-api/class-wc-payments-api-client.php#L2483)).
    - Alternatively, you can enable logging for WooPayments and inspect the logs in WooCommerce -> Status -> Logs.

### Testing that has already taken place

This PR has been tested locally with WooPayments in both `develop` and https://github.com/Automattic/woocommerce-payments/pull/11001

| Scenario | Result |
|-|-|
| `trunk` + any WooPayments | **6 external API calls**, 2 from WooPayments and **4 for `get_wcpay_card_info()`** |
| this branch + WooPayments `develop` | There are **3 external API calls**, 2 from WooPayments and **1 for `get_wcpay_card_info()`**. The rest are cached. |
| this branch + https://github.com/Automattic/woocommerce-payments/pull/11001 | **Only 2 external calls**, since WooPayments populated the DB with a part of one of those calls' results and the filter takes precedence. |

🗒️ Note regarding unit tests: Testing most of `get_wcpay_card_info` would require elaborate mocks of WooPayments or the plugin itself. Avoiding both, I've only added a test that ensures the filter takes precedence.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Cache data while preparing WooPayments card info, allow the `wc_order_payment_card_info` filter to take precedence over the built-in fallback.

</details>