### PR TITLE
[Payments NOX] Prevent activate payments dead-ends and allow NOX profile reset

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPLUG-5298-activate-payments-dead-ends-prevention
+++ b/plugins/woocommerce/changelog/update-WOOPLUG-5298-activate-payments-dead-ends-prevention
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Prevent WooPayments activate payments dead-ends and allow for NOX profile reset regardless of the presence of a connected account.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu-content.tsx
@@ -51,6 +51,10 @@ interface EllipsisMenuContentProps {
 	 * Indicates if the payment gateway is enabled for payment processing. Optional.
 	 */
 	isEnabled?: boolean;
+	/**
+	 * Indicates if the onboarding can be reset. Optional.
+	 */
+	canResetOnboarding?: boolean;
 }
 
 /**
@@ -67,6 +71,7 @@ export const EllipsisMenuContent = ( {
 	canResetAccount = false,
 	setResetAccountModalVisible = () => {},
 	isEnabled = false,
+	canResetOnboarding = false,
 }: EllipsisMenuContentProps ) => {
 	const { deactivatePlugin } = useDispatch( pluginsStore );
 	const [ isDeactivating, setIsDeactivating ] = useState( false );
@@ -275,7 +280,7 @@ export const EllipsisMenuContent = ( {
 					</Button>
 				</div>
 			) }
-			{ canResetAccount && (
+			{ ( canResetAccount || canResetOnboarding ) && (
 				<div
 					className="woocommerce-ellipsis-menu__content__item"
 					key="reset-account"
@@ -287,6 +292,7 @@ export const EllipsisMenuContent = ( {
 								provider,
 								{
 									link_type: 'reset_onboarding',
+									with_account: canResetAccount, // Indicates if the reset is for an account or just for onboarding.
 								}
 							);
 							setResetAccountModalVisible( true );
@@ -294,7 +300,9 @@ export const EllipsisMenuContent = ( {
 						} }
 						className={ 'components-button__danger' }
 					>
-						{ __( 'Reset account', 'woocommerce' ) }
+						{ canResetAccount
+							? __( 'Reset account', 'woocommerce' )
+							: __( 'Reset onboarding', 'woocommerce' ) }
 					</Button>
 				</div>
 			) }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
@@ -52,6 +52,7 @@ export const EllipsisMenuWrapper = ( {
 		! canResetAccount &&
 		isWooPayments( provider.id ) &&
 		provider._type === 'gateway' &&
+		! provider.state?.account_connected &&
 		provider.onboarding?.state?.started &&
 		!! provider.onboarding?._links?.reset?.href;
 

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
@@ -80,6 +80,7 @@ export const EllipsisMenuWrapper = ( {
 			<WooPaymentsResetAccountModal
 				isOpen={ resetAccountModalVisible }
 				onClose={ () => setResetAccountModalVisible( false ) }
+				hasAccount={ provider.state?.account_connected }
 				isTestMode={ provider.onboarding?.state?.test_mode }
 				resetUrl={ provider.onboarding?._links?.reset?.href }
 			/>

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/ellipsis-menu-content/ellipsis-menu.tsx
@@ -45,6 +45,16 @@ export const EllipsisMenuWrapper = ( {
 			! provider.onboarding?.state?.completed ) &&
 		!! provider.onboarding?._links?.reset?.href;
 
+	// For WooPayments, we can reset onboarding if there is no account connected but onboarding has been started.
+	// This is an escape hatch for when the account is reset from the Transact Platform, but the onboarding state is not reset.
+	// This is mutually exclusive with canResetAccount since resetting the account already includes resetting the onboarding.
+	const canResetOnboarding =
+		! canResetAccount &&
+		isWooPayments( provider.id ) &&
+		provider._type === 'gateway' &&
+		provider.onboarding?.state?.started &&
+		!! provider.onboarding?._links?.reset?.href;
+
 	return (
 		<>
 			<EllipsisMenu
@@ -61,6 +71,7 @@ export const EllipsisMenuWrapper = ( {
 						setResetAccountModalVisible={
 							setResetAccountModalVisible
 						}
+						canResetOnboarding={ canResetOnboarding }
 					/>
 				) }
 				focusOnMount={ true }

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
@@ -33,6 +33,11 @@ interface WooPaymentsResetAccountModalProps {
 	onClose: () => void;
 
 	/**
+	 * Indicates if there is a connected account.
+	 */
+	hasAccount?: boolean;
+
+	/**
 	 * Indicates if the account is a test-drive/sandbox account.
 	 */
 	isTestMode?: boolean;
@@ -49,11 +54,12 @@ interface WooPaymentsResetAccountModalProps {
 }
 
 /**
- * A modal component that allows users to reset their WooPayments test account.
+ * A modal component that allows users to reset their WooPayments account.
  */
 export const WooPaymentsResetAccountModal = ( {
 	isOpen,
 	onClose,
+	hasAccount,
 	isTestMode,
 	isEmbeddedResetFlow = false,
 	resetUrl,
@@ -96,10 +102,23 @@ export const WooPaymentsResetAccountModal = ( {
 				} );
 				createNotice(
 					'error',
-					__(
-						'Failed to reset your WooPayments account.',
-						'woocommerce'
-					),
+					hasAccount
+						? sprintf(
+								/* translators: %s: Provider name */
+								__(
+									'Failed to reset your %s account.',
+									'woocommerce'
+								),
+								'WooPayments'
+						  )
+						: sprintf(
+								/* translators: %s: Provider name */
+								__(
+									'Failed to reset your %s onboarding.',
+									'woocommerce'
+								),
+								'WooPayments'
+						  ),
 					{
 						isDismissible: true,
 					}
@@ -111,41 +130,64 @@ export const WooPaymentsResetAccountModal = ( {
 			} );
 	};
 
-	let content = isTestMode
-		? sprintf(
-				/* translators: %s: plugin name */
-				__(
-					'When you reset your test account, all payment data — including your %s account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.',
-					'woocommerce'
-				),
-				'WooPayments'
-		  )
-		: sprintf(
-				/* translators: %s: plugin name */
-				__(
-					'When you reset your account, all payment data — including your %s account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.',
-					'woocommerce'
-				),
-				'WooPayments'
-		  );
+	let title: string;
+	let content: string;
+	let buttonText: string;
+	if ( hasAccount ) {
+		title = isTestMode
+			? __( 'Reset your test account', 'woocommerce' )
+			: __( 'Reset your account', 'woocommerce' );
 
-	if ( isEmbeddedResetFlow ) {
-		// If reseting the account from NOX, override the content.
+		content = isTestMode
+			? sprintf(
+					/* translators: %s: Provider name */
+					__(
+						'When you reset your test account, all payment data — including your %s account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.',
+						'woocommerce'
+					),
+					'WooPayments'
+			  )
+			: sprintf(
+					/* translators: %s: Provider name */
+					__(
+						'When you reset your account, all payment data — including your %s account details, test transactions, and payouts history — will be lost. Your order history will remain. This action cannot be undone, but you can create a new test account at any time.',
+						'woocommerce'
+					),
+					'WooPayments'
+			  );
+		if ( isEmbeddedResetFlow ) {
+			// If resetting the account from NOX, override the content.
+			content = sprintf(
+				/* translators: 1: Provider name, 2: Provider name */
+				__(
+					'You need to reset your test account to continue onboarding with %1$s. This will create a new test account and reset any existing %2$s account details and test transactions.',
+					'woocommerce'
+				),
+				'WooPayments',
+				'WooPayments'
+			);
+		}
+
+		buttonText = isTestMode
+			? __( 'Yes, reset test account', 'woocommerce' )
+			: __( 'Yes, reset account', 'woocommerce' );
+	} else {
+		title = __( 'Reset onboarding', 'woocommerce' );
 		content = sprintf(
-			/* translators: %1$s: plugin name, %2$s: plugin name */
+			/* translators: %s: Provider name */
 			__(
-				'You need to reset your test account to continue onboarding with %1$s. This will create a new test account and reset any existing %2$s account details and test transactions.',
+				'When you reset the %s onboarding your progress and the provided data will be lost. This action cannot be undone, but you can restart the onboarding any time.',
 				'woocommerce'
 			),
-			'WooPayments',
 			'WooPayments'
 		);
+		buttonText = __( 'Yes, reset onboarding', 'woocommerce' );
 	}
 	return (
 		<>
 			{ isOpen && (
 				<Modal
-					title={ __( 'Reset your test account', 'woocommerce' ) }
+					title={ title }
 					className="woocommerce-woopayments-modal"
 					isDismissible={ true }
 					onRequestClose={ onClose }
@@ -186,7 +228,7 @@ export const WooPaymentsResetAccountModal = ( {
 								handleResetAccount();
 							} }
 						>
-							{ __( 'Yes, reset account', 'woocommerce' ) }
+							{ buttonText }
 						</Button>
 					</div>
 				</Modal>

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Enums\OrderInternalStatus;
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders;
 use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsRestController;
+use Automattic\WooCommerce\Internal\Admin\Settings\PaymentsProviders\WooPayments\WooPaymentsService;
 use Automattic\WooCommerce\Internal\Admin\Settings\Payments;
 use Automattic\WooCommerce\Internal\Admin\Settings\Utils;
 use Automattic\WooCommerce\Internal\Logging\SafeGlobalFunctionProxy;
@@ -57,7 +58,7 @@ class WooPayments extends PaymentGateway {
 		// If the WooPayments installed version is less than minimum required version,
 		// we can't use the in-context onboarding flows.
 		if ( Constants::is_defined( 'WCPAY_VERSION_NUMBER' ) &&
-			version_compare( Constants::get_constant( 'WCPAY_VERSION_NUMBER' ), PaymentsProviders\WooPayments\WooPaymentsService::EXTENSION_MINIMUM_VERSION, '<' ) ) {
+			version_compare( Constants::get_constant( 'WCPAY_VERSION_NUMBER' ), WooPaymentsService::EXTENSION_MINIMUM_VERSION, '<' ) ) {
 
 			return $details;
 		}
@@ -100,6 +101,37 @@ class WooPayments extends PaymentGateway {
 					'source' => 'settings-payments',
 				)
 			);
+		}
+
+		// Override the onboarding state with the entries provided by the WooPayments service.
+		if ( ! empty( $country_code ) ) {
+			try {
+				/**
+				 * The WooPayments service instance.
+				 *
+				 * @var WooPaymentsService $service
+				 */
+				$service = wc_get_container()->get( WooPaymentsService::class );
+
+				$onboarding_details = $service->get_onboarding_details( $country_code, $rest_controller->get_rest_url_path( 'onboarding' ) );
+				if ( ! empty( $onboarding_details['state'] ) && is_array( $onboarding_details['state'] ) ) {
+					// Merge the onboarding state with the one provided by the service.
+					$details['onboarding']['state'] = array_merge(
+						$details['onboarding']['state'],
+						$onboarding_details['state']
+					);
+				}
+			} catch ( \Throwable $e ) {
+				// If the service is not available, we can't impose the more specific logic.
+				// This is not a critical error, so we just ignore it.
+				// Log so we can investigate.
+				SafeGlobalFunctionProxy::wc_get_logger()->error(
+					'Failed to get the WooPayments service instance: ' . $e->getMessage(),
+					array(
+						'source' => 'settings-payments',
+					)
+				);
+			}
 		}
 
 		return $details;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
@@ -40,6 +40,8 @@ class WooPayments extends PaymentGateway {
 	 *                                         This should be an ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return array The payment gateway provider details.
+	 *
+	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing -- We wrap the throw in a try/catch.
 	 */
 	public function get_details( WC_Payment_Gateway $gateway, int $order = 0, string $country_code = '' ): array {
 		$details = parent::get_details( $gateway, $order, $country_code );
@@ -113,7 +115,7 @@ class WooPayments extends PaymentGateway {
 				 */
 				$service = wc_get_container()->get( WooPaymentsService::class );
 
-				// Ensure we have a valid rest_controller from the earlier try block
+				// Ensure we have a valid rest_controller from the earlier try block.
 				if ( ! isset( $rest_controller ) ) {
 					throw new \RuntimeException( 'WooPayments REST controller not available' );
 				}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
@@ -534,7 +534,7 @@ class WooPayments extends PaymentGateway {
 			if ( ! empty( $account_service ) && is_callable( array( $account_service, 'get_account_status_data' ) ) ) {
 				$account_status = $account_service->get_account_status_data();
 
-				return ! empty( $account_status['testDrive'] ) || empty( $account_status['isLive'] );
+				return ! empty( $account_status['testDrive'] );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
@@ -46,7 +46,8 @@ class WooPayments extends PaymentGateway {
 	public function get_details( WC_Payment_Gateway $gateway, int $order = 0, string $country_code = '' ): array {
 		$details = parent::get_details( $gateway, $order, $country_code );
 
-		$has_test_account = $this->has_test_drive_account();
+		$has_test_account    = $this->has_test_account();
+		$has_sandbox_account = $this->has_sandbox_account();
 
 		// Switch the onboarding type to native.
 		$details['onboarding']['type'] = self::ONBOARDING_TYPE_NATIVE;
@@ -82,8 +83,8 @@ class WooPayments extends PaymentGateway {
 			 */
 			$rest_controller = wc_get_container()->get( WooPaymentsRestController::class );
 
-			// Add disable test account URL to onboarding links, if the current account is a test account.
-			if ( $has_test_account ) {
+			// Add disable test account URL to onboarding links, if the current account is a test or sandbox account.
+			if ( $has_test_account || $has_sandbox_account ) {
 				$details['onboarding']['_links']['disable_test_account'] = array(
 					'href' => rest_url( $rest_controller->get_rest_url_path( 'onboarding/test_account/disable' ) ),
 				);
@@ -252,7 +253,7 @@ class WooPayments extends PaymentGateway {
 		}
 
 		// Test-drive accounts don't need setup.
-		if ( $this->has_test_drive_account() ) {
+		if ( $this->has_test_account() ) {
 			return false;
 		}
 
@@ -520,17 +521,43 @@ class WooPayments extends PaymentGateway {
 	}
 
 	/**
-	 * Determines if the current account is a test-drive account.
+	 * Determines if the current account is a test account.
 	 *
-	 * @return bool True if the account is a test-drive account, false otherwise.
+	 * Test accounts are test-drive accounts.
+	 * They are different from sandbox accounts (i.e. accounts onboarded in test mode).
+	 *
+	 * @return bool True if the account is a test account, false otherwise.
 	 */
-	private function has_test_drive_account(): bool {
+	private function has_test_account(): bool {
 		if ( function_exists( '\wcpay_get_container' ) && class_exists( '\WC_Payments_Account' ) ) {
 			$account_service = \wcpay_get_container()->get( \WC_Payments_Account::class );
 			if ( ! empty( $account_service ) && is_callable( array( $account_service, 'get_account_status_data' ) ) ) {
 				$account_status = $account_service->get_account_status_data();
 
-				return ! empty( $account_status['testDrive'] );
+				return ! empty( $account_status['testDrive'] ) || empty( $account_status['isLive'] );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determines if the current account is a sandbox account.
+	 *
+	 * Sandbox accounts are accounts that were onboarded in test mode.
+	 * They are different from test accounts (i.e. test-drive accounts).
+	 *
+	 * Sandbox accounts are generally created in development or staging environments when simulating live onboarding.
+	 *
+	 * @return bool True if the account is a sandbox account, false otherwise.
+	 */
+	private function has_sandbox_account(): bool {
+		if ( function_exists( '\wcpay_get_container' ) && class_exists( '\WC_Payments_Account' ) ) {
+			$account_service = \wcpay_get_container()->get( \WC_Payments_Account::class );
+			if ( ! empty( $account_service ) && is_callable( array( $account_service, 'get_account_status_data' ) ) ) {
+				$account_status = $account_service->get_account_status_data();
+
+				return empty( $account_status['isLive'] ) && empty( $account_status['testDrive'] );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments.php
@@ -113,6 +113,11 @@ class WooPayments extends PaymentGateway {
 				 */
 				$service = wc_get_container()->get( WooPaymentsService::class );
 
+				// Ensure we have a valid rest_controller from the earlier try block
+				if ( ! isset( $rest_controller ) ) {
+					throw new \RuntimeException( 'WooPayments REST controller not available' );
+				}
+
 				$onboarding_details = $service->get_onboarding_details( $country_code, $rest_controller->get_rest_url_path( 'onboarding' ) );
 				if ( ! empty( $onboarding_details['state'] ) && is_array( $onboarding_details['state'] ) ) {
 					// Merge the onboarding state with the one provided by the service.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1455,7 +1455,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Disable test account during the switch-to-live onboarding flow.
+	 * Disable a test account during the switch-to-live onboarding flow.
 	 *
 	 * @param string      $location The location for which we are onboarding.
 	 *                              This is an ISO 3166-1 alpha-2 country code.
@@ -1473,37 +1473,76 @@ class WooPaymentsService {
 		// Ensure the payment gateways logic is initialized in case actions need to be taken on payment gateway changes.
 		WC()->payment_gateways();
 
+		$has_test_account    = $this->has_test_account();
+		$has_sandbox_account = $this->has_sandbox_account();
+
 		// Lock the onboarding to prevent concurrent actions.
 		$this->set_onboarding_lock();
 
 		$source = $this->validate_onboarding_source( $source );
 
-		try {
-			// Call the WooPayments API to disable the test account and prepare for the switch to live.
-			$response = $this->proxy->call_static(
-				Utils::class,
-				'rest_endpoint_post_request',
-				'/wc/v3/payments/onboarding/test_drive_account/disable',
-				array(
-					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-					'source' => $source,
-				)
-			);
-		} catch ( Exception $e ) {
-			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
-			);
+		$response = array(
+			'success' => true,
+		);
+
+		// First, check if we have a test account to disable.
+		if ( $has_test_account ) {
+			try {
+				// Call the WooPayments API to disable the test account and prepare for the switch to live.
+				$response = $this->proxy->call_static(
+					Utils::class,
+					'rest_endpoint_post_request',
+					'/wc/v3/payments/onboarding/test_drive_account/disable',
+					array(
+						'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+						'source' => $source,
+					)
+				);
+			} catch ( Exception $e ) {
+				// Catch any exceptions to allow for proper error handling and onboarding unlock.
+				$response = new WP_Error(
+					'woocommerce_woopayments_onboarding_client_api_exception',
+					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
+					array(
+						'code'    => $e->getCode(),
+						'message' => $e->getMessage(),
+						'trace'   => $e->getTrace(),
+					)
+				);
+			}
+		} else if ( $has_sandbox_account ) {
+			try {
+				// Call the WooPayments API to reset onboarding.
+				$response = $this->proxy->call_static(
+					Utils::class,
+					'rest_endpoint_post_request',
+					'/wc/v3/payments/onboarding/reset',
+					array(
+						'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+						'source' => $source,
+					)
+				);
+			} catch ( Exception $e ) {
+				// Catch any exceptions to allow for proper error handling and onboarding unlock.
+				$response = new WP_Error(
+					'woocommerce_woopayments_onboarding_client_api_exception',
+					esc_html__( 'An unexpected error happened while disabling the test account.', 'woocommerce' ),
+					array(
+						'code'    => $e->getCode(),
+						'message' => $e->getMessage(),
+						'trace'   => $e->getTrace(),
+					)
+				);
+			}
 		}
 
 		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
+
+		// Make sure the onboarding mode is reset.
+		if ( class_exists( 'WC_Payments_Onboarding_Service' ) && defined( 'WC_Payments_Onboarding_Service::TEST_MODE_OPTION' ) ) {
+			$this->proxy->call_function( 'update_option', Constants::get_constant( 'WC_Payments_Onboarding_Service::TEST_MODE_OPTION' ), 'no' );
+		}
 
 		// Track the failure to disable the test account.
 		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['success'] ) ) {
@@ -1547,7 +1586,8 @@ class WooPaymentsService {
 			self::EVENT_PREFIX . 'onboarding_test_account_disabled',
 			$location,
 			array(
-				'source' => $source,
+				'account_type' => $has_test_account ? 'test_drive' : ( $has_sandbox_account ? 'sandbox' : 'unknown' ),
+				'source'       => $source,
 			)
 		);
 
@@ -2453,6 +2493,22 @@ class WooPaymentsService {
 		$account_status  = $account_service->get_account_status_data();
 
 		return ! empty( $account_status['testDrive'] );
+	}
+
+	/**
+	 * Determine if WooPayments has a sandbox account set up.
+	 *
+	 * @return bool Whether WooPayments has a sandbox account set up.
+	 */
+	private function has_sandbox_account(): bool {
+		if ( ! $this->has_account() ) {
+			return false;
+		}
+
+		$account_service = $this->proxy->call_static( '\WC_Payments', 'get_account_service' );
+		$account_status  = $account_service->get_account_status_data();
+
+		return empty( $account_status['isLive'] ) && empty( $account_status['testDrive'] );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1377,27 +1377,34 @@ class WooPaymentsService {
 			'source'       => $source,
 		);
 
-		try {
-			// Call the WooPayments API to reset onboarding.
-			$response = $this->proxy->call_static(
-				Utils::class,
-				'rest_endpoint_post_request',
-				'/wc/v3/payments/onboarding/reset',
-				array(
-					'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
-					'source' => $source,
-				)
-			);
-		} catch ( Exception $e ) {
-			// Catch any exceptions to allow for proper error handling and onboarding unlock.
-			$response = new WP_Error(
-				'woocommerce_woopayments_onboarding_client_api_exception',
-				esc_html__( 'An unexpected error happened while resetting onboarding.', 'woocommerce' ),
-				array(
-					'code'    => $e->getCode(),
-					'message' => $e->getMessage(),
-					'trace'   => $e->getTrace(),
-				)
+		if ( $this->has_account() ) {
+			try {
+				// Call the WooPayments API to reset onboarding.
+				$response = $this->proxy->call_static(
+					Utils::class,
+					'rest_endpoint_post_request',
+					'/wc/v3/payments/onboarding/reset',
+					array(
+						'from'   => ! empty( $from ) ? esc_attr( $from ) : self::FROM_PAYMENT_SETTINGS,
+						'source' => $source,
+					)
+				);
+			} catch ( Exception $e ) {
+				// Catch any exceptions to allow for proper error handling and onboarding unlock.
+				$response = new WP_Error(
+					'woocommerce_woopayments_onboarding_client_api_exception',
+					esc_html__( 'An unexpected error happened while resetting onboarding.', 'woocommerce' ),
+					array(
+						'code'    => $e->getCode(),
+						'message' => $e->getMessage(),
+						'trace'   => $e->getTrace(),
+					)
+				);
+			}
+		} else {
+			// If there is no account to reset, we can just use a success response.
+			$response = array(
+				'success' => true,
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -272,8 +272,14 @@ class WooPaymentsService {
 					return self::ONBOARDING_STEP_STATUS_COMPLETED;
 				}
 				break;
-			case self::ONBOARDING_STEP_PAYMENT_METHODS:
 			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
+				// The step can only be completed if the requirements are met. Otherwise, ignore the stored completed status.
+				// Sanity check: we only report the completed status if there is a live account and the account is valid (i.e. completed KYC).
+				if ( $meets_requirements && $this->has_valid_account() && $this->has_live_account() && $this->was_onboarding_step_marked_completed( $step_id, $location ) ) {
+					return self::ONBOARDING_STEP_STATUS_COMPLETED;
+				}
+				break;
+			case self::ONBOARDING_STEP_PAYMENT_METHODS:
 			default:
 				// The step can only be completed if the requirements are met. Otherwise, ignore the stored completed status.
 				if ( $meets_requirements && $this->was_onboarding_step_marked_completed( $step_id, $location ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1515,7 +1515,7 @@ class WooPaymentsService {
 					)
 				);
 			}
-		} else if ( $has_sandbox_account ) {
+		} elseif ( $has_sandbox_account ) {
 			try {
 				// Call the WooPayments API to reset onboarding.
 				$response = $this->proxy->call_static(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1385,7 +1385,7 @@ class WooPaymentsService {
 		// Before resetting the onboarding, record its details for tracking purposes.
 		$event_props = array(
 			'has_account'  => $this->has_account(),
-			'account_mode' => $this->has_account() ? ( $this->has_live_account() ? 'live' : 'test' ) : 'none' ,
+			'account_mode' => $this->has_account() ? ( $this->has_live_account() ? 'live' : 'test' ) : 'none',
 			'test_account' => $this->has_test_account(),
 			'source'       => $source,
 		);
@@ -2045,7 +2045,7 @@ class WooPaymentsService {
 	/**
 	 * Save the NOX profile data.
 	 *
-	 * @param array  $data The data to save in the profile.
+	 * @param array $data The data to save in the profile.
 	 *
 	 * @return bool Whether the data was saved.
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1844,12 +1844,24 @@ class WooPaymentsService {
 		}
 
 		// Add the live account business verification onboarding step details.
+		$business_verification_step_sub_steps = $this->get_nox_profile_onboarding_step_data_entry(
+			self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+			$location,
+			'sub_steps',
+			array()
+		);
+		// Sanity check: If there is no account connected, the sub-steps details should be forced empty.
+		// This way we allow for the Transact Platform account reset to take effect and
+		// allow the user to restart the business verification process, including the self-assessment business step.
+		if ( ! $this->has_account() ) {
+			$business_verification_step_sub_steps = array();
+		}
 		$business_verification_step = $this->standardize_onboarding_step_details(
 			array(
 				'id'      => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				'context' => array(
 					'fields'           => array(),
-					'sub_steps'        => $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'sub_steps', array() ),
+					'sub_steps'        => $business_verification_step_sub_steps,
 					'self_assessment'  => $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'self_assessment', array() ),
 					'has_test_account' => $this->has_test_account(),
 				),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -923,15 +923,8 @@ class WooPaymentsService {
 
 		// Nothing to do if there is a connected account, but it is not a test account.
 		if ( $this->has_account() ) {
-			// Mark the onboarding step as blocked, if it is not already.
-			$this->mark_onboarding_step_blocked(
-				self::ONBOARDING_STEP_TEST_ACCOUNT,
-				$location,
-				array(
-					'code'    => 'account_already_exists',
-					'message' => esc_html__( 'An account is already set up. Reset the onboarding first.', 'woocommerce' ),
-				)
-			);
+			// Mark the onboarding step as completed, if it is not already.
+			$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 
 			throw new ApiException(
 				'woocommerce_woopayments_onboarding_action_error',
@@ -1163,17 +1156,10 @@ class WooPaymentsService {
 		// Add the user locale to the account session data to allow for localized KYC sessions.
 		$response['locale'] = $this->proxy->call_function( 'get_user_locale' );
 
-		// For sanity, make sure the test account step is blocked if not already completed,
+		// For sanity, make sure the test account step is completed if not already,
 		// since we are doing live account KYC.
 		if ( ! $this->is_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-			$this->mark_onboarding_step_blocked(
-				self::ONBOARDING_STEP_TEST_ACCOUNT,
-				$location,
-				array(
-					'code'    => 'live_account_kyc_session',
-					'message' => esc_html__( 'A live account is set up. Reset the onboarding first.', 'woocommerce' ),
-				)
-			);
+			$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, );
 		}
 
 		// Record an event for the KYC session being created.
@@ -1299,17 +1285,10 @@ class WooPaymentsService {
 		// Mark the business verification step as completed.
 		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, false, $source );
 
-		// For sanity, make sure the test account step is blocked if not already completed,
+		// For sanity, make sure the test account step is completed, if not already,
 		// since we are doing live account KYC.
 		if ( ! $this->is_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-			$this->mark_onboarding_step_blocked(
-				self::ONBOARDING_STEP_TEST_ACCOUNT,
-				$location,
-				array(
-					'code'    => 'live_account_kyc_session',
-					'message' => esc_html__( 'A live account is set up. Reset the onboarding first.', 'woocommerce' ),
-				)
-			);
+			$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		}
 
 		return $response;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1382,9 +1382,10 @@ class WooPaymentsService {
 
 		$source = $this->validate_onboarding_source( $source );
 
-		// Before resetting the account, record its details for tracking purposes.
+		// Before resetting the onboarding, record its details for tracking purposes.
 		$event_props = array(
-			'account_mode' => $this->has_live_account() ? 'live' : 'test',
+			'has_account'  => $this->has_account(),
+			'account_mode' => $this->has_account() ? ( $this->has_live_account() ? 'live' : 'test' ) : 'none' ,
 			'test_account' => $this->has_test_account(),
 			'source'       => $source,
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1411,6 +1411,9 @@ class WooPaymentsService {
 		// Unlock the onboarding after the API call finished or errored.
 		$this->clear_onboarding_lock();
 
+		// Clean up any NOX-specific onboarding data, regardless of the API response.
+		$this->proxy->call_function( 'delete_option', self::NOX_PROFILE_OPTION_KEY );
+
 		if ( is_wp_error( $response ) ) {
 			throw new ApiException(
 				'woocommerce_woopayments_onboarding_client_api_error',
@@ -1427,9 +1430,6 @@ class WooPaymentsService {
 				(int) WP_Http::FAILED_DEPENDENCY
 			);
 		}
-
-		// Clean up any NOX-specific onboarding data.
-		$this->proxy->call_function( 'delete_option', self::NOX_PROFILE_OPTION_KEY );
 
 		// Record an event for the onboarding reset.
 		$this->record_event(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -147,10 +147,16 @@ class WooPaymentsService {
 
 		$source = $this->validate_onboarding_source( $source );
 
+		$onboarding_started = $this->provider->is_onboarding_started( $this->get_payment_gateway() );
+		if ( ! $onboarding_started && ! empty( $this->get_nox_profile_onboarding( $location ) ) ) {
+			// If the onboarding profile is stored, we consider the onboarding started.
+			$onboarding_started = true;
+		}
+
 		return array(
 			// This state is high-level data, independent of the type of onboarding flow.
 			'state'   => array(
-				'started'   => $this->provider->is_onboarding_started( $this->get_payment_gateway() ),
+				'started'   => $onboarding_started,
 				'completed' => $this->provider->is_onboarding_completed( $this->get_payment_gateway() ),
 				'test_mode' => $this->provider->is_in_test_mode_onboarding( $this->get_payment_gateway() ),
 				'dev_mode'  => $this->provider->is_in_dev_mode( $this->get_payment_gateway() ),

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -2043,6 +2043,61 @@ class WooPaymentsService {
 	}
 
 	/**
+	 * Save the NOX profile data.
+	 *
+	 * @param array  $data The data to save in the profile.
+	 *
+	 * @return bool Whether the data was saved.
+	 */
+	private function save_nox_profile( array $data ): bool {
+		return $this->proxy->call_function( 'update_option', self::NOX_PROFILE_OPTION_KEY, $data, false );
+	}
+
+	/**
+	 * Get the onboarding data from the NOX profile.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is an ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array The onboarding stored data from the NOX profile.
+	 *               If the step data is not found, an empty array is returned.
+	 */
+	private function get_nox_profile_onboarding( string $location ): array {
+		$nox_profile = $this->get_nox_profile();
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
+			$nox_profile['onboarding'][ $location ] = array();
+		}
+
+		return $nox_profile['onboarding'][ $location ];
+	}
+
+	/**
+	 * Save the onboarding data in the NOX profile.
+	 *
+	 * @param string $location The location for which we are onboarding.
+	 *                         This is an ISO 3166-1 alpha-2 country code.
+	 * @param array  $data     The onboarding step data to save in the profile.
+	 *
+	 * @return bool Whether the onboarding data was saved.
+	 */
+	private function save_nox_profile_onboarding( string $location, array $data ): bool {
+		$nox_profile = $this->get_nox_profile();
+
+		if ( empty( $nox_profile['onboarding'] ) ) {
+			$nox_profile['onboarding'] = array();
+		}
+
+		// Update the stored data.
+		$nox_profile['onboarding'][ $location ] = $data;
+
+		return $this->save_nox_profile( $nox_profile );
+	}
+
+	/**
 	 * Get the onboarding step data from the NOX profile.
 	 *
 	 * @param string $step_id  The ID of the onboarding step.
@@ -2053,22 +2108,16 @@ class WooPaymentsService {
 	 *               If the step data is not found, an empty array is returned.
 	 */
 	private function get_nox_profile_onboarding_step( string $step_id, string $location ): array {
-		$nox_profile = $this->get_nox_profile();
+		$nox_profile_onboarding = $this->get_nox_profile_onboarding( $location );
 
-		if ( empty( $nox_profile['onboarding'] ) ) {
-			$nox_profile['onboarding'] = array();
+		if ( empty( $nox_profile_onboarding['steps'] ) ) {
+			$nox_profile_onboarding['steps'] = array();
 		}
-		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
-			$nox_profile['onboarding'][ $location ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'][ $step_id ] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = array();
+		if ( empty( $nox_profile_onboarding['steps'][ $step_id ] ) ) {
+			$nox_profile_onboarding['steps'][ $step_id ] = array();
 		}
 
-		return $nox_profile['onboarding'][ $location ]['steps'][ $step_id ];
+		return $nox_profile_onboarding['steps'][ $step_id ];
 	}
 
 	/**
@@ -2082,22 +2131,16 @@ class WooPaymentsService {
 	 * @return bool Whether the onboarding step data was saved.
 	 */
 	private function save_nox_profile_onboarding_step( string $step_id, string $location, array $data ): bool {
-		$nox_profile = $this->get_nox_profile();
+		$nox_profile_onboarding = $this->get_nox_profile_onboarding( $location );
 
-		if ( empty( $nox_profile['onboarding'] ) ) {
-			$nox_profile['onboarding'] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ] ) ) {
-			$nox_profile['onboarding'][ $location ] = array();
-		}
-		if ( empty( $nox_profile['onboarding'][ $location ]['steps'] ) ) {
-			$nox_profile['onboarding'][ $location ]['steps'] = array();
+		if ( empty( $nox_profile_onboarding['steps'] ) ) {
+			$nox_profile_onboarding['steps'] = array();
 		}
 
 		// Update the stored step data.
-		$nox_profile['onboarding'][ $location ]['steps'][ $step_id ] = $data;
+		$nox_profile_onboarding['steps'][ $step_id ] = $data;
 
-		return $this->proxy->call_function( 'update_option', self::NOX_PROFILE_OPTION_KEY, $nox_profile, false );
+		return $this->save_nox_profile_onboarding( $location, $nox_profile_onboarding );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1427,6 +1427,11 @@ class WooPaymentsService {
 		// Clean up any NOX-specific onboarding data, regardless of the API response.
 		$this->proxy->call_function( 'delete_option', self::NOX_PROFILE_OPTION_KEY );
 
+		// Make sure the onboarding mode is reset.
+		if ( class_exists( 'WC_Payments_Onboarding_Service' ) && defined( 'WC_Payments_Onboarding_Service::TEST_MODE_OPTION' ) ) {
+			$this->proxy->call_function( 'update_option', Constants::get_constant( 'WC_Payments_Onboarding_Service::TEST_MODE_OPTION' ), 'no' );
+		}
+
 		if ( is_wp_error( $response ) ) {
 			throw new ApiException(
 				'woocommerce_woopayments_onboarding_client_api_error',

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -2026,7 +2026,7 @@ class WooPaymentsService {
 	}
 
 	/**
-	 * Get the entire stored NOX profile data
+	 * Get the entire stored NOX profile data.
 	 *
 	 * @return array The stored NOX profile.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -4152,7 +4152,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored completed with no account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
 				),
@@ -4184,7 +4184,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored completed with valid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
 				),
@@ -4216,7 +4216,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored completed with invalid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
 				),
@@ -4248,7 +4248,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored completed with invalid live account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
 				),
@@ -4313,7 +4313,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started and completed with no account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
@@ -4347,7 +4347,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started and completed with valid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
@@ -4381,7 +4381,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started and completed with invalid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
@@ -4415,7 +4415,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started and completed with invalid live account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
@@ -4484,7 +4484,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, failed, and completed with no account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED => $current_time - 5,
@@ -4520,7 +4520,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, failed, and completed with valid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED => $current_time - 5,
@@ -4556,7 +4556,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, failed, and completed with invalid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED => $current_time - 5,
@@ -4592,7 +4592,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, failed, and completed with invalid live account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED => $current_time - 5,
@@ -4664,7 +4664,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, blocked, and completed with no account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED => $current_time - 5,
@@ -4700,7 +4700,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, blocked, and completed with valid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED => $current_time - 5,
@@ -4736,7 +4736,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, blocked, and completed with invalid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED => $current_time - 5,
@@ -4772,7 +4772,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'business_verification - stored started, blocked, and completed with invalid live account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
-				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED,
 				array(
 					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
 					WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED => $current_time - 5,
@@ -7650,14 +7650,20 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that reset_onboarding throws an exception when the REST API call fails.
+	 * Test that reset_onboarding with a connected account throws an exception when the REST API call fails.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
-	public function test_reset_onboarding_throws_on_error_response() {
+	public function test_reset_onboarding_with_account_throws_on_error_response() {
 		// Arrange.
 		$location = 'US';
+
+		// Arrange the account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
 
 		// Arrange the REST API requests.
 		$requests_made  = array();
@@ -7689,14 +7695,20 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that reset_onboarding throws an exception when the REST API call doesn't respond properly.
+	 * Test that reset_onboarding with a connected account throws an exception when the REST API call doesn't respond properly.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
-	public function test_reset_onboarding_throws_on_invalid_response() {
+	public function test_reset_onboarding_with_account_throws_on_invalid_response() {
 		// Arrange.
 		$location = 'US';
+
+		// Arrange the account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
 
 		// Arrange the REST API requests.
 		$requests_made = array();
@@ -7726,14 +7738,20 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that reset_onboarding throws an exception when the REST API call doesn't succeed.
+	 * Test that reset_onboarding with a connected account throws an exception when the REST API call doesn't succeed.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
-	public function test_reset_onboarding_throws_on_failure() {
+	public function test_reset_onboarding_with_account_throws_on_failure() {
 		// Arrange.
 		$location = 'US';
+
+		// Arrange the account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
 
 		// Arrange the REST API requests.
 		$requests_made = array();
@@ -7763,14 +7781,20 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test reset_onboarding.
+	 * Test reset_onboarding with a connected account.
 	 *
 	 * @return void
 	 * @throws \Exception On POST request not mocked.
 	 */
-	public function test_reset_onboarding() {
+	public function test_reset_onboarding_with_account() {
 		// Arrange.
 		$location = 'US';
+
+		// Arrange the account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( true );
 
 		// Arrange the REST API requests.
 		$requests_made     = array();
@@ -7798,6 +7822,32 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
+		// Arrange the DB options.
+		$onboarding_lock_cleared = 0;
+		$deleted_profiles = 0;
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'update_option' => function ( $option_name, $value ) use ( &$onboarding_lock_cleared ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name && 'no' === $value ) {
+						$onboarding_lock_cleared++;
+
+						return true;
+					}
+
+					return true;
+				},
+				'delete_option' => function ( $option_name ) use ( &$deleted_profiles ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						$deleted_profiles++;
+
+						return true;
+					}
+
+					return true;
+				},
+			)
+		);
+
 		// Act.
 		$result = $this->sut->reset_onboarding( $location );
 
@@ -7805,6 +7855,82 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		self::assertEquals( $expected_response, $result );
 		self::assertCount( 1, $requests_made );
 		self::assertEquals( $expected_payload, $requests_made[0] );
+		self::assertEquals( 1, $onboarding_lock_cleared ); // The onboarding lock should be cleared.
+		self::assertEquals( 1, $deleted_profiles ); // The NOX profile option should be deleted.
+	}
+
+	/**
+	 * Test reset_onboarding with no connected account.
+	 *
+	 * @return void
+	 * @throws \Exception On POST request not mocked.
+	 */
+	public function test_reset_onboarding_without_account() {
+		// Arrange.
+		$location = 'US';
+
+		// Arrange the account.
+		$this->mock_provider
+			->expects( $this->any() )
+			->method( 'is_account_connected' )
+			->willReturn( false );
+
+		// Arrange the REST API requests.
+		$requests_made     = array();
+		$expected_response = array(
+			'success' => true,
+		);
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'rest_endpoint_post_request' => function ( string $endpoint, $params = array() ) use ( &$requests_made ) {
+						if ( '/wc/v3/payments/onboarding/reset' === $endpoint ) {
+							$requests_made[] = $params;
+
+							return;
+						}
+
+						throw new \Exception( esc_html( 'POST endpoint response is not mocked: ' . $endpoint ) );
+					},
+				),
+			)
+		);
+
+		// Arrange the DB options.
+		$onboarding_lock_cleared = 0;
+		$deleted_profiles = 0;
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'update_option' => function ( $option_name, $value ) use ( &$onboarding_lock_cleared ) {
+					if ( WooPaymentsService::NOX_ONBOARDING_LOCKED_KEY === $option_name && 'no' === $value ) {
+						$onboarding_lock_cleared++;
+
+						return true;
+					}
+
+					return true;
+				},
+				'delete_option' => function ( $option_name ) use ( &$deleted_profiles ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
+						$deleted_profiles++;
+
+						return true;
+					}
+
+					return true;
+				},
+			)
+		);
+
+		// Act.
+		$result = $this->sut->reset_onboarding( $location );
+
+		// Assert.
+		self::assertEquals( $expected_response, $result );
+		self::assertCount( 0, $requests_made ); // No request should be made when there is no connected account.
+		self::assertEquals( 1, $onboarding_lock_cleared ); // The onboarding lock should be cleared.
+		self::assertEquals( 1, $deleted_profiles ); // The NOX profile option should be deleted.
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -7824,7 +7824,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 
 		// Arrange the DB options.
 		$onboarding_lock_cleared = 0;
-		$deleted_profiles = 0;
+		$deleted_profiles        = 0;
 		$this->mockable_proxy->register_function_mocks(
 			array(
 				'update_option' => function ( $option_name, $value ) use ( &$onboarding_lock_cleared ) {
@@ -7899,7 +7899,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 
 		// Arrange the DB options.
 		$onboarding_lock_cleared = 0;
-		$deleted_profiles = 0;
+		$deleted_profiles        = 0;
 		$this->mockable_proxy->register_function_mocks(
 			array(
 				'update_option' => function ( $option_name, $value ) use ( &$onboarding_lock_cleared ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -7367,9 +7367,10 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$updated_stored_profiles = array();
 		$this->mockable_proxy->register_function_mocks(
 			array(
-				'get_option'    => function ( $option_name, $default_value = null ) use ( $stored_profile ) {
+				'get_option'    => function ( $option_name, $default_value = null ) use ( $stored_profile, &$updated_stored_profiles ) {
 					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
-						return $stored_profile;
+						// Chain the responses to simulate the sequence of DB updates.
+						return ! empty( $updated_stored_profiles ) ? end( $updated_stored_profiles ) : $stored_profile;
 					}
 
 					return $default_value;
@@ -7425,8 +7426,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		self::assertEquals( $expected_response, $result );
 		self::assertCount( 1, $requests_made );
 		self::assertEquals( $expected_payload, $requests_made[0] );
-		// One is from the step status update, two are from the onboarding block.
-		$this->assertCount( 3, $updated_stored_profiles );
+		// One is from the step status update and one is from the test account being marked as completed.
+		$this->assertCount( 2, $updated_stored_profiles );
 		// The step status should have been set to `completed`.
 		$this->assertEquals(
 			array(
@@ -7435,7 +7436,15 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $this->current_time,
 				),
 			),
-			$updated_stored_profiles[0]['onboarding'][ $location ]['steps'][ $step_id ]
+			$updated_stored_profiles[1]['onboarding'][ $location ]['steps'][ $step_id ]
+		);
+		$this->assertEquals(
+			array(
+				'statuses' => array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $this->current_time,
+				),
+			),
+			$updated_stored_profiles[1]['onboarding'][ $location ]['steps'][ WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT ]
 		);
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- We reduce our NOX in-context business verification step completion logic reliance on the stored step status as a means to prevent weird dead-ends where the user has no account but can't activate payments.
- To further allow escape-hatches, we provide a WooPayments contextual menu "Reset onboarding" link when no account is connected to force-reset the NOX in-context stored progress.
- We also resolved some edge-cases where the NOX step progression ended up with a blocked test account step that confused the user. Now the test account step is force-marked as completed whenever we initialize a live account.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5298
Contributes to WOOPMNT-5253

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Unit tests should pass.
2. Checkout this PR's branch on your local WooCommerce installation, the one that is used together with our local WooPayments installation.
3. Build WooCommerce by running `cd ./plugins/woocommerce && npm run build`
4. Go to your local WooPayments installation and delete/reset any account you may have connected.
5. Make sure you have dev mode enable via the WCPay Dev Tools.
6. Make sure you have the [Options View](https://wordpress.org/plugins/options-view/) plugin installed and activated. 
7. Go to Tools > Options view and delete the `woocommerce_woopayments_nox_profile` DB option.
8. Go to WooCommerce > Settings > Payments, click on "Complete setup" for WooPayments, complete the "Choose your payment methods" step, and close the modal.
9. In the contextual menu for WooPayments you should have a "Reset onboarding" link:
<img width="271" height="325" alt="Screenshot 2025-08-12 at 13 57 01" src="https://github.com/user-attachments/assets/79fb3f2d-a804-418c-bca6-9414ca916505" />

10. Click "Reset onboarding", and you should see a confirmation modal with copy tailored for this scenario:
<img width="596" height="365" alt="Screenshot 2025-08-12 at 13 58 03" src="https://github.com/user-attachments/assets/a0e6e14e-aaca-4fe7-aa11-40a7e63882e2" />

11. Click "Yes, reset onboarding" and the providers should refresh.
12. You should NOT have a "Reset onboarding" item in the contextual menu for WooPayments.
13. Click on "Complete setup" for WooPayments, complete the "Choose your payment methods" step, and close the modal.
14. Click again on "Complete setup" for WooPayments and you should be presented directly with the "Activate payments" step in the state where you can choose to activate or test payments:
<img width="1489" height="925" alt="Screenshot 2025-08-12 at 14 00 15" src="https://github.com/user-attachments/assets/d85aff12-8f81-49dc-9522-cdeabf1498ef" />

15. Click on "Test payments" and wait until you have a test account onboarded:
<img width="1490" height="929" alt="Screenshot 2025-08-12 at 14 01 43" src="https://github.com/user-attachments/assets/324cde76-46e4-47e8-a032-53575233468f" />

16. Click on the "Set up payments" task and you should be redirected to the Payments Settings page.
17. Go to your local Transact Platform [PHPMyAdmin](http://localhost:8087/index.php?route=/sql&pos=0&db=wordpress&table=wcpay_accounts) and mark the current account as deleted.
18. Go to WCPay Dev Tools and clear the account cache. You should have an empty array in the cache.
19. Go to WooCommerce > Settings > Payments and WooPayments should feature a "Complete setup" button and a "Reset onboarding" link in the contextual menu:
<img width="1489" height="585" alt="Screenshot 2025-08-12 at 14 04 43" src="https://github.com/user-attachments/assets/e0030db1-4a45-4174-87fe-9a11036bd87c" />

20. Click "Complete setup" and notice that the payment methods step is marked as completed and you are presented with the business verification step since the test account is already stored as completed in the NOX profile.
21. Fill in the business verification self-assessment sub-step but don't click on "Continue"; just close the modal.
<img width="1487" height="925" alt="Screenshot 2025-08-12 at 14 08 02" src="https://github.com/user-attachments/assets/5a95ab39-e0b8-44c1-8a52-0cfdaa39cdef" />

22. Click "Complete setup" and you should be presented with the business verification step with the values you previously selected.
23. Close the modal and click "Reset onboarding" for WooPayments.
24. Click "Complete setup" and you should be presented with the payment methods step.
25. Complete the payment methods step, choose "Start accepting payments", complete the self-assessment, and you should be presented with the embedded KYC:
<img width="1491" height="926" alt="Screenshot 2025-08-12 at 14 11 29" src="https://github.com/user-attachments/assets/8babe75c-7dd1-4833-a383-cf4cd5e6791d" />

26. Complete the 2FA embedded step and close the modal.
27. Click on "Complete setup" and you should be presented with the embedded KYC step where you dropped off:
<img width="1487" height="925" alt="Screenshot 2025-08-12 at 14 12 31" src="https://github.com/user-attachments/assets/b9401053-81e1-43eb-a3cd-6604c8f29b0b" />

28. Go to your local Transact Platform [PHPMyAdmin](http://localhost:8087/index.php?route=/sql&pos=0&db=wordpress&table=wcpay_accounts) and mark the current account as deleted.
29. Go to WCPay Dev Tools and clear the account cache. You should have an empty array in the cache.
30. Go to WooCommerce > Settings > Payments and WooPayments should feature a "Complete setup" button and a "Reset onboarding" link in the contextual menu.
31. Click on "Continue setup" and you should be presented with the Activate payments step with the self-assessment data already prefilled (since it is stored in the NOX profile):
<img width="1491" height="928" alt="Screenshot 2025-08-12 at 14 15 00" src="https://github.com/user-attachments/assets/9038a4b2-dc2e-418d-8cd5-30bba4d835d4" />

32. Close the modal, click on "Reset onboarding", confirm it, and start the onboarding again.
33. Notice that you are taken back to the payment methods set.
34. Complete the payment methods step and you should be presented with the choice between live and test account.
35. Choose to activate payments and complete the onboarding flow and click on "Close this window" at the end.
36. Go to WooCommerce > Settings > Payments and click on "Reset account" for WooPayments. It should work and you should be able to restart the NOX flow from scratch.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
