### PR TITLE
Simplify classic-template e2e test

### DIFF
--- a/plugins/woocommerce/changelog/update-classic-template-e2e-test
+++ b/plugins/woocommerce/changelog/update-classic-template-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Simplify classic-template e2e test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -249,32 +249,20 @@ test.describe( `${ blockData.name } Block `, () => {
 
 		await editor.page.getByLabel( 'Open Navigation' ).click();
 
-		// Reset the template.
-		await editor.page.getByPlaceholder( 'Search' ).fill( 'Single Product' );
-		const resetNotice = editor.page
-			.getByLabel( 'Dismiss this notice' )
-			.getByText( `"Single Product" reset.` );
-		const searchResults = editor.page.getByLabel( 'Actions', {
-			exact: true,
+		await editor.revertTemplate( {
+			templateName: 'Single Product',
 		} );
-		// Wait until there's only one search result.
-		await expect.poll( async () => await searchResults.count() ).toBe( 1 );
 
 		const actionsButton = editor.page.getByRole( 'button', {
 			name: 'Actions',
 		} );
-		await actionsButton.click();
-
-		await editor.page.getByRole( 'menuitem', { name: 'Reset' } ).click();
-		await editor.page.getByRole( 'button', { name: 'Reset' } ).click();
-		await expect( resetNotice ).toBeVisible();
+		if ( wpCoreVersion >= 6.8 ) {
+			await actionsButton.click();
+		}
 
 		const editButton = editor.page.getByRole( 'menuitem', {
 			name: 'Edit',
 		} );
-		if ( wpCoreVersion >= 6.8 ) {
-			await actionsButton.click();
-		}
 
 		// Edit the template again.
 		await editButton.click();

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/classic-template/classic-template.block_theme.spec.ts
@@ -253,10 +253,10 @@ test.describe( `${ blockData.name } Block `, () => {
 			templateName: 'Single Product',
 		} );
 
-		const actionsButton = editor.page.getByRole( 'button', {
-			name: 'Actions',
-		} );
 		if ( wpCoreVersion >= 6.8 ) {
+			const actionsButton = editor.page.getByRole( 'button', {
+				name: 'Actions',
+			} );
 			await actionsButton.click();
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the recent PRs migrating to the Template registration API, I noticed the `is still available after resetting a modified WC template` test becoming more flaky than usual. I'm not 100% sure if this will fix it, but at least it removes a bunch of code that handled resetting the template. Instead, we use a util that we are using in several other tests and seemed not to be flaky so far.

### How to test the changes in this Pull Request:

1. Verify e2e tests keep passing.
