### PR TITLE
Fix padding for checkout steps when step numbers are enabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-padding-in-checkout-with-step-numbers
+++ b/plugins/woocommerce/changelog/fix-padding-in-checkout-with-step-numbers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix padding for checkout steps when step numbers are enabled

--- a/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
+++ b/plugins/woocommerce/client/blocks/assets/css/abstracts/_mixins.scss
@@ -318,6 +318,12 @@ $fontSizes: (
 	}
 }
 
+@mixin cart-checkout-below-medium-container {
+	@container (max-width: 519px) {
+		@content;
+	}
+}
+
 @mixin cart-checkout-small-container {
 	@container (min-width: 400px) and (max-width: 519px) {
 		@content;

--- a/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
+++ b/plugins/woocommerce/client/blocks/packages/components/form-step/style.scss
@@ -2,41 +2,6 @@
 	counter-reset: checkout-step;
 }
 
-@mixin step-mobile-styles() {
-	padding-left: 0;
-	margin-bottom: $gap-larger;
-
-	// The below CSS rules are to show a separator between Checkout steps on mobile.
-	// This media query is required because on themes where the Checkout block is rendered alongside something else,
-	// e.g. Storefront using the "Default Template" (which has a sidebar) the checkout block can get the `.is-small`
-	// class, but the screen itself is larger than 400px.
-	@include breakpoint("<600px") {
-		padding-top: $gap-larger;
-
-		// Remove padding from the first checkout step. First of type is required here as the first-child is the express payment methods block.
-		&:first-of-type {
-			padding-top: 0;
-		}
-
-		&::after {
-			position: absolute;
-			content: "";
-			// Required because the box shadows are offset by 1px down so we need to move the element up by 1px.
-			bottom: calc(1px - $gap-larger);
-			width: 100%;
-			height: 1px;
-			opacity: 0.11;
-			background: currentColor;
-			// This box-shadow rule creates two visible shadows:
-			// - One 50vw to the left of the element.
-			// - Another 50vw to the right
-			// Both shadows are sharp (no blur) and use the current color of the element.
-			// Its purpose is to add a full-width divider between checkout sections which is otherwise impossible as
-			// the parent element has padding.
-			box-shadow: -50vw 0 0 0 currentColor, 50vw 0 0 0 currentColor;
-		}
-	}
-}
 .wc-block-components-form .wc-block-components-checkout-step {
 	position: relative;
 	border: none;
@@ -44,12 +9,45 @@
 	background: none;
 	margin: 0 0 $gap-largest 0;
 
-	@include cart-checkout-mobile-container {
-		@include step-mobile-styles();
-	}
+	@include cart-checkout-below-medium-container {
+		padding-left: 0;
+		margin-bottom: $gap-larger;
 
-	@include cart-checkout-small-container {
-		@include step-mobile-styles();
+		// The below CSS rules show a separator between Checkout steps on mobile.
+		// This media query is required because on themes where the Checkout
+		// block is rendered alongside something else, e.g. Storefront using the
+		// "Default Template" (which has a sidebar) the checkout block can get
+		// the `.is-small` class, but the screen itself is larger than 400px.
+		@include breakpoint("<600px") {
+			padding-top: $gap-larger;
+
+			// Remove padding from the first checkout step. First of type is
+			// required here as the first-child is the express payment methods
+			// block.
+			&:first-of-type {
+				padding-top: 0;
+			}
+
+			&::after {
+				position: absolute;
+				content: "";
+				// Required because the box shadows are offset by 1px down so we
+				// need to move the element up by 1px.
+				bottom: calc(1px - $gap-larger);
+				width: 100%;
+				height: 1px;
+				opacity: 0.11;
+				background: currentColor;
+				// This box-shadow rule creates two visible shadows:
+				// - One 50vw to the left of the element.
+				// - Another 50vw to the right
+				// Both shadows are sharp (no blur) and use the current color of the element.
+				// Its purpose is to add a full-width divider between checkout
+				// sections which is otherwise impossible as the parent element has
+				// padding.
+				box-shadow: -50vw 0 0 0 currentColor, 50vw 0 0 0 currentColor;
+			}
+		}
 	}
 }
 
@@ -73,14 +71,17 @@
 		margin-bottom: 0;
 	}
 }
+
 .wc-block-components-checkout-step--with-step-number
 	.wc-block-components-checkout-step__content
 	> :last-child {
 	margin-bottom: 0;
 }
+
 .wc-block-checkout__contact-fields .wc-block-components-checkout-step__heading {
 	margin-top: em($gap-smaller);
 }
+
 .wc-block-components-checkout-step__heading {
 	margin: 0 0 $gap-smaller;
 	position: relative;
@@ -121,17 +122,20 @@
 	margin: 0 0 $gap;
 }
 
-@mixin step-number-mobile-styles {
-	position: static;
-	transform: none;
-	left: auto;
-	top: auto;
-	content: counter(checkout-step) ".\00a0";
-	content: counter(checkout-step) ".\00a0"/ "";
-}
 .wc-block-checkout__form--with-step-numbers {
 	.wc-block-components-checkout-step--with-step-number {
 		padding: 0 0 0 $gap-larger;
+
+		@include cart-checkout-below-medium-container {
+			// This media query is required because on themes where the Checkout
+			// block is rendered alongside something else, e.g. Storefront using
+			// the "Default Template" (which has a sidebar) the checkout block
+			// can get the `.is-small` class, but the screen itself is larger
+			// than 400px.
+			@include breakpoint("<600px") {
+				padding: $gap-larger 0 0 0;
+			}
+		}
 
 		.wc-block-components-checkout-step__title::before {
 			@include reset-box();
@@ -146,12 +150,13 @@
 			transform: translateX(-50%);
 			white-space: nowrap;
 
-			@include cart-checkout-mobile-container {
-				@include step-number-mobile-styles;
-			}
-
-			@include cart-checkout-small-container {
-				@include step-number-mobile-styles;
+			@include cart-checkout-below-medium-container {
+				position: static;
+				transform: none;
+				left: auto;
+				top: auto;
+				content: counter(checkout-step) ".\00a0";
+				content: counter(checkout-step) ".\00a0"/ "";
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Fixes incorrect padding when step numbers are enabled for checkout.

Bug introduced in PR #57826

### Screenshots or screen recordings:

| Before | After |
|--------|-------|
| <img width="824" height="856" alt="CleanShot 2025-08-19 at 15 44 06@2x" src="https://github.com/user-attachments/assets/02de1621-5fab-49fd-96f3-2a7c5a453ce2" /> | <img width="824" height="892" alt="CleanShot 2025-08-19 at 15 44 29@2x" src="https://github.com/user-attachments/assets/7bdca5ea-c26b-4a68-9db0-37bf073813cd" /> |

### How to test the changes in this Pull Request:

1. Open checkout page in the editor
2. Select "Checkout" (top-level) block and enable the "Show form step numbers" option
3. Open your store on a mobile device (emulating with devtools is fine)
4. Add a product to your cart and proceed to checkout
5. Verify that the checkout steps have consistent padding
6. Repeat those steps with "Show form step numbers" disabled