### PR TITLE
Improve email E2E test by making locator more strict

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-e2e-test
+++ b/plugins/woocommerce/changelog/fix-email-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E test improvement
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/settings-email-listing.spec.js
@@ -41,7 +41,7 @@ test.describe( 'WooCommerce Email Settings List View', () => {
 		await expect( listViewLocator ).toBeVisible();
 
 		// Check that "New order" email type exists within the list view
-		await expect( listViewLocator.getByText( 'New order' ) ).toBeVisible();
+		await expect( listViewLocator.getByText( /New order/ ) ).toBeVisible();
 
 		// Check table columns
 		// Check that Title column exists

--- a/plugins/woocommerce/tests/e2e-pw/utils/email.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/email.js
@@ -97,7 +97,7 @@ export async function getWooEmails( params ) {
 export async function accessTheEmailEditor( page, emailTitle = 'New order' ) {
 	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=email' );
 	await page
-		.getByRole( 'row', { name: emailTitle } )
+		.getByRole( 'row', { name: new RegExp( emailTitle ) } )
 		.getByLabel( 'Edit' )
 		.click();
 	await expect( page.locator( '#woocommerce-email-editor' ) ).toBeVisible();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

The tests we're running for Additional Variation Images plugin, there were two tests failing from:
- email-editor/email-editor-settings-sidebar.spec.js - WooCommerce Email Editor Settings Sidebar Integration > Can update email recipients
- Email settings list view renders correctly and allows to edit email status and search
- email/settings-email-listing.spec.js - WooCommerce Email Settings List View > Email settings list view renders correctly and allows to edit email status and search

They were failing because locators were resolved to two elements when looking for "New order":
<img width="462" height="63" alt="image" src="https://github.com/user-attachments/assets/6eedd130-4eab-4299-9256-ef3383edb46c" />
<img width="469" height="61" alt="image" src="https://github.com/user-attachments/assets/81f27db4-5951-4af0-a12a-c30d7f690685" />

```
Error: expect.toBeVisible: Error: strict mode violation: locator('.woocommerce-email-listing-listview').getByText('New order') resolved to 2 elements:
    1) New order emails are sent to chosen recipient(s) … aka getByText('New order emails are sent to')
    2) New receipt emails are sent to customers when a n… aka getByText('New receipt emails are sent')
```

That was because the locator is taking the whole text into account (heading and subtext) and `new order` appeared in the description of the other one.

This PR makes the locator more strict by using case sensitive regex.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI is green - in this env there's no condition for the tests to fail so these changes should not affect existing tests

If you want to test it locally for the case I described above:

1. Go to `plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php`
2. Edit label `Receive an email notification when an order that was processing or on hold gets cancelled` by adding `new order` anywhere in the text e.g. `Receive an email notification when an order that was processing or new order on hold gets cancelled`
3. Run tests I listed earlier
4. **Expected:** They pass while they fail on `trunk`


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
