### PR TITLE
Implement CodeRabbit suggestions to Template registration API PR

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/coming-soon/newsletter-panel.tsx
@@ -16,8 +16,8 @@ const NewsletterPanel = () => {
 		select( 'core/editor' ).getCurrentPostId()
 	);
 
-	// Restrict the panel to only show on the coming soon page tempalte
-	if ( ! postId?.endsWith( '//coming-soon' ) ) {
+	// Restrict the panel to only show on the coming soon page template.
+	if ( typeof postId === 'string' && ! postId?.endsWith( '//coming-soon' ) ) {
 		return null;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/product-query/variations/product-query.tsx
@@ -79,7 +79,7 @@ subscribe( () => {
 
 	if ( isSiteEditorPage( store ) ) {
 		const inherit = ARCHIVE_PRODUCT_TEMPLATES.some( ( template ) =>
-			currentTemplateId?.endsWith( template )
+			currentTemplateId?.includes( template )
 		);
 
 		const inheritQuery: Partial< ProductQueryBlockQuery > = {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/on-sale-badge/on-sale-badge-single-product-template.block_theme.spec.ts
@@ -134,7 +134,7 @@ test.describe( `${ blockData.name }`, () => {
 			await expect( block.first() ).toBeVisible();
 		} );
 
-		test( `should be not rendered when the product isn't on sale the frontend side`, async ( {
+		test( `should not render on the frontend when the product is not on sale`, async ( {
 			frontendUtils,
 			editor,
 			page,

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/related-products/related-products.block_theme.spec.ts
@@ -8,7 +8,7 @@ import {
 	BLOCK_THEME_SLUG,
 } from '@woocommerce/e2e-utils';
 
-// Block is soft-depreacted meaning that it's hidden from the inserter.
+// Block is soft-deprecated, meaning that it's hidden from the inserter.
 const blockData: BlockData = {
 	name: 'Related Products',
 	slug: 'woocommerce/related-products',

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-priority.block_theme.spec.ts
@@ -39,7 +39,7 @@ test.describe( 'Template priority', () => {
 			path: '/product/hoodie',
 			templateName: 'Single Product',
 			templatePath: 'single-product',
-			identificableText: 'Related products',
+			identifiableText: 'Related products',
 		},
 		{
 			path: '/product-category/clothing',
@@ -49,7 +49,7 @@ test.describe( 'Template priority', () => {
 				templateName: 'Product Catalog',
 				templatePath: 'archive-product',
 			},
-			identificableText: 'Showing all 9 results',
+			identifiableText: 'Showing all 9 results',
 		},
 	];
 
@@ -66,7 +66,7 @@ test.describe( 'Template priority', () => {
 
 				// Verify it loaded correctly but has no custom text.
 				await expect(
-					page.getByText( testData.identificableText )
+					page.getByText( testData.identifiableText )
 				).toBeVisible();
 				await expect(
 					page.getByText( 'Custom template' )
@@ -78,8 +78,10 @@ test.describe( 'Template priority', () => {
 					BLOCK_THEME_WITH_TEMPLATES_SLUG
 				);
 
+				await page.goto( testData.path );
+
 				await expect(
-					page.getByText( testData.identificableText )
+					page.getByText( testData.identifiableText )
 				).toBeVisible();
 				await expect(
 					page.getByText( 'Custom template' )
@@ -97,7 +99,7 @@ test.describe( 'Template priority', () => {
 					await page.goto( testData.path );
 
 					await expect(
-						page.getByText( testData.identificableText )
+						page.getByText( testData.identifiableText )
 					).toBeVisible();
 					await expect(
 						page.getByText(
@@ -115,7 +117,7 @@ test.describe( 'Template priority', () => {
 					await page.goto( testData.path );
 
 					await expect(
-						page.getByText( testData.identificableText )
+						page.getByText( testData.identifiableText )
 					).toBeVisible();
 					await expect(
 						page.getByText(
@@ -139,7 +141,7 @@ test.describe( 'Template priority', () => {
 				await page.goto( testData.path );
 
 				await expect(
-					page.getByText( testData.identificableText )
+					page.getByText( testData.identifiableText )
 				).toBeVisible();
 				await expect(
 					page.getByText( 'Custom fallback template with theme slug' )
@@ -190,7 +192,7 @@ test.describe( 'Template priority', () => {
 				await page.goto( testData.path );
 
 				await expect(
-					page.getByText( testData.identificableText )
+					page.getByText( testData.identifiableText )
 				).toBeVisible();
 				await expect(
 					page.getByText( 'Custom template with theme slug' )

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/utils/register-block-single-product-template.block_theme.spec.ts
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-import { test, expect, Editor, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
+import { test, expect, BLOCK_THEME_SLUG } from '@woocommerce/e2e-utils';
+import type { Editor, Admin } from '@woocommerce/e2e-utils';
 
-const insertSingleProductBlock = async (
-	blockName: string,
-	editor: Editor
-) => {
+const insertSingleProductBlock = async ( editor: Editor ) => {
 	await editor.insertBlock( { name: 'woocommerce/single-product' } );
 	await editor.canvas.getByText( 'Album' ).click();
 	await editor.canvas.getByText( 'Done' ).click();
@@ -49,7 +47,6 @@ test.describe( 'registerProductBlockType registers', () => {
 
 		await test.step( 'Available in post within Single Product block', async () => {
 			const singleProductClientId = await insertSingleProductBlock(
-				blockName,
 				editor
 			);
 			// One from the global inserter, one from the single product block
@@ -175,7 +172,7 @@ test.describe( 'registerProductBlockType registers', () => {
 
 		await test.step( 'Unavailable in post, also within Single Product block', async () => {
 			await admin.createNewPost();
-			await insertSingleProductBlock( blockName, editor );
+			await insertSingleProductBlock( editor );
 
 			await editor.canvas
 				.getByRole( 'button', { name: 'Add block' } )

--- a/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/ProductAttributeTemplate.php
@@ -73,7 +73,7 @@ class ProductAttributeTemplate extends AbstractTemplateWithFallback {
 	public function template_hierarchy( $templates ) {
 		$queried_object = get_queried_object();
 
-		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wp_is_block_theme() ) {
+		if ( ! is_null( $queried_object ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) && wp_is_block_theme() ) {
 			// If Products by Attribute template has been customized or it's in the
 			// theme, we load it first, otherwise we only load the fallback template.
 			// If we don't do that, the WC core template would always have priority

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -709,7 +709,7 @@ class BlockTemplateUtils {
 	 * @param array  $slugs An array of slugs to retrieve templates for.
 	 * @param string $template_type wp_template or wp_template_part.
 	 *
-	 * @return int[]|\WP_Post[] An array of found templates.
+	 * @return \WP_Post[] An array of found templates.
 	 */
 	public static function get_block_templates_from_db( $slugs = array(), $template_type = 'wp_template' ) {
 		$check_query_args = array(

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -585,7 +585,7 @@ class BlockTemplateUtils {
 		$customized_theme_template_slugs = array_column(
 			array_filter(
 				$templates,
-				function ( $template ) {
+				function ( $template ) use ( $theme_slug ) {
 					// This template has been customised and saved as a post.
 					return 'custom' === $template->source && $theme_slug === $template->theme;
 				}

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -582,29 +582,31 @@ class BlockTemplateUtils {
 	public static function remove_duplicate_customized_templates( $templates ) {
 		$theme_slug = get_stylesheet();
 
-		$filtered_templates = array_filter(
+		$customized_theme_template_slugs = array_column(
+			array_filter(
+				$templates,
+				function ( $template ) {
+					// This template has been customised and saved as a post.
+					return 'custom' === $template->source && $theme_slug === $template->theme;
+				}
+			),
+			'slug'
+		);
+
+		return array_filter(
 			$templates,
-			function ( $template ) use ( $templates, $theme_slug ) {
+			function ( $template ) use ( $theme_slug, $customized_theme_template_slugs ) {
 				if ( $template->theme === $theme_slug ) {
 					// This is a customized template based on the theme template, so it should be returned.
 					return true;
 				}
-				// This is a template customized from the WooCommerce default template.
-				// Only return it if there isn't a customized version of the theme template.
-				$is_there_a_customized_theme_template = array_filter(
-					$templates,
-					function ( $theme_template ) use ( $template, $theme_slug ) {
-						return $theme_template->slug === $template->slug && $theme_template->theme === $theme_slug && 'custom' === $theme_template->source;
-					}
-				);
-				if ( $is_there_a_customized_theme_template ) {
-					return false;
+				// Customized from the WooCommerce default template: keep only if there is no customized theme template with same slug.
+				if ( 'custom' === $template->source ) {
+					return ! in_array( $template->slug, $customized_theme_template_slugs, true );
 				}
 				return true;
-			},
+			}
 		);
-
-		return $filtered_templates;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -553,7 +553,7 @@ class BlockTemplateUtils {
 				$templates,
 				function ( $template ) {
 					// This template has been customised and saved as a post.
-					return 'custom' === $template->source && 'woocommerce/woocommerce' === $template->theme;
+					return 'custom' === $template->source && ( self::PLUGIN_SLUG === $template->theme || self::DEPRECATED_PLUGIN_SLUG === $template->theme );
 				}
 			),
 			'slug'

--- a/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
+++ b/plugins/woocommerce/src/Blocks/Utils/BlockTemplateUtils.php
@@ -711,7 +711,7 @@ class BlockTemplateUtils {
 	 * @param array  $slugs An array of slugs to retrieve templates for.
 	 * @param string $template_type wp_template or wp_template_part.
 	 *
-	 * @return \WP_Post[] An array of found templates.
+	 * @return \WP_Block_Template[] An array of found templates.
 	 */
 	public static function get_block_templates_from_db( $slugs = array(), $template_type = 'wp_template' ) {
 		$check_query_args = array(

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -175,6 +175,11 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 				'theme'  => 'my-theme',
 			),
 			(object) array(
+				'slug'   => 'taxonomy-product_tag',
+				'source' => 'custom',
+				'theme'  => 'woocommerce',
+			),
+			(object) array(
 				'slug'   => 'taxonomy-product_cat',
 				'source' => 'theme',
 				'theme'  => 'my-theme',
@@ -183,11 +188,6 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 				'slug'   => 'taxonomy-product_cat',
 				'source' => 'custom',
 				'theme'  => 'woocommerce/woocommerce',
-			),
-			(object) array(
-				'slug'   => 'taxonomy-product_tag',
-				'source' => 'custom',
-				'theme'  => 'woocommerce',
 			),
 		);
 
@@ -199,7 +199,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_tag',
-				'source' => 'theme',
+				'source' => 'custom',
 				'theme'  => 'woocommerce',
 			),
 			(object) array(

--- a/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Utils/BlockTemplateUtilsTest.php
@@ -184,6 +184,11 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 				'source' => 'custom',
 				'theme'  => 'woocommerce/woocommerce',
 			),
+			(object) array(
+				'slug'   => 'taxonomy-product_tag',
+				'source' => 'custom',
+				'theme'  => 'woocommerce',
+			),
 		);
 
 		$expected_templates = array(
@@ -195,7 +200,7 @@ class BlockTemplateUtilsTest extends WP_UnitTestCase {
 			(object) array(
 				'slug'   => 'taxonomy-product_tag',
 				'source' => 'theme',
-				'theme'  => 'my-theme',
+				'theme'  => 'woocommerce',
 			),
 			(object) array(
 				'slug'   => 'taxonomy-product_cat',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements the CodeRabbit suggestions to https://github.com/woocommerce/woocommerce/pull/60191.

Because that PR is a meta PR including several PRs, and it's already quite big, I preferred breaking the CodeRabbit fixes into a separate PR so it's easier to review.

### How to test the changes in this Pull Request:

1. This PR mostly includes cleanups, fixing typos and low-risk changes, but it would be good to smoke test editing templates, reverting them, and verifying changes are correctly applied to the frontend.