### PR TITLE
Fix site logo align right in group

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-5204-email-editor-site-logo-align-right-value-not-working-with
+++ b/packages/js/email-editor/changelog/wooplug-5204-email-editor-site-logo-align-right-value-not-working-with
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix site logo not rendered properly. In the email editor if the site logo was in a group block the right alignment didn't work.

--- a/packages/js/email-editor/src/components/block-editor/style.scss
+++ b/packages/js/email-editor/src/components/block-editor/style.scss
@@ -107,6 +107,6 @@
 	margin-left: auto;
 	margin-right: 0;
 	float: right;
-    margin-inline-start: 2em;
-    margin-inline-end: 0;
+	margin-inline-start: 2em;
+	margin-inline-end: 0;
 }

--- a/packages/js/email-editor/src/components/block-editor/style.scss
+++ b/packages/js/email-editor/src/components/block-editor/style.scss
@@ -101,3 +101,12 @@
 .force-hidden {
 	display: none !important;
 }
+
+/* Ensure right alignment for Site Logo when nested in containers without is-layout-flow (e.g., Group block) */
+.block-editor-block-list__layout .wp-block-site-logo.alignright {
+	margin-left: auto;
+	margin-right: 0;
+	float: right;
+    margin-inline-start: 2em;
+    margin-inline-end: 0;
+}

--- a/packages/js/email-editor/src/components/block-editor/style.scss
+++ b/packages/js/email-editor/src/components/block-editor/style.scss
@@ -102,11 +102,12 @@
 	display: none !important;
 }
 
-/* Ensure right alignment for Site Logo when nested in containers without is-layout-flow (e.g., Group block) */
-.block-editor-block-list__layout .wp-block-site-logo.alignright {
+/* Align Site Logo right in flow layouts (uses float + physical margins) */
+.is-layout-flow .wp-block-site-logo.alignright,
+.block-editor-block-list__layout .wp-block-site-logo.alignright,
+.is-layout-constrained .wp-block-site-logo.alignright,
+.wp-block-group .wp-block-site-logo.alignright {
+	float: right;
 	margin-left: auto;
 	margin-right: 0;
-	float: right;
-	margin-inline-start: 2em;
-	margin-inline-end: 0;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the Site logo block is used in the group block, the align-right attribute is not correctly rendered. Testing the content in the preview shows the standard placement, but not in the editor.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60064 [WOOPLUG-5204].

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/59624

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1584" height="450" alt="Markup 2025-08-08 at 11 51 14" src="https://github.com/user-attachments/assets/c798603d-1ca3-44e5-b344-539655fcb75c" />   |   <img width="2298" height="580" alt="Screenshot on 2025-08-08 at 12-15-25" src="https://github.com/user-attachments/assets/47b14c0d-58a4-4d1e-850c-481f856cf807" />    |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Using the Twenty Twenty-Five
2. Open any email content in the email editor
3. Add a group block
4. Add the Site logo block in the group block
5. Set the align attribute to right
6. Notice that the alignment does not work
7. Add a Site logo block to the content
8. Set the align attribute to right
9. Notice that the alignment works.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
