### PR TITLE
Product Gallery: fix ghost overflow

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-gallery-ghost-overflow
+++ b/plugins/woocommerce/changelog/fix-product-gallery-ghost-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product Gallery: Fix ghost scrollbar in thumbnails issue

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -555,19 +555,11 @@ const productGallery = {
 				element.style.scrollbarWidth = 'none';
 			}
 		},
-		initScrollable: () => {
-			callbacks.initResizeObserver();
-			callbacks.hideGhostOverflow();
-		},
 	},
 };
 
-const { actions, callbacks } = store(
-	'woocommerce/product-gallery',
-	productGallery,
-	{
-		lock: true,
-	}
-);
+const { actions } = store( 'woocommerce/product-gallery', productGallery, {
+	lock: true,
+} );
 
 export type Store = typeof productGallery;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-gallery/frontend.ts
@@ -538,11 +538,36 @@ const productGallery = {
 				resizeObserver.disconnect();
 			};
 		},
+		// There's this issue with the scrollbar on the thumbnails block,
+		// that in certain cases thumbnails overflow slightly the container.
+		// This triggers the overflow and scrollbar makes thumbnails smaller
+		// so they no longer overflow resulting in a ghost scrollbar (no scroll).
+		// scrollbar-gutter doesn't work well in flexbox and doesn't solve it,
+		// hence programmatic solution.
+		// See https://github.com/woocommerce/woocommerce/issues/59810.
+		hideGhostOverflow: () => {
+			const element = getElement()?.ref as HTMLElement;
+			if ( ! element ) return;
+
+			const { clientWidth, scrollWidth } = element;
+
+			if ( clientWidth >= scrollWidth ) {
+				element.style.scrollbarWidth = 'none';
+			}
+		},
+		initScrollable: () => {
+			callbacks.initResizeObserver();
+			callbacks.hideGhostOverflow();
+		},
 	},
 };
 
-const { actions } = store( 'woocommerce/product-gallery', productGallery, {
-	lock: true,
-} );
+const { actions, callbacks } = store(
+	'woocommerce/product-gallery',
+	productGallery,
+	{
+		lock: true,
+	}
+);
 
 export type Store = typeof productGallery;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -81,7 +81,8 @@ class ProductGalleryThumbnails extends AbstractBlock {
 			data-wp-class--wc-block-product-gallery-thumbnails--overflow-right="context.thumbnailsOverflow.right">
 			<div
 				class="wc-block-product-gallery-thumbnails__scrollable"
-				data-wp-init="callbacks.initScrollable"
+				data-wp-init--init-resize-observer="callbacks.initResizeObserver"
+				data-wp-init--hide-ghost-overflow="callbacks.hideGhostOverflow"
 				data-wp-on--scroll="actions.onScroll"
 				role="listbox">
 				<?php foreach ( $product_gallery_images as $index => $image ) : ?>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductGalleryThumbnails.php
@@ -81,7 +81,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 			data-wp-class--wc-block-product-gallery-thumbnails--overflow-right="context.thumbnailsOverflow.right">
 			<div
 				class="wc-block-product-gallery-thumbnails__scrollable"
-				data-wp-init="callbacks.initResizeObserver"
+				data-wp-init="callbacks.initScrollable"
 				data-wp-on--scroll="actions.onScroll"
 				role="listbox">
 				<?php foreach ( $product_gallery_images as $index => $image ) : ?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

There's this interesting bug happening in Product Gallery Thumbails. There's a ghost scrollbar showing up under specific conditions:

<img width="706" height="484" alt="image" src="https://github.com/user-attachments/assets/742540d6-fe37-496e-b038-aebd8b71c475" />

It only appears under special conditions, in this case
- 4 images and default thumbnails size (25%)
- 3 images and thumbnails size 33%.

It would also appear with 5 images and thumbnails size 20%, etc. Basically, in such conditions, thumbnails actually overflow (but barely) and so the scrollbar appears. However scrollbar pushes the thumbnails from the bottom making them smaller and eventually NOT overflowing. And hence the scrollbar is there but empty!

This PR fixes it by checking if there's `ghost overflow` via iAPI, and if so make the scrollbar disappear. Keep in mind `scrollbar-gutter` which is designed for this purpose, unfortunately doesn't work well with horizontal scrollbar and flexbox like in this case hence programmatic approach.

Closes https://github.com/woocommerce/woocommerce/issues/59810

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Below images of Product Galleries for
    - 2 Images product - no changes
    - 4 Images product - NO GHOST SCROLLBAR
    - 5 Images product - no changes

| Before | After |
| ------ | ----- |
|    <img width="337" height="1223" alt="image" src="https://github.com/user-attachments/assets/360ea6ef-7e1f-4511-a1a4-eb9199d28007" />    |   <img width="348" height="1231" alt="image" src="https://github.com/user-attachments/assets/cf9dac54-af5e-464d-8f26-01d2210e4141" />    |

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:
0. If needed create products with 2, 4 and 5 images.
1. Create new post
2. Insert 3 Product blocks and choose products you created:
    - 2 Images product
    - 4 Images product
    - 5 Images product
3. In each block Product block:
    - Replace Product Image with Product Gallery (Beta)
    - Change Product Gallery orientation so thumbnails become horizontal
4. Save and go to frontend
5. Expected:
    - 2 Images product - there's no scrollbar
    - 4 Images product - thumbnails overflow slightly but there's no scrollbar
    - 5 Images product - thumbnails overflow slightly and there is scrollbar

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
