### PR TITLE
Remove Add to Cart Button hardcoded size from Add to Cart + Options template parts

### DIFF
--- a/plugins/woocommerce/changelog/update-add-to-cart-with-options-button-size
+++ b/plugins/woocommerce/changelog/update-add-to-cart-with-options-button-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove Add to Cart Button hardcoded size from Add to Cart + Options template parts

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -42,8 +42,6 @@
 		display: inline-flex;
 		justify-content: center;
 		text-align: center;
-		// Set button font size so it inherits from parent.
-		font-size: 1em;
 		width: auto;
 	}
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/style.scss
@@ -45,15 +45,10 @@
 			color: currentColor;
 			margin: 0;
 			font-size: 0.8em;
-			height: 1.5em;
 			box-sizing: content-box;
-			/**
-			* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
-			*
-			* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
-			*/
-			padding: 0.9rem 0;
+			padding: 0.7rem 0;
 			margin-right: unset;
+			max-width: 3.631em; /* This value is based on the WC core styles. */
 
 			&:focus {
 				border-radius: unset;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -126,7 +126,13 @@
 		text-decoration: none;
 		font-size: medium;
 		cursor: pointer;
+	}
 
+	// Reset the margin top in the Add to Cart + Options block.
+	// @see https://github.com/woocommerce/woocommerce/pull/60413
+	// Extra class for specificity.
+	.wp-block-add-to-cart-with-options .wp-block-button__link.wp-block-button__link {
+		margin-top: 0;
 	}
 
 	// Style the 'Showing A-B of X results' text.

--- a/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/external-product-add-to-cart-with-options.html
@@ -1,3 +1,3 @@
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/grouped-product-add-to-cart-with-options.html
@@ -29,5 +29,5 @@
 </div>
 <!-- /wp:woocommerce/add-to-cart-with-options-grouped-product-selector -->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /--></div>
+<div class="wp-block-group"><!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/simple-product-add-to-cart-with-options.html
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/product-stock-indicator {"style":{"spacing":{"margin":{"top":"1rem","bottom":"1rem"}}}} /-->
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
-<!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /--></div>
+<!-- wp:woocommerce/product-button {"textAlign":"left"} /--></div>
 <!-- /wp:group -->

--- a/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
+++ b/plugins/woocommerce/templates/parts/variable-product-add-to-cart-with-options.html
@@ -29,6 +29,6 @@
 <div class="wp-block-group">
 	<!-- wp:woocommerce/add-to-cart-with-options-quantity-selector {"quantitySelectorStyle":"stepper"} /-->
 
-	<!-- wp:woocommerce/product-button {"textAlign":"left","fontSize":"medium"} /-->
+	<!-- wp:woocommerce/product-button {"textAlign":"left"} /-->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the `"fontSize":"medium"` style from the the _Add to Cart + Options_ template parts, which was hardcoded in the _Add to Cart Button_ block. It also reduces the _Product Quantity_ block vertical padding so it doesn't look out of proportion with different button sizes.

I also took the opportunity to fix the _Product Quantity_ block being too wide in the editor.

Closes WOOPLUG-5331.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Click on the _Add to Cart with Options_ block and update to the blockified version.
3. Verify the quantity input isn't too big:

Before | After
--- | ---
<img width="640" height="400" alt="imatge" src="https://github.com/user-attachments/assets/6f8f8011-c9bc-4711-b756-7ab8660c5c3a" /> | <img width="640" height="400" alt="imatge" src="https://github.com/user-attachments/assets/fb11885e-91ab-4505-8167-6fa57a5c7923" />

4. Visit an external, a simple, a variable and a grouped product in the frontend.
5. Verify the add to cart form still looks good, but the button is slightly smaller than before.

Before | After
--- | ---
<img width="640" height="400" alt="imatge" src="https://github.com/user-attachments/assets/4d8280d6-92d0-453c-9279-e9702092d90f" /> | <img width="640" height="400" alt="imatge" src="https://github.com/user-attachments/assets/a59e63d0-af74-4fcc-a53f-ba8c21453860" />


