### PR TITLE
Apply consistent font sizes and spacing in checkout (payment methods)

### DIFF
--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.tsx
@@ -15,6 +15,8 @@ import NoPaymentMethods from './no-payment-methods';
 import OnlyExpressPayments from './only-express-payments';
 import PaymentMethodOptions from './payment-method-options';
 import SavedPaymentMethodOptions from './saved-payment-method-options';
+
+import './style-legacy.scss';
 import './style.scss';
 
 /**
@@ -87,9 +89,8 @@ const PaymentMethods = ( {
 					) }
 					wrapperElement="p"
 					wrapperProps={ {
-						className: [
+						className:
 							'wc-block-components-checkout-step__description wc-block-components-checkout-step__description-payments-aligned',
-						],
 					} }
 				/>
 			) }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style-legacy.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style-legacy.scss
@@ -1,0 +1,181 @@
+// This file contains legacy styles that WooCommerce itself no longer uses,
+// but some extensions are still relying on them, so please don't remove
+// unless you're sure these dependencies are resolved.
+
+.wc-block-card-elements {
+	display: flex;
+	width: 100%;
+
+	.wc-block-components-validation-error {
+		position: static;
+	}
+}
+
+.wc-block-gateway-container {
+	position: relative;
+	margin-bottom: em($gap-large);
+	margin-top: $gap-smaller;
+	white-space: nowrap;
+
+	&.wc-card-number-element {
+		flex-basis: 15em;
+		flex-grow: 1;
+		min-width: min(15em, 60%);
+	}
+
+	&.wc-card-expiry-element {
+		flex-basis: 7em;
+		margin-left: $gap-small;
+		min-width: min(7em, calc(24% - #{$gap-small}));
+	}
+
+	&.wc-card-cvc-element {
+		flex-basis: 7em;
+		margin-left: $gap-small;
+		// Notice the min width ems value is smaller than flex-basis. That's because
+		// by default we want it to have the same width as `expiry-element`, but
+		// if available space is scarce, `cvc-element` should get smaller faster.
+		min-width: min(5em, calc(16% - #{$gap-small}));
+	}
+
+	.wc-block-gateway-input {
+		@include font-size(regular);
+		line-height: 1.375; // =22px when font-size is 16px.
+		background-color: #fff;
+		padding: em($gap-small) 0 em($gap-small) $gap;
+		border-radius: $universal-border-radius;
+		border: 1px solid $universal-border-strong;
+		width: 100%;
+		font-family: inherit;
+		margin: 0;
+		box-sizing: border-box;
+		height: 3em;
+		color: $input-text-light;
+		cursor: text;
+
+		&:focus {
+			background-color: #fff;
+		}
+	}
+
+	&:focus {
+		background-color: #fff;
+	}
+
+	label {
+		@include reset-color();
+		@include reset-typography();
+		@include font-size(regular);
+		line-height: 1.375; // =22px when font-size is 16px.
+		position: absolute;
+		transform: translateY(0.75em);
+		left: 0;
+		top: 0;
+		transform-origin: top left;
+		color: $gray-700;
+		transition: transform 200ms ease;
+		margin: 0 0 0 #{$gap + 1px};
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: calc(100% - #{$gap + $gap-smaller});
+		cursor: text;
+
+		@media screen and (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+	}
+
+	&.wc-inline-card-element {
+		label {
+			// $gap is the padding of the input box, 1.5em the width of the card
+			// icon and $gap-smaller the space between the card
+			// icon and the label.
+			margin-left: calc(#{$gap + $gap-smaller} + 1.5em);
+		}
+		.wc-block-gateway-input.focused.empty,
+		.wc-block-gateway-input:not(.empty) {
+			+ label {
+				margin-left: $gap;
+				transform: translateY(#{$gap-smallest}) scale(0.75);
+			}
+		}
+		+ .wc-block-components-validation-error {
+			position: static;
+			margin-top: -$gap-large;
+		}
+	}
+
+	.wc-block-gateway-input.focused.empty,
+	.wc-block-gateway-input:not(.empty) {
+		padding: em($gap-large) 0 em($gap-smallest) $gap;
+		+ label {
+			transform: translateY(#{$gap-smallest}) scale(0.75);
+		}
+	}
+
+	.wc-block-gateway-input.has-error {
+		border-color: $alert-red;
+		&:focus {
+			outline-color: $alert-red;
+		}
+	}
+
+	.wc-block-gateway-input.has-error + label {
+		color: $alert-red;
+	}
+}
+
+// These elements have available space below, so we can display errors with a
+// larger line height.
+@mixin medium-large-styles {
+	.wc-card-expiry-element,
+	.wc-card-cvc-element {
+		.wc-block-components-validation-error > p {
+			line-height: 16px;
+			padding-top: 4px;
+		}
+	}
+}
+
+@include cart-checkout-medium-container {
+	@include medium-large-styles;
+}
+@include cart-checkout-large-container {
+	@include medium-large-styles;
+}
+
+@mixin small-mobile-styles {
+	.wc-card-expiry-element,
+	.wc-card-cvc-element {
+		.wc-block-components-validation-error > p {
+			min-height: 28px;
+		}
+	}
+
+	.wc-block-card-elements {
+		flex-wrap: wrap;
+	}
+
+	.wc-block-gateway-container.wc-card-number-element {
+		flex-basis: 100%;
+	}
+
+	.wc-block-gateway-container.wc-card-expiry-element {
+		flex-basis: calc(50% - #{$gap-smaller});
+		margin-left: 0;
+		margin-right: $gap-smaller;
+	}
+
+	.wc-block-gateway-container.wc-card-cvc-element {
+		flex-basis: calc(50% - #{$gap-smaller});
+		margin-left: $gap-smaller;
+	}
+}
+
+@include cart-checkout-small-container {
+	@include small-mobile-styles;
+}
+
+@include cart-checkout-mobile-container {
+	@include small-mobile-styles;
+}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -27,30 +27,30 @@
 		border-width: 1px;
 	}
 
-	.wc-block-components-radio-control-accordion-option {
-		.wc-block-components-radio-control__option::after {
-			border-width: 0;
-		}
-		.wc-block-components-radio-control__label {
-			display: flex;
-			align-items: center;
-			justify-content: flex-start;
-			border-width: 0;
-			// This label uses the font-regular-locked mixin in the base radio control
-			// component, which sets line-height to 20px. We're increasing it to 24px
-			// to match the image size defined below and keep them vertically aligned.
-			// Alternatively, we could change the img size to 20px, but some extensions
-			// have hardcoded elements with 24px size already (note: extensions fully
-			// control the rendering of the label).
-			line-height: 24px;
-		}
-		.wc-block-components-radio-control__label img {
-			height: 24px;
-			max-height: 24px;
-			max-width: 100%;
-			object-fit: contain;
-			object-position: left;
-		}
+	.wc-block-components-radio-control__option::after {
+		border-width: 0;
+	}
+
+	.wc-block-components-radio-control__label {
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
+		border-width: 0;
+		// This label uses the font-regular-locked mixin in the base radio control
+		// component, which sets line-height to 20px. We're increasing it to 24px
+		// to match the image size defined below and keep them vertically aligned.
+		// Alternatively, we could change the img size to 20px, but some extensions
+		// have hardcoded elements with 24px size already (note: extensions fully
+		// control the rendering of the label).
+		line-height: 24px;
+	}
+
+	.wc-block-components-radio-control__label img {
+		height: 24px;
+		max-height: 24px;
+		max-width: 100%;
+		object-fit: contain;
+		object-position: left;
 	}
 
 	.wc-block-components-radio-control.disable-radio-control {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -1,207 +1,10 @@
-.wc-block-card-elements {
-	display: flex;
-	width: 100%;
-
-	.wc-block-components-validation-error {
-		position: static;
-	}
-}
-
-.wc-block-gateway-container {
-	position: relative;
-	margin-bottom: em($gap-large);
-	margin-top: $gap-smaller;
-	white-space: nowrap;
-
-	&.wc-card-number-element {
-		flex-basis: 15em;
-		flex-grow: 1;
-		// Currently, min() CSS function calls need to be wrapped with unquote.
-		min-width: string.unquote("min(15em, 60%)");
-	}
-
-	&.wc-card-expiry-element {
-		flex-basis: 7em;
-		margin-left: $gap-small;
-		min-width: string.unquote("min(7em, calc(24% - #{$gap-small}))");
-	}
-
-	&.wc-card-cvc-element {
-		flex-basis: 7em;
-		margin-left: $gap-small;
-		// Notice the min width ems value is smaller than flex-basis. That's because
-		// by default we want it to have the same width as `expiry-element`, but
-		// if available space is scarce, `cvc-element` should get smaller faster.
-		min-width: string.unquote("min(5em, calc(16% - #{$gap-small}))");
-	}
-
-	.wc-block-gateway-input {
-		@include font-size(regular);
-		line-height: 1.375; // =22px when font-size is 16px.
-		background-color: #fff;
-		padding: em($gap-small) 0 em($gap-small) $gap;
-		border-radius: $universal-border-radius;
-		border: 1px solid $universal-border-strong;
-		width: 100%;
-		font-family: inherit;
-		margin: 0;
-		box-sizing: border-box;
-		height: 3em;
-		color: $input-text-light;
-		cursor: text;
-
-		&:focus {
-			background-color: #fff;
-		}
-	}
-
-	&:focus {
-		background-color: #fff;
-	}
-
-	label {
-		@include reset-color();
-		@include reset-typography();
-		@include font-size(regular);
-		line-height: 1.375; // =22px when font-size is 16px.
-		position: absolute;
-		transform: translateY(0.75em);
-		left: 0;
-		top: 0;
-		transform-origin: top left;
-		color: $gray-700;
-		transition: transform 200ms ease;
-		margin: 0 0 0 #{$gap + 1px};
-		overflow: hidden;
-		text-overflow: ellipsis;
-		max-width: calc(100% - #{$gap + $gap-smaller});
-		cursor: text;
-
-		@media screen and (prefers-reduced-motion: reduce) {
-			transition: none;
-		}
-	}
-
-	&.wc-inline-card-element {
-		label {
-			// $gap is the padding of the input box, 1.5em the width of the card
-			// icon and $gap-smaller the space between the card
-			// icon and the label.
-			margin-left: calc(#{$gap + $gap-smaller} + 1.5em);
-		}
-		.wc-block-gateway-input.focused.empty,
-		.wc-block-gateway-input:not(.empty) {
-			+ label {
-				margin-left: $gap;
-				transform: translateY(#{$gap-smallest}) scale(0.75);
-			}
-		}
-		+ .wc-block-components-validation-error {
-			position: static;
-			margin-top: -$gap-large;
-		}
-	}
-
-	.wc-block-gateway-input.focused.empty,
-	.wc-block-gateway-input:not(.empty) {
-		padding: em($gap-large) 0 em($gap-smallest) $gap;
-		+ label {
-			transform: translateY(#{$gap-smallest}) scale(0.75);
-		}
-	}
-
-	.wc-block-gateway-input.has-error {
-		border-color: $alert-red;
-		&:focus {
-			outline-color: $alert-red;
-		}
-	}
-
-	.wc-block-gateway-input.has-error + label {
-		color: $alert-red;
-	}
-}
-
-// These elements have available space below, so we can display errors with a
-// larger line height.
-@mixin medium-large-styles {
-	.wc-card-expiry-element,
-	.wc-card-cvc-element {
-		.wc-block-components-validation-error > p {
-			line-height: 16px;
-			padding-top: 4px;
-		}
-	}
-}
-
-@include cart-checkout-medium-container {
-	@include medium-large-styles;
-}
-@include cart-checkout-large-container {
-	@include medium-large-styles;
-}
-
-@mixin small-mobile-styles {
-	.wc-card-expiry-element,
-	.wc-card-cvc-element {
-		.wc-block-components-validation-error > p {
-			min-height: 28px;
-		}
-	}
-
-	.wc-block-card-elements {
-		flex-wrap: wrap;
-	}
-
-	.wc-block-gateway-container.wc-card-number-element {
-		flex-basis: 100%;
-	}
-
-	.wc-block-gateway-container.wc-card-expiry-element {
-		flex-basis: calc(50% - #{$gap-smaller});
-		margin-left: 0;
-		margin-right: $gap-smaller;
-	}
-
-	.wc-block-gateway-container.wc-card-cvc-element {
-		flex-basis: calc(50% - #{$gap-smaller});
-		margin-left: $gap-smaller;
-	}
-}
-
-@include cart-checkout-small-container {
-	@include small-mobile-styles;
-}
-
-@include cart-checkout-mobile-container {
-	@include small-mobile-styles;
-}
-
 .wc-block-components-checkout-payment-methods * {
 	pointer-events: all; // Overrides parent disabled component in editor context
 }
 
 .wc-block-checkout__payment-method {
-	.wc-block-components-radio-control__option {
-		padding-left: em($gap-huge);
-		padding-right: em($gap-small);
-
-		&::after {
-			content: none;
-		}
-
-		.wc-block-components-radio-control__input {
-			left: 16px;
-		}
-	}
-
-	// We need to add the first-child and last-child pseudoclasses for specificity.
-	.wc-block-components-radio-control__option,
-	.wc-block-components-radio-control__option:first-child,
-	.wc-block-components-radio-control__option:last-child {
-		margin: 0;
-		padding-bottom: em($gap);
-		padding-top: em($gap);
+	.wc-block-components-radio-control__option::after {
+		content: none;
 	}
 
 	.wc-block-components-radio-control-accordion-option
@@ -233,6 +36,13 @@
 			align-items: center;
 			justify-content: flex-start;
 			border-width: 0;
+			// This label uses the font-regular-locked mixin in the base radio control
+			// component, which sets line-height to 20px. We're increasing it to 24px
+			// to match the image size defined below and keep them vertically aligned.
+			// Alternatively, we could change the img size to 20px, but some extensions
+			// have hardcoded elements with 24px size already (note: extensions fully
+			// control the rendering of the label).
+			line-height: 24px;
 		}
 		.wc-block-components-radio-control__label img {
 			height: 24px;
@@ -245,7 +55,7 @@
 
 	.wc-block-components-radio-control.disable-radio-control {
 		.wc-block-components-radio-control__option {
-			padding-left: 16px;
+			padding-left: $gap;
 		}
 
 		.wc-block-components-radio-control__input {
@@ -254,12 +64,14 @@
 	}
 
 	.wc-block-components-checkout-step__description-payments-aligned {
-		padding-top: 14px;
-		height: 28px;
+		@include font-regular-locked;
+		padding-top: $gap-small;
+		padding-bottom: $gap-smaller;
 	}
 }
 .wc-block-components-radio-control-accordion-content {
-	padding: 0 em($gap) em($gap);
+	@include font-regular-locked;
+	padding: 0 $gap $gap;
 
 	&:empty,
 	&:has(> *:only-child:empty) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/test/block.tsx
@@ -291,6 +291,7 @@ describe( 'Testing Checkout', () => {
 				} )
 			);
 		} );
+
 		const { rerender } = render( <CheckoutBlock /> );
 
 		await waitFor( () =>
@@ -299,11 +300,7 @@ describe( 'Testing Checkout', () => {
 			).toBeVisible()
 		);
 
-		expect(
-			screen.getByText( 'Toronto ON M4W 1A6', {
-				selector: '.wc-block-components-address-card span',
-			} )
-		).toBeVisible();
+		expect( screen.getByText( /Toronto ON M4W 1A6/ ) ).toBeVisible();
 
 		// Async is needed here despite the IDE warnings. Testing Library gives a warning if not awaited.
 		await act( () =>
@@ -323,9 +320,7 @@ describe( 'Testing Checkout', () => {
 		rerender( <CheckoutBlock /> );
 
 		expect(
-			screen.getByText( 'Hyogo Kobe Address 1 JP', {
-				selector: '.wc-block-components-address-card span',
-			} )
+			screen.getByText( /Hyogo Kobe Address 1 JP/ )
 		).toBeInTheDocument();
 
 		// Testing the default address format
@@ -345,21 +340,9 @@ describe( 'Testing Checkout', () => {
 		);
 		rerender( <CheckoutBlock /> );
 
-		expect(
-			screen.getByText( 'Liverpool', {
-				selector: '.wc-block-components-address-card span',
-			} )
-		).toBeInTheDocument();
-		expect(
-			screen.getByText( 'Merseyside', {
-				selector: '.wc-block-components-address-card span',
-			} )
-		).toBeInTheDocument();
-		expect(
-			screen.getByText( 'L1 0BP', {
-				selector: '.wc-block-components-address-card span',
-			} )
-		).toBeInTheDocument();
+		expect( screen.getByText( /Liverpool/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Merseyside/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /L1 0BP/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'Renders the billing address card if the address is filled and the cart contains a virtual product', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/59738

Bonus: while working on this task, I discovered some styles that don't have corresponding HTML elements rendered by core. I didn't remove them, as a quick search revealed that they are used by some extensions ([one example](https://github.com/search?q=org%3Awoocommerce%20wc-block-card-elements&type=code)). I moved them to a separate file with some comment at the top explaining what is going on. Thanks to @Aljullu for help with this investigation 🙏 

### Screenshots or screen recordings

Before here is not showing the `trunk`, but the current state of the branch that contains work around typography and spacing optimizations in checkout (this branch is being rebased with `trunk` daily).

| Before | After |
| ------ | ----- |
| <img width="787" height="391" alt="Screenshot 2025-08-14 at 17 44 22" src="https://github.com/user-attachments/assets/0f3a70b6-17c8-43ac-8ea4-e7e21e2fecff" /> | <img width="793" height="402" alt="Screenshot 2025-08-14 at 17 43 04" src="https://github.com/user-attachments/assets/b509b10c-6beb-4ff2-a67d-bf5ebdad622d" /> |

Changes here are less apparent, but still there! Paddings are more consistent and tighter now, and most importantly, we don't use relative units anymore, so you can't mess it up quickly like this:

<img width="400" alt="Screenshot 2025-08-14 at 17 54 34" src="https://github.com/user-attachments/assets/e4af3117-e053-4c7b-b1f8-4a9a75ab080c" />

### How to test the changes in this Pull Request:

1. Set up some payment methods in your testing store; make sure to have at least one that is delivered through an extension; don't settle on offline methods
2. Add some products to the cart and go to checkout
3. Verify that the radio control components have consistent typography and spacing (you can compare with the shipping method ones, as they were done earlier and are verified to be aligned with designs)
4. Make sure that it is correct after expanding a particular option (just click on it; the "content" of the particular option is expanded after selection)
5. It would be nice to test the view with the saved payment method (the one I used for the diff screenshot table); to get to it, you need to have an extension that offers this capability (stripe, woo payments, etc.); after setting it up, go through checkout flow and remember the payment method, then do it again and the payment methods should be grouped accordingly

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.
-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This PR doesn't target `trunk`. Changelog will be added when the main branch will be merged to `trunk`.

</details>
