### PR TITLE
Add tests for quantity changes

### DIFF
--- a/plugins/woocommerce/changelog/tests-quantity-admin-changes
+++ b/plugins/woocommerce/changelog/tests-quantity-admin-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Added test for quantity handling

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-functions-test.php
@@ -8,7 +8,7 @@
 use Automattic\WooCommerce\Enums\OrderStatus;
 
 /**
- * Class WC_Admin_Functions_Test_Test
+ * Class WC_Admin_Functions_Test
  */
 class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
@@ -87,7 +87,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -99,9 +99,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 10,
 					'refund_total' => 0,
@@ -142,7 +142,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -154,9 +154,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 10,
 					'refund_total' => 0,
@@ -195,7 +195,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -207,9 +207,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 5,
 					'refund_total' => 0,
@@ -250,7 +250,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -262,9 +262,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 5,
 					'refund_total' => 0,
@@ -306,7 +306,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -318,9 +318,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 5,
 					'refund_total' => 0,
@@ -365,7 +365,7 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
 		$order->set_status( OrderStatus::ON_HOLD );
 		$order_item_id = $order->add_product( $product, 10 );
-		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
 
 		// Stocks have not reduced yet.
 		$product = wc_get_product( $product->get_id() );
@@ -377,9 +377,9 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 90, $product->get_stock_quantity() );
 
 		$args = array(
-			'amount'     => 10,
-			'order_id'   => $order->get_id(),
-			'line_items' => array(
+			'amount'         => 10,
+			'order_id'       => $order->get_id(),
+			'line_items'     => array(
 				$order_item_id => array(
 					'qty'          => 5,
 					'refund_total' => 0,
@@ -405,5 +405,134 @@ class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
 
 		// Stocks should remain unchanged from the original order.
 		$this->assertEquals( 90, $product->get_stock_quantity() );
+	}
+
+	/**
+	 * Test adjust line item function that results in negative stock quantities.
+	 * Ensures stock adjustments work correctly when inventory goes negative.
+	 *
+	 * Covers the scenario where:
+	 * 1. Product starts with stock of 1
+	 * 2. Order line item quantity is edited from 2 to 5 (increasing by 3)
+	 * 3. Stock should go negative: 1 - 3 = -2
+	 */
+	public function test_wc_maybe_adjust_line_item_product_stock_negative_inventory() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1 );
+		$product->set_backorders( 'yes' );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order_item_id = $order->add_product( $product, 2 );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
+
+		// Verify initial stock.
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 1, $product->get_stock_quantity() );
+
+		// Actually reduce stock for this order item (simulating initial order processing).
+		wc_maybe_adjust_line_item_product_stock( $order_item, 2 );
+
+		// This should have made stock negative: 1 - 2 = -1.
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $product->get_stock_quantity(), 'Stock should be -1 after reducing by 2 from initial stock of 1' );
+
+		// Now edit the order item quantity from 2 to 5 (increasing by 3).
+		$order_item->set_quantity( 5 );
+		$result = wc_maybe_adjust_line_item_product_stock( $order_item, 5 );
+
+		// Verify the function returned expected change data.
+		$this->assertIsArray( $result, 'Stock adjustment should return change data array' );
+		$this->assertArrayHasKey( 'from', $result, 'Result should contain from value' );
+		$this->assertArrayHasKey( 'to', $result, 'Result should contain to value' );
+
+		// Verify stock was decreased by 3 more (from -1 to -4).
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -4, $product->get_stock_quantity(), 'Stock should be adjusted from -1 to -4 when increasing order quantity by 3' );
+
+		// Verify the _reduced_stock meta was updated.
+		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$this->assertEquals( 5, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
+	}
+
+	/**
+	 * Test adjust line item function - decrease order quantity with already negative stock.
+	 * Tests the scenario where we reduce order quantity and return stock to negative inventory.
+	 */
+	public function test_wc_maybe_adjust_line_item_product_stock_negative_inventory_decrease_quantity() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1 );
+		$product->set_backorders( 'yes' );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order_item_id = $order->add_product( $product, 5 );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
+
+		// Actually reduce stock for this order item (simulating initial order processing).
+		wc_maybe_adjust_line_item_product_stock( $order_item, 5 );
+
+		// This should have made stock negative: 1 - 5 = -4.
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -4, $product->get_stock_quantity(), 'Stock should be -4 after reducing by 5 from initial stock of 1' );
+
+		// Now edit the order item quantity from 5 to 3 (decreasing by 2).
+		$order_item->set_quantity( 3 );
+		$result = wc_maybe_adjust_line_item_product_stock( $order_item, 3 );
+
+		// Verify the function returned expected change data.
+		$this->assertIsArray( $result, 'Stock adjustment should return change data array' );
+
+		// Verify stock was increased by 2 (from -4 to -2).
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -2, $product->get_stock_quantity(), 'Stock should be adjusted from -4 to -2 when decreasing order quantity by 2' );
+
+		// Verify the _reduced_stock meta was updated.
+		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$this->assertEquals( 3, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
+	}
+
+	/**
+	 * Test adjust line item function when backorders are NOT enabled.
+	 * Tests the scenario where stock adjustments are made when backorders are disabled.
+	 * WooCommerce should still handle the stock adjustment calculations correctly.
+	 */
+	public function test_wc_maybe_adjust_line_item_product_stock_no_backorders() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1 );
+		$product->set_backorders( 'no' );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order_item_id = $order->add_product( $product, 2 );
+		$order_item    = new WC_Order_Item_Product( $order_item_id );
+
+		// Actually reduce stock for this order item (simulating initial order processing).
+		wc_maybe_adjust_line_item_product_stock( $order_item, 2 );
+
+		// This should have made stock negative: 1 - 2 = -1 (even with backorders disabled, stock can go negative).
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $product->get_stock_quantity(), 'Stock should be -1 after reducing by 2 from initial stock of 1, even with backorders disabled' );
+
+		// Now edit the order item quantity from 2 to 4 (increasing by 2).
+		$order_item->set_quantity( 4 );
+		$result = wc_maybe_adjust_line_item_product_stock( $order_item, 4 );
+
+		// Verify the function returned expected change data.
+		$this->assertIsArray( $result, 'Stock adjustment should return change data array' );
+
+		// Verify stock was decreased by 2 more (from -1 to -3).
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -3, $product->get_stock_quantity(), 'Stock should be adjusted from -1 to -3 when increasing order quantity by 2, regardless of backorder setting' );
+
+		// Verify the _reduced_stock meta was updated.
+		$order_item = new WC_Order_Item_Product( $order_item_id );
+		$this->assertEquals( 4, $order_item->get_meta( '_reduced_stock', true ), 'Reduced stock meta should be updated to new quantity' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -219,6 +219,7 @@ class QuantityLimitsTests extends TestCase {
 		$quantity_limits      = new QuantityLimits();
 		$limits_when_disabled = $quantity_limits->get_add_to_cart_limits( $product );
 
+		/* Filter the maximum quantity to allow extensions to override the default value for testing purposes. */
 		$expected_max = apply_filters( 'woocommerce_store_api_product_quantity_maximum', 9999, $product );
 		$this->assertEquals( $expected_max, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should ignore product-level manage_stock/stock and use the default maximum' );
 		$this->assertEquals( 1, $limits_when_disabled['minimum'], 'Minimum should remain default when stock management is globally disabled' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -219,7 +219,7 @@ class QuantityLimitsTests extends TestCase {
 		$quantity_limits      = new QuantityLimits();
 		$limits_when_disabled = $quantity_limits->get_add_to_cart_limits( $product );
 
-		/* Filter the maximum quantity to allow extensions to override the default value for testing purposes. */
+		/** Filter the maximum quantity to allow extensions to override the default value for testing purposes. */
 		$expected_max = apply_filters( 'woocommerce_store_api_product_quantity_maximum', 9999, $product );
 		$this->assertEquals( $expected_max, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should ignore product-level manage_stock/stock and use the default maximum' );
 		$this->assertEquals( 1, $limits_when_disabled['minimum'], 'Minimum should remain default when stock management is globally disabled' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -182,6 +182,47 @@ class QuantityLimitsTests extends TestCase {
 	}
 
 	/**
+	 * Test quantity limit when stock management is disabled but product has manage_stock enabled from when it was previously enabled.
+	 * This reproduces the Cart Block bug where products retain their stock quantity as max even when stock management is globally disabled.
+	 */
+	public function test_quantity_limit_when_stock_management_disabled_but_product_has_manage_stock_enabled() {
+		$fixtures = new FixtureData();
+		$product  = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => 10,
+			)
+		);
+
+		// Step 1: Enable stock management globally and on product level.
+		update_option( 'woocommerce_manage_stock', 'yes' );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 10 );
+		$product->set_backorders( 'no' );
+		$product->save();
+
+		// Verify that with stock management enabled, max is limited to stock quantity.
+		$quantity_limits     = new QuantityLimits();
+		$limits_when_enabled = $quantity_limits->get_add_to_cart_limits( $product );
+		$this->assertEquals( 10, $limits_when_enabled['maximum'], 'When stock management is enabled, maximum should be limited to stock quantity' );
+
+		// Step 2: Disable stock management globally but leave product-level manage_stock as true.
+		// This simulates the scenario from import or when stock management was previously enabled.
+		update_option( 'woocommerce_manage_stock', 'no' );
+
+		// The product still has manage_stock = true and stock_quantity = 10.
+		$product = wc_get_product( $product->get_id() );
+		$this->assertTrue( $product->get_manage_stock(), 'Product should still have manage_stock = true' );
+		$this->assertEquals( 10, $product->get_stock_quantity(), 'Product should still have stock quantity of 10' );
+
+		// Step 3: Test quantity limits - this should return 9999, not 10.
+		$quantity_limits      = new QuantityLimits();
+		$limits_when_disabled = $quantity_limits->get_add_to_cart_limits( $product );
+
+		$this->assertEquals( 9999, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should be 9999 regardless of product-level manage_stock setting or stock quantity' );
+	}
+
+	/**
 	 * Test quantity limit when stock quantity is sold individually.
 	 */
 	public function test_quantity_limit_when_stock_quantity_is_sold_individually() {

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -219,7 +219,16 @@ class QuantityLimitsTests extends TestCase {
 		$quantity_limits      = new QuantityLimits();
 		$limits_when_disabled = $quantity_limits->get_add_to_cart_limits( $product );
 
-		/** Filter the maximum quantity to allow extensions to override the default value for testing purposes. */
+		/**
+		 * Filter the maximum quantity to allow extensions to override the default value for testing purposes.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param mixed $value The value being filtered.
+		 * @param \WC_Product $product The product object.
+		 * @param array|null $cart_item The cart item if the product exists in the cart, or null.
+		 * @return mixed
+		 */
 		$expected_max = apply_filters( 'woocommerce_store_api_product_quantity_maximum', 9999, $product );
 		$this->assertEquals( $expected_max, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should ignore product-level manage_stock/stock and use the default maximum' );
 		$this->assertEquals( 1, $limits_when_disabled['minimum'], 'Minimum should remain default when stock management is globally disabled' );

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/QuantityLimitsTests.php
@@ -219,7 +219,10 @@ class QuantityLimitsTests extends TestCase {
 		$quantity_limits      = new QuantityLimits();
 		$limits_when_disabled = $quantity_limits->get_add_to_cart_limits( $product );
 
-		$this->assertEquals( 9999, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should be 9999 regardless of product-level manage_stock setting or stock quantity' );
+		$expected_max = apply_filters( 'woocommerce_store_api_product_quantity_maximum', 9999, $product );
+		$this->assertEquals( $expected_max, $limits_when_disabled['maximum'], 'When stock management is globally disabled, maximum should ignore product-level manage_stock/stock and use the default maximum' );
+		$this->assertEquals( 1, $limits_when_disabled['minimum'], 'Minimum should remain default when stock management is globally disabled' );
+		$this->assertEquals( 1, $limits_when_disabled['multiple_of'], 'Multiple-of should remain default when stock management is globally disabled' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds tests for the fixes from this bug https://linear.app/a8c/issue/WOOPLUG-5238/enabling-stripe-express-checkout-breaks-backorder-quantity-handling-in. The bug was introduced in [this PR](https://github.com/woocommerce/woocommerce/pull/58392/files). The fix was made[ in this PR](https://github.com/woocommerce/woocommerce/pull/58693/files#diff-2c6ae22d8cac91cb50ae2b00742e56a91b3121f1ce63fdd52c5c14a17730da53R206). The bug incorrectly limited quantities when backorders were allowed due to using || instead of &&, and the fix ensured stock limits now apply only when managing stock and backorders aren’t allowed.

I've added tests for  the fix made  [this PR](https://github.com/woocommerce/woocommerce/pull/58693/files#diff-2c6ae22d8cac91cb50ae2b00742e56a91b3121f1ce63fdd52c5c14a17730da53R206) and other backorder related test cases. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->



(For Bug Fixes) Bug introduced in PR # .



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run tests locally
2. Check tests pass in the CI
3.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
