### PR TITLE
Improve 'Editor: In taxonomies templates' Product Collection flaky test with the new Template registration API

### DIFF
--- a/plugins/woocommerce/changelog/fix-improve-editor-in-taxonomies-flaky-test
+++ b/plugins/woocommerce/changelog/fix-improve-editor-in-taxonomies-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Improve 'Editor: In taxonomies templates' Product Collection flaky test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -911,6 +911,13 @@ test.describe( 'Product Collection', () => {
 				} )
 				.click();
 
+			// We need to wait for Product categories to load. Otherwise clicking
+			// on Products by Category might direct the user to the generic
+			// template.
+			await admin.page.waitForResponse( ( response ) => {
+				return response.url().includes( 'wp-json/wp/v2/product_cat' );
+			} );
+
 			await page
 				.getByRole( 'button', { name: 'Products by Category' } )
 				.click();
@@ -956,6 +963,12 @@ test.describe( 'Product Collection', () => {
 							: 'Add New Template',
 				} )
 				.click();
+
+			// We need to wait for Product tags to load. Otherwise clicking
+			// on Products by Tag might direct the user to the generic template.
+			await admin.page.waitForResponse( ( response ) => {
+				return response.url().includes( 'wp-json/wp/v2/product_tag' );
+			} );
 
 			await page
 				.getByRole( 'button', { name: 'Products by Tag' } )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since the changes in https://github.com/woocommerce/woocommerce/pull/60191, the Product Collection 'Editor: In taxonomies templates' tests became a bit flaky. The fact is that the _Products by Category_ and _Product by Tag_ buttons change their behavior based on the server responses, so at the beginning they direct the user to the generic template, but when the server responds with categories/tags, the button directs to a popup where the user can select between the generic template or a specific one.

<img width="1077" height="1091" alt="imatge" src="https://github.com/user-attachments/assets/de7b8147-5d17-4a4e-b320-e216493c4683" />

This PR fixes the flakiness by waiting for the requests to finish loading.

### How to test the changes in this Pull Request:

1. Verify e2e tests keep passing.