### PR TITLE
Restore 70/30 variant assignment split between MailPoet and Klaviyo

### DIFF
--- a/plugins/woocommerce/changelog/60476-wooplug-5373-revert-the-variant-assignment-configuration-for-mailpoet-and
+++ b/plugins/woocommerce/changelog/60476-wooplug-5373-revert-the-variant-assignment-configuration-for-mailpoet-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Restore 70/30 variant assignment split between MailPoet and Klaviyo extensions

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -190,7 +190,7 @@ class DefaultFreeExtensions {
 					array(
 						'type'        => 'option',
 						'option_name' => 'woocommerce_remote_variant_assignment',
-						'value'       => array( 1, 60 ), // 50% segment with klaviyo
+						'value'       => array( 1, 84 ), // 70% segment with klaviyo
 						'default'     => false,
 						'operation'   => 'range',
 					),
@@ -220,7 +220,7 @@ class DefaultFreeExtensions {
 					array(
 						'type'        => 'option',
 						'option_name' => 'woocommerce_remote_variant_assignment',
-						'value'       => array( 61, 120 ), // 50% segment with mailpoet
+						'value'       => array( 85, 120 ), // 30% segment with mailpoet
 						'default'     => false,
 						'operation'   => 'range',
 					),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR reverts the variant assignment configuration to restore the original 70/30 split between MailPoet and Klaviyo extensions.

**Changes Made:**
- **MailPoet extension**: Updated variant assignment range from `array(1, 60)` to `array(1, 84)` to cover 70% of users
- **Klaviyo extension**: Updated variant assignment range from `array(61, 120)` to `array(85, 120)` to cover 30% of users

**Technical Details:**
- Modified `DefaultFreeExtensions.php` to adjust the `woocommerce_remote_variant_assignment` option values
- **MailPoet**: Targets users with variant IDs 1-84 (70% segment: 84/120 variants)
- **Klaviyo**: Targets users with variant IDs 85-120 (30% segment: 36/120 variants)

**Files Changed:**
- `plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php` (4 lines changed: 2 insertions, 2 deletions)

### Screenshots or screen recordings:

<!-- No UI changes in this PR -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

* Set up a fresh WooCommerce installation
* Verify the woocommerce_remote_variant_assignment option is set (it should be a random number between 1-120)
* Test with different variant assignments:
    * For values 1-84: Verify MailPoet is visible
    * For values 85-120: Verify Klaviyo is visible
* Verify that the visibility is mutually exclusive (stores should only see one of the plugins)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Restore 70/30 variant assignment split between MailPoet and Klaviyo extensions

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
