### PR TITLE
[NOX] Resolve SCSS load order issues causing build warnings (modals.scss)

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-5364-scss-files-order-conflict
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-5364-scss-files-order-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Resolved SCSS load order warnings between Payments Settings and Launch Your Store chunks.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
@@ -1,5 +1,7 @@
-// Import styles once to avoid build errors.
-import './modals.scss';
+/**
+ * Internal dependencies
+ */
+import './modals.scss'; // Import styles once to avoid build errors.
 
 export * from './woo-payments-reset-account-modal';
 export * from './woo-payments-post-sandbox-account-setup-modal';

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
@@ -1,7 +1,2 @@
-/**
- * Internal dependencies
- */
-import './modals.scss'; // Import styles once to avoid build errors.
-
 export * from './woo-payments-reset-account-modal';
 export * from './woo-payments-post-sandbox-account-setup-modal';

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/index.ts
@@ -1,2 +1,5 @@
+// Import styles once to avoid build errors.
+import './modals.scss';
+
 export * from './woo-payments-reset-account-modal';
 export * from './woo-payments-post-sandbox-account-setup-modal';

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/modals.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/modals.scss
@@ -1,3 +1,7 @@
+/**
+ * This styles are imported into the main settings-payments.scss file directly.
+ * This is done to avoid build errors when importing the same file in multiple places.
+ */
 .components-modal__frame {
 	@media screen and (max-width: 782px) {
 		margin: auto;

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-post-sandbox-account-setup-modal.tsx
@@ -11,7 +11,6 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import './modals.scss';
 import {
 	getWooPaymentsSetupLiveAccountLink,
 	recordPaymentsEvent,

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/modals/woo-payments-reset-account-modal.tsx
@@ -14,7 +14,6 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import './modals.scss';
 import { recordPaymentsEvent } from '~/settings-payments/utils';
 import {
 	wooPaymentsExtensionSlug,

--- a/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
+++ b/plugins/woocommerce/client/admin/client/settings-payments/onboarding/providers/woopayments/steps/test-account/index.tsx
@@ -15,7 +15,7 @@ import WooPaymentsStepHeader from '../../components/header';
 import { useOnboardingContext } from '../../data/onboarding-context';
 import { WC_ASSET_URL } from '~/utils/admin-settings';
 import { recordPaymentsOnboardingEvent } from '~/settings-payments/utils';
-import { WooPaymentsResetAccountModal } from '~/settings-payments/components/modals/woo-payments-reset-account-modal';
+import { WooPaymentsResetAccountModal } from '~/settings-payments/components/modals';
 import './style.scss';
 
 const TEST_ACCOUNT_ERROR_CODES = {

--- a/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/settings-payments-main.scss
@@ -1,3 +1,9 @@
+/* *
+ * Internal dependencies
+ */
+/* This is imported here to avoid build errors when importing the same file in multiple places. */
+@import "./components/modals/modals.scss";
+
 /* These keyframes and spinner style are copied from the Stripe Spinner component https://docs.stripe.com/stripe-apps/components/spinner?app-sdk-version=8  */
 @keyframes SpinnerAnimationShow {
 	0% {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a CSS order conflict warning raised during the client/admin build by the mini-css-extract-plugin. The issue was caused by modal styles being imported separately in multiple components and reused across different chunk groups (settings-payments-main and launch-store).

Closes WOOPLUG-5364

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1245" height="649" alt="Screenshot 2025-08-19 at 9 43 11" src="https://github.com/user-attachments/assets/5d8b3563-5f9d-4728-8881-bc236fc313b9" /> | <img width="1290" height="494" alt="Screenshot 2025-08-19 at 9 38 38" src="https://github.com/user-attachments/assets/b265c6bb-821c-4a2c-baa8-2bafb7b80b85" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this PR's branch locally.
2. Run `pnpm --filter=@woocommerce/plugin-woocommerce watch:build`.
3. Verify there are no SCSS conflicts during the building of the plugin.
4. Smoke test account reset to verify the styles are displayed correctly.

<!-- End testing instructions -->

### Testing that has already taken place:

Check above

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
