### PR TITLE
Simplify has_block_template function

### DIFF
--- a/plugins/woocommerce/changelog/update-simplify-has_block_template
+++ b/plugins/woocommerce/changelog/update-simplify-has_block_template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Simplify has_block_template function
+
+

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -134,36 +134,12 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template      = false;
-		$template_filename = $template_name . '.html';
-		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
-		// we should check both these possible directories for backwards-compatibility.
-		$possible_templates_dirs = array( 'templates', 'block-templates' );
-
-		// Combine the possible root directory names with either the template directory
-		// or the stylesheet directory for child themes, getting all possible block templates
-		// locations combinations.
-		$filepath        = DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$legacy_filepath = DIRECTORY_SEPARATOR . 'block-templates' . DIRECTORY_SEPARATOR . $template_filename;
-		$possible_paths  = array(
-			get_stylesheet_directory() . $filepath,
-			get_stylesheet_directory() . $legacy_filepath,
-			get_template_directory() . $filepath,
-			get_template_directory() . $legacy_filepath,
-		);
-
-		// Check the first matching one.
-		foreach ( $possible_paths as $path ) {
-			if ( is_readable( $path ) ) {
-				$has_template = true;
-				break;
-			}
-		}
+		$has_template = WP_Block_Templates_Registry::get_instance()->is_registered( 'woocommerce//' . $template_name );
 
 		/**
 		 * Filters the value of the result of the block template check.
 		 *
-		 * @since x.x.x
+		 * @since 10.2.0
 		 *
 		 * @param boolean $has_template value to be filtered.
 		 * @param string $template_name The name of the template.

--- a/plugins/woocommerce/src/Blocks/Templates/CartTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/CartTemplate.php
@@ -16,15 +16,6 @@ class CartTemplate extends AbstractPageTemplate {
 	const SLUG = 'page-cart';
 
 	/**
-	 * Initialization method.
-	 */
-	public function init() {
-		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
-
-		parent::init();
-	}
-
-	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string
@@ -40,17 +31,6 @@ class CartTemplate extends AbstractPageTemplate {
 	 */
 	public function get_template_description() {
 		return __( 'The Cart template displays the items selected by the user for purchase, including quantities, prices, and discounts. It allows users to review their choices before proceeding to checkout.', 'woocommerce' );
-	}
-
-	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
-	 */
-	public function render_block_template() {
-		if (
-			! is_embed() && is_cart()
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Templates/CheckoutTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/CheckoutTemplate.php
@@ -16,15 +16,6 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	const SLUG = 'page-checkout';
 
 	/**
-	 * Initialization method.
-	 */
-	public function init() {
-		parent::init();
-
-		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
-	}
-
-	/**
 	 * Returns the title of the template.
 	 *
 	 * @return string
@@ -40,17 +31,6 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	 */
 	public function get_template_description() {
 		return __( 'The Checkout template guides users through the final steps of the purchase process. It enables users to enter shipping and billing information, select a payment method, and review order details.', 'woocommerce' );
-	}
-
-	/**
-	 * Renders the default block template from Woo Blocks if no theme templates exist.
-	 */
-	public function render_block_template() {
-		if (
-			! is_embed() && is_checkout()
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -62,8 +62,6 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductCatalogTemplate.php
@@ -58,8 +58,6 @@ class ProductCatalogTemplate extends AbstractTemplate {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductSearchResultsTemplate.php
@@ -57,8 +57,6 @@ class ProductSearchResultsTemplate extends AbstractTemplate {
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -97,8 +97,6 @@ class SingleProductTemplate extends AbstractTemplate {
 					)
 				);
 			}
-
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/47887.

With access to the `WP_Block_Templates_Registry`, it's easier to know when a block template exists.

### How to test the changes in this Pull Request:

Testing this PR means making sure that block templates keep being loaded as expected. If they aren't loaded, it's easy to notice because the layout is broken (missing header, margins, etc.).

1. Go to some pages in the frontend and verify they load as expected. _Single Product_, _Shop_ page, _Cart_ page, _Products by Category_ and _Products by Attribute_ would be good ones to test.
2. Now, make some edits to some of those templates. Verify they are still rendered without any visible breakage.
3. Add a template for a specific product or taxonomy to your theme (ie: `single-product-belt.html`). In the frontend, verify it's loaded as expected.
