### PR TITLE
Add preview save reminder notice for unsaved changes

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-4597-display-warning-message-when-user-clicks-on-preview-in-new
+++ b/packages/js/email-editor/changelog/wooplug-4597-display-warning-message-when-user-clicks-on-preview-in-new
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Display warning message when user clicks on "Preview in new tab" without saving the edited changes

--- a/packages/js/email-editor/src/components/block-editor/editor.tsx
+++ b/packages/js/email-editor/src/components/block-editor/editor.tsx
@@ -26,6 +26,7 @@ import { storeName } from '../../store';
 import { useNavigateToEntityRecord } from '../../hooks/use-navigate-to-entity-record';
 import { Editor, FullscreenMode } from '../../private-apis';
 import { useEmailCss } from '../../hooks';
+import { PreviewSaveGuard } from '../preview/preview-save-guard';
 import { TemplateSelection } from '../template-select';
 import { StylesSidebar } from '../styles-sidebar';
 import { SendPreview } from '../preview';
@@ -143,6 +144,7 @@ export function InnerEditor( {
 					<TemplateSelection />
 					<StylesSidebar />
 					<SendPreview />
+					<PreviewSaveGuard />
 					<FullscreenMode
 						isActive={ isFullScreenForced || isFullscreenEnabled }
 					/>

--- a/packages/js/email-editor/src/components/preview/preview-save-guard.ts
+++ b/packages/js/email-editor/src/components/preview/preview-save-guard.ts
@@ -22,18 +22,16 @@ export const PreviewSaveGuard = () => {
 	const guard = async ( event ) => {
 		const target = event.target;
 
-		// Find the triggering element (the preview button).
+		// Find the triggering element by the selector and early return if not found.
 		const triggerEl = target?.closest( selector );
 		if ( ! triggerEl ) {
 			return;
 		}
 
-		// Check if there are any unsaved changes using the editor data store.
 		const editorStoreInstance = select( editorStore );
 		const isDirty = editorStoreInstance?.isEditedPostDirty?.();
 
 		if ( ! isDirty ) {
-			// If the post is saved, do nothing and let the preview open normally.
 			return;
 		}
 
@@ -42,22 +40,21 @@ export const PreviewSaveGuard = () => {
 		event.stopPropagation();
 		event.stopImmediatePropagation();
 
-		// Dispatch a notice to inform the user they need to save first.
 		dispatch( noticesStore ).createNotice(
-			'info',
+			'warning',
 			__(
 				'You have unsaved changes. Please save the post before previewing.',
 				'woocommerce'
 			),
 			{
-				type: 'snackbar',
+				context: 'email-editor',
 				isDismissible: true,
 			}
 		);
 	};
 
 	/**
-	 * Handles keydown events for the preview button.
+	 * Handles keydown events for the preview button for Enter and Space keys.
 	 *
 	 * @param {KeyboardEvent} event The triggered event.
 	 */
@@ -65,7 +62,6 @@ export const PreviewSaveGuard = () => {
 		( event ) => {
 			try {
 				const target = event.target;
-				// Trigger on 'Enter' or 'Space' keys if the target is the preview button.
 				if (
 					( event.key === 'Enter' || event.key === ' ' ) &&
 					target?.closest( selector )
@@ -80,7 +76,6 @@ export const PreviewSaveGuard = () => {
 		[ selector ]
 	);
 
-	// The `useEffect` hook manages the lifecycle of the event listeners.
 	useEffect( () => {
 		// Add event listeners when the component is mounted.
 		// We use the 'capture' phase to ensure our handler runs before the default React handler.
@@ -97,6 +92,5 @@ export const PreviewSaveGuard = () => {
 		};
 	}, [ keydownHandler ] );
 
-	// The component doesn't need to render any UI, its functionality is purely in the `useEffect` hook.
 	return null;
 };

--- a/packages/js/email-editor/src/components/preview/preview-save-guard.ts
+++ b/packages/js/email-editor/src/components/preview/preview-save-guard.ts
@@ -29,7 +29,7 @@ export const PreviewSaveGuard = () => {
 		}
 
 		const editorStoreInstance = select( editorStore );
-		const isDirty = editorStoreInstance?.isEditedPostDirty?.();
+		const isDirty = editorStoreInstance?.isEditedPostDirty();
 
 		if ( ! isDirty ) {
 			return;

--- a/packages/js/email-editor/src/components/preview/preview-save-guard.ts
+++ b/packages/js/email-editor/src/components/preview/preview-save-guard.ts
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useCallback, useEffect } from '@wordpress/element';
+import { select, dispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * A component that adds a confirmation dialog for unsaved changes
+ * when a user tries to open a preview in a new tab.
+ */
+export const PreviewSaveGuard = () => {
+	const selector = '.editor-preview-dropdown__button-external';
+
+	/**
+	 * Handles click/keydown events to check for unsaved changes before previewing.
+	 *
+	 * @param {Event} event The triggered event.
+	 */
+	const guard = async ( event ) => {
+		const target = event.target;
+
+		// Find the triggering element (the preview button).
+		const triggerEl = target?.closest( selector );
+		if ( ! triggerEl ) {
+			return;
+		}
+
+		// Check if there are any unsaved changes using the editor data store.
+		const editorStoreInstance = select( editorStore );
+		const isDirty = editorStoreInstance?.isEditedPostDirty?.();
+
+		if ( ! isDirty ) {
+			// If the post is saved, do nothing and let the preview open normally.
+			return;
+		}
+
+		// If there are unsaved changes, prevent the default action (opening the link).
+		event.preventDefault();
+		event.stopPropagation();
+		event.stopImmediatePropagation();
+
+		// Dispatch a notice to inform the user they need to save first.
+		dispatch( noticesStore ).createNotice(
+			'info',
+			__(
+				'You have unsaved changes. Please save the post before previewing.',
+				'woocommerce'
+			),
+			{
+				type: 'snackbar',
+				isDismissible: true,
+			}
+		);
+	};
+
+	/**
+	 * Handles keydown events for the preview button.
+	 *
+	 * @param {KeyboardEvent} event The triggered event.
+	 */
+	const keydownHandler = useCallback(
+		( event ) => {
+			try {
+				const target = event.target;
+				// Trigger on 'Enter' or 'Space' keys if the target is the preview button.
+				if (
+					( event.key === 'Enter' || event.key === ' ' ) &&
+					target?.closest( selector )
+				) {
+					guard( event );
+				}
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.warn( 'Preview save message guard error:', error );
+			}
+		},
+		[ selector ]
+	);
+
+	// The `useEffect` hook manages the lifecycle of the event listeners.
+	useEffect( () => {
+		// Add event listeners when the component is mounted.
+		// We use the 'capture' phase to ensure our handler runs before the default React handler.
+		document.addEventListener( 'click', guard, true );
+		document.addEventListener( 'auxclick', guard, true );
+		document.addEventListener( 'keydown', keydownHandler, true );
+
+		// The cleanup function, which runs when the component is unmounted.
+		// This ensures the listeners are properly removed, preventing memory leaks.
+		return () => {
+			document.removeEventListener( 'click', guard, true );
+			document.removeEventListener( 'auxclick', guard, true );
+			document.removeEventListener( 'keydown', keydownHandler, true );
+		};
+	}, [ keydownHandler ] );
+
+	// The component doesn't need to render any UI, its functionality is purely in the `useEffect` hook.
+	return null;
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4597, closes https://github.com/woocommerce/woocommerce/issues/58758

- The new component stops propagation for opening a preview in a new tab where there are unsaved email changes and displays a message.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1535" height="1222" alt="Screenshot 2025-08-12 at 11 01 29" src="https://github.com/user-attachments/assets/1f510ce1-af91-462f-be46-2d94c00eb64e" />|<img width="1534" height="1222" alt="Screenshot 2025-08-12 at 9 06 35" src="https://github.com/user-attachments/assets/1cc8cb72-d845-4c6c-af9f-1e3c298992fd" />|


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from __WooCommerce → Settings → Advanced → Features → Block Email Editor (alpha)__
2. Open an email in the editor __WooCommerce → Settings → Emails__
3. Edit the email content and __don't save changes__
4. Try to open the preview in a new tab
5. You should see a message and the new tab should not be opened
6. Save the changes
7. Try to open the preview again
8. You should see the updated preview in the new tab

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
