### PR TITLE
[NOX] Scroll to top of the page when navigating to Offline Gateways page

### DIFF
--- a/plugins/woocommerce/changelog/enhance-WOOPLUG-5353-offline-gateway-pages-scroll-to-top
+++ b/plugins/woocommerce/changelog/enhance-WOOPLUG-5353-offline-gateway-pages-scroll-to-top
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fixed scroll position issue by ensuring the Offline Gateways page always loads at the top.

--- a/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/index.tsx
@@ -104,6 +104,10 @@ const OfflinePaymentGatewayWrapper = ( {
 	title,
 	chunkComponent: ChunkComponent,
 }: OfflinePaymentGatewayWrapperProps ) => {
+	useEffect( () => {
+		window.scrollTo( 0, 0 ); // Scrolls to the top of the page.
+	}, [] );
+
 	return (
 		<>
 			<div className="settings-payments-offline__container">
@@ -354,6 +358,10 @@ export const SettingsPaymentsMethods = () => {
  * Wraps the offline payment gateways settings page.
  */
 export const SettingsPaymentsOfflineWrapper = () => {
+	useEffect( () => {
+		window.scrollTo( 0, 0 ); // Scrolls to the top of the page.
+	}, [] );
+
 	return (
 		<>
 			<div className="settings-payments-offline__container">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses an issue where soft routing to the Offline Gateways page preserves the previous page’s scroll position (e.g., from Payments), causing users to land partway down the page instead of at the top.

Closes WOOPLUG-5353

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

Before

https://github.com/user-attachments/assets/974e9f78-631b-4947-ae10-559b39ca8d4b

After

https://github.com/user-attachments/assets/a19b7318-debc-43c1-9fe0-0851aa0fb3d8


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new JN store with WooCommerce on this PR's branch, WooPayments and WCPay Dev Tools (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=enhance/WOOPLUG-5353-offline-gateway-pages-scroll-to-top)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Navigate to WooCommerce > Settings > Payments.
4. Open your browser’s developer tools to extend the page height, then scroll until the “Take offline payments” section aligns with the top of your screen.
5. Click the “Take offline payments” button on the right.
6. Confirm that after redirection, the page automatically scrolls to the top.
7. Enable Direct bank transfer, then scroll until the “Manage” link aligns with the top of your screen.
8. Click “Manage” and confirm that after redirection, the page automatically scrolls to the top.
9. Do the same with the other two gateways.

### Testing that has already taken place:
Check above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
