### PR TITLE
Partial revert to make getValidationError always re-select

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5133-custom-checkboxes-not-validated-in-checkout-block-since-woo
+++ b/plugins/woocommerce/changelog/wooplug-5133-custom-checkboxes-not-validated-in-checkout-block-since-woo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure inner blocks rerender when validation data store changes

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -34,19 +34,24 @@ export const useValidation = (): ValidationData => {
 
 	const prefix = 'extensions-errors';
 
-	const { hasValidationErrors, getValidationError } = useSelect(
-		( select ) => {
-			const store = select( validationStore );
-			return {
-				hasValidationErrors: store.hasValidationErrors(),
-				getValidationError: ( validationErrorId: string ) =>
-					store.getValidationError(
-						`${ prefix }-${ validationErrorId }`
-					),
-			};
-		},
-		[]
-	);
+	const {
+		hasValidationErrors,
+		getValidationError,
+	}: {
+		hasValidationErrors: boolean;
+		getValidationError: (
+			validationErrorId: string
+		) => ValidationContextError;
+	} = useSelect( ( select ) => {
+		const store = select( validationStore );
+		return {
+			hasValidationErrors: store.hasValidationErrors(),
+			getValidationError: ( validationErrorId: string ) =>
+				store.getValidationError(
+					`${ prefix }-${ validationErrorId }`
+				),
+		};
+	}, [] );
 
 	const clearValidationErrorCallback = useCallback(
 		( validationErrorId: string ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -42,16 +42,19 @@ export const useValidation = (): ValidationData => {
 		getValidationError: (
 			validationErrorId: string
 		) => ValidationContextError;
-	} = useSelect( ( select ) => {
-		const store = select( validationStore );
-		return {
-			hasValidationErrors: store.hasValidationErrors(),
-			getValidationError: ( validationErrorId: string ) =>
-				store.getValidationError(
-					`${ prefix }-${ validationErrorId }`
-				),
-		};
-	}, [] );
+	} = useSelect(
+		( select ) => {
+			const store = select( validationStore );
+			return {
+				hasValidationErrors: store.hasValidationErrors(),
+				getValidationError: ( validationErrorId: string ) =>
+					store.getValidationError(
+						`${ prefix }-${ validationErrorId }`
+					),
+			};
+		},
+		[ prefix ]
+	);
 
 	const clearValidationErrorCallback = useCallback(
 		( validationErrorId: string ) =>

--- a/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/context/hooks/use-validation.ts
@@ -34,21 +34,18 @@ export const useValidation = (): ValidationData => {
 
 	const prefix = 'extensions-errors';
 
-	const { hasValidationErrors, getValidationErrorSelector } = useSelect(
+	const { hasValidationErrors, getValidationError } = useSelect(
 		( select ) => {
 			const store = select( validationStore );
 			return {
 				hasValidationErrors: store.hasValidationErrors(),
-				getValidationErrorSelector: store.getValidationError,
+				getValidationError: ( validationErrorId: string ) =>
+					store.getValidationError(
+						`${ prefix }-${ validationErrorId }`
+					),
 			};
 		},
 		[]
-	);
-
-	const getValidationError = useCallback(
-		( validationErrorId: string ) =>
-			getValidationErrorSelector( `${ prefix }-${ validationErrorId }` ),
-		[ getValidationErrorSelector, prefix ]
 	);
 
 	const clearValidationErrorCallback = useCallback(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/blob/9fb54e5576067f16cd3a5c473e36ca0350589e9c/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/frontend.tsx#L50 inner blocks are cloned and  `validation` is one of the props, derived from the `useValidation` hook.

Previously, the `useValidation` hook returned a function called `getValidationError` which was a callback, dependent on the prefix, or `getValidationErrorSelector` from the `wc/store/validation` `@wordpress/data` store.

Because of the above, an inner block received this callback when first rendered, and then after that it would not be updated. This is because `getValidationErrorSelector` did not change, it was always the same callback. In the `useSelect` the selector was not being executed, it was being returned so it could be executed later, the selector is the same function.

This meant that any changes to the validation store that happened after an inner block was first rendered would not cause `useValidation` to return different data, and therefore inner blocks would not re-render when validation errors were shown/changed.

This PR changes the `useSelect` to return a function as `getValidationError`, which will be recreated whenever the data inside `wc/store/validation` changes. This is desirable and correct.

An alternative solution would be to check if any new errors were added to the `wc/store/validation` data store and recreate the callback if so, but that would require a new selector to get all validation errors (not in place now, and not needed outside of this edge case) returning a new function each time the data changes is easier to reason with and does not introduce a new selector.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5133

(For Bug Fixes) Bug introduced in PR https://github.com/woocommerce/woocommerce/pull/57673/files#diff-5322ded514cd969c2d06a9199b3270dd11d61faa613335af0656e29f9097c3b6 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the test plugin 
[test-plugin.zip](https://github.com/user-attachments/files/21834280/test-plugin.zip)
**OR** Create a custom inner block (use `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block your_extension_name`) - after the script is done running, go into the new directory and run `npm run start`
2. Go to the `src/js/checkout-newsletter-subscription-block/block.js` file update the contents to the following:

```js
/**
 * External dependencies
 */
import { useEffect } from '@wordpress/element';
import { useSelect, useDispatch } from '@wordpress/data';

const VALIDATION_STORE = 'wc/store/validation';
const HELLO_WORLD_ERROR = 'hello_world_error';

function HelloWorld() {
	const { getValidationError } = useSelect( ( select ) =>
		select( VALIDATION_STORE )
	);
	const { setValidationErrors } = useDispatch( VALIDATION_STORE );

	useEffect( () => {
		setValidationErrors( {
			[ HELLO_WORLD_ERROR ]: {
				hidden: true,
				message: 'Hello world has an error',
			},
		} );
	}, [] );

	const error = getValidationError( HELLO_WORLD_ERROR );

	/**
	 * On "Place Order", `error.hidden` is not set to false.
	 */
	console.log( error );

	if ( ! error ) {
		return null;
	}

	const errorEl = ! error.hidden && (
		<div className="wc-block-components-validation-error">
			<p>{ error.message }</p>
		</div>
	);

	return (
		<>
			<h1>Hello, World.</h1>
			{ errorEl }
		</>
	);
}
const Block = ( { children, checkoutExtensionData } ) => {
	return (
		<>
			<HelloWorld />
		</>
	);
};

export default Block;
```

4. Go to the Checkout block on the front end, you should see:
<img width="857" height="309" alt="image" src="https://github.com/user-attachments/assets/ba3bb1fe-4a20-4a83-93ed-d5c9a016d593" />

5. Try to place the order and ensure it fails and an error shows under "Hello world"

<img width="835" height="343" alt="image" src="https://github.com/user-attachments/assets/c822c5be-0cf8-4bb2-ae79-79920e78d8b7" />


<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
