### PR TITLE
Add to Cart + Options: select default attributes instantly on page load and add unit tests

### DIFF
--- a/plugins/woocommerce/changelog/update-add-to-cart-with-options-faster-default-option
+++ b/plugins/woocommerce/changelog/update-add-to-cart-with-options-faster-default-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add to Cart + Options: default attributes are now selected instantly on page load

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -146,6 +146,17 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 		$attribute_slug  = wc_variation_attribute_name( $block->context['woocommerce/attributeName'] );
 		$attribute_terms = $block->context['woocommerce/attributeTerms'];
 
+		wp_interactivity_state(
+			'woocommerce/add-to-cart-with-options',
+			array(
+				'isOptionSelected' =>
+				function () {
+					$context = wp_interactivity_get_context();
+					return $context['option']['isSelected'];
+				},
+			)
+		);
+
 		$pills = '';
 		foreach ( $attribute_terms as $attribute_term ) {
 			$input = sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -178,7 +178,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				)
 			);
 
-			$pills .= '<label class="wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill">' . $input . $attribute_term['label'] . '</label>';
+			$pills .= '<label class="wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill">' . $input . esc_html( $attribute_term['label'] ) . '</label>';
 		}
 
 		return sprintf(
@@ -247,7 +247,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 				$this->get_normalized_attributes(
 					$option_attributes
 				),
-				$attribute_term['label']
+				esc_html( $attribute_term['label'] )
 			);
 		}
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/VariationSelectorAttributeOptions.php
@@ -175,8 +175,7 @@ class VariationSelectorAttributeOptions extends AbstractBlock {
 							'option' => $attribute_term,
 						),
 					),
-				),
-				$attribute_term['label']
+				)
 			);
 
 			$pills .= '<label class="wc-block-add-to-cart-with-options-variation-selector-attribute-options__pill">' . $input . $attribute_term['label'] . '</label>';

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -279,7 +279,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$product_id = $product->get_id();
 
-		$variation = $fixtures->get_variation_product(
+		$fixtures->get_variation_product(
 			$product_id,
 			array(
 				'pa_color' => 'red-slug',
@@ -296,7 +296,11 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringNotContainsString( '<input checked type="radio"', $markup, 'No options are checked by default.' );
+		$this->assertDoesNotMatchRegularExpression(
+			'/<input[^>]*type="radio"[^>]* checked(?:="checked")?[^>]*>/',
+			$markup,
+			'No radio options should be checked by default.'
+		);
 
 		$product->set_default_attributes( array( 'pa_size' => 'small-slug' ) );
 
@@ -304,6 +308,10 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
-		$this->assertStringContainsString( '<input checked type="radio"', $markup, 'Options are checked by default if they are set as the default attribute.' );
+		$this->assertMatchesRegularExpression(
+			'/<input[^>]*checked(?:=" checked")?[^>]*type="radio"[^>]*value="small-slug"[^>]*>/',
+			$markup,
+			'The "small" size option should be checked when set as the default attribute.'
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -4,12 +4,18 @@ declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Enums\ProductStockStatus;
 use Automattic\WooCommerce\Tests\Blocks\Utils\WC_Product_Custom;
+use Automattic\WooCommerce\Tests\Blocks\Helpers\FixtureData;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsQuantitySelectorMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsGroupedProductSelectorMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsGroupedProductItemMock;
 use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsGroupedProductItemSelectorMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeNameMock;
+use Automattic\WooCommerce\Tests\Blocks\Mocks\AddToCartWithOptionsVariationSelectorAttributeOptionsMock;
 
 /**
  * Tests for the AddToCartWithOptions block type
@@ -37,6 +43,10 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			new AddToCartWithOptionsGroupedProductSelectorMock();
 			new AddToCartWithOptionsGroupedProductItemMock();
 			new AddToCartWithOptionsGroupedProductItemSelectorMock();
+			new AddToCartWithOptionsVariationSelectorMock();
+			new AddToCartWithOptionsVariationSelectorAttributeMock();
+			new AddToCartWithOptionsVariationSelectorAttributeNameMock();
+			new AddToCartWithOptionsVariationSelectorAttributeOptionsMock();
 
 			self::$are_blocks_registered = true;
 		}
@@ -249,5 +259,51 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'data-wp-on--submit', $markup, 'The form doesn\'t have an on submit event when an extension hooks into the form.' );
 
 		remove_action( 'woocommerce_before_add_to_cart_button', array( $this, 'hook_into_add_to_cart_button_action' ) );
+	}
+
+	/**
+	 * Tests that the default option is set in variable products.
+	 */
+	public function test_variable_product_default_option_render() {
+		global $product;
+
+		$fixtures = new FixtureData();
+
+		$product = $fixtures->get_variable_product(
+			array(),
+			array(
+				$fixtures->get_product_attribute( 'color', array( 'red', 'green', 'blue' ) ),
+				$fixtures->get_product_attribute( 'size', array( 'small', 'medium', 'large' ) ),
+			)
+		);
+
+		$product_id = $product->get_id();
+
+		$variation = $fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'red-slug',
+				'pa_size'  => 'small-slug',
+			),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		// Sync the variable product to update its children list.
+		\WC_Product_Variable::sync( $product_id );
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringNotContainsString( '<input checked type="radio"', $markup, 'No options are checked by default.' );
+
+		$product->set_default_attributes( array( 'pa_size' => 'small-slug' ) );
+
+		$product->save();
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertStringContainsString( '<input checked type="radio"', $markup, 'Options are checked by default if they are set as the default attribute.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -141,7 +141,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'Add to cart', $markup, 'The Simple Product Add to Cart Button is visible for purchasable in stock products.' );
 
-		$product->set_stock_status( 'outofstock' );
+		$product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
 		$product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
@@ -165,7 +165,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hook into add to cart action', $markup, 'The Add to Cart + Options correctly renders the contents from the wrapper hook.' );
 		$this->assertStringContainsString( 'Hook into add to cart button action', $markup, 'The Add to Cart + Options doesn\'t render the contents from the inner hooks.' );
 
-		$product->set_stock_status( 'outofstock' );
+		$product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
 		$product_id = $product->save();
 		$markup     = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 
@@ -195,7 +195,7 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'type="checkbox"', $markup, 'The Grouped Product Add to Cart + Options form contains a checkbox.' );
 
-		$simple_product->set_stock_status( 'outofstock' );
+		$simple_product->set_stock_status( ProductStockStatus::OUT_OF_STOCK );
 		$simple_product->save();
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $grouped_product_id . '} --><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 		$this->assertStringContainsString( 'Read more', $markup, 'The Grouped Product Add to Cart + Options form contains a button.' );

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductItemMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductItemMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsGroupedProductItemMock extends GroupedProductItem {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductItemSelectorMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductItemSelectorMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsGroupedProductItemSelectorMock extends GroupedProductI
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductSelectorMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsGroupedProductSelectorMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsGroupedProductSelectorMock extends GroupedProductSelec
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsMock extends AddToCartWithOptions {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsQuantitySelectorMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsQuantitySelectorMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsQuantitySelectorMock extends QuantitySelector {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsVariationSelectorAttributeMock extends VariationSelect
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeMock.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttribute;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * AddToCartWithOptionsVariationSelectorAttributeMock used to test VariationSelectorAttribute block functions.
+ */
+class AddToCartWithOptionsVariationSelectorAttributeMock extends VariationSelectorAttribute {
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeNameMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeNameMock.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttributeName;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * AddToCartWithOptionsVariationSelectorAttributeNameMock used to test VariationSelectorAttributeName block functions.
+ */
+class AddToCartWithOptionsVariationSelectorAttributeNameMock extends VariationSelectorAttributeName {
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeNameMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeNameMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsVariationSelectorAttributeNameMock extends VariationSe
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeOptionsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeOptionsMock.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelectorAttributeOptions;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * AddToCartWithOptionsVariationSelectorAttributeOptionsMock used to test VariationSelectorAttributeOptions block functions.
+ */
+class AddToCartWithOptionsVariationSelectorAttributeOptionsMock extends VariationSelectorAttributeOptions {
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeOptionsMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorAttributeOptionsMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsVariationSelectorAttributeOptionsMock extends Variatio
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorMock.php
@@ -1,0 +1,26 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\AddToCartWithOptions\VariationSelector;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
+/**
+ * AddToCartWithOptionsVariationSelectorMock used to test VariationSelector block functions.
+ */
+class AddToCartWithOptionsVariationSelectorMock extends VariationSelector {
+	/**
+	 * Initialize our mock class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			new IntegrationRegistry(),
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/AddToCartWithOptionsVariationSelectorMock.php
@@ -18,7 +18,7 @@ class AddToCartWithOptionsVariationSelectorMock extends VariationSelector {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksTestBlock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/BlockHooksTestBlock.php
@@ -41,7 +41,7 @@ class BlockHooksTestBlock extends AbstractBlock {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductCollectionMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductCollectionMock.php
@@ -23,7 +23,7 @@ class ProductCollectionMock extends Controller {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductDetailsNoRegisterMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductDetailsNoRegisterMock.php
@@ -21,7 +21,7 @@ class ProductDetailsNoRegisterMock extends ProductDetails {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);

--- a/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductQueryMock.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Mocks/ProductQueryMock.php
@@ -19,7 +19,7 @@ class ProductQueryMock extends ProductQuery {
 	 */
 	public function __construct() {
 		parent::__construct(
-			Package::container()->get( API::class ),
+			Package::container()->get( Api::class ),
 			Package::container()->get( AssetDataRegistry::class ),
 			new IntegrationRegistry(),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR:

* Adds PHP tests to verify the default attributes are checked in the _Add to Cart + Options_ block on page load (683be462c076a54494c5e8582b417eaf92fdffe9).
* Refactors the _Add to Cart + Options_ block so the default attribute is selected when rendering the page, instead of having to wait for the iAPI to load (b0dc774a8ac4a00f4b1de5fd521031d7abd4f266).
* Refactors the existing tests to use `ProductStockStatus` instead of hardcoded stock statuses (8a887a4a8fa992d2796dc306ec0a1c538270cc80).
* Removes a variable that I think was never used (0a7d0c5c4083c7c93a6221e753df86f71bd887b7).

### How to test the changes in this Pull Request:

1. Edit a variable product and make it so it has a default attribute selected:

<img width="1312" height="637" alt="imatge" src="https://github.com/user-attachments/assets/7bf42fa4-b1b4-4327-b101-fa38c94c808b" />

2. Load the variable product in the frontend, making sure the _Add to Cart + Options_ block is in the _Single Product_ template.
3. Verify the default option is correctly selected (and it's slightly faster than before):

Before:

https://github.com/user-attachments/assets/65ee9f25-1213-4a3b-9a60-1968fe691697

After:

https://github.com/user-attachments/assets/d33fba65-fb8e-4629-a9cc-77d788265227

