### PR TITLE
Fix template parts not being listed in the Site Editor after migrating to the Template registration API

### DIFF
--- a/plugins/woocommerce/changelog/fix-template-registration-api-template-parts
+++ b/plugins/woocommerce/changelog/fix-template-registration-api-template-parts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix template parts not being listed in the Site Editor after migrating to the Template registration API
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts.spec.ts
@@ -49,7 +49,6 @@ test.describe( 'Template part customization', () => {
 	} );
 
 	const templateName = 'Mini-Cart';
-	const templatePath = 'mini-cart';
 
 	const userText = `Hello World in the ${ templateName } template`;
 
@@ -60,11 +59,12 @@ test.describe( 'Template part customization', () => {
 			page,
 			testUtils,
 		} ) => {
-			// Edit the theme template.
 			await admin.visitSiteEditor( {
-				postId: `${ CLASSIC_CHILD_THEME_WITH_BLOCK_TEMPLATE_PARTS_SLUG }//${ templatePath }`,
 				postType: 'wp_template_part',
-				canvas: 'edit',
+			} );
+
+			await editor.openTemplate( {
+				templateName,
 			} );
 
 			await editor.insertBlock( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/templates/template-part-customization.classic_theme_with_template_parts_support.spec.ts
@@ -62,9 +62,11 @@ test.describe( 'Template part customization', () => {
 			testUtils,
 		} ) => {
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ templatePath }`,
 				postType: 'wp_template_part',
-				canvas: 'edit',
+			} );
+
+			await editor.openTemplate( {
+				templateName,
 			} );
 
 			await editor.insertBlock( {
@@ -108,9 +110,10 @@ test.describe( 'Template part customization', () => {
 		} ) => {
 			// Edit the WooCommerce default template
 			await admin.visitSiteEditor( {
-				postId: `woocommerce/woocommerce//${ templatePath }`,
 				postType: 'wp_template_part',
-				canvas: 'edit',
+			} );
+			await editor.openTemplate( {
+				templateName,
 			} );
 
 			await editor.insertBlock( {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -91,6 +91,16 @@ export class Editor extends CoreEditor {
 		}
 	}
 
+	async openTemplate( { templateName }: { templateName: string } ) {
+		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
+		// Let's wait for the search to finish.
+		await expect(
+			this.page.locator( '.dataviews-view-grid__title-actions' ).first()
+		).toHaveText( templateName );
+
+		await this.page.getByLabel( templateName ).click();
+	}
+
 	async revertTemplate( { templateName }: { templateName: string } ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
 		// Let's wait for the search to finish.

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -99,6 +99,11 @@ export class Editor extends CoreEditor {
 		).toHaveText( templateName );
 
 		await this.page.getByLabel( templateName ).click();
+
+		// Wait until editor has loaded.
+		await this.page
+			.getByRole( 'heading', { name: templateName, level: 1 } )
+			.waitFor();
 	}
 
 	async revertTemplate( { templateName }: { templateName: string } ) {

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -91,14 +91,34 @@ export class Editor extends CoreEditor {
 		}
 	}
 
-	async openTemplate( { templateName }: { templateName: string } ) {
+	/**
+	 * Search for a template or template part in the Site Editor.
+	 */
+	async searchTemplate( { templateName }: { templateName: string } ) {
 		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
-		// Let's wait for the search to finish.
-		await expect(
-			this.page.locator( '.dataviews-view-grid__title-actions' ).first()
-		).toHaveText( templateName );
 
-		await this.page.getByLabel( templateName ).click();
+		// Wait for the search to finish.
+		await expect(
+			this.page.getByRole( 'button', { name: 'Reset' } )
+		).toBeVisible();
+		await expect( this.page.getByLabel( 'No results' ) ).toBeHidden();
+	}
+
+	/**
+	 * Opens a template or template part in the Site Editor given it's name.
+	 */
+	async openTemplate( { templateName }: { templateName: string } ) {
+		const templateButton = this.page
+			.getByRole( 'button', {
+				name: templateName,
+				exact: true,
+			} )
+			.first();
+		if ( ! ( await templateButton.isVisible() ) ) {
+			await this.searchTemplate( { templateName } );
+		}
+
+		await templateButton.click();
 
 		// Wait until editor has loaded.
 		await this.page
@@ -107,11 +127,7 @@ export class Editor extends CoreEditor {
 	}
 
 	async revertTemplate( { templateName }: { templateName: string } ) {
-		await this.page.getByPlaceholder( 'Search' ).fill( templateName );
-		// Let's wait for the search to finish.
-		await expect(
-			this.page.locator( '.dataviews-view-grid__title-actions' ).first()
-		).toHaveText( templateName );
+		await this.searchTemplate( { templateName } );
 
 		await this.page
 			.getByRole( 'button', { name: 'Actions' } )

--- a/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTemplatesController.php
@@ -234,7 +234,10 @@ class BlockTemplatesController {
 			return $query_result;
 		}
 
-		$template_files = BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
+		// For templates, we only need to load templates from the database. For
+		// template parts, we also need to load them from the filesystem, as
+		// there is no Template registration API for template parts.
+		$template_files = 'wp_template' === $template_type ? BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type ) : $this->get_block_templates( $slugs, $template_type );
 		$new_templates  = array();
 
 		foreach ( $template_files as $template_file ) {
@@ -248,6 +251,37 @@ class BlockTemplatesController {
 				)
 			) {
 				array_unshift( $new_templates, $template_file );
+				continue;
+			}
+
+			// We only need to build templates from the filesystem for template parts.
+			// Regular templates are handled by the Template registration API.
+			if ( 'wp_template_part' === $template_type ) {
+				$theme_slug            = get_stylesheet();
+				$possible_template_ids = [
+					$theme_slug . '//' . $template_file->slug,
+					$theme_slug . '//' . BlockTemplateUtils::DIRECTORY_NAMES['TEMPLATE_PARTS'] . '/' . $template_file->slug,
+					$theme_slug . '//' . BlockTemplateUtils::DIRECTORY_NAMES['DEPRECATED_TEMPLATE_PARTS'] . '/' . $template_file->slug,
+				];
+
+				$is_custom                 = false;
+				$query_result_template_ids = array_column( $query_result, 'id' );
+
+				foreach ( $possible_template_ids as $template_id ) {
+					if ( in_array( $template_id, $query_result_template_ids, true ) ) {
+						$is_custom = true;
+						break;
+					}
+				}
+				$fits_slug_query =
+					! isset( $query['slug__in'] ) || in_array( $template_file->slug, $query['slug__in'], true );
+				$fits_area_query =
+					! isset( $query['area'] ) || ( property_exists( $template_file, 'area' ) && $template_file->area === $query['area'] );
+				$should_include  = ! $is_custom && $fits_slug_query && $fits_area_query;
+				if ( $should_include ) {
+					$template       = BlockTemplateUtils::build_template_result_from_file( $template_file, $template_type );
+					$query_result[] = $template;
+				}
 			}
 		}
 
@@ -264,6 +298,18 @@ class BlockTemplatesController {
 			// See: https://github.com/woocommerce/woocommerce/issues/42220.
 			$query_result = BlockTemplateUtils::remove_duplicate_customized_templates( $query_result );
 		}
+
+		/**
+		 * WC templates from theme aren't included in `$this->get_block_templates()` but are handled by Gutenberg.
+		 * We need to do additional search through all templates file to update title and description for WC
+		 * templates that aren't listed in theme.json.
+		 */
+		$query_result = array_map(
+			function ( $template ) use ( $template_type ) {
+				return BlockTemplateUtils::update_template_data( $template, $template_type );
+			},
+			$query_result
+		);
 
 		return $query_result;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Based on https://github.com/woocommerce/woocommerce/pull/60191.

I didn't notice at that moment, but with the cleanup done in https://github.com/woocommerce/woocommerce/pull/60234, I broke template parts, so they weren't displayed in the Site Editor. The Template registration API only covers templates, so template parts still need some of the custom code that I tried to clean up.

This PR:

1. Adds the necessary WooCommerce custom code that was removed in #60191 that makes template parts to show up in the editor.
2. Strengthens the tests so instead of going directly to the template part, they go to the editor and manually open the template part. While this might be a bit slower, it's more future-proof, as it makes sure template parts are listed in the editor.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Patterns_.
2. Verify in the sidebar there is a _Mini-Cart_ and _Add to Cart + Options_ sections.
3. Edit some of those template parts and verify edits are applied to the front end.
4. Revert the edits and verify the front end updates accordingly.
5. In your theme, add a template part in `parts/mini-cart.html` (for example). Verify it's rendered in the frontend as long as you didn't have any customizations.