### PR TITLE
Improve validation in `Release: Build ZIP file` workflow

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch.'
+        description: 'Release branch (e.g.: release/x.y).'
         required: true
-        default: ''
       skip_verify:
         description: 'Skip verification steps.'
         type: boolean
@@ -13,22 +12,21 @@ on:
       create_github_release:
         description: 'Create GitHub release.'
         type: boolean
-        required: true
+        default: false
   workflow_call:
     inputs:
       branch:
         description: 'Release branch.'
         type: string
         required: true
-        default: ''
       skip_verify:
         description: 'Skip verification steps.'
         type: boolean
-        required: true
+        default: false
       create_github_release:
         description: 'Create GitHub release.'
         type: boolean
-        required: true
+        default: false
     outputs:
       artifact_url:
         description: 'URL of the built release artifact'
@@ -43,6 +41,8 @@ jobs:
   verify:
     name: 'Pre-build verification'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
+    permissions:
+      contents: write # Required to fetch draft releases for some reason. See https://github.com/cli/cli/issues/9076#issuecomment-2146148572.
     steps:
       - name: Workflow checks
         run: |

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -230,7 +230,7 @@ jobs:
           gh release create ${{ steps.get_version.outputs.version }} \
             './woocommerce.zip' \
             --title '${{ steps.get_version.outputs.version }}' \
-            --notes '' \
+            --notes '${{ steps.get_version.outputs.version }}' \
             --target '${{ needs.build.outputs.commit-hash }}' \
             --latest=false \
             --draft \

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -3,30 +3,30 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Release branch to use. Defaults to the branch the workflow is run from.'
-        required: false
+        description: 'Release branch.'
+        required: true
         default: ''
       skip_verify:
         description: 'Skip verification steps.'
         type: boolean
         required: true
       create_github_release:
-        description: 'Create a draft GitHub release.'
+        description: 'Create GitHub release.'
         type: boolean
         required: true
   workflow_call:
     inputs:
       branch:
-        description: 'Release branch to use. Defaults to the branch the workflow is run from.'
+        description: 'Release branch.'
         type: string
-        required: false
+        required: true
         default: ''
       skip_verify:
         description: 'Skip verification steps.'
         type: boolean
         required: true
       create_github_release:
-        description: 'Create a draft GitHub release.'
+        description: 'Create GitHub release.'
         type: boolean
         required: true
     outputs:
@@ -40,87 +40,28 @@ concurrency:
   group: release-build-zip-file-${{ inputs.branch }}-${{ ( inputs.create_github_release == true && 'with-release' ) || github.run_id }}
 
 jobs:
-  verify-prs:
-    name: 'Verify if any PR is left open by author:app/github-actions'
-    outputs:
-      runBuildZipJob: ${{ steps.verify-prs.outputs.runBuildZipJob }}
+  verify:
+    name: 'Pre-build verification'
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
     steps:
-        - name: Verify if any PR is left open by author:app/github-actions
-          id: verify-prs
-          uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
-          with:
-              github-token: ${{ secrets.GITHUB_TOKEN }}
-              script: |
-                  let runBuildZipJob = true;
-                  const event = context.payload;
+      - name: Workflow checks
+        run: |
+          # No special checks when running as a reusable workflow.
+          if [ "${{ ! contains( github.workflow_ref, 'release-build-zip-file.yml' ) }}" = "true" ]; then
+            exit 0
+          fi
 
-                  if ('${{ inputs.skip_verify }}' === 'true') {
-                    core.setOutput('runBuildZipJob', runBuildZipJob);
-                    console.log('Skipping verification step');
-                    return;
-                  }
+          # Must run from trunk.
+          if [ "${{ github.ref }}" != "refs/heads/trunk" ]; then
+              echo "::error::This workflow must be run from the `trunk` branch. Enter the release branch as input."
+              exit 1
+          fi
 
-                  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-
-                  // Helper function to add delay between API calls
-                  const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-
-                  // Function to handle API call with retry logic
-                  const searchPRs = async (query) => {
-                    let attempts = 0;
-                    while (attempts < 5) {
-                      try {
-                        return await github.rest.search.issuesAndPullRequests({ q: query });
-                      } catch (error) {
-                        if (error.status === 403 && error.message.includes('secondary rate limit')) {
-                          console.log('Rate limit hit, retrying...');
-                          await delay(31000); // 31 second delay before retry
-                          attempts++;
-                        } else {
-                          throw error;
-                        }
-                      }
-                    }
-                    throw new Error('Failed to fetch PRs after multiple attempts');
-                  };
-
-                  // Search for PRs from github-actions bot
-                  const githubActionsPRsQuery = await searchPRs(`repo:${owner}/${repo} is:pr is:open author:app/github-actions`);
-                  const prsOpenByGithubActions = githubActionsPRsQuery.data.items;
-
-                  let failureMessage = ``;
-
-                  if (prsOpenByGithubActions.length > 0) {
-                      runBuildZipJob = false;
-
-                      failureMessage += `Identified \`${prsOpenByGithubActions.length}\` open PR(s) from \`github-actions\` bot which should be merged or closed before proceeding. <https://github.com/${owner}/${repo}/issues?q=is%3Apr+is%3Aopen+author%3Aapp%2Fgithub-actions|Link to PRs>`;
-
-                      failureMessage += '\n\nThis step maintains the code integrity and is critical to avoid regression in future releases. Please merge them or close them before proceeding or set \`skip_verify\` to \`true\` before running the workflow to skip this step if you are confident that the PRs are irrelevant.';
-
-                      console.error(failureMessage);
-                      core.setOutput('failureMessage', failureMessage);
-                  }
-                  core.setOutput('runBuildZipJob', runBuildZipJob);
-
-        - name: Notify Slack on failure
-          if: ${{ steps.verify-prs.outputs.failureMessage != '' && inputs.create_github_release }}
-          uses: archive/github-actions-slack@f530f3aa696b2eef0e5aba82450e387bd7723903 #v2.0.0
-          with:
-              slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-              slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
-              slack-text: |
-                  :x: Oops we may have missed PRs left open by `github-actions` bot. WooCommerce release zip build failed.
-                  :warning-8c: ${{ steps.verify-prs.outputs.failureMessage }}
-                  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>
-              slack-optional-unfurl_links: false
-              slack-optional-unfurl_media: false
-          continue-on-error: true
-
-  verify-release-versions:
-    name: 'Verify release and stable tag versions'
-    runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    steps:
+          # Can not skip verification for actual releases.
+          if [ "${{ inputs.create_github_release }}" = "true" ] && [ "${{ inputs.skip_verify }}" = "true" ]; then
+              echo "::error::Verification can not be skipped when building for a release."
+              exit 1
+          fi
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
@@ -129,13 +70,22 @@ jobs:
             /plugins/woocommerce/woocommerce.php
             /plugins/woocommerce/readme.txt
           sparse-checkout-cone-mode: false
-        if: ${{ inputs.create_github_release && ! inputs.skip_verify }}
+        if: ${{ ! inputs.skip_verify }}
 
       - name: 'Pre-build verification'
-        if: ${{ inputs.create_github_release && ! inputs.skip_verify }}
+        if: ${{ ! inputs.skip_verify }}
         env:
           BRANCH: ${{ inputs.branch || github.ref }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
+            # No PRs by automated tools should remain open.
+            count=$( gh pr list --search "is:open author:app/github-actions" --limit 1 --json number | jq length )
+            if (( count > 0 )); then
+                echo "::error::Pre-build verification: there are automated PRs by 'github-actions' still open."
+                exit 1
+            fi
+
             # Branch name must be 'release/*'.
             branch_name="${BRANCH#refs/heads/}"
             if  [[ $branch_name != release/* ]] ; then
@@ -149,6 +99,12 @@ jobs:
             if [[ $branch_plugin_version != "$version_prefix."* ]] ; then
                 echo "::error::Pre-build verification: release version in branch ($branch_plugin_version) is not matching '$version_prefix.*' pattern."
                 exit 1
+            fi
+
+            # GH release should not already exist.
+            if gh release view "$branch_plugin_version" &>/dev/null; then
+              echo "::error::Pre-build verification: GitHub release '$branch_plugin_version' already exists."
+              exit 1
             fi
 
             # Release should not already exist on wporg.
@@ -166,10 +122,25 @@ jobs:
                 exit 1
             fi
 
+            # No PRs against release branch should remain open.
+            count=$( gh pr list --search "is:open base:$BRANCH" --limit 1 --json number | jq length )
+            if (( count > 0 )); then
+                echo "::error::Pre-build verification: there are PRs against the release branch ($BRANCH) still open."
+                exit 1
+            fi
+
+            # No PRs with same milestone as main version should remain open.
+            milestone="$version_prefix.0"
+            count=$( gh pr list --search "is:open milestone:$milestone" --limit 1 --json number | jq length )
+            if (( count > 0 )); then
+                echo "::error::Pre-build verification: there are PRs with milestone '$milestone' still open."
+                exit 1
+            fi
+
   build:
     name: Build release zip file
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-4vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: [ verify-prs, verify-release-versions ]
+    needs: [ verify ]
     outputs:
       artifact-url: ${{ steps.fetch-build-details.outputs.artifact-url }}
       commit-hash: ${{ steps.fetch-build-details.outputs.commit-hash }}
@@ -224,7 +195,7 @@ jobs:
   create-release:
     name: Create GitHub release
     runs-on: ${{ ( github.repository == 'woocommerce/woocommerce' && 'blacksmith-2vcpu-ubuntu-2404' ) || 'ubuntu-latest' }}
-    needs: build
+    needs: [ build ]
     if: ${{ inputs.create_github_release }}
     permissions:
       contents: write

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -177,7 +177,6 @@ jobs:
           gh release edit '${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev' \
             --prerelease \
             --latest=false \
-            --notes='' \
             --draft=false
 
           echo "release-zip=https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare-for-code-freeze.outputs.nextReleaseVersion }}-dev/woocommerce.zip" >> $GITHUB_OUTPUT

--- a/docs/contribution/releases/building-and-publishing.md
+++ b/docs/contribution/releases/building-and-publishing.md
@@ -30,9 +30,9 @@ sidebar_label: Building and Publishing
    - Run from `trunk` and enter the major version number and the intended release date.
    - Review and merge the two PRs created (one for trunk, one for the release branch).
    - Ensure the changelog date is correct.
-3. **Build the release ZIP file.**
-   - Run the [“Release: Build ZIP file” workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml) from the release branch.
-   - Set "Create a draft GitHub release" to `true`.
+3. **Build the release ZIP file using the [“Release: Build ZIP file” workflow](https://github.com/woocommerce/woocommerce/actions/workflows/release-build-zip-file.yml).**
+   - Run from `trunk` and enter the release branch as argument.
+   - Set "Create GitHub release" to `true`.
    - The workflow will create a [draft release tag](https://github.com/woocommerce/woocommerce/releases) with an attached `woocommerce.zip` file.
 
 ## Publishing the Release


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
This PR simplifies and enhances pre-build validation in the `Release: Build ZIP file`. In particular:

- Removes unnecessary Slack notification when ZIP can't be built due to GH actions generated PRs still being open. This step is instead moved to other pre-build validations.
- Makes the release branch a required input so that the workflow isn't accidentally run from `trunk` or a release branch.
- Enhances pre-build validation by ensuring that no PRs against the release branch or with the same milestone as the release are open.
- Ensures validation **is not optional** when creating a GitHub release at the same time, as this is the process used when releasing to wporg.

Closes #60087.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Fork this repository, ensuring both `release/10.1` and `release/10.0` is included.
1. Prepare your fork for testing by:
   1. Ensuring label `Release` exists in **Issues > Labels** or creating it as necessary.
   1. Ensuring milestone `10.1.0` exists in **Issues > Milestones** or creating it as necessary.
   1. Creating a draft release with tag `10.1.0-rc.2` in **Code > Releases**, with any target commit/branch. There's no need to upload a ZIP.
1. Run **Actions > Release: Build ZIP file** and confirm that it **fails** with any of the following input combos:

   - Release branch: `release/10.0`, ☐ Skip verification steps, ☐ Create GitHub release.
       **Fails because `10.0.4` is already tagged on wporg.**
   - Release branch: `release/10.1`, ☐ Skip verification steps, ☐ Create GitHub release.
       **Fails because `10.1.0-rc.2` is already tagged on GitHub.**
   - Release branch: `release/10.1`, ☒ Skip verification steps, ☒ Create GitHub release.
       **Fails because verification steps can't be skipped when creating a release.**
1. Use **Actions > Release: Bump version number** with release branch `release/10.1` and bump type `rc` to generate a PR bumping versions in `release/10.1` to `10.1.0-rc.3`. Merge the resulting PR.
1. Use the GH UI to create a PR with _any_ change against branch `release/10.1`. Do not merge this PR.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.1` and confirm that it fails. It should complain about open PRs against `release/10.1`.
1. Change the PR created in step 5 to have base branch `trunk` instead but apply the `10.1.0` milestone to it.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.1` and confirm that it fails. This time, it should complain about open PRs with milestone `10.1.0`.
1. Close the PR you opened in step 5.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.1` and ☒ Create GitHub release checked. Confirm that it succeeds and creates a draft release `10.1.0-rc.3` after it's done.

<!-- End testing instructions -->