### PR TITLE
Add `WOOCOMMERCE_CART` constant when on `update_cart` AJAX actions

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5336-is_cart-returns-false-after-cart-is-updated
+++ b/plugins/woocommerce/changelog/wooplug-5336-is_cart-returns-false-after-cart-is-updated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set the WOOCOMMERCE_CART constant on update cart AJAX routes

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -637,6 +637,8 @@ class WC_Form_Handler {
 			return;
 		}
 
+		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
+
 		wc_nocache_headers();
 
 		$nonce_value = wc_get_var( $_REQUEST['woocommerce-cart-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- When on the `update_cart` AJAX action, the `WOOCOMMERCE_CART` should be set. This is in line with the other cart methods: `get_cart_totals` and `update_shipping_method`

Closes WOOPLUG-5336
Closes: #60403

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a custom snippet
```php
add_action( 'woocommerce_after_cart_item_quantity_update', function () {
	var_dump( is_cart() );
} );
```
2. With dev tools open, view the network tab.
3. Add an item, then go to the Shortcode cart, increase the item quantity.
4. In the network tab of dev tools, look for a request to the checkout page, and then view the response. You should see a dump of `true` in the response.
5. Remove the snippet from step 1.
6. Ensure adding/removing coupons, removing items, undoing removal of items, and proceeding to checkout all work as expected. 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
