### PR TITLE
Fix: include billing first name in admin order search (CPT)

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -615,8 +615,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					'_billing_address_index',
 					'_shipping_address_index',
 					'_billing_last_name',
-					'_billing_email',
-					'_billing_phone',
+                    '_billing_first_name',
+                    '_billing_email',
+                    '_billing_phone',
+
 				)
 			)
 		);


### PR DESCRIPTION
**Summary**
Fixes admin orders search not returning results when searching by customer first name in CPT-based setups.

**Changes**
- Added `_billing_first_name` to the default meta keys for CPT order searches.

**Testing**
- Create orders with unique billing first names, search for those names in WooCommerce admin Orders list — orders should appear.

**Note**
HPOS search updates not included in this PR due to branch version; can be added in follow-up if needed.

