### PR TITLE
Switch to correct action name for recurring actions and add wrappers for risky actions

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5229-prevent-generate_category_lookup_table-from-running-during
+++ b/plugins/woocommerce/changelog/wooplug-5229-prevent-generate_category_lookup_table-from-running-during
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure recurring actions are registered and dependent classes are loaded as needed

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1390,6 +1390,7 @@ final class WooCommerce {
 	 * to prevent errors, and load the classes where the callback is added.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function add_recurring_action_wrappers() {
 		add_action( 'woocommerce_tracker_send_event_wrapper', array( $this, 'add_woocommerce_tracker_send_event_wrapper' ) );
@@ -1402,6 +1403,7 @@ final class WooCommerce {
 	 * Unschedule unwrapped actions that may have been added to the site.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function unschedule_unwrapped_actions() {
 		// Unschedule the unwrapped actions.
@@ -1416,6 +1418,7 @@ final class WooCommerce {
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function add_woocommerce_tracker_send_event_wrapper() {
 		if ( true !== wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
@@ -1438,6 +1441,7 @@ final class WooCommerce {
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function add_wc_admin_daily_wrapper() {
 		try {
@@ -1456,6 +1460,7 @@ final class WooCommerce {
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function add_generate_category_lookup_table_wrapper() {
 		try {
@@ -1474,6 +1479,7 @@ final class WooCommerce {
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
 	 * @return void
+	 * @internal For exclusive usage of WooCommerce core, backwards compatibility not guaranteed.
 	 */
 	public function add_woocommerce_cleanup_rate_limits_wrapper() {
 		try {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1436,9 +1436,11 @@ final class WooCommerce {
 	}
 
 	/**
-	 * Wrapper for the `wc_admin_daily` action. This prevents the event failing when the class is not loaded.
+	 * Wrapper for the `generate_category_lookup_table` action. This prevents the event failing when the class is not loaded.
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
+	 * @return void
+	 */
 	 * @return void
 	 */
 	public function add_generate_category_lookup_table_wrapper() {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1399,6 +1399,7 @@ final class WooCommerce {
 	public function add_recurring_action_wrappers() {
 		add_action( 'woocommerce_tracker_send_event_wrapper', array( $this, 'add_woocommerce_tracker_send_event_wrapper' ) );
 		add_action( 'wc_admin_daily_wrapper', array( $this, 'add_wc_admin_daily_wrapper' ) );
+		add_action( 'generate_category_lookup_table_wrapper', array( $this, 'add_generate_category_lookup_table_wrapper' ) );
 	}
 
 	/**
@@ -1428,6 +1429,20 @@ final class WooCommerce {
 		}
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'wc_admin_daily' );
+	}
+
+	/**
+	 * Wrapper for the `wc_admin_daily` action. This prevents the event failing when the class is not loaded.
+	 * It loads the class if it exists, and then calls the actual action.
+	 *
+	 * @return void
+	 */
+	public function add_generate_category_lookup_table_wrapper() {
+		if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
+			\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance();
+		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'generate_category_lookup_table' );
 	}
 
 	/**
@@ -1495,7 +1510,7 @@ final class WooCommerce {
 		as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
 
 		// Note: this is potentially redundant when the core package exists.
-		as_schedule_single_action( time() + 10, 'generate_category_lookup_table', array(), 'woocommerce', true );
+		as_schedule_single_action( time() + 10, 'generate_category_lookup_table_wrapper', array(), 'woocommerce', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -310,7 +310,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
-		add_action( 'action_scheduler_schedule_recurring_actions', array( $this, 'register_recurring_actions' ) );
+		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'register_recurring_actions' ) );
 
 		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1503,14 +1503,8 @@ final class WooCommerce {
 
 		as_schedule_recurring_action( time() + MINUTE_IN_SECONDS, 15 * DAY_IN_SECONDS, 'woocommerce_geoip_updater', array(), 'woocommerce', true );
 
-		/**
-		 * How frequent to schedule the tracker send event.
-		 *
-		 * @since 2.3.0
-		 */
-		$tracker_recurrence = apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' );
-		$core_internals     = wp_get_schedules();
-		as_schedule_recurring_action( time() + 10, $core_internals[ $tracker_recurrence ]['interval'], 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce', true );
+		// Schedule the action to send tracking events if tracking is enabled.
+		$this->schedule_tracking_action();
 
 		// Schedule daily cleanup rate limits at 3 AM.
 
@@ -1538,10 +1532,29 @@ final class WooCommerce {
 		if ( false === wc_string_to_bool( $value ) ) {
 			as_unschedule_all_actions( 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce' );
 		}
-		if ( wc_string_to_bool( $value ) ) {
-			// Schedule the first run of the tracker send event.
-			as_schedule_single_action( time() + 10, 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce', true );
+		if ( true === wc_string_to_bool( $value ) ) {
+			$this->schedule_tracking_action();
 		}
+	}
+
+	/**
+	 * Schedule the action to send tracking events if tracking is enabled.
+	 *
+	 * @return void
+	 */
+	public function schedule_tracking_action() {
+		if ( true !== wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
+			return;
+		}
+
+		/**
+		 * How frequent to schedule the tracker send event.
+		 *
+		 * @since 2.3.0
+		 */
+		$tracker_recurrence = apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' );
+		$core_internals     = wp_get_schedules();
+		as_schedule_recurring_action( time() + 10, $core_internals[ $tracker_recurrence ]['interval'], 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce', true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1568,8 +1568,7 @@ final class WooCommerce {
 		}
 		if ( false === wc_string_to_bool( $value ) ) {
 			as_unschedule_all_actions( 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce' );
-		}
-		if ( true === wc_string_to_bool( $value ) ) {
+		} else {
 			$this->schedule_tracking_action();
 		}
 	}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1433,12 +1433,15 @@ final class WooCommerce {
 		try {
 			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\Events::class ) ) {
 				\Automattic\WooCommerce\Internal\Admin\Events::instance();
+			} else {
+				return;
 			}
-			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-			do_action( 'wc_admin_daily' );
-		} catch ( Exception $e ) {
-			wc_get_logger()->error( 'Error in admin daily wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
+		} catch ( Throwable $e ) {
+			wc_get_logger()->error( 'Error initializing wc_admin_daily: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
+			return;
 		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'wc_admin_daily' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1405,16 +1405,22 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_woocommerce_tracker_send_event_wrapper() {
-		try {
-			if ( true === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
-				include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
-				WC_Tracker::init();
-				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-				do_action( 'woocommerce_tracker_send_event' );
-			}
-		} catch ( Exception $e ) {
-			wc_get_logger()->error( 'Error in tracker wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
+		if ( true !== wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
+			return;
 		}
+		try {
+			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
+			if ( ! class_exists( 'WC_Tracker' ) ) {
+				wc_get_logger()->warning( 'WC_Tracker class not found; skipping tracker send.', array( 'source' => 'woocommerce-scheduled-actions' ) );
+				return;
+			}
+			WC_Tracker::init();
+		} catch ( Throwable $e ) {
+			wc_get_logger()->error( 'Error initializing WC_Tracker: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
+			return;
+		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'woocommerce_tracker_send_event' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1410,14 +1410,11 @@ final class WooCommerce {
 		}
 		try {
 			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
-			if ( ! class_exists( 'WC_Tracker' ) ) {
-				wc_get_logger()->warning( 'WC_Tracker class not found; skipping tracker send.', array( 'source' => 'woocommerce-scheduled-actions' ) );
-				return;
+			if ( class_exists( WC_Tracker::class ) ) {
+				WC_Tracker::init();
 			}
-			WC_Tracker::init();
 		} catch ( Throwable $e ) {
 			wc_get_logger()->error( 'Error initializing WC_Tracker: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
-			return;
 		}
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_tracker_send_event' );
@@ -1433,12 +1430,9 @@ final class WooCommerce {
 		try {
 			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\Events::class ) ) {
 				\Automattic\WooCommerce\Internal\Admin\Events::instance();
-			} else {
-				return;
 			}
 		} catch ( Throwable $e ) {
 			wc_get_logger()->error( 'Error initializing wc_admin_daily: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
-			return;
 		}
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'wc_admin_daily' );
@@ -1455,11 +1449,11 @@ final class WooCommerce {
 			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
 				\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance();
 			}
-			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-			do_action( 'generate_category_lookup_table' );
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			wc_get_logger()->error( 'Error in category lookup wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
 		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'generate_category_lookup_table' );
 	}
 
 	/**
@@ -1471,12 +1465,14 @@ final class WooCommerce {
 	public function add_woocommerce_cleanup_rate_limits_wrapper() {
 		try {
 			include_once WC_ABSPATH . 'includes/class-wc-rate-limiter.php';
-			WC_Rate_Limiter::init();
-			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-			do_action( 'woocommerce_cleanup_rate_limits' );
-		} catch ( Exception $e ) {
+			if ( class_exists( WC_Rate_Limiter::class ) ) {
+				WC_Rate_Limiter::init();
+			}
+		} catch ( Throwable $e ) {
 			wc_get_logger()->error( 'Error in rate limiter cleanup wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
 		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'woocommerce_cleanup_rate_limits' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1399,6 +1399,19 @@ final class WooCommerce {
 	}
 
 	/**
+	 * Unschedule unwrapped actions that may have been added to the site.
+	 *
+	 * @return void
+	 */
+	public function unschedule_unwrapped_actions() {
+		// Unschedule the unwrapped actions.
+		as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
+		as_unschedule_all_actions( 'wc_admin_daily' );
+		as_unschedule_all_actions( 'generate_category_lookup_table' );
+		as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
+	}
+
+	/**
 	 * Wrapper for the `woocommerce_tracker_send_event` action. This prevents the event failing when the class is not loaded.
 	 * It loads the class if it exists, and then calls the actual action.
 	 *
@@ -1479,6 +1492,9 @@ final class WooCommerce {
 	 * Register recurring actions.
 	 */
 	public function register_recurring_actions() {
+		// Remove any unwrapped actions that may have been scheduled before scheduling the new wrapped ones.
+		$this->unschedule_unwrapped_actions();
+
 		// Check if Action Scheduler is available.
 		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_schedule_single_action' ) ) {
 			return;

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -312,6 +312,7 @@ final class WooCommerce {
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'maybe_schedule_tracking_action' ), 10, 2 );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'register_recurring_actions' ) );
+		add_action( 'action_scheduler_init', array( $this, 'add_recurring_action_wrappers' ) );
 
 		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
 		add_filter( 'wp_plugin_dependencies_slug', array( $this, 'convert_woocommerce_slug' ) );
@@ -1390,6 +1391,31 @@ final class WooCommerce {
 	}
 
 	/**
+	 * For actions that may fail at execution time due to missing callbacks, register the recurring action in a wrapper
+	 * to prevent errors, and load the classes where the callback is added.
+	 *
+	 * @return void
+	 */
+	public function add_recurring_action_wrappers() {
+		add_action( 'woocommerce_tracker_send_event_wrapper', array( $this, 'add_woocommerce_tracker_send_event_wrapper' ) );
+	}
+
+	/**
+	 * Wrapper for the `woocommerce_tracker_send_event` action. This prevents the event failing when the class is not loaded.
+	 * It loads the class if it exists, and then calls the actual action.
+	 *
+	 * @return void
+	 */
+	public function add_woocommerce_tracker_send_event_wrapper() {
+		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
+			WC_Tracker::init();
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'woocommerce_tracker_send_event' );
+		}
+	}
+
+	/**
 	 * Register recurring actions.
 	 */
 	public function register_recurring_actions() {
@@ -1445,7 +1471,7 @@ final class WooCommerce {
 		 */
 		$tracker_recurrence = apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' );
 		$core_internals     = wp_get_schedules();
-		as_schedule_recurring_action( time() + 10, $core_internals[ $tracker_recurrence ]['interval'], 'woocommerce_tracker_send_event', array(), 'woocommerce', true );
+		as_schedule_recurring_action( time() + 10, $core_internals[ $tracker_recurrence ]['interval'], 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce', true );
 
 		// Schedule daily cleanup rate limits at 3 AM.
 
@@ -1471,11 +1497,11 @@ final class WooCommerce {
 			return;
 		}
 		if ( false === wc_string_to_bool( $value ) ) {
-			as_unschedule_all_actions( 'woocommerce_tracker_send_event', array(), 'woocommerce' );
+			as_unschedule_all_actions( 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce' );
 		}
 		if ( wc_string_to_bool( $value ) ) {
 			// Schedule the first run of the tracker send event.
-			as_schedule_single_action( time() + 10, 'woocommerce_tracker_send_event', array(), 'woocommerce', true );
+			as_schedule_single_action( time() + 10, 'woocommerce_tracker_send_event_wrapper', array(), 'woocommerce', true );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1543,7 +1543,7 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function schedule_tracking_action() {
-		if ( true !== wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
+		if ( false === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1398,6 +1398,7 @@ final class WooCommerce {
 	 */
 	public function add_recurring_action_wrappers() {
 		add_action( 'woocommerce_tracker_send_event_wrapper', array( $this, 'add_woocommerce_tracker_send_event_wrapper' ) );
+		add_action( 'wc_admin_daily_wrapper', array( $this, 'add_wc_admin_daily_wrapper' ) );
 	}
 
 	/**
@@ -1413,6 +1414,20 @@ final class WooCommerce {
 			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 			do_action( 'woocommerce_tracker_send_event' );
 		}
+	}
+
+	/**
+	 * Wrapper for the `wc_admin_daily` action. This prevents the event failing when the class is not loaded.
+	 * It loads the class if it exists, and then calls the actual action.
+	 *
+	 * @return void
+	 */
+	public function add_wc_admin_daily_wrapper() {
+		if ( class_exists( \Automattic\WooCommerce\Internal\Admin\Events::class ) ) {
+			\Automattic\WooCommerce\Internal\Admin\Events::instance();
+		}
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'wc_admin_daily' );
 	}
 
 	/**
@@ -1477,7 +1492,7 @@ final class WooCommerce {
 
 		as_schedule_recurring_action( time() + ( 3 * HOUR_IN_SECONDS ), DAY_IN_SECONDS, 'woocommerce_cleanup_rate_limits', array(), 'woocommerce', true );
 
-		as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'wc_admin_daily', array(), 'woocommerce', true );
+		as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
 
 		// Note: this is potentially redundant when the core package exists.
 		as_schedule_single_action( time() + 10, 'generate_category_lookup_table', array(), 'woocommerce', true );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -310,7 +310,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
-		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'maybe_schedule_tracking_action' ), 10, 2 );
+		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'handle_tracking_setting_change' ), 10, 2 );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'register_recurring_actions' ) );
 		add_action( 'action_scheduler_init', array( $this, 'add_recurring_action_wrappers' ) );
 
@@ -1536,7 +1536,7 @@ final class WooCommerce {
 	 *
 	 * @return void
 	 */
-	public function maybe_schedule_tracking_action( $old_value, $value ) {
+	public function handle_tracking_setting_change( $old_value, $value ) {
 		if ( $old_value === $value ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -760,11 +760,6 @@ final class WooCommerce {
 			$this->frontend_includes();
 		}
 
-		if ( $this->is_request( 'cron' ) && 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
-			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
-			WC_Tracker::init();
-		}
-
 		$this->theme_support_includes();
 		$this->query = new WC_Query();
 	}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1405,7 +1405,7 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_woocommerce_tracker_send_event_wrapper() {
-		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+		if ( true === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
 			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
 			WC_Tracker::init();
 			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -310,6 +310,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_remote_variant' ) );
 		add_action( 'woocommerce_newly_installed', 'wc_set_hooked_blocks_version', 10 );
 		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'get_tracking_history' ), 10, 2 );
+		add_action( 'update_option_woocommerce_allow_tracking', array( $this, 'maybe_schedule_tracking_action' ), 10, 2 );
 		add_action( 'action_scheduler_ensure_recurring_actions', array( $this, 'register_recurring_actions' ) );
 
 		add_filter( 'robots_txt', array( $this, 'robots_txt' ) );
@@ -1454,6 +1455,28 @@ final class WooCommerce {
 
 		// Note: this is potentially redundant when the core package exists.
 		as_schedule_single_action( time() + 10, 'generate_category_lookup_table', array(), 'woocommerce', true );
+	}
+
+	/**
+	 * Schedule the action send tracking events if tracking is enabled, or unregister it if tracking is disabled.
+	 * This will be called when the `woocommerce_allow_tracking` option is updated.
+	 *
+	 * @param string $old_value The old value of the `woocommerce_allow_tracking` option.
+	 * @param string $value     The new value of the `woocommerce_allow_tracking` option.
+	 *
+	 * @return void
+	 */
+	public function maybe_schedule_tracking_action( $old_value, $value ) {
+		if ( $old_value === $value ) {
+			return;
+		}
+		if ( false === wc_string_to_bool( $value ) ) {
+			as_unschedule_all_actions( 'woocommerce_tracker_send_event', array(), 'woocommerce' );
+		}
+		if ( wc_string_to_bool( $value ) ) {
+			// Schedule the first run of the tracker send event.
+			as_schedule_single_action( time() + 10, 'woocommerce_tracker_send_event', array(), 'woocommerce', true );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1400,6 +1400,7 @@ final class WooCommerce {
 		add_action( 'woocommerce_tracker_send_event_wrapper', array( $this, 'add_woocommerce_tracker_send_event_wrapper' ) );
 		add_action( 'wc_admin_daily_wrapper', array( $this, 'add_wc_admin_daily_wrapper' ) );
 		add_action( 'generate_category_lookup_table_wrapper', array( $this, 'add_generate_category_lookup_table_wrapper' ) );
+		add_action( 'woocommerce_cleanup_rate_limits_wrapper', array( $this, 'add_woocommerce_cleanup_rate_limits_wrapper' ) );
 	}
 
 	/**
@@ -1443,6 +1444,19 @@ final class WooCommerce {
 		}
 		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'generate_category_lookup_table' );
+	}
+
+	/**
+	 * Wrapper for the `woocommerce_cleanup_rate_limits` action. This prevents the event failing when the class is not loaded.
+	 * It loads the class if it exists, and then calls the actual action.
+	 *
+	 * @return void
+	 */
+	public function add_woocommerce_cleanup_rate_limits_wrapper() {
+		include_once WC_ABSPATH . 'includes/class-wc-rate-limiter.php';
+		WC_Rate_Limiter::init();
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'woocommerce_cleanup_rate_limits' );
 	}
 
 	/**
@@ -1505,7 +1519,7 @@ final class WooCommerce {
 
 		// Schedule daily cleanup rate limits at 3 AM.
 
-		as_schedule_recurring_action( time() + ( 3 * HOUR_IN_SECONDS ), DAY_IN_SECONDS, 'woocommerce_cleanup_rate_limits', array(), 'woocommerce', true );
+		as_schedule_recurring_action( time() + ( 3 * HOUR_IN_SECONDS ), DAY_IN_SECONDS, 'woocommerce_cleanup_rate_limits_wrapper', array(), 'woocommerce', true );
 
 		as_schedule_recurring_action( time(), DAY_IN_SECONDS, 'wc_admin_daily_wrapper', array(), 'woocommerce', true );
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1405,11 +1405,15 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_woocommerce_tracker_send_event_wrapper() {
-		if ( true === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
-			include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
-			WC_Tracker::init();
-			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-			do_action( 'woocommerce_tracker_send_event' );
+		try {
+			if ( true === wc_string_to_bool( get_option( 'woocommerce_allow_tracking', 'no' ) ) ) {
+				include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
+				WC_Tracker::init();
+				// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+				do_action( 'woocommerce_tracker_send_event' );
+			}
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error in tracker wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
 		}
 	}
 
@@ -1420,11 +1424,15 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_wc_admin_daily_wrapper() {
-		if ( class_exists( \Automattic\WooCommerce\Internal\Admin\Events::class ) ) {
-			\Automattic\WooCommerce\Internal\Admin\Events::instance();
+		try {
+			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\Events::class ) ) {
+				\Automattic\WooCommerce\Internal\Admin\Events::instance();
+			}
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'wc_admin_daily' );
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error in admin daily wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
 		}
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-		do_action( 'wc_admin_daily' );
 	}
 
 	/**
@@ -1434,11 +1442,15 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_generate_category_lookup_table_wrapper() {
-		if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
-			\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance();
+		try {
+			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {
+				\Automattic\WooCommerce\Internal\Admin\CategoryLookup::instance();
+			}
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'generate_category_lookup_table' );
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error in category lookup wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
 		}
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-		do_action( 'generate_category_lookup_table' );
 	}
 
 	/**
@@ -1448,10 +1460,14 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function add_woocommerce_cleanup_rate_limits_wrapper() {
-		include_once WC_ABSPATH . 'includes/class-wc-rate-limiter.php';
-		WC_Rate_Limiter::init();
-		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
-		do_action( 'woocommerce_cleanup_rate_limits' );
+		try {
+			include_once WC_ABSPATH . 'includes/class-wc-rate-limiter.php';
+			WC_Rate_Limiter::init();
+			// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
+			do_action( 'woocommerce_cleanup_rate_limits' );
+		} catch ( Exception $e ) {
+			wc_get_logger()->error( 'Error in rate limiter cleanup wrapper: ' . $e->getMessage(), array( 'source' => 'woocommerce-scheduled-actions' ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -1450,8 +1450,6 @@ final class WooCommerce {
 	 *
 	 * @return void
 	 */
-	 * @return void
-	 */
 	public function add_generate_category_lookup_table_wrapper() {
 		try {
 			if ( class_exists( \Automattic\WooCommerce\Internal\Admin\CategoryLookup::class ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Unit tests for WooCommerce recurring actions.
+ *
+ * @package WooCommerce\Tests
+ */
+
+/**
+ * Class WC_Recurring_Actions_Test
+ */
+class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up the test environment.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Clear any existing scheduled actions first.
+		$this->clear_scheduled_actions();
+	}
+
+	/**
+	 * Test that recurring actions are properly enqueued when ensure_recurring_actions is called.
+	 */
+	public function test_recurring_actions_are_enqueued() {
+		// Allow tracking for the purpose of this test.
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		// Clear any existing scheduled actions first.
+		$this->clear_scheduled_actions();
+
+		// Ensure recurring actions are scheduled.
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'action_scheduler_ensure_recurring_actions' );
+
+		// Check that all wrapper actions are scheduled.
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
+			'Tracker send event wrapper should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'wc_admin_daily_wrapper' ),
+			'Admin daily wrapper should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'generate_category_lookup_table_wrapper' ),
+			'Category lookup table wrapper should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_cleanup_rate_limits_wrapper' ),
+			'Rate limits cleanup wrapper should be scheduled'
+		);
+
+		// Check that other core recurring actions are scheduled.
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_scheduled_sales' ),
+			'Scheduled sales should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_cleanup_personal_data' ),
+			'Personal data cleanup should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_cleanup_logs' ),
+			'Log cleanup should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_cleanup_sessions' ),
+			'Session cleanup should be scheduled'
+		);
+
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_geoip_updater' ),
+			'GeoIP updater should be scheduled'
+		);
+	}
+
+	/**
+	 * Test that wrapper actions execute without fatal errors even when tracking is disabled.
+	 */
+	public function test_tracker_wrapper_not_added_when_tracking_disabled() {
+		// Disable tracking.
+		update_option( 'woocommerce_allow_tracking', 'no' );
+		$this->assertFalse(
+			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
+			'Tracker send event wrapper should be scheduled'
+		);
+	}
+
+	/**
+	 * Test that wrapper actions execute without fatal errors even when tracking is disabled.
+	 */
+	public function test_tracker_wrapper_removed_added_when_tracking_disabled() {
+		// Enable tracking.
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		$this->assertTrue(
+			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
+			'Tracker send event wrapper should be scheduled'
+		);
+
+		// Disable tracking.
+		update_option( 'woocommerce_allow_tracking', 'no' );
+		$this->assertFalse(
+			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
+			'Tracker send event wrapper should not be scheduled'
+		);
+	}
+
+	/**
+	 * Helper method to clear all scheduled actions.
+	 */
+	private function clear_scheduled_actions() {
+		$actions = array(
+			// Wrapper actions
+			'woocommerce_tracker_send_event_wrapper',
+			'wc_admin_daily_wrapper',
+			'generate_category_lookup_table_wrapper',
+			'woocommerce_cleanup_rate_limits_wrapper',
+			// Core recurring actions
+			'woocommerce_scheduled_sales',
+			'woocommerce_cleanup_personal_data',
+			'woocommerce_cleanup_logs',
+			'woocommerce_cleanup_sessions',
+			'woocommerce_geoip_updater',
+		);
+
+		foreach ( $actions as $action ) {
+			while ( as_has_scheduled_action( $action ) ) {
+				as_unschedule_all_actions( $action );
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -95,6 +95,13 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
 			'Tracker send event wrapper should be scheduled'
 		);
+		// Validate the wrapper is not scheduled when ensure_recurring_actions is called with tracking disabled.
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'action_scheduler_ensure_recurring_actions' );
+		$this->assertFalse(
+			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
+			'Tracker send event wrapper should not be scheduled'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -34,7 +34,6 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'action_scheduler_ensure_recurring_actions' );
 
-		// Check that all wrapper actions are scheduled.
 		$this->assertTrue(
 			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
 			'Tracker send event wrapper should be scheduled'
@@ -55,7 +54,6 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 			'Rate limits cleanup wrapper should be scheduled'
 		);
 
-		// Check that other core recurring actions are scheduled.
 		$this->assertTrue(
 			as_has_scheduled_action( 'woocommerce_scheduled_sales' ),
 			'Scheduled sales should be scheduled'
@@ -83,7 +81,7 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wrapper actions execute without fatal errors even when tracking is disabled.
+	 * Test that the tracker wrapper is not added when tracking is disabled.
 	 */
 	public function test_tracker_wrapper_not_added_when_tracking_disabled() {
 		// Disable tracking.
@@ -95,7 +93,7 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that wrapper actions execute without fatal errors even when tracking is disabled.
+	 * Test that tracker wrapper is removed when tracking is disabled and added back when tracking is enabled.
 	 */
 	public function test_tracker_wrapper_removed_added_when_tracking_disabled() {
 		// Enable tracking.
@@ -118,12 +116,10 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	 */
 	private function clear_scheduled_actions() {
 		$actions = array(
-			// Wrapper actions
 			'woocommerce_tracker_send_event_wrapper',
 			'wc_admin_daily_wrapper',
 			'generate_category_lookup_table_wrapper',
 			'woocommerce_cleanup_rate_limits_wrapper',
-			// Core recurring actions
 			'woocommerce_scheduled_sales',
 			'woocommerce_cleanup_personal_data',
 			'woocommerce_cleanup_logs',

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types=1 );
 /**
  * Unit tests for WooCommerce recurring actions.
  *

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -25,6 +25,11 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	 * Test that recurring actions are properly enqueued when ensure_recurring_actions is called.
 	 */
 	public function test_recurring_actions_are_enqueued() {
+		$this->assertTrue(
+			as_supports( 'ensure_recurring_actions_hook' ),
+			'Action Scheduler must support ensure_recurring_actions_hook for WooCommerce recurring actions to work properly'
+		);
+
 		// Allow tracking for the purpose of this test.
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 		// Clear any existing scheduled actions first.

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -108,7 +108,7 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	/**
 	 * Test that tracker wrapper is removed when tracking is disabled and added back when tracking is enabled.
 	 */
-	public function test_tracker_wrapper_removed_added_when_tracking_disabled() {
+	public function test_tracker_wrapper_added_then_removed_on_tracking_toggle() {
 		// Ensure we transition from "no" -> "yes" so update_option hooks fire.
 		update_option( 'woocommerce_allow_tracking', 'no' );
 		// Enable tracking.
@@ -142,9 +142,7 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 		);
 
 		foreach ( $actions as $action ) {
-			while ( as_has_scheduled_action( $action ) ) {
-				as_unschedule_all_actions( $action );
-			}
+			as_unschedule_all_actions( $action );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -94,7 +94,7 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_allow_tracking', 'no' );
 		$this->assertFalse(
 			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
-			'Tracker send event wrapper should be scheduled'
+			'Tracker send event wrapper should not be scheduled'
 		);
 		// Validate the wrapper is not scheduled when ensure_recurring_actions is called with tracking disabled.
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment

--- a/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-recurring-actions-test.php
@@ -101,13 +101,14 @@ class WC_Recurring_Actions_Test extends WC_Unit_Test_Case {
 	 * Test that tracker wrapper is removed when tracking is disabled and added back when tracking is enabled.
 	 */
 	public function test_tracker_wrapper_removed_added_when_tracking_disabled() {
+		// Ensure we transition from "no" -> "yes" so update_option hooks fire.
+		update_option( 'woocommerce_allow_tracking', 'no' );
 		// Enable tracking.
 		update_option( 'woocommerce_allow_tracking', 'yes' );
 		$this->assertTrue(
 			as_has_scheduled_action( 'woocommerce_tracker_send_event_wrapper' ),
 			'Tracker send event wrapper should be scheduled'
 		);
-
 		// Disable tracking.
 		update_option( 'woocommerce_allow_tracking', 'no' );
 		$this->assertFalse(

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -27,27 +27,19 @@ wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
 
-add_action(
-	'action_scheduler_init',
-	function () {
-		// Clear Action Scheduler events.
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-				as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
-				as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
-				as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );
-				as_unschedule_all_actions( 'woocommerce_cleanup_personal_data' );
-				as_unschedule_all_actions( 'woocommerce_cleanup_logs' );
-				as_unschedule_all_actions( 'woocommerce_geoip_updater' );
-				as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
-				as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
-				as_unschedule_all_actions( 'wc_admin_daily' );
-				as_unschedule_all_actions( 'generate_category_lookup_table' );
-				as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
-		}
-	},
-	10,
-	0
-);
+if ( function_exists( 'as_unschedule_all_actions' ) && ActionScheduler::is_initialized() ) {
+	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
+	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_personal_data' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_logs' );
+	as_unschedule_all_actions( 'woocommerce_geoip_updater' );
+	as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
+	as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
+	as_unschedule_all_actions( 'wc_admin_daily' );
+	as_unschedule_all_actions( 'generate_category_lookup_table' );
+	as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
+}
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -27,7 +27,7 @@ wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
 
-if ( function_exists( 'as_unschedule_all_actions' ) && ActionScheduler::is_initialized() ) {
+if ( class_exists( ActionScheduler::class ) && ActionScheduler::is_initialized() && function_exists( 'as_unschedule_all_actions' ) ) {
 	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
 	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
 	as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -27,20 +27,27 @@ wp_clear_scheduled_hook( 'wc_admin_daily' );
 wp_clear_scheduled_hook( 'generate_category_lookup_table' );
 wp_clear_scheduled_hook( 'wc_admin_unsnooze_admin_notes' );
 
-// Clear Action Scheduler events.
-if ( function_exists( 'as_unschedule_all_actions' ) ) {
-	as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
-	as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
-	as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );
-	as_unschedule_all_actions( 'woocommerce_cleanup_personal_data' );
-	as_unschedule_all_actions( 'woocommerce_cleanup_logs' );
-	as_unschedule_all_actions( 'woocommerce_geoip_updater' );
-	as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
-	as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
-	as_unschedule_all_actions( 'wc_admin_daily' );
-	as_unschedule_all_actions( 'generate_category_lookup_table' );
-	as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
-}
+add_action(
+	'action_scheduler_init',
+	function () {
+		// Clear Action Scheduler events.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( 'woocommerce_scheduled_sales' );
+				as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+				as_unschedule_all_actions( 'woocommerce_cleanup_sessions' );
+				as_unschedule_all_actions( 'woocommerce_cleanup_personal_data' );
+				as_unschedule_all_actions( 'woocommerce_cleanup_logs' );
+				as_unschedule_all_actions( 'woocommerce_geoip_updater' );
+				as_unschedule_all_actions( 'woocommerce_tracker_send_event' );
+				as_unschedule_all_actions( 'woocommerce_cleanup_rate_limits' );
+				as_unschedule_all_actions( 'wc_admin_daily' );
+				as_unschedule_all_actions( 'generate_category_lookup_table' );
+				as_unschedule_all_actions( 'wc_admin_unsnooze_admin_notes' );
+		}
+	},
+	10,
+	0
+);
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some recurring actions could fail if there is no callback registered for them. The events this could happen for are:
- `woocommerce_tracker_send_event`
- `wc_admin_daily`
- `generate_category_lookup_table`
- `woocommerce_cleanup_rate_limits`

This will happen if the class is not loaded when processing the action scheduler queue. To fix this I created wrapper actions that will always exist (preventing errors). These wrapper actions load the required class and then do the real action. Errors in the real action would still be caught.

Another fix made here was to update the action used to register recurring actions to `action_scheduler_ensure_recurring_actions`  

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

(For Bug Fixes) Bug introduced in PR #59325


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WC -> Settings -> Advanced -> WooCommerce.com and check the "Allow usage of WooCommerce to be tracked"
2. Go to WC -> Status -> Scheduled Actions -> Failed and bulk delete all events.
3. Go to the Pending tab and clear all pending and failed events, then run the `action_scheduler_run_recurring_actions_schedule_hook` action.
4. You should have several pending events now. There should be four events suffixed with `_wrapper`.
5.  Run each event in pending once and ensure no failed events occur.
6. For the wrapped events you will need to modify code to ensure this is working as expected. Run the following events with the code changes
  - Add `throw new Exception('wc_admin_daily');` in [`do_wc_admin_daily`](https://github.com/woocommerce/woocommerce/blob/778b0ca6395a1ff605e6ad60ed32d9eb2c9942cb/plugins/woocommerce/src/Internal/Admin/Events.php#L138) - run `wc_admin_daily_wrapper` and ensure it fails with your exception.
  - Add `throw new Exception('send tracking data');` in [`send_tracking_data`](https://github.com/woocommerce/woocommerce/blob/77164437a2a425544c4dd6c06d5b82f66108b015/plugins/woocommerce/includes/class-wc-tracker.php#L50) - run `woocommerce_tracker_send_event_wrapper` and ensure it fails with your exception.
  - Add `throw new Exception('generate category lookup table');` in [`regenerate`](https://github.com/woocommerce/woocommerce/blob/b37421fb981b121ba8956f46bdd06f69cf4a1358/plugins/woocommerce/src/Internal/Admin/CategoryLookup.php#L63) - run `generate_category_lookup_table_wrapper` and ensure it fails with your exception.
  - Add `throw new Exception('woocommerce_cleanup_rate_limits');` in [`cleanup`](https://github.com/woocommerce/woocommerce/blob/433bd34b18e95ca9064135e1f06995f27af42704/plugins/woocommerce/includes/class-wc-rate-limiter.php#L158) - run `woocommerce_cleanup_rate_limits_wrapper` and ensure it fails with your exception.

7. Remove all of the code changes made from the steps above.
8. Go to the pending tab and notice `woocommerce_tracker_send_event_wrapper` is pending.
9. Go to WC -> Settings -> Advanced -> WooCommerce.com and uncheck the "Allow usage of WooCommerce to be tracked"
10. Go to the pending tab and notice `woocommerce_tracker_send_event_wrapper` is not there.
11. Go to WC -> Settings -> Advanced -> WooCommerce.com and checl the "Allow usage of WooCommerce to be tracked"
12. Go to the pending tab and notice `woocommerce_tracker_send_event_wrapper` is back. Run it and ensure no failures.

### Testing removing unwrapped actions

1. On [this line](https://github.com/woocommerce/woocommerce/blob/aae60c53ef5a71eb0365da2c1a33745adc463f5d/plugins/woocommerce/includes/class-woocommerce.php#L1550) rename `wc_admin_daily_wrapper` to `wc_admin_daily` then run the `action_scheduler_run_recurring_actions_schedule_hook` action.
2. Ensure an action for `wc_admin_daily` is added.
3. Revert the change made in step 1.
4. Re-run  the `action_scheduler_run_recurring_actions_schedule_hook` action.
5. Ensure an action for `wc_admin_daily` was removed, but one for `wc_admin_daily_wrapper` was added.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
