### PR TITLE
Address PHP warnings in `WC_Admin_Tests_Admin_Helper` unit test

### DIFF
--- a/plugins/woocommerce/changelog/fix-60226
+++ b/plugins/woocommerce/changelog/fix-60226
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix warnings in `WC_Admin_Tests_Admin_Helper` unit test.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php
@@ -33,7 +33,7 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 	 *
 	 * @var int
 	 */
-	private static $product_id;
+	private $product_id;
 
 	/**
 	 * Set up before class.
@@ -56,12 +56,6 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 		global $wp_rewrite;
 		$wp_rewrite->set_permalink_structure( '/%postname%/' );
 
-		// Create a product.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_status( 'publish' );
-		$product->save();
-		self::$product_id = $product->get_id();
-
 		// Flush rewrite rules.
 		$wp_rewrite->init();
 		$wp_rewrite->flush_rules( true );
@@ -76,12 +70,36 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 		$wp_rewrite->set_permalink_structure( self::$original_permalink_structure );
 		update_option( 'woocommerce_permalinks', self::$original_wc_permalinks );
 
-		// Clean up product.
-		WC_Helper_Product::delete_product( self::$product_id );
-
 		// Flush rewrite rules one final time.
 		$wp_rewrite->flush_rules();
 		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Initialize environment for tests by creating a simple product.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create a product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_status( 'publish' );
+		$product->save();
+		$this->product_id = $product->get_id();
+	}
+
+	/**
+	 * Clean up environment for tests by deleting the simple product.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Clean up product.
+		WC_Helper_Product::delete_product( $this->product_id );
 	}
 
 	/**
@@ -264,7 +282,7 @@ class WC_Admin_Tests_Admin_Helper extends WC_Unit_Test_Case {
 			array( 'shop', get_permalink( wc_get_page_id( 'shop' ) ), true ),
 			array( 'checkout', get_permalink( wc_get_page_id( 'checkout' ) ), true ),
 			array( 'product archive', get_post_type_archive_link( 'product' ), true ),
-			array( 'product', get_permalink( self::$product_id ), true ),
+			array( 'product', get_permalink( $this->product_id ), true ),
 			// Should return true if a shop page contains a query param.
 			array( 'shop with query', get_permalink( wc_get_page_id( 'shop' ) ) . '?query=test', true ),
 			// Should non-store pages return false.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
Current version of the `WC_Admin_Tests_Admin_Helper` unit test [unregisters product-related taxonomies and post type](https://github.com/woocommerce/woocommerce/blob/0c7ebc45fff1d612c62e975dbf5a464ab3363c7c/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php#L47-L51) and _then_ [creates a product](https://github.com/woocommerce/woocommerce/blob/0c7ebc45fff1d612c62e975dbf5a464ab3363c7c/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/wc-admin-helper.php#L59-L63).

This results in a few PHP warnings along these lines:

```
2025-08-06T09:51:26.2769657Z [06-Aug-2025 09:51:26 UTC] PHP Warning:  Attempt to read property "term_id" on array in /var/www/html/wp-content/plugins/woocommerce/includes/wc-term-functions.php on line 741
2025-08-06T09:51:26.2772051Z [06-Aug-2025 09:51:26 UTC] PHP Warning:  Attempt to read property "parent" on array in /var/www/html/wp-content/plugins/woocommerce/includes/wc-term-functions.php on line 741
...
```

This PR ensures that the product is created not during the test class set up but before each test (when we're sure the taxonomies and post types have been initialized by `WC_Unit_Test_Case::setUp()`).

Closes #60226.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### On CI
1. Confirm that the warnings were occurring on current `trunk`: [example CI run](https://github.com/woocommerce/woocommerce/actions/runs/16915763287/job/47929162434?pr=60327#step:9:118).
1. Confirm that those specific warnings are no longer present for [the CI run on this branch](https://github.com/woocommerce/woocommerce/actions/runs/16985306984/job/48152955670?pr=60391#step:9:1).

#### Locally (optional)
1. Run test with `./vendor/bin/phpunit --filter 'WC_Admin_Tests_Admin_Helper'` or via `pnpm --filter=@woocommerce/plugin-woocommerce test:unit:env -- --filter=WC_Admin_Tests_Admin_Helper`.
3. No PHP warnings should be printed.
4. (Optional) Repeat the above on `trunk` to confirm the warnings do happen on current `trunk`.

<!-- End testing instructions -->