### PR TITLE
Fix PHPUnit test failure in `COTMigrationUtilTest` 

### DIFF
--- a/plugins/woocommerce/changelog/fix-60305
+++ b/plugins/woocommerce/changelog/fix-60305
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix failure in `COTMigrationUtilTest` test.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -463,8 +463,7 @@ class CustomOrdersTableController {
 			return 'no';
 		}
 
-		$sync_is_pending = $this->data_synchronizer->has_orders_pending_sync();
-		if ( $sync_is_pending && ! $this->changing_data_source_with_sync_pending_is_allowed() ) {
+		if ( ! $this->changing_data_source_with_sync_pending_is_allowed() && $this->data_synchronizer->has_orders_pending_sync() ) {
 			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -25,6 +25,13 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	);
 
 	/**
+	 * Backup of global $theorder to restore global state after tests are done.
+	 *
+	 * @var null|\WC_Order
+	 */
+	private static $theorder;
+
+	/**
 	 * Setup for every single test.
 	 */
 	public function setUp(): void {
@@ -43,6 +50,9 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		foreach ( self::$modified_options as $option_name => $option_value ) {
 			self::$modified_options[ $option_name ] = $option_value;
 		}
+
+		// Back up global $theorder.
+		self::$theorder = $GLOBALS['theorder'] ?? null;
 	}
 
 	/**
@@ -54,6 +64,9 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		foreach ( self::$modified_options as $option_name => $option_value ) {
 			update_option( $option_name, $option_value );
 		}
+
+		// Restore $theorder to prior state.
+		$GLOBALS['theorder'] = self::$theorder;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -25,13 +25,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	);
 
 	/**
-	 * Backup of global $theorder to restore global state after tests are done.
-	 *
-	 * @var null|\WC_Order
-	 */
-	private static $theorder;
-
-	/**
 	 * Setup for every single test.
 	 */
 	public function setUp(): void {
@@ -50,9 +43,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		foreach ( self::$modified_options as $option_name => $option_value ) {
 			self::$modified_options[ $option_name ] = $option_value;
 		}
-
-		// Back up global $theorder.
-		self::$theorder = $GLOBALS['theorder'] ?? null;
 	}
 
 	/**
@@ -64,9 +54,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		foreach ( self::$modified_options as $option_name => $option_value ) {
 			update_option( $option_name, $option_value );
 		}
-
-		// Restore $theorder to prior state.
-		$GLOBALS['theorder'] = self::$theorder;
 	}
 
 	/**
@@ -210,8 +197,6 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		$product = WC_Helper_Product::create_simple_product();
 		$order   = WC_Helper_Order::create_order( 1, $product );
 
-		global $theorder;
-		$theorder = $order;
 		return $order;
 	}
 
@@ -236,10 +221,19 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 * @param function $callback to wrap.
 	 */
 	private function with_order( $callback ) {
-		$order = $this->create_order();
+		// Back up global $theorder.
+		$theorder_backup = $GLOBALS['theorder'] ?? null;
 
-		$callback( $this );
+		$order               = $this->create_order();
+		$GLOBALS['theorder'] = $order;
 
-		$this->destroy_order( $order );
+		try {
+			$callback( $this );
+
+			$this->destroy_order( $order );
+		} finally {
+			// Restore $theorder to prior state.
+			$GLOBALS['theorder'] = $theorder_backup;
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
@@ -63,6 +63,10 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_init_theorder_object() {
 		global $theorder;
+
+		// Back up $theorder before running test.
+		$theorder_backup = $theorder;
+
 		$order1           = OrderHelper::create_order();
 		$order2           = OrderHelper::create_order();
 		$post_from_order2 = get_post( $order2->get_id() );
@@ -73,6 +77,9 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 		$theorder = null;
 		$this->sut->init_theorder_object( $post_from_order2 );
 		$this->assertEquals( $theorder->get_id(), $order2->get_id() );
+
+		// Restore original $theorder.
+		$theorder = $theorder_backup;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/COTMigrationUtilTest.php
@@ -24,6 +24,11 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	private $prev_cot_state;
 
 	/**
+	 * @var null|\WC_Order
+	 */
+	private $prev_theorder;
+
+	/**
 	 * Set-up subject under test.
 	 */
 	public function setUp(): void {
@@ -33,6 +38,7 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 		add_filter( 'wc_allow_changing_orders_storage_while_sync_is_pending', '__return_true' );
 		$cot_controller       = wc_get_container()->get( CustomOrdersTableController::class );
 		$this->prev_cot_state = $cot_controller->custom_orders_table_usage_is_enabled();
+		$this->prev_theorder  = $GLOBALS['theorder'] ?? null;
 	}
 
 	/**
@@ -43,6 +49,7 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	public function tearDown(): void {
 		OrderHelper::toggle_cot_feature_and_usage( $this->prev_cot_state );
 		remove_all_filters( 'wc_allow_changing_orders_storage_while_sync_is_pending' );
+		$GLOBALS['theorder'] = $this->prev_theorder;
 		parent::tearDown();
 	}
 
@@ -64,9 +71,6 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 	public function test_init_theorder_object() {
 		global $theorder;
 
-		// Back up $theorder before running test.
-		$theorder_backup = $theorder;
-
 		$order1           = OrderHelper::create_order();
 		$order2           = OrderHelper::create_order();
 		$post_from_order2 = get_post( $order2->get_id() );
@@ -77,9 +81,6 @@ class COTMigrationUtilTest extends \WC_Unit_Test_Case {
 		$theorder = null;
 		$this->sut->init_theorder_object( $post_from_order2 );
 		$this->assertEquals( $theorder->get_id(), $order2->get_id() );
-
-		// Restore original $theorder.
-		$theorder = $theorder_backup;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Tests in class `WC_Admin_Tests_Shipping_Label_Banner_Display_Rules` make use of an utility function `create_order()` that [overrides the global `$theorder`](https://github.com/woocommerce/woocommerce/blob/9f0e00e19fcabf928c326c102e78c4b16455c197/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php#L200-L202). The global is not restored after the tests in the class run, effectively leaking incorrect state to other tests, producing failures, in particular in `COTMigrationUtilTest`.

This PR makes sure tests that modify `$theorder` restore the prior value, fixing the failures.

Closes #60305.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. (On trunk) Run `phpunit --filter '--filter 'WC_Admin_Tests_Shipping_Label_Banner_Display_Rules|test_init_theorder_object' and confirm that `test_init_theorder_object` fails.
2. Check out this branch (`fix/60305`).
3. Repeat step 1 and confirm that the test run succeeds.

<!-- End testing instructions -->