### PR TITLE
Exclude issues opened by Linear from community contribution label

### DIFF
--- a/.github/workflows/automate-team-review-assignment.yml
+++ b/.github/workflows/automate-team-review-assignment.yml
@@ -32,7 +32,7 @@ jobs:
                           repo: context.repo.repo,
                           username: username,
                       } );
-                      const contributor = ( permission === 'read' || permission === 'none' ) && username !== 'gglobalstep';
+                      const contributor = ( permission === 'read' || permission === 'none' ) && username !== 'gglobalstep' && username !== 'linear[bot]';
                       core.setOutput( 'contributor', contributor ? 'yes' : 'no' );
 
             - name: Add community label
@@ -79,7 +79,7 @@ jobs:
           with:
               config: '.github/automate-team-review-assignment-config.yml'
               GITHUB_TOKEN: ${{ secrets.PR_ASSIGN_TOKEN }}
-    
+
     add-testing-instructions-review-comment:
       name: Remind reviewers to also review the testing instructions and test coverage
       if: ${{ github.event.pull_request && github.event.action == 'review_requested' }}
@@ -129,14 +129,14 @@ jobs:
               body: |
                   ## Testing Guidelines
                   Hi ${{ env.REVIEWERS }} ${{ env.TEAMS }},
-                  
+
                   Apart from reviewing the code changes, please make sure to **review the testing instructions** ([Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)) and verify that relevant tests (E2E, Unit, Integration, etc.) have been added or updated as needed.
-                  
+
                   **Reminder:** PR reviewers are required to document testing performed. This includes:
                   - 🖼️ **Screenshots or screen recordings**.
                   - 📝 **List of functionality tested / steps followed**.
                   - 🌐 **Site details** (environment attributes such as hosting type, plugins, theme, store size, store age, and relevant settings).
                   - 🔍 **Any analysis performed**, such as assessing potential impacts on environment attributes and other plugins, conducting performance profiling, or using LLM/AI-based analysis.
-                  
+
                   ⚠️ Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public issue.
               edit-mode: replace


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, issues opened on the Linear side that aren't attributed to an user (I guess because the accounts aren't connected) receive the [`type: community contribution` label](https://github.com/woocommerce/woocommerce/issues?q=label%3A%22type%3A%20community%20contribution%22). Examples: https://github.com/woocommerce/woocommerce/issues/60003, https://github.com/woocommerce/woocommerce/issues/60084.

(Note: I have since removed the label from the issues above, but it can still be seen in the issue activity.)

This PR ensures issues opened by the Linear app don't get labeled as community.

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->