### PR TITLE
Fix account settings unit test

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5289-phpunit-test-failure
+++ b/plugins/woocommerce/changelog/wooplug-5289-phpunit-test-failure
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Fix unit test failure by conditionally expecting delayed-account-creation setting on block themes

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
@@ -70,6 +70,12 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 			'woocommerce_anonymize_completed_orders'       => 'relative_date_selector',
 		);
 
+		// The delayed account creation setting is conditionally shown based on checkout block configuration.
+		$is_block_theme = wp_is_block_theme();
+		if ( $is_block_theme ) {
+			$expected['woocommerce_enable_delayed_account_creation'] = 'checkbox';
+		}
+
 		$this->assertEquals( $expected, $setting_ids_and_types );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes failed unit test when full test suite runs. Individually the test passes. The issue is, that `woocommerce_enable_delayed_account_creation` setting is only present on block-based themes or when block checkout is enabled. One of the tests in suite is not cleaning up its setup properly, but to prevent breaking in the future, I added a condition to include this setting when it should be present, instead of trying to figure out which of the 7,344 tests is not cleaning up properly. 

```
3) WC_Settings_Accounts_Test::test_get_settings__all_settings_are_present
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'woocommerce_trash_cancelled_orders' => 'relative_date_selector'
     'woocommerce_anonymize_refunded_orders' => 'relative_date_selector'
     'woocommerce_anonymize_completed_orders' => 'relative_date_selector'
+    'woocommerce_enable_delayed_account_creation' => 'checkbox'
 )
```

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60301, closes WOOPLUG-5289.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `cd plugins/woocommerce`
2. `pnpm run test:php:env`
3. There might be some failing tests, but you shouldn't see `WC_Settings_Accounts_Test::test_get_settings__all_settings_are_present`. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>
