### PR TITLE
Fix: Email editor conflict with Site Editor and improve theme style inheritance

### DIFF
--- a/packages/js/email-editor/changelog/wooplug-5356-site-editor-broken-when-email-editor-is-active
+++ b/packages/js/email-editor/changelog/wooplug-5356-site-editor-broken-when-email-editor-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Ensure the email editor obtains and utilizes the site theme styles as part of its default values.

--- a/packages/js/email-editor/src/components/styles-sidebar/panels/typography-element-panel.tsx
+++ b/packages/js/email-editor/src/components/styles-sidebar/panels/typography-element-panel.tsx
@@ -211,10 +211,7 @@ export function TypographyElementPanel( {
 	};
 
 	const resetAll = () => {
-		updateElementStyleProp(
-			[ 'typography' ],
-			defaultElementStyles.typography
-		);
+		updateElementStyleProp( [ 'typography' ], {} );
 		recordEvent(
 			'styles_sidebar_screen_typography_element_panel_reset_all_styles_selected',
 			{
@@ -232,7 +229,7 @@ export function TypographyElementPanel( {
 			<ToolsPanelItem
 				label={ __( 'Font family', 'woocommerce' ) }
 				hasValue={ hasFontFamily }
-				onDeselect={ () => setFontFamily( defaultFontFamily ) }
+				onDeselect={ () => setFontFamily( undefined ) }
 				isShownByDefault={ defaultControls.fontFamily }
 			>
 				<FontFamilyControl
@@ -247,7 +244,7 @@ export function TypographyElementPanel( {
 				<ToolsPanelItem
 					label={ __( 'Font size', 'woocommerce' ) }
 					hasValue={ hasFontSize }
-					onDeselect={ () => setFontSize( defaultFontSize ) }
+					onDeselect={ () => setFontSize( undefined ) }
 					isShownByDefault={ defaultControls.fontSize }
 				>
 					<FontSizePicker
@@ -268,8 +265,8 @@ export function TypographyElementPanel( {
 				hasValue={ hasFontAppearance }
 				onDeselect={ () => {
 					setFontAppearance( {
-						fontStyle: defaultFontStyle,
-						fontWeight: defaultFontWeight,
+						fontStyle: undefined,
+						fontWeight: undefined,
 					} );
 				} }
 				isShownByDefault={ defaultControls.fontAppearance }
@@ -289,7 +286,7 @@ export function TypographyElementPanel( {
 				className="single-column"
 				label={ __( 'Line height', 'woocommerce' ) }
 				hasValue={ hasLineHeight }
-				onDeselect={ () => setLineHeight( defaultLineHeight ) }
+				onDeselect={ () => setLineHeight( undefined ) }
 				isShownByDefault={ defaultControls.lineHeight }
 			>
 				<LineHeightControl
@@ -304,7 +301,7 @@ export function TypographyElementPanel( {
 				className="single-column"
 				label={ __( 'Letter spacing', 'woocommerce' ) }
 				hasValue={ hasLetterSpacing }
-				onDeselect={ () => setLetterSpacing( defaultLetterSpacing ) }
+				onDeselect={ () => setLetterSpacing( undefined ) }
 				isShownByDefault={ defaultControls.letterSpacing }
 			>
 				<LetterSpacingControl
@@ -318,7 +315,7 @@ export function TypographyElementPanel( {
 				className="single-column"
 				label={ __( 'Text decoration', 'woocommerce' ) }
 				hasValue={ hasTextDecoration }
-				onDeselect={ () => setTextDecoration( defaultTextDecoration ) }
+				onDeselect={ () => setTextDecoration( undefined ) }
 				isShownByDefault={ defaultControls.textDecoration }
 			>
 				<TextDecorationControl

--- a/packages/js/email-editor/src/hooks/use-email-styles.ts
+++ b/packages/js/email-editor/src/hooks/use-email-styles.ts
@@ -24,6 +24,19 @@ interface EmailStylesData {
 }
 
 /**
+ * Check if a nested object is empty.
+ *
+ * @param {Object} obj The object to check.
+ * @return {boolean} True if the nested object is empty, false otherwise.
+ */
+function isNestedEmpty( obj ) {
+	const isNotEmpty = Object.keys( obj ).some(
+		( key ) => Object.keys( obj[ key ] ).length > 0
+	);
+	return ! isNotEmpty;
+}
+
+/**
  * Immutably sets a value inside an object. Like `lodash#set`, but returning a
  * new object. Treats nullish initial values as empty objects. Clones any
  * nested objects. Supports arrays, too.
@@ -114,7 +127,10 @@ function cleanupUserStyles( obj ) {
 			for ( const key in current ) {
 				if ( current.hasOwnProperty( key ) ) {
 					const cleanedValue = cleanObject( current[ key ] );
-					if ( cleanedValue === undefined ) {
+					if (
+						cleanedValue === undefined ||
+						isNestedEmpty( cleanedValue )
+					) {
 						delete current[ key ]; // Remove keys with undefined values
 					} else {
 						current[ key ] = cleanedValue;

--- a/packages/php/email-editor/changelog/wooplug-5356-site-editor-broken-when-email-editor-is-active
+++ b/packages/php/email-editor/changelog/wooplug-5356-site-editor-broken-when-email-editor-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Email editor conflict with the site editor.

--- a/packages/php/email-editor/src/Engine/class-email-editor.php
+++ b/packages/php/email-editor/src/Engine/class-email-editor.php
@@ -105,8 +105,6 @@ class Email_Editor {
 		$this->logger->info( 'Initializing email editor' );
 		do_action( 'woocommerce_email_editor_initialized' );
 		add_filter( 'woocommerce_email_editor_rendering_theme_styles', array( $this, 'extend_email_theme_styles' ), 10, 2 );
-		// Initialize the assets manager.
-		$this->assets_manager->initialize();
 
 		$this->register_block_patterns();
 		$this->register_email_post_types();
@@ -116,6 +114,8 @@ class Email_Editor {
 		$is_editor_page = apply_filters( 'woocommerce_is_email_editor_page', false );
 		if ( $is_editor_page ) {
 			$this->extend_email_post_api();
+			// Initialize the assets manager.
+			$this->assets_manager->initialize();
 		}
 		add_action( 'rest_api_init', array( $this, 'register_email_editor_api_routes' ) );
 		add_filter( 'woocommerce_email_editor_send_preview_email', array( $this->send_preview_email, 'send_preview_email' ), 11, 1 ); // allow for other filter methods to take precedent.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60439 WOOPLUG-5356.

This PR fixes a critical conflict between the WooCommerce Email Editor and WordPress Site Editor that was preventing the Site Editor from functioning properly when the Email Editor plugin was active. Additionally, it improves how the Email Editor inherits and utilizes theme styles.

**Why are these changes needed?**

The Email Editor was initializing its assets manager globally, causing conflicts with the Site Editor interface. This made it impossible for users to use the Site Editor when the Email Editor was active, significantly impacting the user experience. Furthermore, the typography reset functionality wasn't properly leveraging theme.json styles from the site theme, preventing proper style inheritance.

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="1726" height="800" alt="Screenshot 2025-08-18 at 5 48 08 PM" src="https://github.com/user-attachments/assets/4973aa70-7609-4a0d-9d7e-79228cbcd362" />  |   <img width="1728" height="909" alt="Screenshot 2025-08-19 at 12 33 33 PM" src="https://github.com/user-attachments/assets/30255503-8ec5-43f0-ac81-95ae185f282b" /> |
| <img width="487" height="70" alt="Screenshot 2025-08-19 at 10 24 05 AM" src="https://github.com/user-attachments/assets/64209572-0f92-4b08-8b25-c9fc1aec2409" /> | <img width="423" height="64" alt="Screenshot 2025-08-19 at 10 25 33 AM" src="https://github.com/user-attachments/assets/beb49509-b11e-43e6-9332-53ab0d54d483" /> | 



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Test Site Editor Functionality:**
   - Activate the WooCommerce Email Editor
   - Navigate to WordPress Admin > Appearance > Site Editor
   - Verify that the Site Editor loads and functions normally without conflicts
   - Confirm you can edit site templates and navigate through the interface

2. **Test Email Editor Style Inheritance:**
   - Navigate to WooCommerce > Settings > Emails > Customize Email
   - Open the Typography panel for any text element
   - Modify typography settings (font family, size, weight, etc.)
   - Click the "Reset all" button and verify styles reset to theme.json values
   - Individual typography controls should also reset to theme values when deselected

3. **Test Typography Reset Functionality:**
   - In the Email Editor, customize typography settings for headers, paragraphs, or links
   - Use individual reset buttons for each typography property
   - Verify that reset values come from the active theme's theme.json or email editor theme.json
   - Ensure no hardcoded default values are applied




<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

- **Local Development Testing**: Verified on a local WordPress installation with various themes
- **Site Editor Compatibility**: Confirmed Site Editor functionality is restored when Email Editor is active
- **Typography Reset Behavior**: Tested individual and bulk reset functionality with different theme configurations
- **Style Inheritance**: Verified proper fallback to theme.json values for typography properties
- **Code Analysis**: Reviewed initialization flow to ensure assets are only loaded when necessary


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
