### PR TITLE
Handle `WooCommerce::$version` possibly being a prerelease

### DIFF
--- a/plugins/woocommerce/changelog/fix-60345-core-changes
+++ b/plugins/woocommerce/changelog/fix-60345-core-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Improve version and db version management.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -129,7 +129,7 @@ class WC_Admin_Addons {
 		return array(
 			'wccom-site'          => site_url(),
 			'wccom-back'          => rawurlencode( $back_admin_path ),
-			'wccom-woo-version'   => WC()->version(),
+			'wccom-woo-version'   => WC()->stable_version(),
 			'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
 		);
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -129,7 +129,7 @@ class WC_Admin_Addons {
 		return array(
 			'wccom-site'          => site_url(),
 			'wccom-back'          => rawurlencode( $back_admin_path ),
-			'wccom-woo-version'   => Constants::get_constant( 'WC_VERSION' ),
+			'wccom-woo-version'   => WC()->version(),
 			'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
 		);
 	}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -37,9 +37,9 @@ class WC_Install {
 	 * at install time (e.g. populating tables), use the 'woocommerce_installed' hook.
 	 *
 	 * IMPORTANT:
-	 * If your update targets a version that already has a key in this array (and we're past feature freeze),
-	 * add your update under a new key by appending a suffix like `-1`, `-2`, etc. (e.g., use `10.2.0-1` if `10.2.0` exists).
-	 * This ensures updates are applied for users upgrading from beta or RC versions to the final release.
+	 * When adding new update callbacks after feature freeze, always use a unique version key with a suffix (e.g. `10.2.0-1`)
+	 * if the base version already exists in the array.
+	 * This ensures all users, including those on beta or RC versions, receive the update.
 	 *
 	 * @var array
 	 */
@@ -693,7 +693,7 @@ class WC_Install {
 	public static function needs_db_update() {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
 
-		return ! is_null( $current_db_version ) && version_compare( $current_db_version, self::get_last_db_update_version(), '<' );
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, array_key_last( self::$db_updates ), '<' );
 	}
 
 	/**
@@ -776,25 +776,11 @@ class WC_Install {
 	}
 
 	/**
-	 * Get the version of the last DB update.
-	 *
-	 * @since 10.2.0
-	 *
-	 * @return string
-	 */
-	public static function get_last_db_update_version(): string {
-		return self::$db_updates
-			? array_key_last( self::$db_updates )
-			: WC()->version();
-	}
-
-	/**
 	 * Push all needed DB updates to the queue for processing.
 	 */
 	private static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );
 		$updates            = self::get_db_update_callbacks();
-		$wc_db_version      = array_key_last( $updates );
 		$scheduled_time     = time();
 
 		wc_get_logger()->info(
@@ -846,7 +832,10 @@ class WC_Install {
 			}
 		}
 
-		// After the callbacks finish, update the db version to the current WC version.
+		// After the callbacks finish, update the db version to the current WC db version.
+		$wc_db_version = array_key_last( $updates );
+		$wc_db_version = version_compare( WC()->version, $wc_db_version, '>' ) ? WC()->version : $wc_db_version;
+
 		$success = true;
 		if ( version_compare( $current_db_version, $wc_db_version, '<' ) &&
 			! WC()->queue()->get_next( 'woocommerce_update_db_to_current_version' ) ) {
@@ -881,7 +870,12 @@ class WC_Install {
 	 * @param string|null $version New WooCommerce DB version or null.
 	 */
 	public static function update_db_version( $version = null ) {
-		update_option( 'woocommerce_db_version', is_null( $version ) ? self::get_last_db_update_version() : $version );
+		if ( is_null( $version ) ) {
+			$last_db_version = array_key_last( self::$db_updates );
+			$version         = version_compare( WC()->version, $last_db_version, '>' ) ? WC()->version : $last_db_version;
+		}
+
+		update_option( 'woocommerce_db_version', $version );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -813,21 +813,26 @@ class WC_Install {
 
 		$loop = 0;
 		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
-			if ( version_compare( $current_db_version, $version, '<' ) ) {
-				foreach ( $update_callbacks as $update_callback ) {
-					WC()->queue()->schedule_single(
-						$scheduled_time + $loop,
-						'woocommerce_run_update_callback',
-						array(
-							'update_callback' => $update_callback,
-						),
-						'woocommerce-db-updates'
-					);
-					++$loop;
-				}
+			if ( version_compare( $current_db_version, $version, '>=' ) ) {
+				continue;
+			}
+
+			// Version without pre-release info to reduce noise in logs.
+			$log_version = preg_replace( '/-.*/', '', $version );
+
+			foreach ( $update_callbacks as $update_callback ) {
+				WC()->queue()->schedule_single(
+					$scheduled_time + $loop,
+					'woocommerce_run_update_callback',
+					array(
+						'update_callback' => $update_callback,
+					),
+					'woocommerce-db-updates'
+				);
+				++$loop;
 
 				wc_get_logger()->info(
-					sprintf( '  Updates from version %s scheduled.', $version ),
+					sprintf( '  [%s] Scheduled \'%s\'.', $log_version, $update_callback ),
 					array( 'source' => 'wc-updater' )
 				);
 			}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -36,6 +36,11 @@ class WC_Install {
 	 * via dbDelta at both install and update time. If any other kind of database change is required
 	 * at install time (e.g. populating tables), use the 'woocommerce_installed' hook.
 	 *
+	 * IMPORTANT:
+	 * If your update targets a version that already has a key in this array (and we're past feature freeze),
+	 * add your update under a new key by appending a suffix like `-1`, `-2`, etc. (e.g., use `10.2.0-1` if `10.2.0` exists).
+	 * This ensures updates are applied for users upgrading from beta or RC versions to the final release.
+	 *
 	 * @var array
 	 */
 	private static $db_updates = array(

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -692,11 +692,8 @@ class WC_Install {
 	 */
 	public static function needs_db_update() {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
-		$updates            = self::get_db_update_callbacks();
-		$update_versions    = array_keys( $updates );
-		usort( $update_versions, 'version_compare' );
 
-		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, self::get_last_db_update_version(), '<' );
 	}
 
 	/**
@@ -779,15 +776,29 @@ class WC_Install {
 	}
 
 	/**
+	 * Get the version of the last DB update.
+	 *
+	 * @since 10.2.0
+	 *
+	 * @return string
+	 */
+	public static function get_last_db_update_version(): string {
+		return self::$db_updates
+			? array_key_last( self::$db_updates )
+			: WC()->version();
+	}
+
+	/**
 	 * Push all needed DB updates to the queue for processing.
 	 */
 	private static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );
-		$current_wc_version = WC()->version;
+		$updates            = self::get_db_update_callbacks();
+		$wc_db_version      = array_key_last( $updates );
 		$scheduled_time     = time();
 
 		wc_get_logger()->info(
-			sprintf( 'Scheduling database updates (from %s to %s)...', $current_db_version, $current_wc_version ),
+			sprintf( 'Scheduling database updates (from %s)...', $current_db_version ),
 			array( 'source' => 'wc-updater' )
 		);
 
@@ -812,13 +823,10 @@ class WC_Install {
 		}
 
 		$loop = 0;
-		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
+		foreach ( $updates as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '>=' ) ) {
 				continue;
 			}
-
-			// Version without pre-release info to reduce noise in logs.
-			$log_version = preg_replace( '/-.*/', '', $version );
 
 			foreach ( $update_callbacks as $update_callback ) {
 				WC()->queue()->schedule_single(
@@ -832,7 +840,7 @@ class WC_Install {
 				++$loop;
 
 				wc_get_logger()->info(
-					sprintf( '  [%s] Scheduled \'%s\'.', $log_version, $update_callback ),
+					sprintf( '  [%s] Scheduled \'%s\'.', $version, $update_callback ),
 					array( 'source' => 'wc-updater' )
 				);
 			}
@@ -840,13 +848,13 @@ class WC_Install {
 
 		// After the callbacks finish, update the db version to the current WC version.
 		$success = true;
-		if ( version_compare( $current_db_version, $current_wc_version, '<' ) &&
+		if ( version_compare( $current_db_version, $wc_db_version, '<' ) &&
 			! WC()->queue()->get_next( 'woocommerce_update_db_to_current_version' ) ) {
 			$success = WC()->queue()->schedule_single(
 				$scheduled_time + $loop,
 				'woocommerce_update_db_to_current_version',
 				array(
-					'version' => $current_wc_version,
+					'version' => $wc_db_version,
 				),
 				'woocommerce-db-updates'
 			) > 0;
@@ -873,7 +881,7 @@ class WC_Install {
 	 * @param string|null $version New WooCommerce DB version or null.
 	 */
 	public static function update_db_version( $version = null ) {
-		update_option( 'woocommerce_db_version', is_null( $version ) ? WC()->version : $version );
+		update_option( 'woocommerce_db_version', is_null( $version ) ? self::get_last_db_update_version() : $version );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -984,7 +984,7 @@ class WC_Tracker {
 	 */
 	private static function get_all_woocommerce_options_values() {
 		return array(
-			'version'                               => WC()->version(),
+			'version'                               => WC()->stable_version(),
 			'currency'                              => get_woocommerce_currency(),
 			'base_location'                         => WC()->countries->get_base_country(),
 			'base_state'                            => WC()->countries->get_base_state(),

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -984,7 +984,7 @@ class WC_Tracker {
 	 */
 	private static function get_all_woocommerce_options_values() {
 		return array(
-			'version'                               => WC()->version,
+			'version'                               => WC()->version(),
 			'currency'                              => get_woocommerce_currency(),
 			'base_location'                         => WC()->countries->get_base_country(),
 			'base_state'                            => WC()->countries->get_base_state(),

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -241,7 +241,7 @@ final class WooCommerce {
 	 * @return string The WooCommerce version.
 	 */
 	public function version( ?bool $include_prerelease_info = false ): string {
-		return $include_prerelease_info ? $this->version : preg_replace( '/-.*/', '', $this->version );
+		return explode( '-', $this->version, 2 )[0];
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -232,7 +232,15 @@ final class WooCommerce {
 		return class_exists( 'WC_Legacy_REST_API_Plugin', false );
 	}
 
-	public function version( $include_prerelease_info = false ) {
+	/**
+	 * Get the WooCommerce version.
+	 *
+	 * @since 10.2.0
+	 *
+	 * @param bool $include_prerelease_info Whether to include pre-release information in the version string.
+	 * @return string The WooCommerce version.
+	 */
+	public function version( ?bool $include_prerelease_info = false ): string {
 		return $include_prerelease_info ? $this->version : preg_replace( '/-.*/', '', $this->version );
 	}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -235,12 +235,11 @@ final class WooCommerce {
 	/**
 	 * Get the WooCommerce version.
 	 *
-	 * @since 10.2.0
+	 * @since 10.3.0
 	 *
-	 * @param bool $include_prerelease_info Whether to include pre-release information in the version string.
 	 * @return string The WooCommerce version.
 	 */
-	public function version( ?bool $include_prerelease_info = false ): string {
+	public function stable_version(): string {
 		return explode( '-', $this->version, 2 )[0];
 	}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -232,6 +232,10 @@ final class WooCommerce {
 		return class_exists( 'WC_Legacy_REST_API_Plugin', false );
 	}
 
+	public function version( $include_prerelease_info = false ) {
+		return $include_prerelease_info ? $this->version : preg_replace( '/-.*/', '', $this->version );
+	}
+
 	/**
 	 * WooCommerce Constructor.
 	 */

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -46,7 +46,7 @@ class WC_Tracks {
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'store_id'       => get_option( \WC_Install::STORE_ID_OPTION, null ),
 				'products_count' => self::get_products_count(),
-				'wc_version'     => WC()->version,
+				'wc_version'     => WC()->version(),
 			);
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -46,7 +46,7 @@ class WC_Tracks {
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'store_id'       => get_option( \WC_Install::STORE_ID_OPTION, null ),
 				'products_count' => self::get_products_count(),
-				'wc_version'     => WC()->version(),
+				'wc_version'     => WC()->stable_version(),
 			);
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4307,7 +4307,7 @@ function wc_set_hooked_blocks_version() {
 		return;
 	}
 
-	add_option( $option_name, WC()->version() );
+	add_option( $option_name, WC()->stable_version() );
 }
 
 /**
@@ -4379,7 +4379,7 @@ function wc_set_hooked_blocks_version_on_theme_switch( $old_name, $old_theme ) {
 
 	// Sites with the option value set to "no" have already been migrated, and block hooks have been disabled. Checking explicitly for false to avoid setting the option again.
 	if ( ! $old_theme->is_block_theme() && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) && false === $option_value ) {
-		add_option( $option_name, WC()->version() );
+		add_option( $option_name, WC()->stable_version() );
 	}
 }
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -4307,7 +4307,7 @@ function wc_set_hooked_blocks_version() {
 		return;
 	}
 
-	add_option( $option_name, WC()->version );
+	add_option( $option_name, WC()->version() );
 }
 
 /**
@@ -4379,7 +4379,7 @@ function wc_set_hooked_blocks_version_on_theme_switch( $old_name, $old_theme ) {
 
 	// Sites with the option value set to "no" have already been migrated, and block hooks have been disabled. Checking explicitly for false to avoid setting the option again.
 	if ( ! $old_theme->is_block_theme() && ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) && false === $option_value ) {
-		add_option( $option_name, WC()->version );
+		add_option( $option_name, WC()->version() );
 	}
 }
 

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -297,12 +297,12 @@ class RemoteLogger extends \WC_Log_Handler {
 			}
 		}
 
-		if ( function_exists( 'WC' ) && method_exists( WC(), 'stable_version' ) ) {
-			return WC()->stable_version();
-		}
-
 		if ( defined( 'WC_VERSION' ) ) {
 			return WC_VERSION;
+		}
+
+		if ( function_exists( 'WC' ) ) {
+			return WC()->version;
 		}
 
 		// Return null since none of the above worked.

--- a/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
+++ b/plugins/woocommerce/src/Internal/Logging/RemoteLogger.php
@@ -297,8 +297,8 @@ class RemoteLogger extends \WC_Log_Handler {
 			}
 		}
 
-		if ( function_exists( 'WC' ) && method_exists( WC(), 'version' ) ) {
-			return WC()->version();
+		if ( function_exists( 'WC' ) && method_exists( WC(), 'stable_version' ) ) {
+			return WC()->stable_version();
 		}
 
 		if ( defined( 'WC_VERSION' ) ) {

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -110,7 +110,8 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 * No note should be created/exist if db version is equal to WC code version.
 	 */
 	public function test_noop_db_update_note() {
-		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
+		// Set the db version to the latest.
+		\WC_Install::update_db_version();
 
 		// No notes initially.
 		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
@@ -138,7 +139,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( self::get_db_update_notes() ), 'A db update note should be created if db is NOT up to date.' );
 
 		// Update the db option back.
-		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
+		\WC_Install::update_db_version();
 	}
 
 	/**
@@ -182,7 +183,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 'update-db_run', $actions[0]->name, 'A db update note to update the database should be displayed now.' );
 
 		// Simulate database update has been performed.
-		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
+		\WC_Install::update_db_version();
 
 		// Magic 2: update-db note to thank you note.
 		WC_Notes_Run_Db_Update::show_reminder();

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -110,7 +110,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 * No note should be created/exist if db version is equal to WC code version.
 	 */
 	public function test_noop_db_update_note() {
-		update_option( 'woocommerce_db_version', WC()->version );
+		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
 
 		// No notes initially.
 		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
@@ -138,7 +138,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( self::get_db_update_notes() ), 'A db update note should be created if db is NOT up to date.' );
 
 		// Update the db option back.
-		update_option( 'woocommerce_db_version', WC()->version );
+		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
 	}
 
 	/**
@@ -182,7 +182,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$this->assertEquals( 'update-db_run', $actions[0]->name, 'A db update note to update the database should be displayed now.' );
 
 		// Simulate database update has been performed.
-		update_option( 'woocommerce_db_version', WC()->version );
+		update_option( 'woocommerce_db_version', \WC_Install::get_last_db_update_version() );
 
 		// Magic 2: update-db note to thank you note.
 		WC_Notes_Run_Db_Update::show_reminder();

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
@@ -41,6 +41,16 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that `version_main` is the same or ahead of `version`.
+	 *
+	 * @since 10.2.0
+	 */
+	public function test_version_method() {
+		$this->assertTrue( version_compare( $this->wc->version(), $this->wc->version, '>=' ) );
+		$this->assertTrue( version_compare( $this->wc->version( true ), $this->wc->version, '=' ) );
+	}
+
+	/**
 	 * Test that all WC constants are set.
 	 *
 	 * @since 2.2

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
@@ -41,13 +41,12 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that `version()` returns the correct version.
+	 * Test that `stable_version()` returns the correct version.
 	 *
 	 * @since 10.2.0
 	 */
-	public function test_version_method() {
-		$this->assertTrue( version_compare( $this->wc->version(), $this->wc->version, '>=' ) );
-		$this->assertTrue( version_compare( $this->wc->version( true ), $this->wc->version, '=' ) );
+	public function test_stable_version_method() {
+		$this->assertTrue( version_compare( $this->wc->stable_version(), $this->wc->version, '>=' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
@@ -42,8 +42,6 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 
 	/**
 	 * Test that `stable_version()` returns the correct version.
-	 *
-	 * @since 10.2.0
 	 */
 	public function test_stable_version_method() {
 		$this->assertTrue( version_compare( $this->wc->stable_version(), $this->wc->version, '>=' ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/main-class.php
@@ -41,7 +41,7 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that `version_main` is the same or ahead of `version`.
+	 * Test that `version()` returns the correct version.
 	 *
 	 * @since 10.2.0
 	 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -278,4 +278,17 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 			$this->assertFalse( $update_scheduled );
 		}
 	}
+
+	/**
+	 * Ensures that the `WC_Install::$db_update_callbacks` array is sorted by version.
+	 *
+	 * @since 10.2.0
+	 */
+	public function test_db_update_callbacks_are_sorted_by_version(): void {
+		$callbacks = \WC_Install::get_db_update_callbacks();
+		$versions  = array_keys( $callbacks );
+		usort( $versions, 'version_compare' );
+
+		$this->assertSame( $versions, array_keys( $callbacks ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -282,7 +282,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Ensures that the versions in `WC_Install::$db_update_callbacks` are correct.
 	 *
-	 * @since 10.2.0
+	 * @since 10.3.0
 	 */
 	public function test_db_update_callbacks_versions(): void {
 		$callbacks = \WC_Install::get_db_update_callbacks();
@@ -298,7 +298,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 
 		// Greatest version can't be ahead of current stable (except, possibly, for its suffix).
 		$this->assertTrue(
-			empty( $versions ) || version_compare( preg_replace( '/-.*$/', '', end( $versions ) ), WC()->version(), '<=' ),
+			empty( $versions ) || version_compare( preg_replace( '/-.*$/', '', end( $versions ) ), WC()->stable_version(), '<=' ),
 			'WC_Install::$db_update_callbacks must not contain versions that are ahead of current stable (except, possibly, for suffix).',
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -280,15 +280,26 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Ensures that the `WC_Install::$db_update_callbacks` array is sorted by version.
+	 * Ensures that the versions in `WC_Install::$db_update_callbacks` are correct.
 	 *
 	 * @since 10.2.0
 	 */
-	public function test_db_update_callbacks_are_sorted_by_version(): void {
+	public function test_db_update_callbacks_versions(): void {
 		$callbacks = \WC_Install::get_db_update_callbacks();
 		$versions  = array_keys( $callbacks );
 		usort( $versions, 'version_compare' );
 
-		$this->assertSame( $versions, array_keys( $callbacks ) );
+		// Array must be sorted by version.
+		$this->assertSame(
+			$versions,
+			array_keys( $callbacks ),
+			'WC_Install::$db_update_callbacks must be sorted by version.',
+		);
+
+		// Greatest version can't be ahead of current stable (except, possibly, for its suffix).
+		$this->assertTrue(
+			empty( $versions ) || version_compare( preg_replace( '/-.*$/', '', end( $versions ) ), WC()->version(), '<=' ),
+			'WC_Install::$db_update_callbacks must not contain versions that are ahead of current stable (except, possibly, for suffix).',
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -281,8 +281,6 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 
 	/**
 	 * Ensures that the versions in `WC_Install::$db_update_callbacks` are correct.
-	 *
-	 * @since 10.3.0
 	 */
 	public function test_db_update_callbacks_versions(): void {
 		$callbacks = \WC_Install::get_db_update_callbacks();

--- a/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
+++ b/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
@@ -58,9 +58,9 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		$sut->update();
 
 		$this->assertEquals(
-			WC()->version,
+			\WC_Install::get_last_db_update_version(),
 			get_option( 'woocommerce_db_version' ),
-			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the current `WC()->version` property.'
+			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the last db update version in code.'
 		);
 	}
 
@@ -78,9 +78,9 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		$sut->update();
 
 		$this->assertEquals(
-			WC()->version,
+			\WC_Install::get_last_db_update_version(),
 			get_option( 'woocommerce_db_version' ),
-			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the current `WC()->version` property.'
+			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the last db update version in code.'
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
+++ b/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
@@ -57,9 +57,8 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		$sut = new WC_CLI_Update_Command();
 		$sut->update();
 
-		$this->assertEquals(
-			\WC_Install::get_last_db_update_version(),
-			get_option( 'woocommerce_db_version' ),
+		$this->assertTrue(
+			version_compare( get_option( 'woocommerce_db_version' ), WC()->version, '>=' ),
 			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the last db update version in code.'
 		);
 	}
@@ -77,9 +76,8 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		$sut = new WC_CLI_Update_Command();
 		$sut->update();
 
-		$this->assertEquals(
-			\WC_Install::get_last_db_update_version(),
-			get_option( 'woocommerce_db_version' ),
+		$this->assertTrue(
+			version_compare( get_option( 'woocommerce_db_version' ), WC()->version, '>=' ),
 			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the last db update version in code.'
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Database/BlockHooksVersionTests.php
+++ b/plugins/woocommerce/tests/php/src/Database/BlockHooksVersionTests.php
@@ -37,7 +37,7 @@ class BlockHooksVersionTests extends \WC_Unit_Test_Case {
 
 		WC_Install::newly_installed();
 
-		$this->assertEquals( WC()->version, get_option( self::$option_name ) );
+		$this->assertEquals( WC()->version(), get_option( self::$option_name ) );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class BlockHooksVersionTests extends \WC_Unit_Test_Case {
 
 		// This fires the action that sets the block hooks version: 'after_switch_theme'.
 		check_theme_switched();
-		$this->assertEquals( WC()->version, get_option( self::$option_name ) );
+		$this->assertEquals( WC()->version(), get_option( self::$option_name ) );
 		$this->assertEquals( $initial_option_value, false );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Database/BlockHooksVersionTests.php
+++ b/plugins/woocommerce/tests/php/src/Database/BlockHooksVersionTests.php
@@ -37,7 +37,7 @@ class BlockHooksVersionTests extends \WC_Unit_Test_Case {
 
 		WC_Install::newly_installed();
 
-		$this->assertEquals( WC()->version(), get_option( self::$option_name ) );
+		$this->assertEquals( WC()->stable_version(), get_option( self::$option_name ) );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class BlockHooksVersionTests extends \WC_Unit_Test_Case {
 
 		// This fires the action that sets the block hooks version: 'after_switch_theme'.
 		check_theme_switched();
-		$this->assertEquals( WC()->version(), get_option( self::$option_name ) );
+		$this->assertEquals( WC()->stable_version(), get_option( self::$option_name ) );
 		$this->assertEquals( $initial_option_value, false );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -109,16 +109,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 					'setup'     => function () {
 						$version = WC()->version;
 						// Next major version. (e.g. 9.0.1 -> 10.0.0).
-						$next_version = implode(
-							'.',
-							array_map(
-								function ( $n, $i ) {
-									return 0 === $i ? $n + 1 : 0;
-								},
-								explode( '.', $version ),
-								array_keys( explode( '.', $version ) )
-							)
-						);
+						$next_version = sprintf( '%d.0.0', explode( '.', $version )[0] + 1 );
 
 						set_site_transient( RemoteLogger::WC_NEW_VERSION_TRANSIENT, $next_version, WEEK_IN_SECONDS );
 					},

--- a/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Logging/RemoteLoggerTest.php
@@ -109,7 +109,7 @@ namespace Automattic\WooCommerce\Tests\Internal\Logging {
 					'setup'     => function () {
 						$version = WC()->version;
 						// Next major version. (e.g. 9.0.1 -> 10.0.0).
-						$next_version = sprintf( '%d.0.0', explode( '.', $version )[0] + 1 );
+						$next_version = sprintf( '%d.0.0', explode( '.', $version, 2 )[0] + 1 );
 
 						set_site_transient( RemoteLogger::WC_NEW_VERSION_TRANSIENT, $next_version, WEEK_IN_SECONDS );
 					},


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

In #60356 we updated our workflows so that the internal WC version stored in `WooCommerce::$version` (or `WC_VERSION`) matches the plugin version. See p1754985704041959-slack-C07JJG089M0. There are a few places where we don't necessarily want to expose prerelease information or that could break external flows (e.g. tracking).

This PR introduces `WooCommerce::version()` as an utility method that can remove prerelease bits from the version number as needed.

It also slightly changes how db versions and updates are handled, so that we have a way of ensuring updates run throughout the beta > RC > stable cycle for those installing prerelease versions. This is particularly important for the RC > stable case, since the RC is used for internal (final) checks prior to the stable.

> [!NOTE]
> Ideally the database version (`woocommerce_db_version` option) wouldn't be tied to the WC version so that we can freely add updates without worrying about the exact version number we should use. For simplicity's sake, this PR doesn't fully implement such disconnect but it is a step in that direction.
>
> After this PR, the upgrade routine will set the db version to either the WC version or the last key in the `$db_updates` array, whichever is higher, allowing us to keep the current convention of using `X.Y.Z` even for prereleases and also adding new routines post feature freeze, as long as we suffix those like `10.2.0-1`.
>
> The above will ensure that anyone gets the correct updates regardless of whether they're upgrading from a beta or RC version.

Related to #60345.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Simulate a fresh install:**
   1. Run `wp option delete woocommerce_db_version && wp option delete woocommerce_version`.
   1. Load any admin page on your site.
   1. Ensure that both `wp option get woocommerce_version` and `wp option get woocommerce_db_version` return `10.2.0-dev`.
1. **Simulate an update from 9.9.5**:
   1. Run `wp transient delete wc_installing && wp option set woocommerce_db_version 9.9.5 && wp option set woocommerce_version 9.9.5`.
   1. Load any admin page on your site.
   1. Go to WC > Status > Logs > `wc-updater` and confirm it contains the following entries:
      <img width="738" height="176" alt="Screenshot 2025-08-20 at 16 39 15" src="https://github.com/user-attachments/assets/3a19cac8-9742-4e41-a01c-dcd4fac3c013" />
   1. Ensure that both `wp option get woocommerce_version` and `wp option get woocommerce_db_version` return `10.2.0-dev`.
1. **Simulate an update routine introduced before the RC:**
   1. Edit `class-wc-install.php` and locate the `$db_updates` array. Add an entry such as the following to the end of the array:
      ```php
      '10.2.0' => array(
          '__return_false',
      )
      ```
   1. Edit `class-woocommerce.php` and change `$version` to `10.2.0-rc.1`.
   1. Load any admin page on your site.
   1. Go to WC > Status > Logs > `wc-updater` and confirm it contains a new entry about the newly introduced `__return_false` update.
   1. Wait for A-S to process the updates or manually run them via Tools > Action Scheduler.
   1. Ensure that `wp option get woocommerce_version` returns `10.2.0-rc.1` and `wp option get woocommerce_db_version` returns `10.2.0`.
1. **Ensure db updates don't run unnecessarily:**
   1. Edit `class-woocommerce.php` and change `$version` to `10.2.0-rc.2`.
   1. Load any admin page on your site.
   1. Go to WC > Status > Logs > `wc-updater` and confirm it **doesn't** contain any new entries.
   1. Ensure that `wp option get woocommerce_version` returns `10.2.0-rc.2` and `wp option get woocommerce_db_version` still returns `10.2.0`.
1. **Simulate an update routine introduced after the RC, before the final:**
   1. Edit `class-wc-install.php` and locate the `$db_updates` array. Add an entry such as the following to the end of the array:
      ```php
      '10.2.0-1' => array(
          '__return_false',
      )
      ```
   1. Edit `class-woocommerce.php` and change `$version` to `10.2.0`.
   1. Load any admin page on your site.
   1. Go to WC > Status > Logs > `wc-updater` and confirm it contains a new entry about the newly introduced `__return_false` update.
   1. Wait for A-S to process the updates or manually run them via Tools > Action Scheduler.
   1. Ensure that `wp option get woocommerce_version` returns `10.2.0` and `wp option get woocommerce_db_version` returns `10.2.0-1`.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
