### PR TITLE
Accessibility: Set aria-role to presentational for layout tables within emails.

### DIFF
--- a/plugins/woocommerce/changelog/60447-fix-60410-a11y-email-template-presentational-tables
+++ b/plugins/woocommerce/changelog/60447-fix-60410-a11y-email-template-presentational-tables
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Improve accessibility of emails by setting the aria-role of layout tables to presentation.

--- a/plugins/woocommerce/templates/emails/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/admin-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/admin-failed-order.php
@@ -65,7 +65,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/admin-failed-order.php
+++ b/plugins/woocommerce/templates/emails/admin-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/admin-new-order.php
@@ -63,7 +63,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/admin-new-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/admin-new-order.php
+++ b/plugins/woocommerce/templates/emails/admin-new-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -75,7 +75,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-cancelled-order.php
+++ b/plugins/woocommerce/templates/emails/customer-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.9.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -70,7 +70,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-failed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-failed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-failed-order.php
@@ -80,7 +80,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
@@ -80,7 +80,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">';
+	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo '</td></tr></table>';
 }

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-created.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.1.0
+ * @version 10.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
@@ -80,7 +80,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">';
+	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo '</td></tr></table>';
 }

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-deleted.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.1.0
+ * @version 10.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\HTML
- * @version 10.1.0
+ * @version 10.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
+++ b/plugins/woocommerce/templates/emails/customer-fulfillment-updated.php
@@ -81,7 +81,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">';
+	echo '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo '</td></tr></table>';
 }

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -120,7 +120,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;

--- a/plugins/woocommerce/templates/emails/customer-invoice.php
+++ b/plugins/woocommerce/templates/emails/customer-invoice.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Enums\OrderStatus;

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -61,7 +61,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -76,7 +76,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-note.php
+++ b/plugins/woocommerce/templates/emails/customer-note.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/customer-on-hold-order.php
@@ -70,7 +70,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/customer-on-hold-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-on-hold-order.php
+++ b/plugins/woocommerce/templates/emails/customer-on-hold-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
@@ -78,7 +78,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-completed-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
@@ -89,7 +89,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-pos-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.9.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -73,7 +73,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-processing-order.php
+++ b/plugins/woocommerce/templates/emails/customer-processing-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-refunded-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-refunded-order.php
+++ b/plugins/woocommerce/templates/emails/customer-refunded-order.php
@@ -87,7 +87,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -61,7 +61,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
  * Show user-defined additional content - this is set in each email's settings.
  */
 if ( $additional_content ) {
-	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
+	echo $email_improvements_enabled ? '<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tr><td class="email-additional-content email-additional-content-aligned">' : '';
 	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
 	echo $email_improvements_enabled ? '</td></tr></table>' : '';
 }

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/customer-reset-password.php
+++ b/plugins/woocommerce/templates/emails/customer-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.8.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -26,7 +26,7 @@ $shipping = $order->get_formatted_shipping_address();
 
 $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improvements' );
 
-?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0">
+?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: <?php echo $email_improvements_enabled ? '0' : '40px'; ?>; padding:0;" border="0" role="presentation">
 	<tr>
 		<td class="font-family text-align-left" style="border:0; padding:0;" valign="top" width="50%">
 			<?php if ( $email_improvements_enabled ) { ?>

--- a/plugins/woocommerce/templates/emails/email-addresses.php
+++ b/plugins/woocommerce/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 9.9.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -43,7 +43,14 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 	<?php foreach ( $downloads as $download ) : ?>
 		<tr>
 			<?php foreach ( $columns as $column_id => $column_name ) : ?>
-				<<?php echo 'download-product' === $column_id ? 'th scope="row"' : 'td'; ?> class="td <?php echo $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left'; ?>">
+				<?php
+					$column_alignment_class = $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left';
+					if ( 'download-product' === $column_id ) :
+				?>
+					<th class="td <?php echo esc_attr( $column_alignment_class ); ?>" scope="row">
+				<?php else : ?>
+					<td class="td <?php echo esc_attr( $column_alignment_class ); ?>">
+				<?php endif; ?>
 					<?php
 					if ( has_action( 'woocommerce_email_downloads_column_' . $column_id ) ) {
 						do_action( 'woocommerce_email_downloads_column_' . $column_id, $download, $plain_text );
@@ -71,7 +78,11 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 						}
 					}
 					?>
-				</<?php echo 'download-product' === $column_id ? 'th' : 'td'; ?>>
+					<?php if ( 'download-product' === $column_id ) : ?>
+						</th>
+					<?php else : ?>
+						</td>
+					<?php endif; ?>
 			<?php endforeach; ?>
 		</tr>
 	<?php endforeach; ?>

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -43,7 +43,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 	<?php foreach ( $downloads as $download ) : ?>
 		<tr>
 			<?php foreach ( $columns as $column_id => $column_name ) : ?>
-				<td class="td <?php echo $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left'; ?>">
+				<<?php echo 'download-product' === $column_id ? 'th scope="row"' : 'td'; ?> class="td <?php echo $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left'; ?>">
 					<?php
 					if ( has_action( 'woocommerce_email_downloads_column_' . $column_id ) ) {
 						do_action( 'woocommerce_email_downloads_column_' . $column_id, $download, $plain_text );
@@ -71,7 +71,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 						}
 					}
 					?>
-				</td>
+				</<?php echo 'download-product' === $column_id ? 'th' : 'td'; ?>>
 			<?php endforeach; ?>
 		</tr>
 	<?php endforeach; ?>

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-downloads.php
+++ b/plugins/woocommerce/templates/emails/email-downloads.php
@@ -44,9 +44,9 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 		<tr>
 			<?php foreach ( $columns as $column_id => $column_name ) : ?>
 				<?php
-					$column_alignment_class = $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left';
-					if ( 'download-product' === $column_id ) :
-				?>
+				$column_alignment_class = $email_improvements_enabled && array_key_last( $columns ) === $column_id ? 'text-align-right' : 'text-align-left';
+				if ( 'download-product' === $column_id ) :
+					?>
 					<th class="td <?php echo esc_attr( $column_alignment_class ); ?>" scope="row">
 				<?php else : ?>
 					<td class="td <?php echo esc_attr( $column_alignment_class ); ?>">

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -37,10 +37,10 @@ $email = $email ?? null;
 							<tr>
 								<td align="center" valign="top">
 									<!-- Footer -->
-									<table border="0" cellpadding="10" cellspacing="0" width="100%" id="template_footer">
+									<table border="0" cellpadding="10" cellspacing="0" width="100%" id="template_footer" role="presentation">
 										<tr>
 											<td valign="top">
-												<table border="0" cellpadding="10" cellspacing="0" width="100%">
+												<table border="0" cellpadding="10" cellspacing="0" width="100%" role="presentation">
 													<tr>
 														<td colspan="2" valign="middle" id="credit">
 															<?php

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -33,12 +33,12 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 		<title><?php echo esc_html( $store_name ); ?></title>
 	</head>
 	<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-		<table width="100%" id="outer_wrapper">
+		<table width="100%" id="outer_wrapper" role="presentation">
 			<tr>
 				<td><!-- Deliberately empty to support consistent sizing and layout across multiple email clients. --></td>
 				<td width="600">
 					<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
-						<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="inner_wrapper">
+						<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="inner_wrapper" role="presentation">
 							<tr>
 								<td align="center" valign="top">
 									<?php
@@ -55,7 +55,7 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 
 									if ( $email_improvements_enabled ) :
 										?>
-										<table border="0" cellpadding="0" cellspacing="0" width="100%">
+										<table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation">
 											<tr>
 												<td id="template_header_image">
 													<?php
@@ -77,11 +77,11 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 											?>
 										</div>
 									<?php endif; ?>
-									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_container">
+									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_container" role="presentation">
 										<tr>
 											<td align="center" valign="top">
 												<!-- Header -->
-												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
+												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header" role="presentation">
 													<tr>
 														<td id="header_wrapper">
 															<h1><?php echo esc_html( $email_heading ); ?></h1>
@@ -94,11 +94,11 @@ $store_name                 = $store_name ?? get_bloginfo( 'name', 'display' );
 										<tr>
 											<td align="center" valign="top">
 												<!-- Body -->
-												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_body">
+												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_body" role="presentation">
 													<tr>
 														<td valign="top" id="body_content">
 															<!-- Content -->
-															<table border="0" cellpadding="20" cellspacing="0" width="100%">
+															<table border="0" cellpadding="20" cellspacing="0" width="100%" role="presentation">
 																<tr>
 																	<td valign="top" id="body_content_inner_cell">
 																		<div id="body_content_inner">

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.0.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -75,7 +75,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			<tr>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
-				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $email_improvements_enabled ? 'right' : $text_align ); ?>;"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $order_total_text_align ); ?>;"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -71,15 +71,13 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 
 <div style="margin-bottom: <?php echo $email_improvements_enabled ? '24px' : '40px'; ?>;">
 	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">
-		<?php if ( ! $email_improvements_enabled ) { ?>
 		<thead>
 			<tr>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
-				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
+				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $email_improvements_enabled ? 'right' : $text_align ); ?>;"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
-		<?php } ?>
 		<tbody>
 			<?php
 			$image_size = $email_improvements_enabled ? 48 : 32;

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -102,7 +102,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		if ( $item_totals ) {
 			$i = 0;
 			foreach ( $item_totals as $total ) {
-				$i++;
+				++$i;
 				$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
 				?>
 				<tr class="order-totals order-totals-<?php echo esc_attr( $total['type'] ?? 'unknown' ); ?><?php echo esc_attr( $last_class ); ?>">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -25,6 +25,7 @@ $email_improvements_enabled = FeaturesUtil::feature_is_enabled( 'email_improveme
 $heading_class              = $email_improvements_enabled ? 'email-order-detail-heading' : '';
 $order_table_class          = $email_improvements_enabled ? 'email-order-details' : '';
 $order_total_text_align     = $email_improvements_enabled ? 'right' : 'left';
+$order_quantity_text_align  = $email_improvements_enabled ? 'right' : 'left';
 
 if ( $email_improvements_enabled ) {
 	add_filter( 'woocommerce_order_shipping_to_display_shipped_via', '__return_false' );
@@ -74,7 +75,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		<thead>
 			<tr>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
-				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
+				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $order_quantity_text_align ); ?>;"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></th>
 				<th class="td" scope="col" style="text-align:<?php echo esc_attr( $order_total_text_align ); ?>;"><?php esc_html_e( 'Price', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.1.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -93,41 +93,41 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 			);
 			?>
 		</tbody>
-		<tfoot>
-			<?php
-			$item_totals       = $order->get_order_item_totals();
-			$item_totals_count = count( $item_totals );
+	</table>
+	<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1">
+		<?php
+		$item_totals       = $order->get_order_item_totals();
+		$item_totals_count = count( $item_totals );
 
-			if ( $item_totals ) {
-				$i = 0;
-				foreach ( $item_totals as $total ) {
-					$i++;
-					$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
-					?>
-					<tr class="order-totals order-totals-<?php echo esc_attr( $total['type'] ?? 'unknown' ); ?><?php echo esc_attr( $last_class ); ?>">
-						<th class="td text-align-left" scope="row" colspan="2" style="<?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>">
-							<?php
-							echo wp_kses_post( $total['label'] ) . ' ';
-							if ( $email_improvements_enabled ) {
-								echo isset( $total['meta'] ) ? wp_kses_post( $total['meta'] ) : '';
-							}
-							?>
-						</th>
-						<td class="td text-align-<?php echo esc_attr( $order_total_text_align ); ?>" style="<?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>"><?php echo wp_kses_post( $total['value'] ); ?></td>
-					</tr>
-					<?php
-				}
-			}
-			if ( $order->get_customer_note() && ! $email_improvements_enabled ) {
+		if ( $item_totals ) {
+			$i = 0;
+			foreach ( $item_totals as $total ) {
+				$i++;
+				$last_class = ( $i === $item_totals_count ) ? ' order-totals-last' : '';
 				?>
-				<tr>
-					<th class="td text-align-left" scope="row" colspan="2"><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td class="td text-align-left"><?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array() ); ?></td>
+				<tr class="order-totals order-totals-<?php echo esc_attr( $total['type'] ?? 'unknown' ); ?><?php echo esc_attr( $last_class ); ?>">
+					<th class="td text-align-left" scope="row" colspan="2" style="<?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>">
+						<?php
+						echo wp_kses_post( $total['label'] ) . ' ';
+						if ( $email_improvements_enabled ) {
+							echo isset( $total['meta'] ) ? wp_kses_post( $total['meta'] ) : '';
+						}
+						?>
+					</th>
+					<td class="td text-align-<?php echo esc_attr( $order_total_text_align ); ?>" style="<?php echo ( 1 === $i ) ? 'border-top-width: 4px;' : ''; ?>"><?php echo wp_kses_post( $total['value'] ); ?></td>
 				</tr>
 				<?php
 			}
+		}
+		if ( $order->get_customer_note() && ! $email_improvements_enabled ) {
 			?>
-		</tfoot>
+			<tr>
+				<th class="td text-align-left" scope="row" colspan="2"><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
+				<td class="td text-align-left"><?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array() ); ?></td>
+			</tr>
+			<?php
+		}
+		?>
 	</table>
 	<?php if ( $order->get_customer_note() && $email_improvements_enabled ) { ?>
 		<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1" role="presentation">

--- a/plugins/woocommerce/templates/emails/email-order-details.php
+++ b/plugins/woocommerce/templates/emails/email-order-details.php
@@ -126,19 +126,19 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				</tr>
 				<?php
 			}
-			if ( $order->get_customer_note() && $email_improvements_enabled ) {
-				?>
-				<tr class="order-customer-note">
-					<td class="td text-align-left" colspan="3">
-						<b><?php esc_html_e( 'Customer note', 'woocommerce' ); ?></b><br>
-						<?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
-					</td>
-				</tr>
-				<?php
-			}
 			?>
 		</tfoot>
 	</table>
+	<?php if ( $order->get_customer_note() && $email_improvements_enabled ) { ?>
+		<table class="td font-family <?php echo esc_attr( $order_table_class ); ?>" cellspacing="0" cellpadding="6" style="width: 100%;" border="1" role="presentation">
+			<tr class="order-customer-note">
+				<td class="td text-align-left">
+					<b><?php esc_html_e( 'Customer note', 'woocommerce' ); ?></b><br>
+					<?php echo wp_kses( nl2br( wc_wptexturize_order_note( $order->get_customer_note() ) ), array( 'br' => array() ) ); ?>
+				</td>
+			</tr>
+		</table>
+	<?php } ?>
 </div>
 
 <?php

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 9.9.0
+ * @version 10.3.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -42,7 +42,7 @@ foreach ( $items as $item_id => $item ) :
 
 	?>
 	<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
-		<th class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;" scope="row">
+		<td class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;" scope="row">
 			<?php if ( $email_improvements_enabled ) { ?>
 				<table class="order-item-data" role="presentation">
 					<tr>
@@ -68,7 +68,7 @@ foreach ( $items as $item_id => $item ) :
 							 * @param WC_Order_Item_Product $item      The item being displayed.
 							 * @since 2.1.0
 							 */
-							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', "<h3 style='font-size: inherit;'>" . $item->get_name() . "</h3>", $item, false ) );
 
 							// SKU.
 							if ( $show_sku && $sku ) {

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 10.3.0
+ * @version 10.4.0
  */
 
 use Automattic\WooCommerce\Utilities\FeaturesUtil;

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -42,7 +42,7 @@ foreach ( $items as $item_id => $item ) :
 
 	?>
 	<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
-		<td class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;">
+		<th class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;" scope="row">
 			<?php if ( $email_improvements_enabled ) { ?>
 				<table class="order-item-data">
 					<tr>

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -44,7 +44,7 @@ foreach ( $items as $item_id => $item ) :
 	<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
 		<th class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;" scope="row">
 			<?php if ( $email_improvements_enabled ) { ?>
-				<table class="order-item-data">
+				<table class="order-item-data" role="presentation">
 					<tr>
 						<?php
 						// Show title/image etc.

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -68,7 +68,8 @@ foreach ( $items as $item_id => $item ) :
 							 * @param WC_Order_Item_Product $item      The item being displayed.
 							 * @since 2.1.0
 							 */
-							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', "<h3 style='font-size: inherit;'>" . $item->get_name() . '</h3>', $item, false ) );
+							$order_item_name = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
+							echo wp_kses_post( "<h3 style='font-size: inherit;font-weight: inherit;'>{$order_item_name}</h3>" );
 
 							// SKU.
 							if ( $show_sku && $sku ) {

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -68,7 +68,7 @@ foreach ( $items as $item_id => $item ) :
 							 * @param WC_Order_Item_Product $item      The item being displayed.
 							 * @since 2.1.0
 							 */
-							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', "<h3 style='font-size: inherit;'>" . $item->get_name() . "</h3>", $item, false ) );
+							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', "<h3 style='font-size: inherit;'>" . $item->get_name() . '</h3>', $item, false ) );
 
 							// SKU.
 							if ( $show_sku && $sku ) {

--- a/plugins/woocommerce/templates/emails/email-order-items.php
+++ b/plugins/woocommerce/templates/emails/email-order-items.php
@@ -42,7 +42,7 @@ foreach ( $items as $item_id => $item ) :
 
 	?>
 	<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
-		<td class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;" scope="row">
+		<td class="td font-family text-align-left" style="vertical-align: middle; word-wrap:break-word;">
 			<?php if ( $email_improvements_enabled ) { ?>
 				<table class="order-item-data" role="presentation">
 					<tr>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Modifies the email templates to add `role="presentation"` to table elements used for layout purposes. In the accessibility tree, this sets the nodes to "generic" rather than "table", removing incorrect information for users of assistive technology.

Closes #60410.
Closes https://linear.app/a8c/issue/WOO10UP-29/tracking-issue-for-accessibility-email-tables

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This pull request changes the HTML markup in all the emails generated by WooCommerce Core and any extensions making use of the actions for generating the HTML emails (which is most extensions in my experience).

These emails can be found listed on `/wp-admin/admin.php?page=wc-settings&tab=email`.

The HTML markup for emails should be checked both with and without "Email improvements" enabled, see `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`

Firefox makes it easier to open an iframe in it's own tab, so I suggest you use that.

1. Navigate to emails, `/wp-admin/admin.php?page=wc-settings&tab=email`
2. Select the first email in the dropdown list for previewing emails. <img width="720" height="311" alt="Screenshot 2025-09-10 at 12 06 43 pm" src="https://github.com/user-attachments/assets/98fb761d-b998-4cc4-a9d8-d6623742d289" />
3. Once the preview loads in the iframe, in Firefox you can right click on the email select "This frame > Open Frame in new tab".
4. In the browser console, run `$$( 'table:not([role="presentation"])')` (works in both Chrome and Firefox)
5. Ensure that each of the elements listed are tables containing table data. In both Chrome and Firefox you can click on each list in the items returned.
   In most emails, this should be two items: the order details (listing each product) and the order summary (ie, subtotal, etc)
6. In the browser console run `$$( 'table[role="presentation"]')` to list tables that have had their semantic role removed
7. Ensure that each of the elements listed are NOT tables containing presentational table data.






<!-- End testing instructions -->

### Testing that has already taken place:

Above with a sub-section of the emails: New order, processing, new account with email improvements enabled and disabled.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Improve accessibility of emails by setting the aria-role of layout tables to presentation.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
