### PR TITLE
[Payments NOX] Better handle sandbox accounts when activating payments in NOX in-context

### DIFF
--- a/plugins/woocommerce/changelog/update-WOOPLUG-5298-better-handle-sandbox-accounts-when-activating-payments
+++ b/plugins/woocommerce/changelog/update-WOOPLUG-5298-better-handle-sandbox-accounts-when-activating-payments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Show the WooPayments NOX in-context business verification activate sub-step when a sandbox account is in use.
+
+

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/buttons/activate-payments-button.tsx
@@ -84,6 +84,11 @@ export const ActivatePaymentsButton = ( {
 
 		// If no URL to disable the test account is provided, we just point the user to the live account setup.
 		if ( ! disableTestAccountUrl ) {
+			if ( incentive ) {
+				acceptIncentive( incentive.promo_id );
+			}
+
+			setIsUpdating( false );
 			if ( onboardingType === 'native_in_context' ) {
 				// Open the onboarding modal.
 				recordPaymentsOnboardingEvent(
@@ -97,6 +102,8 @@ export const ActivatePaymentsButton = ( {
 			} else {
 				window.location.href = getWooPaymentsSetupLiveAccountLink();
 			}
+
+			return;
 		}
 
 		// Disable test account and redirect to the live account setup link.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
@@ -78,6 +78,25 @@ export const WooPaymentsResetAccountModal = ( {
 	const handleResetAccount = () => {
 		setIsResettingAccount( true );
 
+		if ( ! resetUrl ) {
+			recordPaymentsEvent( 'provider_reset_onboarding_failed', {
+				provider_id: wooPaymentsProviderId,
+				suggestion_id: wooPaymentsSuggestionId,
+				provider_extension_slug: wooPaymentsExtensionSlug,
+				reason: 'missing_reset_url',
+			} );
+			createNotice(
+				'error',
+				__(
+					'Failed to reset: missing reset URL. Please refresh and try again.',
+					'woocommerce'
+				),
+				{ isDismissible: true }
+			);
+			setIsResettingAccount( false );
+			return;
+		}
+
 		apiFetch( {
 			url: resetUrl,
 			method: 'POST',

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -37,10 +37,13 @@ export const BusinessVerificationStep: React.FC = () => {
 		...( currentStep?.context?.self_assessment ?? {} ),
 	};
 	const hasTestAccount = currentStep?.context?.has_test_account ?? false;
+	const hasSandboxAccount =
+		currentStep?.context?.has_sandbox_account ?? false;
 
-	// Only include the activate step if the user has a test account.
+	// Only include the activate step if the user has a test or sandbox account.
+	// The activate step can handle disabling the test or sandbox account and proceed to live onboarding.
 	const subStepsList = [
-		...( hasTestAccount ? [ 'activate' ] : [] ),
+		...( hasTestAccount || hasSandboxAccount ? [ 'activate' ] : [] ),
 		'business',
 		'embedded',
 	];
@@ -95,7 +98,7 @@ export const BusinessVerificationStep: React.FC = () => {
 							);
 						} }
 					>
-						{ hasTestAccount && (
+						{ ( hasTestAccount || hasSandboxAccount ) && (
 							<Step name="activate" showHeading={ false }>
 								<ActivatePayments />
 							</Step>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -40,9 +40,15 @@ export const BusinessVerificationStep: React.FC = () => {
 	const hasSandboxAccount =
 		currentStep?.context?.has_sandbox_account ?? false;
 
-	// Only include the activate step if the user has a test or sandbox account.
+	// Only include the activate step if the user has:
+	// - a test OR;
+	// - a sandbox account and the business verification step is not started;
+	//   this is due to the fact that a sandbox account goes through the same onboarding flow as a live account,
+	//   but with test KYC data.
 	// The activate step can handle disabling the test or sandbox account and proceed to live onboarding.
-	const showActivateSubStep = hasTestAccount || hasSandboxAccount;
+	const showActivateSubStep =
+		hasTestAccount ||
+		( hasSandboxAccount && currentStep?.status === 'not_started' );
 	const subStepsList = [
 		...( showActivateSubStep ? [ 'activate' ] : [] ),
 		'business',

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/index.tsx
@@ -42,8 +42,9 @@ export const BusinessVerificationStep: React.FC = () => {
 
 	// Only include the activate step if the user has a test or sandbox account.
 	// The activate step can handle disabling the test or sandbox account and proceed to live onboarding.
+	const showActivateSubStep = hasTestAccount || hasSandboxAccount;
 	const subStepsList = [
-		...( hasTestAccount || hasSandboxAccount ? [ 'activate' ] : [] ),
+		...( showActivateSubStep ? [ 'activate' ] : [] ),
 		'business',
 		'embedded',
 	];
@@ -98,7 +99,7 @@ export const BusinessVerificationStep: React.FC = () => {
 							);
 						} }
 					>
-						{ ( hasTestAccount || hasSandboxAccount ) && (
+						{ showActivateSubStep && (
 							<Step name="activate" showHeading={ false }>
 								<ActivatePayments />
 							</Step>

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/activate-payments.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/activate-payments.tsx
@@ -35,7 +35,7 @@ const ActivatePayments: React.FC = () => {
 
 		setIsContinueButtonLoading( true );
 
-		// Disable test account and proceed to live KYC.
+		// Disable test account and proceed with business verification.
 		apiFetch( {
 			url: currentStep?.actions?.test_account_disable?.href,
 			method: 'POST',
@@ -44,12 +44,15 @@ const ActivatePayments: React.FC = () => {
 				source: sessionEntryPoint,
 			},
 		} )
-			.then( () => {
-				setIsContinueButtonLoading( false );
+			.then( async () => {
 				// Refresh the entire onboarding store data after disabling the test account.
-				// This ensures that the latest data is available for the next steps.
-				refreshStoreData();
-				// Navigate to the live account setup.
+				// This ensures that the latest data is available for the next sub-steps.
+				await ( typeof refreshStoreData === 'function'
+					? refreshStoreData()
+					: Promise.resolve() );
+				// Stop loading before navigating to avoid setState-after-unmount.
+				setIsContinueButtonLoading( false );
+				// Navigate to the business sub-step.
 				return nextStep();
 			} )
 			.catch( () => {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/activate-payments.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/business-verification/sections/activate-payments.tsx
@@ -14,7 +14,8 @@ import strings from '../strings';
 import { useOnboardingContext } from '~/settings-payments/onboarding/providers/woopayments/data/onboarding-context';
 
 const ActivatePayments: React.FC = () => {
-	const { currentStep, sessionEntryPoint } = useOnboardingContext();
+	const { currentStep, sessionEntryPoint, refreshStoreData } =
+		useOnboardingContext();
 	const { nextStep } = useStepperContext();
 	const [ isContinueButtonLoading, setIsContinueButtonLoading ] =
 		useState( false );
@@ -45,6 +46,9 @@ const ActivatePayments: React.FC = () => {
 		} )
 			.then( () => {
 				setIsContinueButtonLoading( false );
+				// Refresh the entire onboarding store data after disabling the test account.
+				// This ensures that the latest data is available for the next steps.
+				refreshStoreData();
 				// Navigate to the live account setup.
 				return nextStep();
 			} )

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
@@ -123,7 +123,9 @@ export interface WooPaymentsProviderOnboardingStep {
 				status: 'completed' | 'not_started' | 'started';
 			}
 		>;
+		// True when a test (test-drive) account is connected.
 		has_test_account?: boolean;
+		// True when a sandbox (test-mode, non-test-drive) account is connected.
 		has_sandbox_account?: boolean;
 	};
 	errors?: {

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/types.ts
@@ -124,6 +124,7 @@ export interface WooPaymentsProviderOnboardingStep {
 			}
 		>;
 		has_test_account?: boolean;
+		has_sandbox_account?: boolean;
 	};
 	errors?: {
 		message: string;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -202,14 +202,16 @@ class PaymentsProviders {
 	 * We apply the same actions and logic that the non-React Payments settings page uses to get the gateways.
 	 * This way we maintain backwards compatibility.
 	 *
-	 * @param bool $for_display Whether the payment gateway list is intended for display purposes.
-	 *                          This triggers the legacy `woocommerce_admin_field_payment_gateways` action and
-	 *                          the exclusion of "shell" gateways.
-	 *                          Default is true.
+	 * @param bool   $for_display  Whether the payment gateway list is intended for display purposes.
+	 *                             This triggers the legacy `woocommerce_admin_field_payment_gateways` action and
+	 *                             the exclusion of "shell" gateways.
+	 *                             Default is true.
+	 * @param string $country_code Optional. The country code for which the payment gateways are being generated.
+	 *                             This should be an ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return array The payment gateway objects list.
 	 */
-	public function get_payment_gateways( bool $for_display = true ): array {
+	public function get_payment_gateways( bool $for_display = true, string $country_code = '' ): array {
 		// If we are asked for a display gateways list, we need to fire legacy actions and filter out "shells".
 		if ( $for_display ) {
 			if ( ! is_null( $this->payment_gateways_for_display_memo ) ) {
@@ -235,7 +237,7 @@ class PaymentsProviders {
 			$payment_gateways = $this->handle_non_standard_registration_for_payment_gateways( $payment_gateways );
 
 			// Remove "shell" gateways from the list.
-			$payment_gateways = $this->remove_shell_payment_gateways( $payment_gateways );
+			$payment_gateways = $this->remove_shell_payment_gateways( $payment_gateways, $country_code );
 
 			// Store the entire payment gateways list for display for later use.
 			$this->payment_gateways_for_display_memo = $payment_gateways;
@@ -267,12 +269,14 @@ class PaymentsProviders {
 	 * The removal is done in a way that ensures we do not remove all gateways from an extension,
 	 * thus preventing user access to the settings page(s) for that extension.
 	 *
-	 * @param array $payment_gateways The payment gateways list to process.
+	 * @param array  $payment_gateways The payment gateways list to process.
+	 * @param string $country_code     Optional. The country code for which the payment gateways are being generated.
+	 *                                 This should be an ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return array The processed payment gateways list.
 	 */
-	public function remove_shell_payment_gateways( array $payment_gateways ): array {
-		$grouped_payment_gateways = $this->group_gateways_by_extension( $payment_gateways );
+	public function remove_shell_payment_gateways( array $payment_gateways, string $country_code = '' ): array {
+		$grouped_payment_gateways = $this->group_gateways_by_extension( $payment_gateways, $country_code );
 		return array_filter(
 			$payment_gateways,
 			function ( $gateway ) use ( $grouped_payment_gateways ) {
@@ -1429,14 +1433,16 @@ class PaymentsProviders {
 	/**
 	 * Group payment gateways by their plugin extension filename.
 	 *
-	 * @param WC_Payment_Gateway[] $gateways The list of payment gateway instances to group.
+	 * @param WC_Payment_Gateway[] $gateways     The list of payment gateway instances to group.
+	 * @param string               $country_code Optional. The country code for which the gateways are being generated.
+	 *                                           This should be an ISO 3166-1 alpha-2 country code.
 	 *
 	 * @return array The grouped payment gateway instances, keyed by the plugin file.
 	 *               Each group contains an array of payment gateway instances that belong to the same plugin.
 	 *               If a payment gateway does not have a corresponding plugin file,
 	 *               it will be grouped under the 'unknown_extension' key.
 	 */
-	private function group_gateways_by_extension( array $gateways ): array {
+	private function group_gateways_by_extension( array $gateways, string $country_code = '' ): array {
 		$grouped = array(
 			// This is the group for gateways that we don't know how to group by extension.
 			// It can be used for gateways that are not registered by a WP plugin.
@@ -1445,7 +1451,7 @@ class PaymentsProviders {
 
 		foreach ( $gateways as $gateway ) {
 			// Get the payment gateway details, but use a dummy gateway order since it is inconsequential here.
-			$gateway_details = $this->get_payment_gateway_details( $gateway, 0 );
+			$gateway_details = $this->get_payment_gateway_details( $gateway, 0, $country_code );
 			// If we don't have the necessary plugin details, put it in the unknown group.
 			if ( empty( $gateway_details ) || ! isset( $gateway_details['plugin'] ) || empty( $gateway_details['plugin']['file'] ) ) {
 				$grouped['unknown_extension'][] = $gateway;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -214,7 +214,7 @@ class PaymentsProviders {
 	public function get_payment_gateways( bool $for_display = true, string $country_code = '' ): array {
 		// If we are asked for a display gateways list, we need to fire legacy actions and filter out "shells".
 		if ( $for_display ) {
-			if ( ! is_null( $this->payment_gateways_for_display_memo[ $country_code ] ) ) {
+			if ( isset( $this->payment_gateways_for_display_memo[ $country_code ] ) ) {
 				return $this->payment_gateways_for_display_memo[ $country_code ];
 			}
 
@@ -246,7 +246,7 @@ class PaymentsProviders {
 		}
 
 		// We were asked for the raw payment gateways list.
-		if ( ! is_null( $this->payment_gateways_memo[ $country_code ] ) ) {
+		if ( isset( $this->payment_gateways_memo[ $country_code ] ) ) {
 			return $this->payment_gateways_memo[ $country_code ];
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders.php
@@ -165,18 +165,18 @@ class PaymentsProviders {
 	/**
 	 * The memoized payment gateways to avoid computing the list multiple times during a request.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	private ?array $payment_gateways_memo = null;
+	private array $payment_gateways_memo = array();
 
 	/**
 	 * The memoized payment gateways for display to avoid computing the list multiple times during a request.
 	 *
 	 * This is especially important since it avoids triggering the legacy action multiple times during a request.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	private ?array $payment_gateways_for_display_memo = null;
+	private array $payment_gateways_for_display_memo = array();
 
 	/**
 	 * The payment extension suggestions service.
@@ -214,8 +214,8 @@ class PaymentsProviders {
 	public function get_payment_gateways( bool $for_display = true, string $country_code = '' ): array {
 		// If we are asked for a display gateways list, we need to fire legacy actions and filter out "shells".
 		if ( $for_display ) {
-			if ( ! is_null( $this->payment_gateways_for_display_memo ) ) {
-				return $this->payment_gateways_for_display_memo;
+			if ( ! is_null( $this->payment_gateways_for_display_memo[ $country_code ] ) ) {
+				return $this->payment_gateways_for_display_memo[ $country_code ];
 			}
 
 			// We don't want to output anything from the action. So we buffer it and discard it.
@@ -240,14 +240,14 @@ class PaymentsProviders {
 			$payment_gateways = $this->remove_shell_payment_gateways( $payment_gateways, $country_code );
 
 			// Store the entire payment gateways list for display for later use.
-			$this->payment_gateways_for_display_memo = $payment_gateways;
+			$this->payment_gateways_for_display_memo[ $country_code ] = $payment_gateways;
 
 			return $payment_gateways;
 		}
 
 		// We were asked for the raw payment gateways list.
-		if ( ! is_null( $this->payment_gateways_memo ) ) {
-			return $this->payment_gateways_memo;
+		if ( ! is_null( $this->payment_gateways_memo[ $country_code ] ) ) {
+			return $this->payment_gateways_memo[ $country_code ];
 		}
 
 		// Get all payment gateways, ordered by the user.
@@ -257,7 +257,7 @@ class PaymentsProviders {
 		$payment_gateways = $this->handle_non_standard_registration_for_payment_gateways( $payment_gateways );
 
 		// Store the entire payment gateways list for later use.
-		$this->payment_gateways_memo = $payment_gateways;
+		$this->payment_gateways_memo[ $country_code ] = $payment_gateways;
 
 		return $payment_gateways;
 	}
@@ -279,12 +279,12 @@ class PaymentsProviders {
 		$grouped_payment_gateways = $this->group_gateways_by_extension( $payment_gateways, $country_code );
 		return array_filter(
 			$payment_gateways,
-			function ( $gateway ) use ( $grouped_payment_gateways ) {
+			function ( $gateway ) use ( $grouped_payment_gateways, $country_code ) {
 				// If the gateway is a shell, we only remove it if there are other, non-shell gateways from that extension.
 				// This is to avoid removing all the gateways registered by an extension and
 				// preventing user access to the settings page(s) for that extension.
 				if ( $this->is_shell_payment_gateway( $gateway ) ) {
-					$gateway_details = $this->get_payment_gateway_details( $gateway, 0 );
+					$gateway_details = $this->get_payment_gateway_details( $gateway, 0, $country_code );
 					// In case we don't have the needed extension details,
 					// we allow the gateway to be displayed (aka better safe than sorry).
 					if ( empty( $gateway_details ) || ! isset( $gateway_details['plugin'] ) || empty( $gateway_details['plugin']['file'] ) ) {
@@ -1084,8 +1084,8 @@ class PaymentsProviders {
 	 * @return void
 	 */
 	public function reset_memo(): void {
-		$this->payment_gateways_memo             = null;
-		$this->payment_gateways_for_display_memo = null;
+		$this->payment_gateways_memo             = array();
+		$this->payment_gateways_for_display_memo = array();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1160,11 +1160,9 @@ class WooPaymentsService {
 		// Add the user locale to the account session data to allow for localized KYC sessions.
 		$response['locale'] = $this->proxy->call_function( 'get_user_locale' );
 
-		// For sanity, make sure the test account step is completed if not already,
+		// For sanity, make sure the test account step is marked as completed, if not already,
 		// since we are doing live account KYC.
-		if ( ! $this->is_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-			$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, );
-		}
+		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, false, $source );
 
 		// Record an event for the KYC session being created.
 		$event_props = array(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1897,10 +1897,11 @@ class WooPaymentsService {
 			array(
 				'id'      => self::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				'context' => array(
-					'fields'           => array(),
-					'sub_steps'        => $business_verification_step_sub_steps,
-					'self_assessment'  => $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'self_assessment', array() ),
-					'has_test_account' => $this->has_test_account(),
+					'fields'              => array(),
+					'sub_steps'           => $business_verification_step_sub_steps,
+					'self_assessment'     => $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'self_assessment', array() ),
+					'has_test_account'    => $this->has_test_account(),
+					'has_sandbox_account' => $this->has_sandbox_account(),
 				),
 			),
 			$location,

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1564,6 +1564,12 @@ class WooPaymentsService {
 		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		$this->clear_onboarding_step_blocked( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
 		$this->clear_onboarding_step_failed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
+		// Clear the NOX profile data for the business verification step sub-step data.
+		// This way the user will be prompted to complete ALL the business verification sub-steps.
+		$business_verification_sub_step_data = $this->get_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'sub_steps', array() );
+		if ( ! empty( $business_verification_sub_step_data ) ) {
+			$this->save_nox_profile_onboarding_step_data_entry( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, 'sub_steps', array() );
+		}
 
 		// Record an event for the test account being disabled.
 		$this->record_event(

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -1272,6 +1272,10 @@ class WooPaymentsService {
 			);
 		}
 
+		// For sanity, make sure the test account step is marked as completed, if not already,
+		// since we are doing live account KYC.
+		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location, false, $source );
+
 		// Record an event for the KYC session being finished.
 		$event_props = array(
 			'successful_kyc'    => filter_var( $response['success'] ?? false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ?? false,
@@ -1288,12 +1292,6 @@ class WooPaymentsService {
 
 		// Mark the business verification step as completed.
 		$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_BUSINESS_VERIFICATION, $location, false, $source );
-
-		// For sanity, make sure the test account step is completed, if not already,
-		// since we are doing live account KYC.
-		if ( ! $this->is_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location ) ) {
-			$this->mark_onboarding_step_completed( self::ONBOARDING_STEP_TEST_ACCOUNT, $location );
-		}
 
 		return $response;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -276,9 +276,9 @@ class WooPaymentsService {
 				// The step can only be completed if the requirements are met. Otherwise, ignore the stored completed status.
 				// Sanity check: we only report the completed status if there is a live account and the account is valid (i.e. completed KYC).
 				if ( $meets_requirements &&
-					 $this->was_onboarding_step_marked_completed( $step_id, $location ) &&
-					 $this->has_valid_account() &&
-					 ( $this->has_live_account() || $this->has_sandbox_account() )
+					$this->was_onboarding_step_marked_completed( $step_id, $location ) &&
+					$this->has_valid_account() &&
+					( $this->has_live_account() || $this->has_sandbox_account() )
 				) {
 					return self::ONBOARDING_STEP_STATUS_COMPLETED;
 				}

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -275,7 +275,11 @@ class WooPaymentsService {
 			case self::ONBOARDING_STEP_BUSINESS_VERIFICATION:
 				// The step can only be completed if the requirements are met. Otherwise, ignore the stored completed status.
 				// Sanity check: we only report the completed status if there is a live account and the account is valid (i.e. completed KYC).
-				if ( $meets_requirements && $this->has_valid_account() && $this->has_live_account() && $this->was_onboarding_step_marked_completed( $step_id, $location ) ) {
+				if ( $meets_requirements &&
+					 $this->was_onboarding_step_marked_completed( $step_id, $location ) &&
+					 $this->has_valid_account() &&
+					 ( $this->has_live_account() || $this->has_sandbox_account() )
+				) {
 					return self::ONBOARDING_STEP_STATUS_COMPLETED;
 				}
 				break;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -230,8 +230,8 @@ class WooPaymentsService {
 					}
 					break;
 				case self::ONBOARDING_STEP_TEST_ACCOUNT:
-					// If the account is a valid, working test account, the step is completed.
-					if ( $this->has_test_account() && $this->has_valid_account() && $this->has_working_account() ) {
+					// If the account is a valid, working test or sandbox account, the step is completed.
+					if ( ( $this->has_test_account() || $this->has_sandbox_account() ) && $this->has_valid_account() && $this->has_working_account() ) {
 						// Since it takes a while for the account to be fully working after the test account initialization,
 						// we will force mark the step as completed here, if it is not already.
 						// This is a fail-safe to guard against the case when the frontend doesn't mark the step as completed.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -2026,25 +2026,31 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT          => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				),
-				array(), // no stored profile steps
+				array(), // no stored profile steps.
 				$default_recommended_pms,
 				$expected_pms_state,
-				array_merge( $default_wpcom_connection, array(
-					'is_store_connected'  => true,
-					'has_connected_owner' => true,
-				) ),
+				array_merge(
+					$default_wpcom_connection,
+					array(
+						'is_store_connected'  => true,
+						'has_connected_owner' => true,
+					)
+				),
 				array(
 					'has_working_connection' => true,
 					'is_store_connected'     => true,
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array_merge( $default_account_state, array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
-					'sandbox_account'   => true,
-				) ),
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+						'sandbox_account'   => true,
+					)
+				),
 			),
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -2159,9 +2159,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->willReturn(
 				array(
 					'status'           => 'complete',
-					// These two are mirror images of each other.
 					'testDrive'        => $account_state['test_account'] ?? false,
-					'isLive'           => ! ( $account_state['test_account'] ?? false ),
+					'isLive'           => ! ( ( $account_state['test_account'] ?? false ) || ( $account_state['sandbox_account'] ?? false ) ),
 					'paymentsEnabled'  => true,
 					'detailsSubmitted' => true,
 				)

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -6173,7 +6173,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test onboarding_step_check throws excetion when onboarding is locked.
+	 * Test onboarding_step_check throws exception when onboarding is locked.
 	 *
 	 * @return void
 	 * @throws \Exception When trying to mock uncallable user functions.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -483,7 +483,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				'errors'         => array(),
 				'context'        => array(
 					// Only with a working WPCOM connection we include the fields.
-					'fields'           => ( $wpcom_connection['is_store_connected'] && $wpcom_connection['has_connected_owner'] ) ? array(
+					'fields'              => ( $wpcom_connection['is_store_connected'] && $wpcom_connection['has_connected_owner'] ) ? array(
 						'business_types'      => $this->get_mock_onboarding_fields_business_types(),
 						'mccs_display_tree'   => array(
 							array(
@@ -547,9 +547,10 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 						'available_countries' => $this->get_woopayments_supported_countries(),
 						'location'            => $location,
 					) : array(),
-					'sub_steps'        => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['sub_steps'] ?? array(),
-					'self_assessment'  => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['self_assessment'] ?? array(),
-					'has_test_account' => $account_state['has_account'] && $account_state['test_account'],
+					'sub_steps'           => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['sub_steps'] ?? array(),
+					'self_assessment'     => $steps_stored_profile[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ]['self_assessment'] ?? array(),
+					'has_test_account'    => $account_state['has_account'] && $account_state['test_account'],
+					'has_sandbox_account' => $account_state['has_account'] && $account_state['sandbox_account'],
 				),
 				'actions'        => array(
 					'start'                => array(
@@ -781,6 +782,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			'has_account'       => false,
 			'has_valid_account' => false,
 			'test_account'      => false,
+			'sandbox_account'   => false,
 		);
 
 		return array(
@@ -968,7 +970,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses (failed) - working WPCOM connection, test account' => array(
 				array(
-					// The PMs step is force-completd on valid accounts.
+					// The PMs step is force-completed on valid accounts.
 					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
@@ -1015,10 +1017,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses (failed) - working WPCOM connection, live account' => array(
@@ -1070,10 +1075,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses (blocked) - no WPCOM connection, no account' => array(
@@ -1216,10 +1224,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses (blocked) - working WPCOM connection, live account' => array(
@@ -1271,10 +1282,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses (completed) - no WPCOM connection, test account' => array(
@@ -1316,10 +1330,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				$expected_pms_state,
 				$default_wpcom_connection,
 				$expected_wpcom_connection_state,
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses (completed) - no WPCOM connection, live account' => array(
@@ -1361,10 +1378,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				$expected_pms_state,
 				$default_wpcom_connection,
 				$expected_wpcom_connection_state,
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses (completed with failed) - no WPCOM connection, test account' => array(
@@ -1410,10 +1430,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				$expected_pms_state,
 				$default_wpcom_connection,
 				$expected_wpcom_connection_state,
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses (completed with blocked) - no WPCOM connection, live account' => array(
@@ -1459,10 +1482,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				$expected_pms_state,
 				$default_wpcom_connection,
 				$expected_wpcom_connection_state,
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses (mixed)' => array(
@@ -1650,10 +1676,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses ignored - Test account not completed due to unmet requirements' => array(
@@ -1687,10 +1716,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => false,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => true,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => true,
+					)
 				),
 			),
 			'stored statuses respected - Test account started with no account' => array(
@@ -1722,10 +1754,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => false,
-					'has_valid_account' => false,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => false,
+						'has_valid_account' => false,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses respected - Test account step with live, invalid account' => array(
@@ -1758,10 +1793,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => false,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => false,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses respected - Test account with live, valid account' => array(
@@ -1794,10 +1832,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses ignored - Business verification completed with requirements met' => array(
@@ -1835,10 +1876,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses ignored - Business verification not completed due to unmet requirements' => array(
@@ -1879,10 +1923,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => false,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses respected - Business verification started with no account' => array(
@@ -1920,10 +1967,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => false,
-					'has_valid_account' => false,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => false,
+						'has_valid_account' => false,
+						'test_account'      => false,
+					)
 				),
 			),
 			'stored statuses ignored - Business verification with live, valid account' => array(
@@ -1961,10 +2011,13 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_connected_owner'    => true,
 					'is_connection_owner'    => false,
 				),
-				array(
-					'has_account'       => true,
-					'has_valid_account' => true,
-					'test_account'      => false,
+				array_merge(
+					$default_account_state,
+					array(
+						'has_account'       => true,
+						'has_valid_account' => true,
+						'test_account'      => false,
+					)
 				),
 			),
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -2023,7 +2023,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				array(
 					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION      => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
-					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT          => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT          => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				),
 				array(), // no stored profile steps.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -482,7 +482,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 				'status'         => $expected_step_statuses[ WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION ] ?? WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
 				'errors'         => array(),
 				'context'        => array(
-					// Only with a working WPCOM connection we include the fields.
+					// Only with a working WPCOM connection do we include the fields.
 					'fields'              => ( $wpcom_connection['is_store_connected'] && $wpcom_connection['has_connected_owner'] ) ? array(
 						'business_types'      => $this->get_mock_onboarding_fields_business_types(),
 						'mccs_display_tree'   => array(
@@ -642,9 +642,8 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			->willReturn(
 				array(
 					'status'           => 'complete',
-					// These two are mirror images of each other.
 					'testDrive'        => $account_state['test_account'] ?? false,
-					'isLive'           => ! $account_state['test_account'] ?? true,
+					'isLive'           => ! ( ( $account_state['test_account'] ?? false ) || ( $account_state['sandbox_account'] ?? false ) ),
 					'paymentsEnabled'  => true,
 					'detailsSubmitted' => true,
 				)
@@ -1028,7 +1027,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses (failed) - working WPCOM connection, live account' => array(
 				array(
-					// The PMs step is force-completd on valid accounts.
+					// The PMs step is force-completed on valid accounts.
 					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED,
@@ -1235,7 +1234,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			'stored statuses (blocked) - working WPCOM connection, live account' => array(
 				array(
-					// The PMs step is force-completd on valid accounts.
+					// The PMs step is force-completed on valid accounts.
 					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION   => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
 					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT       => WooPaymentsService::ONBOARDING_STEP_STATUS_BLOCKED,
@@ -2020,6 +2019,33 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					)
 				),
 			),
+			'no stored statuses - working WPCOM connection, sandbox account' => array(
+				array(
+					WooPaymentsService::ONBOARDING_STEP_PAYMENT_METHODS       => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+					WooPaymentsService::ONBOARDING_STEP_WPCOM_CONNECTION      => WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+					WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT          => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+					WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION => WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				),
+				array(), // no stored profile steps
+				$default_recommended_pms,
+				$expected_pms_state,
+				array_merge( $default_wpcom_connection, array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				) ),
+				array(
+					'has_working_connection' => true,
+					'is_store_connected'     => true,
+					'has_connected_owner'    => true,
+					'is_connection_owner'    => false,
+				),
+				array_merge( $default_account_state, array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				) ),
+			),
 		);
 	}
 
@@ -2129,7 +2155,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'status'           => 'complete',
 					// These two are mirror images of each other.
 					'testDrive'        => $account_state['test_account'] ?? false,
-					'isLive'           => ! $account_state['test_account'] ?? true,
+					'isLive'           => ! ( $account_state['test_account'] ?? false ),
 					'paymentsEnabled'  => true,
 					'detailsSubmitted' => true,
 				)

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -3754,6 +3754,42 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'test_account'      => false,
 				),
 			),
+			'test_account - stored started with valid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+				),
+				array(
+					'is_store_connected'  => false,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'test_account - stored started, failed, and completed with valid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_TEST_ACCOUNT,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_FAILED => $current_time - 5,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
 			'business_verification - clean slate'          => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
@@ -3796,6 +3832,21 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'test_account'      => true,
 				),
 			),
+			'business_verification - nothing stored with valid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				array(),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
 			'business_verification - nothing stored with invalid test account, met requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
@@ -3808,6 +3859,21 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_account'       => true,
 					'has_valid_account' => false,
 					'test_account'      => true,
+				),
+			),
+			'business_verification - nothing stored with invalid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				array(),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
 				),
 			),
 			'business_verification - nothing stored with invalid live account, unmet requirements' => array(
@@ -3930,6 +3996,40 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'test_account'      => true,
 				),
 			),
+			'business_verification - stored started with valid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored started with valid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
 			'business_verification - stored started with invalid test account, unmet requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
@@ -3960,6 +4060,40 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_account'       => true,
 					'has_valid_account' => false,
 					'test_account'      => true,
+				),
+			),
+			'business_verification - stored started with invalid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored started with invalid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
 				),
 			),
 			'business_verification - stored started with invalid live account, unmet requirements' => array(
@@ -4282,6 +4416,40 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'test_account'      => true,
 				),
 			),
+			'business_verification - stored completed with valid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => false,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored completed with valid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
 			'business_verification - stored completed with invalid test account, unmet requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
@@ -4312,6 +4480,40 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_account'       => true,
 					'has_valid_account' => false,
 					'test_account'      => true,
+				),
+			),
+			'business_verification - stored completed with invalid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => false,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored completed with invalid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_NOT_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
 				),
 			),
 			'business_verification - stored completed with invalid live account, unmet requirements' => array(
@@ -4446,6 +4648,42 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'test_account'      => true,
 				),
 			),
+			'business_verification - stored started and completed with valid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => false,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored started and completed with valid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => true,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
 			'business_verification - stored started and completed with invalid test account, unmet requirements' => array(
 				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
 				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
@@ -4478,6 +4716,42 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'has_account'       => true,
 					'has_valid_account' => false,
 					'test_account'      => true,
+				),
+			),
+			'business_verification - stored started and completed with invalid sandbox account, unmet requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => false,
+					'has_connected_owner' => false,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
+				),
+			),
+			'business_verification - stored started and completed with invalid sandbox account, met requirements' => array(
+				WooPaymentsService::ONBOARDING_STEP_BUSINESS_VERIFICATION,
+				WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED,
+				array(
+					WooPaymentsService::ONBOARDING_STEP_STATUS_STARTED => $current_time - 10,
+					WooPaymentsService::ONBOARDING_STEP_STATUS_COMPLETED => $current_time,
+				),
+				array(
+					'is_store_connected'  => true,
+					'has_connected_owner' => true,
+				),
+				array(
+					'has_account'       => true,
+					'has_valid_account' => false,
+					'test_account'      => false,
+					'sandbox_account'   => true,
 				),
 			),
 			'business_verification - stored started and completed with invalid live account, unmet requirements' => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When a sandbox account is in use (i.e. an account onboarded in test mode, not a test-drive account) and the user navigates to the NOX in-context modal, on the business verification step we show the `activate` sub-step so the user can trigger the disablement of the sandbox account and unlock a new onboarding.

This navigation can happen from WooPayments' "Activate payments" task, the Payments > Overview test account notice, or the WooPayments settings notice:
<img width="724" height="668" alt="Screenshot 2025-08-13 at 14 49 07" src="https://github.com/user-attachments/assets/00504bfc-ed07-4990-861f-31636581a82b" />
<img width="1308" height="610" alt="Screenshot 2025-08-13 at 14 49 30" src="https://github.com/user-attachments/assets/68ca2d79-c387-490d-b192-f3fae8cf7185" />
<img width="719" height="891" alt="Screenshot 2025-08-13 at 14 49 59" src="https://github.com/user-attachments/assets/417692cb-0cf6-4791-8c1b-155e4ac9f048" />

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Contributes to WOOPLUG-5298

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Spin up a new JurassicNinja store with WC on this PR's build, WC Beta Tester, WooPayments, and WCPay Dev Tools (here's a [direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&woocommerce-beta-tester&branches.woocommerce=update/WOOPLUG-5298-better-handle-sandbox-accounts-when-activating-payments))
2. Go to the dashboard, click on WooCommerce to open the WC profiler, skip it, and set your store location to `UK`.
3. Go to WCPay Dev Tools and make sure that dev mode is enabled.
4. Go to WooCommerce > Settings > Payments, click on "Complete setup" for WooPayments, and the NOX in-context modal should open.
5. Complete the payment methods and WPCOM connection steps.
6. When presented with the activate payments step, chose "Start accepting payments" to set up a sandbox account.
7. Go through the onboarding flow and complete it.
8. Go to WooCommerce > Home and you should see a "Activate payments" task in the "Things to do next" task list.
9. Click on the task, confirm the modal, and you should be redirected to the NOX in-context modal, with the "Activate payments" step with the `activate` sub-step:
<img width="1412" height="832" alt="Screenshot 2025-08-13 at 14 58 03" src="https://github.com/user-attachments/assets/541845c6-2956-476f-a88c-e852333f0d28" />

10. Click on "Activate payments", the sandbox account should be disabled (you can check your browser's Network for a call to `/wp-json/wc-admin/settings/payments/woopayments/onboarding/step/business_verification/test_account/disable`), and you should be presented with the `business` sub-step:
<img width="1322" height="789" alt="Screenshot 2025-08-13 at 15 00 17" src="https://github.com/user-attachments/assets/06658bd6-6e12-4849-9083-ef311764f56a" />

11. Close the modal and reset the account from the WooPayments context menu.
12. Click "Complete setup" and setup a sandbox account again.
13. Go to Payments > Settings, click the "Activate payments" button in the test account notice, confirm the modal, and you should be redirected to the NOX in-context modal, with the "Activate payments" step with the `activate` sub-step.
14. Go to Payments > Overview, click "activate your WooPayments account" in the test account notice, confirm the modal, and you should be redirected to the NOX in-context modal, with the "Activate payments" step with the `activate` sub-step.
15. Go to WCPay Dev Tools and disable dev mode.
16. Go to WooCommerce > Settings > Payments, click on "Activate payments" and you should be able to start onboarding a live account (notice the lack of test mode notices in the Stripe KYC).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
