### PR TITLE
Update e2e tests to use the theme template slug instead of the woocommerce slug

### DIFF
--- a/plugins/woocommerce/changelog/fix-update-tests-theme-template-slug
+++ b/plugins/woocommerce/changelog/fix-update-tests-theme-template-slug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update e2e tests to use the theme template slug instead of the woocommerce slug
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
@@ -17,7 +17,7 @@ const NewsletterPanel = () => {
 	);
 
 	// Restrict the panel to only show on the coming soon page tempalte
-	if ( postId !== 'woocommerce/woocommerce//coming-soon' ) {
+	if ( ! postId?.endsWith( '//coming-soon' ) ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-collection/utils.tsx
@@ -67,9 +67,9 @@ export function setQueryAttribute(
 
 const isInProductArchive = () => {
 	const ARCHIVE_PRODUCT_TEMPLATES = [
-		'woocommerce/woocommerce//archive-product',
-		'woocommerce/woocommerce//taxonomy-product_attribute',
-		'woocommerce/woocommerce//product-search-results',
+		'//archive-product',
+		'//taxonomy-product_attribute',
+		'//product-search-results',
 		// Custom taxonomy templates have structure:
 		// <<THEME>>//taxonomy-product_cat-<<CATEGORY>>
 		// hence we're checking if template ID includes the middle part.
@@ -79,6 +79,7 @@ const isInProductArchive = () => {
 		// - woocommerce/woocommerce//taxonomy-product_tag
 		'//taxonomy-product_cat',
 		'//taxonomy-product_tag',
+		'//taxonomy-product_brand',
 	];
 
 	const currentTemplateId = select(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -29,11 +29,12 @@ import {
 } from '../constants';
 
 const ARCHIVE_PRODUCT_TEMPLATES = [
-	'woocommerce/woocommerce//archive-product',
-	'woocommerce/woocommerce//taxonomy-product_cat',
-	'woocommerce/woocommerce//taxonomy-product_tag',
-	'woocommerce/woocommerce//taxonomy-product_attribute',
-	'woocommerce/woocommerce//product-search-results',
+	'//archive-product',
+	'//taxonomy-product_cat',
+	'//taxonomy-product_tag',
+	'//taxonomy-product_brand',
+	'//taxonomy-product_attribute',
+	'//product-search-results',
 ];
 
 const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
@@ -77,7 +78,9 @@ subscribe( () => {
 	}
 
 	if ( isSiteEditorPage( store ) ) {
-		const inherit = ARCHIVE_PRODUCT_TEMPLATES.includes( currentTemplateId );
+		const inherit = ARCHIVE_PRODUCT_TEMPLATES.some( ( template ) =>
+			currentTemplateId?.endsWith( template )
+		);
 
 		const inheritQuery: Partial< ProductQueryBlockQuery > = {
 			inherit,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
@@ -5,7 +5,6 @@ import {
 	test as base,
 	expect,
 	BLOCK_THEME_WITH_TEMPLATES_SLUG,
-	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -36,7 +35,7 @@ test.describe( `Add to Cart + Options Block (block theme with templates)`, () =>
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `${ BLOCK_THEME_SLUG }//single-product`,
+			postId: `${ BLOCK_THEME_WITH_TEMPLATES_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme_with_templates.spec.ts
@@ -5,6 +5,7 @@ import {
 	test as base,
 	expect,
 	BLOCK_THEME_WITH_TEMPLATES_SLUG,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -35,7 +36,7 @@ test.describe( `Add to Cart + Options Block (block theme with templates)`, () =>
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.page.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { Editor, Admin } from '@woocommerce/e2e-utils';
+import { Editor, Admin, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 class AddToCartWithOptionsPage {
 	private page: Page;
@@ -68,7 +68,7 @@ class AddToCartWithOptionsPage {
 
 	async updateSingleProductTemplate() {
 		await this.admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/attributes-filter/attribute-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	wpCLI,
 	TemplateCompiler,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -109,7 +110,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.merchant.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test as base, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -47,7 +52,7 @@ test.describe( 'Merchant → Checkout', () => {
 
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -158,7 +163,7 @@ test.describe( 'Merchant → Checkout', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -201,7 +206,7 @@ test.describe( 'Merchant → Checkout', () => {
 		).toBeVisible();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/checkout-block.shopper.block_theme.spec.ts
@@ -7,6 +7,7 @@ import {
 	customerFile,
 	guestFile,
 	BlockData,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -348,7 +349,7 @@ test.describe( 'Shopper → Shipping and Billing Addresses', () => {
 
 	test.beforeEach( async ( { admin, editor, page } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -654,7 +655,7 @@ test.describe( 'Billing Address Form', () => {
 
 	test( 'Enable company field', async ( { page, admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//page-checkout',
+			postId: `${ BLOCK_THEME_SLUG }//page-checkout`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test as base, expect, guestFile } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	guestFile,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -30,7 +35,7 @@ test.describe( 'Shopper (logged-in) → Order Confirmation', () => {
 		await localPickupUtils.disableLocalPickup();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -34,31 +34,37 @@ const templates = [
 		title: 'Single Product',
 		slug: 'single-product',
 		path: '/product/hoodie',
+		needsCreation: false,
 	},
 	{
-		title: 'Product Attribute',
+		title: 'Products by Attribute',
 		slug: 'taxonomy-product_attribute',
 		path: '/color/blue',
+		needsCreation: false,
 	},
 	{
-		title: 'Product Category',
+		title: 'Products by Category',
 		slug: 'taxonomy-product_cat',
 		path: '/product-category/clothing',
+		needsCreation: true,
 	},
 	{
-		title: 'Product Tag',
+		title: 'Products by Tag',
 		slug: 'taxonomy-product_tag',
 		path: '/product-tag/recommended/',
+		needsCreation: true,
 	},
 	{
 		title: 'Product Catalog',
 		slug: 'archive-product',
 		path: '/shop/',
+		needsCreation: false,
 	},
 	{
 		title: 'Product Search Results',
 		slug: 'product-search-results',
 		path: '/?s=shirt&post_type=product',
+		needsCreation: false,
 	},
 ];
 
@@ -302,17 +308,32 @@ test.describe( `${ blockData.name } Block `, () => {
 			editor,
 			page,
 		} ) => {
-			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_SLUG }//${ template.slug }`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+			if ( template.needsCreation ) {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: template.title,
+				} );
+			} else {
+				await admin.visitSiteEditor( {
+					postId: `${ BLOCK_THEME_SLUG }//${ template.slug }`,
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+			}
 
 			const block = editor.canvas.locator(
 				`[data-type="${ blockData.name }"]`
 			);
 
 			await expect( block ).toBeVisible();
+
+			if ( template.needsCreation ) {
+				await editor.saveSiteEditorEntities( {
+					isOnlyCurrentEntityDirty: true,
+				} );
+			}
 
 			await page.goto( template.path );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { test, expect, wpCLI, BlockData, Editor } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	wpCLI,
+	BlockData,
+	Editor,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -145,7 +152,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -182,7 +189,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -233,7 +240,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		wpCoreVersion,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -296,7 +303,7 @@ test.describe( `${ blockData.name } Block `, () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ template.slug }`,
+				postId: `${ BLOCK_THEME_SLUG }//${ template.slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/mini-cart/mini-cart-block.merchant.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 const blockData: BlockData = {
 	name: 'Mini-Cart',
@@ -20,7 +25,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 	test.describe( 'in FSE editor', () => {
 		test( 'can be inserted in FSE area', async ( { editor, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -35,7 +40,7 @@ test.describe( 'Merchant → Mini Cart', () => {
 
 		test( 'can only be inserted once', async ( { editor, admin } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	Editor,
 	FrontendUtils,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 /**
@@ -92,7 +93,7 @@ test.describe( `${ blockData.name }`, () => {
 	test.describe( `On the Single Product Template`, () => {
 		test.beforeEach( async ( { admin, editor } ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ blockData.slug }`,
+				postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/price-filter/price-filter.block_theme.spec.ts
@@ -7,6 +7,7 @@ import {
 	TemplateCompiler,
 	BASE_URL,
 	wpCLI,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -271,7 +272,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/collections.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -152,7 +152,7 @@ test.describe( 'Product Collection: Collections', () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -394,9 +394,6 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 
 		[
 			`${ BLOCK_THEME_SLUG }//archive-product`,
-			`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
-			`${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
-			`${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
 			`${ BLOCK_THEME_SLUG }//taxonomy-product_attribute`,
 			`${ BLOCK_THEME_SLUG }//product-search-results`,
 		].forEach( ( slug ) => {
@@ -405,6 +402,44 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 				editor,
 			} ) => {
 				await pageObject.goToEditorTemplate( slug );
+				await pageObject.insertProductCollection();
+				await pageObject.chooseCollectionInTemplate();
+				await pageObject.focusProductCollection();
+				await editor.openDocumentSettingsSidebar();
+
+				await expect(
+					pageObject
+						.locateSidebarSettings()
+						.getByLabel( SELECTORS.usePageContextControl )
+				).toBeVisible();
+			} );
+		} );
+
+		[
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
+				title: 'Products by Category',
+			},
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
+				title: 'Products by Tag',
+			},
+			{
+				slug: `${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
+				title: 'Products by Brand',
+			},
+		].forEach( ( template ) => {
+			test( `should be visible in archive template: ${ template.slug }`, async ( {
+				admin,
+				pageObject,
+				editor,
+			} ) => {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: template.title,
+				} );
 				await pageObject.insertProductCollection();
 				await pageObject.chooseCollectionInTemplate();
 				await pageObject.focusProductCollection();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/inspector-controls.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -393,11 +393,12 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 		} );
 
 		[
-			'woocommerce/woocommerce//archive-product',
-			'woocommerce/woocommerce//taxonomy-product_cat',
-			'woocommerce/woocommerce//taxonomy-product_tag',
-			'woocommerce/woocommerce//taxonomy-product_attribute',
-			'woocommerce/woocommerce//product-search-results',
+			`${ BLOCK_THEME_SLUG }//archive-product`,
+			`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
+			`${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
+			`${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
+			`${ BLOCK_THEME_SLUG }//taxonomy-product_attribute`,
+			`${ BLOCK_THEME_SLUG }//product-search-results`,
 		].forEach( ( slug ) => {
 			test( `should be visible in archive template: ${ slug }`, async ( {
 				pageObject,
@@ -418,9 +419,9 @@ test.describe( 'Product Collection: Inspector Controls', () => {
 		} );
 
 		[
-			'woocommerce/woocommerce//single-product',
-			'twentytwentyfour//home',
-			'twentytwentyfour//index',
+			`${ BLOCK_THEME_SLUG }//single-product`,
+			`${ BLOCK_THEME_SLUG }//home`,
+			`${ BLOCK_THEME_SLUG }//index`,
 		].forEach( ( slug ) => {
 			test( `should be visible in non-archive template: ${ slug }`, async ( {
 				pageObject,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -489,9 +489,10 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 				postType: 'wp_template',
-				canvas: 'edit',
+			} );
+			await editor.createTemplate( {
+				templateName: 'Products by Category',
 			} );
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
@@ -518,9 +519,10 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
 				postType: 'wp_template',
-				canvas: 'edit',
+			} );
+			await editor.createTemplate( {
+				templateName: 'Products by Tag',
 			} );
 			await editor.insertBlockUsingGlobalInserter(
 				pageObject.BLOCK_NAME
@@ -607,14 +609,12 @@ test.describe( 'Product Collection', () => {
 			{
 				name: 'Products by Tag',
 				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
+				needsCreation: true,
 			},
 			{
 				name: 'Products by Category',
 				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
-			},
-			{
-				name: 'Products by Brand',
-				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
+				needsCreation: true,
 			},
 			{
 				name: 'Products by Attribute',
@@ -622,9 +622,22 @@ test.describe( 'Product Collection', () => {
 			},
 		];
 
-		genericArchiveTemplates.forEach( ( { name, path } ) => {
-			test( `${ name } template`, async ( { editor, pageObject } ) => {
-				await pageObject.goToEditorTemplate( path );
+		genericArchiveTemplates.forEach( ( { name, path, needsCreation } ) => {
+			test( `${ name } template`, async ( {
+				admin,
+				editor,
+				pageObject,
+			} ) => {
+				if ( needsCreation ) {
+					await admin.visitSiteEditor( {
+						postType: 'wp_template',
+					} );
+					await editor.createTemplate( {
+						templateName: name,
+					} );
+				} else {
+					await pageObject.goToEditorTemplate( path );
+				}
 				await pageObject.focusProductCollection();
 
 				const previewButtonLocator = editor.canvas.getByTestId(

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { Request } from '@playwright/test';
-import { test as base, expect, wpCLI } from '@woocommerce/e2e-utils';
+import {
+	test as base,
+	expect,
+	wpCLI,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -484,7 +489,7 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_cat`,
+				postId: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -513,7 +518,7 @@ test.describe( 'Product Collection', () => {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//taxonomy-product_tag`,
+				postId: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -601,15 +606,19 @@ test.describe( 'Product Collection', () => {
 		const genericArchiveTemplates = [
 			{
 				name: 'Products by Tag',
-				path: 'woocommerce/woocommerce//taxonomy-product_tag',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_tag`,
 			},
 			{
 				name: 'Products by Category',
-				path: 'woocommerce/woocommerce//taxonomy-product_cat',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
+			},
+			{
+				name: 'Products by Brand',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_brand`,
 			},
 			{
 				name: 'Products by Attribute',
-				path: 'woocommerce/woocommerce//taxonomy-product_attribute',
+				path: `${ BLOCK_THEME_SLUG }//taxonomy-product_attribute`,
 			},
 		];
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -2,13 +2,8 @@
  * External dependencies
  */
 import { FrameLocator, Locator, Page } from '@playwright/test';
-import { Editor, Admin } from '@woocommerce/e2e-utils';
+import { Editor, Admin, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 import { BlockRepresentation } from '@wordpress/e2e-test-utils-playwright/build-types/editor/insert-block';
-
-/**
- * Internal dependencies
- */
-import { BLOCK_THEME_SLUG } from '../../utils/constants';
 
 export const BLOCK_LABELS = {
 	productTemplate: 'Block: Product Template',
@@ -336,7 +331,7 @@ class ProductCollectionPage {
 
 	// Going to Product Catalog by default
 	async goToEditorTemplate(
-		template = 'woocommerce/woocommerce//archive-product'
+		template = `${ BLOCK_THEME_SLUG }//archive-product`
 	) {
 		await this.admin.visitSiteEditor( {
 			postId: template,
@@ -348,7 +343,7 @@ class ProductCollectionPage {
 
 	async goToProductCatalogAndInsertCollection( collection: Collections ) {
 		await this.goToTemplateAndInsertCollection(
-			'woocommerce/woocommerce//archive-product',
+			`${ BLOCK_THEME_SLUG }//archive-product`,
 			collection
 		);
 	}

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-picker.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-picker.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -145,7 +145,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 			editor,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//single-product`,
+				postId: `${ BLOCK_THEME_SLUG }//single-product`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );
@@ -168,7 +168,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//page-cart`,
+			postId: `${ BLOCK_THEME_SLUG }//page-cart`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -190,7 +190,7 @@ test.describe( 'Product Collection: Product Picker', () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//order-confirmation`,
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -329,20 +329,20 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			id: 'myCustomCollectionWithProductContext',
 			name: 'My Custom Collection - Product Context',
 			label: 'Block: My Custom Collection - Product Context',
-			previewLabelTemplate: [ 'woocommerce/woocommerce//single-product' ],
+			previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//single-product` ],
 		},
 		{
 			id: 'myCustomCollectionWithCartContext',
 			name: 'My Custom Collection - Cart Context',
 			label: 'Block: My Custom Collection - Cart Context',
-			previewLabelTemplate: [ 'woocommerce/woocommerce//page-cart' ],
+			previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//page-cart` ],
 		},
 		{
 			id: 'myCustomCollectionWithOrderContext',
 			name: 'My Custom Collection - Order Context',
 			label: 'Block: My Custom Collection - Order Context',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//order-confirmation',
+				`${ BLOCK_THEME_SLUG }//order-confirmation`,
 			],
 		},
 		{
@@ -350,7 +350,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			name: 'My Custom Collection - Archive Context',
 			label: 'Block: My Custom Collection - Archive Context',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//taxonomy-product_cat',
+				`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 			],
 		},
 		{
@@ -358,8 +358,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 			name: 'My Custom Collection - Multiple Contexts',
 			label: 'Block: My Custom Collection - Multiple Contexts',
 			previewLabelTemplate: [
-				'woocommerce/woocommerce//single-product',
-				'woocommerce/woocommerce//order-confirmation',
+				`${ BLOCK_THEME_SLUG }//single-product`,
+				`${ BLOCK_THEME_SLUG }//order-confirmation`,
 			],
 		},
 	].forEach( ( collection ) => {
@@ -511,7 +511,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Product Context',
 				label: 'Block: My Custom Collection - Product Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//single-product',
+					`${ BLOCK_THEME_SLUG }//single-product`,
 				],
 				shouldShowProductPicker: true,
 			},
@@ -519,7 +519,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				id: 'myCustomCollectionWithCartContext',
 				name: 'My Custom Collection - Cart Context',
 				label: 'Block: My Custom Collection - Cart Context',
-				previewLabelTemplate: [ 'woocommerce/woocommerce//page-cart' ],
+				previewLabelTemplate: [ `${ BLOCK_THEME_SLUG }//page-cart` ],
 				shouldShowProductPicker: false,
 			},
 			{
@@ -527,7 +527,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Order Context',
 				label: 'Block: My Custom Collection - Order Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//order-confirmation',
+					`${ BLOCK_THEME_SLUG }//order-confirmation`,
 				],
 				shouldShowProductPicker: false,
 			},
@@ -536,7 +536,7 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Archive Context',
 				label: 'Block: My Custom Collection - Archive Context',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//taxonomy-product_cat',
+					`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`,
 				],
 				shouldShowProductPicker: false,
 			},
@@ -545,8 +545,8 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 				name: 'My Custom Collection - Multiple Contexts',
 				label: 'Block: My Custom Collection - Multiple Contexts',
 				previewLabelTemplate: [
-					'woocommerce/woocommerce//single-product',
-					'woocommerce/woocommerce//order-confirmation',
+					`${ BLOCK_THEME_SLUG }//single-product`,
+					`${ BLOCK_THEME_SLUG }//order-confirmation`,
 				],
 				shouldShowProductPicker: true,
 			},

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/register-product-collection.block_theme.spec.ts
@@ -365,10 +365,22 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 	].forEach( ( collection ) => {
 		collection.previewLabelTemplate.forEach( ( template ) => {
 			test( `Collection "${ collection.name }" should show preview label in "${ template }"`, async ( {
+				admin,
 				pageObject,
 				editor,
 			} ) => {
-				await pageObject.goToEditorTemplate( template );
+				if (
+					template === `${ BLOCK_THEME_SLUG }//taxonomy-product_cat`
+				) {
+					await admin.visitSiteEditor( {
+						postType: 'wp_template',
+					} );
+					await editor.createTemplate( {
+						templateName: 'Products by Category',
+					} );
+				} else {
+					await pageObject.goToEditorTemplate( template );
+				}
 				await pageObject.insertProductCollection();
 				await pageObject.chooseCollectionInTemplate(
 					collection.id as Collections
@@ -553,10 +565,23 @@ test.describe( 'Product Collection: Register Product Collection', () => {
 		].forEach( ( collection ) => {
 			collection.previewLabelTemplate.forEach( ( template ) => {
 				test( `Collection "${ collection.name }" should show preview label in "${ template }"`, async ( {
+					admin,
 					pageObject,
 					editor,
 				} ) => {
-					await pageObject.goToEditorTemplate( template );
+					if (
+						template ===
+						`${ BLOCK_THEME_SLUG }//taxonomy-product_cat`
+					) {
+						await admin.visitSiteEditor( {
+							postType: 'wp_template',
+						} );
+						await editor.createTemplate( {
+							templateName: 'Products by Category',
+						} );
+					} else {
+						await pageObject.goToEditorTemplate( template );
+					}
 					await pageObject.insertProductCollection();
 					await pageObject.chooseCollectionInTemplate(
 						collection.id as Collections

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/attribute-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/price-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/price-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/product-filters.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/rating-filter-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/rating-filter-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -33,7 +33,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/removable-chips-editor.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-filters/removable-chips-editor.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ const test = base.extend< { pageObject: ProductFiltersPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image/product-gallery-large-image.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test as base, expect } from '@woocommerce/e2e-utils';
+import { test as base, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ const test = base.extend< { pageObject: ProductGalleryPage } >( {
 test.describe( `${ blockData.name }`, () => {
 	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//${ blockData.slug }`,
+			postId: `${ BLOCK_THEME_SLUG }//${ blockData.slug }`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -34,30 +34,35 @@ const templates = {
 	//	slug: 'taxonomy-product_attribute',
 	//	frontendPage: '/product-attribute/color/',
 	//	legacyBlockName: 'woocommerce/legacy-template',
+	//	needsCreation: false,
 	//},
 	'taxonomy-product_cat': {
 		templateTitle: 'Product Category',
 		slug: 'taxonomy-product_cat',
 		frontendPage: '/product-category/music/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: true,
 	},
 	'taxonomy-product_tag': {
 		templateTitle: 'Product Tag',
 		slug: 'taxonomy-product_tag',
 		frontendPage: '/product-tag/recommended/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: true,
 	},
 	'archive-product': {
 		templateTitle: 'Product Catalog',
 		slug: 'archive-product',
 		frontendPage: '/shop/',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: false,
 	},
 	'product-search-results': {
 		templateTitle: 'Product Search Results',
 		slug: 'product-search-results',
 		frontendPage: '/?s=shirt&post_type=product',
 		legacyBlockName: 'woocommerce/legacy-template',
+		needsCreation: false,
 	},
 };
 
@@ -99,6 +104,7 @@ for ( const {
 	slug,
 	frontendPage,
 	legacyBlockName,
+	needsCreation,
 } of Object.values( templates ) ) {
 	test.describe( `${ templateTitle } template`, () => {
 		test( 'Products block matches with classic template block', async ( {
@@ -106,11 +112,20 @@ for ( const {
 			editor,
 			page,
 		} ) => {
-			await admin.visitSiteEditor( {
-				postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
-				postType: 'wp_template',
-				canvas: 'edit',
-			} );
+			if ( needsCreation ) {
+				await admin.visitSiteEditor( {
+					postType: 'wp_template',
+				} );
+				await editor.createTemplate( {
+					templateName: 'Products by Category',
+				} );
+			} else {
+				await admin.visitSiteEditor( {
+					postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
+					postType: 'wp_template',
+					canvas: 'edit',
+				} );
+			}
 			await editor.setContent( '' );
 			await insertProductsQuery( editor );
 			await editor.insertBlock( { name: legacyBlockName } );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/products/products.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -63,7 +68,7 @@ test.describe( `${ blockData.name } Block `, () => {
 		page,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -102,7 +107,7 @@ for ( const {
 			page,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ slug }`,
+				postId: `${ BLOCK_THEME_SLUG }//${ slug }`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/rating-filter/rating-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	wpCLI,
 	TemplateCompiler,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 const blockData = {
@@ -107,7 +108,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		);
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { test, expect, BlockData } from '@woocommerce/e2e-utils';
+import {
+	test,
+	expect,
+	BlockData,
+	BLOCK_THEME_SLUG,
+} from '@woocommerce/e2e-utils';
 
 // Block is soft-depreacted meaning that it's hidden from the inserter.
 const blockData: BlockData = {
@@ -34,7 +39,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//archive-product`,
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -57,7 +62,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		editor,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: `woocommerce/woocommerce//single-product`,
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -179,7 +179,7 @@ test.describe( 'Compatibility Layer in Single Product template', () => {
 	} ) => {
 		/* Switch to the blockified Add to Cart + Options block to be able to test all hooks */
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//single-product',
+			postId: `${ BLOCK_THEME_SLUG }//single-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/stock-filter/stock-filter.block_theme.spec.ts
@@ -6,6 +6,7 @@ import {
 	expect,
 	TemplateCompiler,
 	wpCLI,
+	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
 export const blockData = {
@@ -121,7 +122,7 @@ test.describe( `${ blockData.name } Block - with PHP classic template`, () => {
 		await page.reload();
 
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/store-notices/store-notices.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { expect, test } from '@woocommerce/e2e-utils';
+import { expect, test, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ test.describe( `${ blockData.slug } Block`, () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//archive-product',
+			postId: `${ BLOCK_THEME_SLUG }//archive-product`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
-const templatePath = 'woocommerce/woocommerce//page-cart';
+const templatePath = `${ BLOCK_THEME_SLUG }//page-cart`;
 const templateType = 'wp_template';
 
 test.describe( 'Test the cart template', () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
-const templatePath = 'woocommerce/woocommerce//page-checkout';
+const templatePath = `${ BLOCK_THEME_SLUG }//page-checkout`;
 const templateType = 'wp_template';
 
 test.describe( 'Test the checkout template', () => {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 test.describe( 'Test the order confirmation template', () => {
 	test( 'Template can be opened in the site editor', async ( {
@@ -9,7 +9,7 @@ test.describe( 'Test the order confirmation template', () => {
 		admin,
 	} ) => {
 		await admin.visitSiteEditor( {
-			postId: 'woocommerce/woocommerce//order-confirmation',
+			postId: `${ BLOCK_THEME_SLUG }//order-confirmation`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/product-search-results.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 test.describe( 'Product Search Results template', () => {
 	// This is a test to verify there are no regressions on
@@ -12,7 +12,7 @@ test.describe( 'Product Search Results template', () => {
 	} ) => {
 		await admin.visitSiteEditor( {
 			canvas: 'edit',
-			postId: 'woocommerce/woocommerce//product-search-results',
+			postId: `${ BLOCK_THEME_SLUG }//product-search-results`,
 			postType: 'wp_template',
 		} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -158,24 +158,9 @@ test.describe( 'Template priority', () => {
 				} );
 
 				if ( testData.fallbackTemplate ) {
-					await page.getByLabel( 'Add Template' ).click();
-
-					const dialog = page.getByRole( 'dialog' );
-					await dialog
-						.getByRole( 'button', { name: testData.templateName } )
-						.click();
-					// There is the chance that the Add template dialog is opened before
-					// product taxonomies could load. In that case, the screen to select
-					// whether to create a template for a specific taxonomy or for all of
-					// them won't be shown. That's why we click the 'All Categories' /
-					// 'All Tags' button only if visible.
-					const allButton = dialog.getByRole( 'button', {
-						name: 'All',
+					await editor.createTemplate( {
+						templateName: testData.templateName,
 					} );
-					if ( await allButton.isVisible() ) {
-						await allButton.click();
-					}
-					await page.getByLabel( 'Fallback content' ).click();
 
 					// Verify we are editing the correct template.
 					await page

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect, Editor } from '@woocommerce/e2e-utils';
+import { test, expect, Editor, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
 
 const insertSingleProductBlock = async (
 	blockName: string,
@@ -24,7 +24,7 @@ const insertInSingleProductTemplate = async (
 	admin: Admin
 ) => {
 	await admin.visitSiteEditor( {
-		postId: `woocommerce/woocommerce//single-product`,
+		postId: `${ BLOCK_THEME_SLUG }//single-product`,
 		postType: 'wp_template',
 		canvas: 'edit',
 	} );
@@ -80,7 +80,7 @@ test.describe( 'registerProductBlockType registers', () => {
 		await test.step( 'Blocks not available in non-product template', async () => {
 			// Visit site editor with a non-product template
 			await admin.visitSiteEditor( {
-				postId: 'woocommerce/woocommerce//coming-soon',
+				postId: `${ BLOCK_THEME_SLUG }//coming-soon`,
 				postType: 'wp_template',
 				canvas: 'edit',
 			} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -126,6 +126,25 @@ export class Editor extends CoreEditor {
 			.waitFor();
 	}
 
+	async createTemplate( { templateName }: { templateName: string } ) {
+		await this.page.getByLabel( 'Add Template' ).click();
+
+		const dialog = this.page.getByRole( 'dialog' );
+		await dialog.getByRole( 'button', { name: templateName } ).click();
+		// There is the chance that the Add template dialog is opened before
+		// product taxonomies could load. In that case, the screen to select
+		// whether to create a template for a specific taxonomy or for all of
+		// them won't be shown. That's why we click the 'All Categories' /
+		// 'All Tags' button only if visible.
+		const allButton = dialog.getByRole( 'button', {
+			name: 'All',
+		} );
+		if ( await allButton.isVisible() ) {
+			await allButton.click();
+		}
+		await this.page.getByLabel( 'Fallback content' ).click();
+	}
+
 	async publishAndVisitPost() {
 		const postId = await this.publishPost();
 		await this.page.goto( `/?p=${ postId }` );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -137,7 +137,7 @@ export class Editor extends CoreEditor {
 		// them won't be shown. That's why we click the 'All Categories' /
 		// 'All Tags' button only if visible.
 		const allButton = dialog.getByRole( 'button', {
-			name: 'All',
+			name: 'For all items',
 		} );
 		if ( await allButton.isVisible() ) {
 			await allButton.click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After migrating to the Template registration API, templates are saved with the theme slug, instead of the `woocommerce/woocommerce` slug. This PR updates all tests that were modifying templates to use the theme slug, so they match what users will do.

### How to test the changes in this Pull Request:

1. Make sure e2e tests keep passing.