### PR TITLE
Fix iAPI based Mini-Cart not showing some values when window.wc.blocksCheckout is missing

### DIFF
--- a/plugins/woocommerce/changelog/fix-iapi-mini-cart-missing-texts
+++ b/plugins/woocommerce/changelog/fix-iapi-mini-cart-missing-texts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure iAPI powered Mini-Cart shows all product values when used with certain other blocks on the same page

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -293,7 +293,7 @@ const { state: cartItemState } = store(
 				// `data-wp-text` directive or an alternative solution.
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					const priceText =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -346,7 +346,7 @@ const { state: cartItemState } = store(
 				// `data-wp-text` directive or an alternative solution.
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					const priceText =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -426,7 +426,7 @@ const { state: cartItemState } = store(
 				let { name } = cartItemState.cartItem;
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					name =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -466,7 +466,7 @@ const { state: cartItemState } = store(
 				// `data-wp-text` directive or an alternative solution.
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					const priceText =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -492,7 +492,7 @@ const { state: cartItemState } = store(
 				// `data-wp-text` directive or an alternative solution.
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					const priceText =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -538,7 +538,7 @@ const { state: cartItemState } = store(
 				// `data-wp-text` directive or an alternative solution.
 				if (
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+					( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 				) {
 					const priceText =
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -593,7 +593,7 @@ const { state: cartItemState } = store(
 
 			get itemShowRemoveItemLink(): boolean {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				return ( window.wc as any )?.blocksCheckout.applyCheckoutFilter
+				return ( window.wc as any )?.blocksCheckout?.applyCheckoutFilter
 					? // eslint-disable-next-line @typescript-eslint/no-explicit-any
 					  ( window.wc as any ).blocksCheckout.applyCheckoutFilter( {
 							filterName: 'showRemoveItemLink',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I found this issue while reviewing #60464:

When using the iAPI-powered Mini-Cart on the same page as certain other blocks, some values like product title weren't displayed. That happened because `window.wc` was defined, but `window.wc.blocksCheckout` wasn't.

### How to test the changes in this Pull Request:

1. Go to *WooCommerce* > *Settings* > *Advanced* > *Features* and enable the *Interactivity API powered Mini Cart*.
2. Create a post or page and add the _All Reviews_ block.
3. In the frontend, open the Mini-Cart.
4. Verify the Mini-Cart texts like product title are displayed correctly.

Before | After
--- | ---
<img width="1376" height="1111" alt="imatge" src="https://github.com/user-attachments/assets/821a2bc8-ee3a-47fb-b8e9-481bd32c9333" /> | <img width="1376" height="1111" alt="imatge" src="https://github.com/user-attachments/assets/ab516774-4cdb-46da-9114-da7fbd079c6e" />
