### PR TITLE
Interactivity API powered MiniCart - Move MiniCart overlay to the `body`

### DIFF
--- a/plugins/woocommerce/changelog/60464-wooplug-5313-text-not-visible-in-the-iapi-mini-cart-if-the-header-text-is
+++ b/plugins/woocommerce/changelog/60464-wooplug-5313-text-not-visible-in-the-iapi-mini-cart-if-the-header-text-is
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move iAPI mini-cart overlay to the `body`

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -49,12 +49,12 @@ const { itemsInCartTextTemplate } = getConfig(
 setStyles();
 
 type MiniCartContext = {
-	isOpen: boolean;
 	productCountVisibility: 'never' | 'always' | 'greater_than_zero';
 };
 
 type MiniCart = {
 	state: {
+		isOpen: boolean;
 		totalItemsInCart: number;
 		formattedSubtotal: string;
 		drawerOverlayClass: string;
@@ -134,23 +134,18 @@ store< MiniCart >(
 			},
 
 			get drawerRole() {
-				const { isOpen } = getContext< MiniCartContext >();
-
-				return isOpen ? 'dialog' : null;
+				return state.isOpen ? 'dialog' : null;
 			},
 
 			get drawerTabIndex() {
-				const { isOpen } = getContext< MiniCartContext >();
-
-				return isOpen ? '-1' : null;
+				return state.isOpen ? '-1' : null;
 			},
 
 			get drawerOverlayClass() {
-				const { isOpen } = getContext< MiniCartContext >();
 				const baseClasses =
 					'wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out';
 
-				return isOpen
+				return state.isOpen
 					? `${ baseClasses } wc-block-components-drawer__screen-overlay--with-slide-in`
 					: `${ baseClasses } wc-block-components-drawer__screen-overlay--is-hidden`;
 			},
@@ -201,26 +196,22 @@ store< MiniCart >(
 					window.location.href = checkoutUrl;
 					return;
 				}
-				const ctx = getContext< MiniCartContext >();
-				ctx.isOpen = true;
+				state.isOpen = true;
 			},
 
 			closeDrawer() {
-				const ctx = getContext< MiniCartContext >();
-				ctx.isOpen = false;
+				state.isOpen = false;
 			},
 
 			overlayCloseDrawer( e: MouseEvent ) {
 				// Only close the drawer if the overlay itself was clicked.
 				if ( e.target === e.currentTarget ) {
-					const ctx = getContext< MiniCartContext >();
-					ctx.isOpen = false;
+					state.isOpen = false;
 				}
 			},
 
 			disableScrollingOnBody() {
-				const { isOpen } = getContext< MiniCartContext >();
-				if ( isOpen ) {
+				if ( state.isOpen ) {
 					Object.assign( document.body.style, {
 						overflow: 'hidden',
 						paddingRight:

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -576,45 +576,9 @@ class MiniCart extends AbstractBlock {
 				: '';
 
 			// Render the minicart overlay in the body, outside of the block itself.
-			add_action(
-				'wp_footer',
-				function () {
-					ob_start();
-					$template_part_contents = $this->get_template_part_contents( false );
-					$template_part_contents = do_blocks( $this->process_template_contents( $template_part_contents ) );					
-					?>
-
-					<div
-						data-wp-interactive="woocommerce/mini-cart"
-						data-wp-router-region='{ "id": "woocommerce/mini-cart-overlay", "attachTo": "body" }'
-						data-wp-key="wc-mini-cart-overlay"
-						data-wp-on--click="callbacks.overlayCloseDrawer"
-						data-wp-bind--class="state.drawerOverlayClass"
-					>
-						<div 
-							data-wp-bind--role="state.drawerRole"
-							data-wp-bind--aria-modal="state.isOpen"
-							data-wp-bind--aria-hidden="!state.isOpen"
-							data-wp-bind--tabindex="state.drawerTabIndex"
-							class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
-						>
-							<div class="wc-block-components-drawer__content">
-								<div class="wc-block-mini-cart__template-part">
-									<?php
-										// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-										echo $template_part_contents;
-									?>
-								</div>
-							</div>
-						</div>
-					</div>				
-
-					<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo wp_interactivity_process_directives( ob_get_clean() );
-				}
-			);
-
+			if ( ! has_action( 'wp_footer', array( $this, 'render_experimental_iapi_mini_cart_overlay' ) ) ) {
+				add_action( 'wp_footer', array( $this, 'render_experimental_iapi_mini_cart_overlay' ) );
+			}
 			ob_start();
 			?>
 		
@@ -658,6 +622,45 @@ class MiniCart extends AbstractBlock {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Echoes the Interactivity API Mini Cart overlay markup.
+	 * 
+	 * @return string The processed template contents.
+	 */
+	public function render_experimental_iapi_mini_cart_overlay() {
+		$template_part_contents = $this->get_template_part_contents( false );
+		$template_part_contents = do_blocks( $this->process_template_contents( $template_part_contents ) );
+		ob_start();
+		?>
+		<div
+			data-wp-interactive="woocommerce/mini-cart"
+			data-wp-router-region='{ "id": "woocommerce/mini-cart-overlay", "attachTo": "body" }'
+			data-wp-key="wc-mini-cart-overlay"
+			data-wp-on--click="callbacks.overlayCloseDrawer"
+			data-wp-bind--class="state.drawerOverlayClass"
+		>
+			<div
+				data-wp-bind--role="state.drawerRole"
+				data-wp-bind--aria-modal="state.isOpen"
+				data-wp-bind--aria-hidden="!state.isOpen"
+				data-wp-bind--tabindex="state.drawerTabIndex"
+				class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
+			>
+				<div class="wc-block-components-drawer__content">
+					<div class="wc-block-mini-cart__template-part">
+						<?php
+							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							echo $template_part_contents;
+						?>
+					</div>
+				</div>
+			</div>
+		</div>				
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_interactivity_process_directives( ob_get_clean() );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -626,8 +626,8 @@ class MiniCart extends AbstractBlock {
 
 	/**
 	 * Echoes the Interactivity API Mini Cart overlay markup.
-	 * 
-	 * @return string The processed template contents.
+	 *
+	 * @return void
 	 */
 	public function render_experimental_iapi_mini_cart_overlay() {
 		$template_part_contents = $this->get_template_part_contents( false );

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -539,6 +539,7 @@ class MiniCart extends AbstractBlock {
 			wp_interactivity_state(
 				$this->get_full_block_name(),
 				array(
+					'isOpen'             => false,
 					'totalItemsInCart'   => $cart_item_count,
 					'badgeIsVisible'     => $badge_is_visible,
 					'formattedSubtotal'  => $formatted_subtotal,
@@ -553,7 +554,6 @@ class MiniCart extends AbstractBlock {
 			);
 
 			$context = array(
-				'isOpen'                       => false,
 				'productCountVisibility'       => $product_count_visibility,
 				'displayCartPriceIncludingTax' => $display_cart_price_including_tax,
 			);
@@ -574,6 +574,43 @@ class MiniCart extends AbstractBlock {
 			$button_role = 'navigate_to_checkout' === $on_cart_click_behaviour
 				? 'role="link"'
 				: '';
+
+			// Render the minicart overlay in the body, outside of the block itself.
+			add_action( 'wp_footer', function() {
+				ob_start();
+				$template_part_contents           = $this->get_template_part_contents( false );
+				$template_part_contents           = do_blocks( $this->process_template_contents( $template_part_contents ) );
+				
+				?>
+
+				<div
+					data-wp-interactive="woocommerce/mini-cart"
+					data-wp-router-region='{ "id": "woocommerce/mini-cart-overlay", "attachTo": "body" }'
+					data-wp-key="wc-mini-cart-overlay"
+					data-wp-on--click="callbacks.overlayCloseDrawer"
+					data-wp-bind--class="state.drawerOverlayClass"
+				>
+					<div 
+						data-wp-bind--role="state.drawerRole"
+						data-wp-bind--aria-modal="state.isOpen"
+						data-wp-bind--aria-hidden="!state.isOpen"
+						data-wp-bind--tabindex="state.drawerTabIndex"
+						class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
+					>
+						<div class="wc-block-components-drawer__content">
+							<div class="wc-block-mini-cart__template-part">
+								<?php
+									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+									echo $template_part_contents;
+								?>
+							</div>
+						</div>
+					</div>
+				</div>				
+
+				<?php
+				echo wp_interactivity_process_directives( ob_get_clean() );
+			});
 
 			ob_start();
 			?>
@@ -612,24 +649,6 @@ class MiniCart extends AbstractBlock {
 						?>
 					<?php endif; ?>
 				</button>
-				<div data-wp-on--click="callbacks.overlayCloseDrawer" data-wp-bind--class="state.drawerOverlayClass">
-					<div 
-						data-wp-bind--role="state.drawerRole"
-						data-wp-bind--aria-modal="context.isOpen"
-						data-wp-bind--aria-hidden="!context.isOpen"
-						data-wp-bind--tabindex="state.drawerTabIndex"
-						class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
-					>
-						<div class="wc-block-components-drawer__content">
-							<div class="wc-block-mini-cart__template-part">
-								<?php
-									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-									echo $template_part_contents;
-								?>
-							</div>
-						</div>
-					</div>
-				</div>
 			</div>
 			<?php
 			return ob_get_clean();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -576,41 +576,44 @@ class MiniCart extends AbstractBlock {
 				: '';
 
 			// Render the minicart overlay in the body, outside of the block itself.
-			add_action( 'wp_footer', function() {
-				ob_start();
-				$template_part_contents           = $this->get_template_part_contents( false );
-				$template_part_contents           = do_blocks( $this->process_template_contents( $template_part_contents ) );
-				
-				?>
+			add_action(
+				'wp_footer',
+				function () {
+					ob_start();
+					$template_part_contents = $this->get_template_part_contents( false );
+					$template_part_contents = do_blocks( $this->process_template_contents( $template_part_contents ) );					
+					?>
 
-				<div
-					data-wp-interactive="woocommerce/mini-cart"
-					data-wp-router-region='{ "id": "woocommerce/mini-cart-overlay", "attachTo": "body" }'
-					data-wp-key="wc-mini-cart-overlay"
-					data-wp-on--click="callbacks.overlayCloseDrawer"
-					data-wp-bind--class="state.drawerOverlayClass"
-				>
-					<div 
-						data-wp-bind--role="state.drawerRole"
-						data-wp-bind--aria-modal="state.isOpen"
-						data-wp-bind--aria-hidden="!state.isOpen"
-						data-wp-bind--tabindex="state.drawerTabIndex"
-						class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
+					<div
+						data-wp-interactive="woocommerce/mini-cart"
+						data-wp-router-region='{ "id": "woocommerce/mini-cart-overlay", "attachTo": "body" }'
+						data-wp-key="wc-mini-cart-overlay"
+						data-wp-on--click="callbacks.overlayCloseDrawer"
+						data-wp-bind--class="state.drawerOverlayClass"
 					>
-						<div class="wc-block-components-drawer__content">
-							<div class="wc-block-mini-cart__template-part">
-								<?php
-									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-									echo $template_part_contents;
-								?>
+						<div 
+							data-wp-bind--role="state.drawerRole"
+							data-wp-bind--aria-modal="state.isOpen"
+							data-wp-bind--aria-hidden="!state.isOpen"
+							data-wp-bind--tabindex="state.drawerTabIndex"
+							class="wc-block-mini-cart__drawer wc-block-components-drawer is-mobile"
+						>
+							<div class="wc-block-components-drawer__content">
+								<div class="wc-block-mini-cart__template-part">
+									<?php
+										// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+										echo $template_part_contents;
+									?>
+								</div>
 							</div>
 						</div>
-					</div>
-				</div>				
+					</div>				
 
-				<?php
-				echo wp_interactivity_process_directives( ob_get_clean() );
-			});
+					<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo wp_interactivity_process_directives( ob_get_clean() );
+				}
+			);
 
 			ob_start();
 			?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I'm moving the iAPI powered minicart overlay to the `body` instead of having it inside the minicart block markup. This is how it is working right now, which makes sense and prevent styling issues.

Closes #60357 .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1201" height="1258" alt="Screenshot 2025-08-19 at 13 25 26" src="https://github.com/user-attachments/assets/04022e70-1017-4fec-bc85-aeb923df3f92" />  |   <img width="1213" height="1263" alt="Screenshot 2025-08-19 at 13 23 18" src="https://github.com/user-attachments/assets/e19481bb-99d3-40ac-af54-280fa4152f6d" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to *WooCommerce* > *Settings* > *Advanced* > *Features* and enable the *Interactivity API powered Mini Cart*.
2. Go to *Appearance* > *Editor* and edit any template.
3. Change the styles of the header so it has dark background and light text.
3. Now go to the front end.
4. Open the Mini-Cart.
5. Notice the text is visible.
6. Check the minicart is working as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary></summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Move iAPI mini-cart overlay to the `body`

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
