### PR TITLE
Taxonomy Filter: use singular label for shorter variation name and consistency

### DIFF
--- a/plugins/woocommerce/changelog/fix-taxonomy-filter-variation-name
+++ b/plugins/woocommerce/changelog/fix-taxonomy-filter-variation-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Taxonomy Filter: use singular label for shorter variation name and consistency.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/edit.tsx
@@ -142,6 +142,7 @@ const Edit = ( props: EditProps ) => {
 			setTermOptions(
 				sortFilterOptions( [ ...termOptionsPreview ], sortOrder )
 			);
+			setIsOptionsLoading( false );
 			return;
 		}
 
@@ -232,8 +233,9 @@ const Edit = ( props: EditProps ) => {
 		}
 	);
 
-	const isLoading =
-		isTermsLoading || isFilterCountsLoading || isOptionsLoading;
+	const isLoading = isPreview
+		? false
+		: isTermsLoading || isFilterCountsLoading || isOptionsLoading;
 
 	if ( ! taxonomy )
 		return (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/index.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/index.tsx
@@ -44,7 +44,7 @@ registerBlockType( metadata, {
 					`Enable customers to filter the product collection by selecting one or more %s terms.`,
 					'woocommerce'
 				),
-				item.labels.singular_name || item.label
+				item.label
 			),
 			attributes: {
 				taxonomy: item.name,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/test/block.ts
@@ -25,13 +25,11 @@ jest.mock( '@woocommerce/settings', () => {
 				return [
 					{
 						name: 'product_cat',
-						label: 'Product Categories',
-						labels: { singular_name: 'Category' },
+						label: 'Category',
 					},
 					{
 						name: 'product_tag',
-						label: 'Product Tags',
-						labels: { singular_name: 'Tag' },
+						label: 'Tag',
 					},
 				];
 			}
@@ -103,23 +101,21 @@ describe( 'Taxonomy Filter block', () => {
 
 		test( 'should display taxonomy filter when taxonomy is selected', async () => {
 			await setup( { taxonomy: 'product_cat' } );
-			await selectBlock( /Block: Product Categories Filter/i );
+			await selectBlock( /Block: Category Filter/i );
 
 			const block = within(
-				screen.getByLabelText( /Block: Product Categories Filter/i )
+				screen.getByLabelText( /Block: Category Filter/i )
 			);
 
 			// Should display the taxonomy label as heading
-			expect(
-				block.getByText( /Product Categories/i )
-			).toBeInTheDocument();
+			expect( block.getByText( /Category/i ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Inspector controls', () => {
 		beforeEach( async () => {
 			await setup( { taxonomy: 'product_cat' } );
-			await selectBlock( /Block: Product Categories Filter/i );
+			await selectBlock( /Block: Category Filter/i );
 		} );
 
 		test( 'should show product counts toggle', () => {
@@ -132,10 +128,10 @@ describe( 'Taxonomy Filter block', () => {
 		} );
 
 		test( 'should allow toggling product counts', async () => {
-			await selectBlock( /Block: Product Categories Filter/i );
+			await selectBlock( /Block: Category Filter/i );
 
 			const block = within(
-				screen.getByLabelText( /Block: Product Categories Filter/i )
+				screen.getByLabelText( /Block: Category Filter/i )
 			);
 
 			// expect the list doesn't have count indicators initially
@@ -161,7 +157,7 @@ describe( 'Taxonomy Filter block', () => {
 	describe( 'Advanced controls', () => {
 		beforeEach( async () => {
 			await setup( { taxonomy: 'product_cat' } );
-			await selectBlock( /Block: Product Categories Filter/i );
+			await selectBlock( /Block: Category Filter/i );
 		} );
 
 		test( 'should show sort order control when enabled', () => {
@@ -222,16 +218,14 @@ describe( 'Taxonomy Filter block', () => {
 				sortOrder: 'name-asc',
 				hideEmpty: false,
 			} );
-			await selectBlock( /Block: Product Categories Filter/i );
+			await selectBlock( /Block: Category Filter/i );
 
 			const block = within(
-				screen.getByLabelText( /Block: Product Categories Filter/i )
+				screen.getByLabelText( /Block: Category Filter/i )
 			);
 
 			// Should display the heading
-			expect(
-				block.getByText( /Product Categories/i )
-			).toBeInTheDocument();
+			expect( block.getByText( /Category/i ) ).toBeInTheDocument();
 
 			// Check that all controls reflect the set attributes
 			expect(
@@ -254,14 +248,14 @@ describe( 'Taxonomy Filter block', () => {
 				taxonomy: 'product_tag',
 				showCounts: true,
 			} );
-			await selectBlock( /Block: Product Tags Filter/i );
+			await selectBlock( /Block: Tag Filter/i );
 
 			const block = within(
-				screen.getByLabelText( /Block: Product Tags Filter/i )
+				screen.getByLabelText( /Block: Tag Filter/i )
 			);
 
 			// Should display the taxonomy label as heading
-			expect( block.getByText( /Product Tags/i ) ).toBeInTheDocument();
+			expect( block.getByText( /Tag/i ) ).toBeInTheDocument();
 
 			// Should show count indicators since showCounts is true
 			expect( block.queryAllByText( /\(\d+\)/ ).length ).toBeGreaterThan(

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-filters/inner-blocks/taxonomy-filter/types.ts
@@ -17,7 +17,4 @@ export type EditProps = BlockEditProps< BlockAttributes >;
 export type TaxonomyItem = {
 	name: string;
 	label: string;
-	labels: {
-		singular_name: string;
-	};
 };

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductFilterTaxonomy.php
@@ -342,11 +342,8 @@ final class ProductFilterTaxonomy extends AbstractBlock {
 			}
 
 			$taxonomy_data[] = array(
-				'label'  => $taxonomy->label,
-				'name'   => $taxonomy->name,
-				'labels' => array(
-					'singular_name' => $taxonomy->labels->singular_name,
-				),
+				'label' => $taxonomy->labels->singular_name,
+				'name'  => $taxonomy->name,
 			);
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

This PR updates the Taxonomy filter variation name to use a singular label, resulting in shorter block names in the list view. The Attribute Filter block also uses singular labels, so this makes the block naming more consistent among filter blocks.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/d3c0f782-9c8f-4519-9891-cab4a2d57536" />j


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add Product Filters block to the Product Catalog template.
2. See the new block name and heading for the category.
3. Add remaining taxonomy filter blocks, see updated label.

<!-- End testing instructions -->


