### PR TITLE
Add type check for product to prevent fatals

### DIFF
--- a/plugins/woocommerce/changelog/60277-fix-add-type-check-for-product-to-prevent-fatals
+++ b/plugins/woocommerce/changelog/60277-fix-add-type-check-for-product-to-prevent-fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add type check for product to prevent fatals in WC_Comments::clear_transients method.

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -259,11 +259,8 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-		if ( 'product' === get_post_type( $post_id ) ) {
-			$product = wc_get_product( $post_id );
-			if ( ! $product instanceof WC_Product ) {
-				return;
-			}
+		$product = $post_id && wc_get_product( $post_id );
+		if ( $product instanceof WC_Product ) {
 			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );
 			$product->set_review_count( self::get_review_count_for_product( $product ) );

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -259,7 +259,7 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-		$product = $post_id && wc_get_product( $post_id );
+		$product = $post_id ? wc_get_product( $post_id ) : $post_id;
 		if ( $product instanceof WC_Product ) {
 			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -259,8 +259,8 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-		if ( 'product' === get_post_type( $post_id ) ) {
-			$product = wc_get_product( $post_id );
+		$product = wc_get_product( $post_id );
+		if ( $product instanceof WC_Product ) {
 			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );
 			$product->set_review_count( self::get_review_count_for_product( $product ) );

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -259,8 +259,11 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-		$product = wc_get_product( $post_id );
-		if ( $product instanceof WC_Product ) {
+		if ( 'product' === get_post_type( $post_id ) ) {
+			$product = wc_get_product( $post_id );
+			if ( ! $product instanceof WC_Product ) {
+				return;
+			}
 			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );
 			$product->set_review_count( self::get_review_count_for_product( $product ) );

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -259,7 +259,12 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-		$product = $post_id ? wc_get_product( $post_id ) : $post_id;
+		$post_id = absint( $post_id );
+		if ( $post_id === 0 || 'product' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$product = wc_get_product( $post_id );
 		if ( $product instanceof WC_Product ) {
 			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -260,7 +260,7 @@ class WC_Comments {
 	 */
 	public static function clear_transients( $post_id ) {
 		$post_id = absint( $post_id );
-		if ( $post_id === 0 || 'product' !== get_post_type( $post_id ) ) {
+		if ( 0 === $post_id || 'product' !== get_post_type( $post_id ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -87,4 +87,79 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		}
 		$this->assertSame( count( $unapproved_reviews ), WC_Comments::get_products_reviews_pending_moderation_counter() );
 	}
+
+	/**
+	 * Test clear_transients with valid product ID.
+	 */
+	public function test_clear_transients_with_valid_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product_id = $product->get_id();
+
+		// Add a review to the product.
+		$review_id = ProductHelper::create_product_review( $product_id, 'Great product!', 5 );
+
+		// Ensure the review is approved.
+		wp_update_comment(
+			array(
+				'comment_ID'       => $review_id,
+				'comment_approved' => '1',
+			)
+		);
+
+		// Clear transients and verify no fatal error occurs.
+		WC_Comments::clear_transients( $product_id );
+
+		// Verify the product still exists and has been updated.
+		$updated_product = wc_get_product( $product_id );
+		$this->assertInstanceOf( 'WC_Product', $updated_product );
+		$this->assertEquals( 1, $updated_product->get_review_count() );
+	}
+
+	/**
+	 * Test clear_transients with invalid product ID.
+	 */
+	public function test_clear_transients_with_invalid_product_id() {
+		$invalid_product_id = 99999;
+
+		// This should not cause a fatal error.
+		WC_Comments::clear_transients( $invalid_product_id );
+
+		// Verify the function completed without error.
+		$this->assertTrue( true, 'clear_transients should handle invalid product ID gracefully.' );
+	}
+
+	/**
+	 * Test clear_transients with non-product post ID.
+	 */
+	public function test_clear_transients_with_non_product_post() {
+		// Create a regular post (not a product).
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		// This should not cause a fatal error.
+		WC_Comments::clear_transients( $post_id );
+
+		// Verify the function completed without error.
+		$this->assertTrue( true, 'clear_transients should handle non-product post ID gracefully.' );
+
+		// Clean up.
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test clear_transients with zero/null product ID.
+	 */
+	public function test_clear_transients_with_zero_product_id() {
+		// This should not cause a fatal error.
+		WC_Comments::clear_transients( 0 );
+
+		// Verify the function completed without error.
+		$this->assertTrue( true, 'clear_transients should handle zero product ID gracefully.' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -96,15 +96,10 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 		$product_id = $product->get_id();
 
 		// Add a review to the product.
-		$review_id = ProductHelper::create_product_review( $product_id, 'Great product!', 5 );
+		$review_id = ProductHelper::create_product_review( $product_id, 'Great product!' );
 
-		// Ensure the review is approved.
-		wp_update_comment(
-			array(
-				'comment_ID'       => $review_id,
-				'comment_approved' => '1',
-			)
-		);
+		// Add rating meta to the review.
+		update_comment_meta( $review_id, 'rating', 5 );
 
 		// Clear transients and verify no fatal error occurs.
 		WC_Comments::clear_transients( $product_id );

--- a/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-comments-test.php
@@ -92,7 +92,7 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 	 * Test clear_transients with valid product ID.
 	 */
 	public function test_clear_transients_with_valid_product() {
-		$product = WC_Helper_Product::create_simple_product();
+		$product    = WC_Helper_Product::create_simple_product();
 		$product_id = $product->get_id();
 
 		// Add a review to the product.
@@ -121,11 +121,9 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 	public function test_clear_transients_with_invalid_product_id() {
 		$invalid_product_id = 99999;
 
-		// This should not cause a fatal error.
+		// This should not cause any errors or exceptions.
+		$this->expectNotToPerformAssertions();
 		WC_Comments::clear_transients( $invalid_product_id );
-
-		// Verify the function completed without error.
-		$this->assertTrue( true, 'clear_transients should handle invalid product ID gracefully.' );
 	}
 
 	/**
@@ -142,24 +140,11 @@ class WC_Comments_Tests extends \WC_Unit_Test_Case {
 			)
 		);
 
-		// This should not cause a fatal error.
+		// This should not cause any errors or exceptions.
+		$this->expectNotToPerformAssertions();
 		WC_Comments::clear_transients( $post_id );
-
-		// Verify the function completed without error.
-		$this->assertTrue( true, 'clear_transients should handle non-product post ID gracefully.' );
 
 		// Clean up.
 		wp_delete_post( $post_id, true );
-	}
-
-	/**
-	 * Test clear_transients with zero/null product ID.
-	 */
-	public function test_clear_transients_with_zero_product_id() {
-		// This should not cause a fatal error.
-		WC_Comments::clear_transients( 0 );
-
-		// Verify the function completed without error.
-		$this->assertTrue( true, 'clear_transients should handle zero product ID gracefully.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR adds a type check for the product object in the `clear_transients` method to prevent fatal errors when the product might not exist or be invalid.

The change modifies `plugins/woocommerce/includes/class-wc-comments.php` to:
- First get the product using `wc_get_product( $post_id )`
- Then check if it's actually a `WC_Product` instance before proceeding with the operations
- This prevents fatal errors when `wc_get_product()` returns `false` or an invalid object

The fix was implemented because we were seeing a fatal in some error logs in a hosting environment where this showed up in the stack trace. I suspect the particular environment was executing the call to `wc_get_product` to early in the request which resulted in a fatal error:

```
Fatal error: Uncaught Error: Call to a member function set_rating_counts() on false in [...]/public_html/wp-content/plugins/woocommerce/woocommerce-9.6.1/includes/class-wc-comments.php:211
```

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Test with valid product ID:**
   - Create a product in WooCommerce
   - Add a review/comment to the product
   - Verify that the `clear_transients` method works correctly and updates the product's rating data

2. **Test with invalid product ID:**
   - Try to call the `clear_transients` method with a non-existent product ID
   - Verify that no fatal error occurs and the method handles the invalid product gracefully

3. **Test with non-product post ID:**
   - Try to call the `clear_transients` method with a post ID that exists but is not a product (e.g., a page or post)
   - Verify that no fatal error occurs and the method handles the non-product post gracefully

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add type check for product to prevent fatals in WC_Comments::clear_transients method.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
