### PR TITLE
[Migrator]: Added tracker for products migrated

### DIFF
--- a/plugins/woocommerce/changelog/migrator-analytics
+++ b/plugins/woocommerce/changelog/migrator-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added tracker for migrated products in wc_migrator_products_count

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -183,6 +183,9 @@ class WC_Tracker {
 		$data['categories'] = self::get_category_counts();
 		$data['brands']     = self::get_brands_counts();
 
+		// Migrator CLI statistics.
+		$data['migrator'] = self::get_migrator_data();
+
 		// Get order snapshot.
 		$data['order_snapshot'] = self::get_order_snapshot();
 
@@ -967,6 +970,17 @@ class WC_Tracker {
 			return 0;
 		}
 		return wp_count_terms( 'product_brand' );
+	}
+
+	/**
+	 * Get migrator CLI statistics.
+	 *
+	 * @return array
+	 */
+	private static function get_migrator_data() {
+		return array(
+			'products_migrated' => absint( get_option( 'wc_migrator_products_count', 0 ) ),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/ProductsController.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/ProductsController.php
@@ -552,7 +552,7 @@ class ProductsController {
 
 			$this->log_batch_results( $batch_results );
 			$processed_count = $batch_results['stats']['successful'];
-			
+
 			if ( $processed_count > 0 ) {
 				$current_count = get_option( 'wc_migrator_products_count', 0 );
 				update_option( 'wc_migrator_products_count', $current_count + $processed_count );

--- a/plugins/woocommerce/src/Internal/CLI/Migrator/Core/ProductsController.php
+++ b/plugins/woocommerce/src/Internal/CLI/Migrator/Core/ProductsController.php
@@ -552,6 +552,11 @@ class ProductsController {
 
 			$this->log_batch_results( $batch_results );
 			$processed_count = $batch_results['stats']['successful'];
+			
+			if ( $processed_count > 0 ) {
+				$current_count = get_option( 'wc_migrator_products_count', 0 );
+				update_option( 'wc_migrator_products_count', $current_count + $processed_count );
+			}
 		}
 
 		return $processed_count;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59841 

Our aim is to track the total products migrated using the migrator. This should be able to give us data point on how many products will be migrated using the migrator for that blog id.
