### PR TITLE
Fix Product Collection flaky test

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5328-flaky-test-as-product-in-specific-single-product-template
+++ b/plugins/woocommerce/changelog/wooplug-5328-flaky-test-as-product-in-specific-single-product-template
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix flaky E2E test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/product-collection/product-collection.block_theme.spec.ts
@@ -469,6 +469,8 @@ test.describe( 'Product Collection', () => {
 				pageObject.BLOCK_NAME
 			);
 
+			await editor.closeGlobalBlockInserter();
+
 			const locationRequestPromise =
 				page.waitForRequest( filterProductRequest );
 			await pageObject.chooseCollectionInTemplate( 'featured' );

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -46,9 +46,14 @@ export class Editor extends CoreEditor {
 	}
 
 	/**
-	 * Opens the global inserter.
+	 * Clicks the global block inserter for given action.
+	 *
+	 * @param action - The action to perform on the global block inserter ( 'toggle' | 'open' | 'close' ).
+	 * @default 'toggle'
 	 */
-	async openGlobalBlockInserter() {
+	async clickGlobalBlockInserter(
+		action: 'toggle' | 'open' | 'close' = 'toggle'
+	) {
 		const toggleButton = this.page.getByRole( 'button', {
 			name:
 				this.wpCoreVersion >= 6.8
@@ -60,9 +65,27 @@ export class Editor extends CoreEditor {
 		const isOpen =
 			( await toggleButton.getAttribute( 'aria-pressed' ) ) === 'true';
 
-		if ( ! isOpen ) {
+		if (
+			action === 'toggle' ||
+			( action === 'open' && ! isOpen ) ||
+			( action === 'close' && isOpen )
+		) {
 			await toggleButton.click();
 		}
+	}
+
+	/**
+	 * Opens the global inserter.
+	 */
+	async openGlobalBlockInserter() {
+		await this.clickGlobalBlockInserter( 'open' );
+	}
+
+	/**
+	 * Closes the global inserter.
+	 */
+	async closeGlobalBlockInserter() {
+		await this.clickGlobalBlockInserter( 'close' );
 	}
 
 	async transformIntoBlocks() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Test became flaky due to UI elements conflict. The flow is as follow:
1. Insert Product Collection using global inserter:
    1.1. Input "Product Collection" string
    1.2 Click on block to insert it
2. Choose collection

For some reason, there's some race condition between 1.1 and 1.2 because after inserting search string block is inserted and only then, the results in inserter are filtered out (Gutenberg) and editor is stuck in such condition (newly filtered results are hovered, displaying preview and covering a collection beneath). 

<img width="1608" height="900" alt="Screen Shot 2025-08-20 at 09 52 40 AM" src="https://github.com/user-attachments/assets/1746e594-8800-403e-a5dd-13d7389e500e" />

The answer to the problem is to close global inserter after successfully inserting block.

For this purpose I add another editor util to close the inserter utilising the same code as util to open it.

Closes https://github.com/woocommerce/woocommerce/issues/60382

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI is green and especially Product Collection > Location is recognized > as product in specific Single Product template in "Blocks e2e tests 6/10" passes at once

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
