### PR TITLE
Update release bump workflow to use next version for WC class property

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -141,7 +141,7 @@ jobs:
           done
 
           # Update $version property in class-woocommerce.php.
-          sed -i -E "s/public \\\$version = '[0-9]+\.[0-9]+\.[0-9]+';/public \\\$version = '$NEXT_STABLE'\;/" includes/class-woocommerce.php
+          sed -i -E "s/public \\\$version = '[0-9]+\.[0-9]+\.[0-9]+.*';/public \\\$version = '$NEXT_VERSION'\;/" includes/class-woocommerce.php
 
           if git diff --quiet; then
             echo "::error::No changes to commit."


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Given the WC internal version (in `WooCommerce::$version` or as constant `WC_VERSION`) is used for caching templates or versioning assets that this version number matches the plugin version is one of the various checks that need to pass before we deploy any version for internal testing (see p1754985704041959-slack-C07JJG089M0).

Given our recent decision to use RC's for this internal testing moving forward, we need to make sure the "bump version" workflow (used at Feature Freeze time and when building betas, RCs and final version) updates the internal version accordingly.

> [!IMPORTANT]
> This changes does introduce some breakage in core as there are a few places where we don't expect prereleases to be used (such as update routines or tracking data).
> I'm handling those in #60400, but that shouldn't prevent testing or merging of this PR as there aren't any update routines in `10.2.0` and we still have at least 2 weeks to fix any issues that might arise.

Related to #60345.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork the WooCommerce repository and merge this PR into `trunk`.
1. Go to **Code > Branches** and create a new branch named `release/10.2` based off of `trunk`.
3. Test the full "cycle" of version bumps ensuring that `WooCommerce::$version` is also updated accordingly:

   1. Run **Actions > Release: Bump version number** with `release/10.2` as _Release branch_ and `beta` as _Type of version bump_. Confirm that the workflow succeeds and creates a PR changing the version numbers to `10.2.0-beta.1`. Merge this PR.
   1. Run **Actions > Release: Bump version number** with `release/10.2` as _Release branch_ and `beta` as _Type of version bump_. Confirm that the workflow succeeds and creates a PR changing the version numbers to `10.2.0-beta.2`. Merge this PR.
   1. Run **Actions > Release: Bump version number** with `release/10.2` as _Release branch_ and `rc` as _Type of version bump_. Confirm that the workflow succeeds and creates a PR changing the version numbers to `10.2.0-rc.1`. Merge this PR.
   1. Run **Actions > Release: Bump version number** with `release/10.2` as _Release branch_ and `stable` as _Type of version bump_. Confirm that the workflow succeeds and creates a PR changing the version numbers to `10.2.0`.
1. Run **Actions > Release: Bump version number** with `trunk` as _Release branch_ and `dev` as _Type of version bump_. Confirm that the workflow succeeds and creates a PR changing the version numbers to `10.3.0-dev`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>