### PR TITLE
Harden `compareVersionSettingIgnorePrerelease()` handling of prereleases

### DIFF
--- a/plugins/woocommerce/changelog/fix-60311
+++ b/plugins/woocommerce/changelog/fix-60311
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix handling of prereleases in isWcVersion().

--- a/plugins/woocommerce/client/blocks/assets/js/settings/shared/utils.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/settings/shared/utils.ts
@@ -74,11 +74,17 @@ const compareVersionSettingIgnorePrerelease = (
 	operator: compareVersions.CompareOperator
 ): boolean => {
 	const settingValue = getSetting( setting, '' ) as string;
-	let replacement = settingValue.replace( /-[a-zA-Z0-9]*[\-]*/, '.0-rc.' );
-	replacement = replacement.endsWith( '.' )
-		? replacement.substring( 0, replacement.length - 1 )
-		: replacement;
-	return compareVersions.compare( replacement, version, operator );
+	let cleanVersion = settingValue;
+
+	// Only augment version if missing patch number.
+	if ( /^\d+\.\d+-.*$/.test( cleanVersion ) ) {
+		cleanVersion = cleanVersion.replace( /-[a-zA-Z0-9]*[\-.]*/, '.0-rc.' );
+		cleanVersion = cleanVersion.endsWith( '.' )
+			? cleanVersion.substring( 0, cleanVersion.length - 1 )
+			: cleanVersion;
+	}
+
+	return compareVersions.compare( cleanVersion, version, operator );
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Utility function `compareVersionSettingIgnorePrerelease()` which powers both [`isWpVersion()`](https://github.com/woocommerce/woocommerce/blob/153d5ef4bcbbabe458e92b02680c200b9124d9ef/plugins/woocommerce/client/blocks/assets/js/settings/shared/utils.ts#L91C14-L100) and [`isWcVersion`](https://github.com/woocommerce/woocommerce/blob/153d5ef4bcbbabe458e92b02680c200b9124d9ef/plugins/woocommerce/client/blocks/assets/js/settings/shared/utils.ts#L109-L118) in Blocks is designed to normalize WP prereleases (which have the format `X.Y-betaN` or `X.Y-rcN` possibly followed by `-MMMM`) so that they can be compared using semver rules. WC versions, on the other hand, follow semver (even prereleases) so the logic in this function was unnecessarily augmenting the version numbers and producing an incorrect result.

For example, for WordPress prerelease `10.0-rc1-1234` the function internally normalizes the version to `10.0-rc.1234` but for WooCommerce prerelease `10.0.0-rc.2` the normalization would result in `10.0.0.0-rc..2` which is not a valid version.

This PR ensures that we only attempt to normalize versions that have format `X.Y-<something>`  and better deal with dots in the version number to prevent duplicating them.

Fixes #60311.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Confirm that the bug existed on `trunk`:
   1. Check out `trunk`.
   2. Rebuild the plugin assets using `pnpm run build`.
   3. Open `plugins/woocommerce/includes/class-woocommerce.php` in your editor and change property `$version` to `10.2.0-rc.1`.
   4. Go to **WooCommerce > Analytics** on the backend.
   5. Attempting to load the page results in an error and analytics are not available.
1. Check out this branch (`fix/60311`).
1. Rebuild the plugin assets using `pnpm run build`.
1. Open `plugins/woocommerce/includes/class-woocommerce.php` in your editor and change property `$version` to `10.2.0-rc.1`.
1. Go to **WooCommerce > Analytics** on the backend.
1. Confirm that the page loads correctly.
1. Repeat steps 2-4 with other version numbers such as `10.2.0-dev`, `10.2-rc.123`, `10.2.0-beta.1`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
