### PR TITLE
Add ambiguous provider match notice to tracking number lookup form

### DIFF
--- a/plugins/woocommerce/changelog/60470-add-WOOPLUG-5095-notice-for-low-confidence-provider-match
+++ b/plugins/woocommerce/changelog/60470-add-WOOPLUG-5095-notice-for-low-confidence-provider-match
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+Comment: Add ambiguous provider match notice to tracking number lookup form
+

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/style.scss
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/fulfillments/style.scss
@@ -297,6 +297,14 @@
 	margin: 0;
 }
 
+.woocommerce-fulfillment-description-button {
+	font-size: 12px !important;
+	font-weight: 400 !important;
+	line-height: 16px !important;
+	padding: 0 !important;
+	height: auto !important;
+}
+
 .woocommerce-fulfillment-status-badge {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new indicator for making ambiguity visible for merchants if a tracking number returns more than one possible providers, if:

- There are multiple providers resolved with each of their ambiguity score is less than 85,
- There are multiple providers resolved with more than one having the score over 85

And we accept that there is no ambiguity when there is only one provider match, or multiple provider matches with one of them having an ambiguity score above 85 (and others less than 85).

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-5095 #59812 

### Screenshots or screen recordings:

<img width="422" height="301" alt="image" src="https://github.com/user-attachments/assets/b7bfbf3f-4d06-45fc-8a2d-183908cc49bc" />


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch to your local
2. Run `npm run watch:build` to rebuild the assets
3. Make sure that you have an US store
4. Create an order if you don't have one
5. Open the fulfillments drawer, and on the shipping information box, make sure the tracking number option is selected.
6. Open the network panel of your browser. 
7. Test the tracking number `123456789012`. It should match FedEx with the ambiguity score of 90, and three others (UPS, DHL, DPD) with less than 85. And it shouldn't show a "Not your provider?" message, as it has one record having an ambiguity score more than 85, and others less than 85.
8. Test the tracking number `1234567890123456`. It should match Amazon Logistics and DPD, with both having 60 as their ambiguity score, and shows the "Not your provider?" message because of that.
9. Test the tracking number `AB123456789US`. It should match DPD and USPS as the highest score with 90, and two others (DHL, UPS) with less than 85. Because of more than one passing the high bar, it should show the "Not your provider?" ambiguity message.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Add ambiguous provider match notice to tracking number lookup form
</details>
