### PR TITLE
iAPI Mini Cart: Hide the image when it doesn't load correctly

### DIFF
--- a/plugins/woocommerce/changelog/60493-wooplug-5379-interactivity-api-powered-mini-cart-hide-the-image-if-the
+++ b/plugins/woocommerce/changelog/60493-wooplug-5379-interactivity-api-powered-mini-cart-hide-the-image-if-the
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini Cart: Hide product image if it does not exist.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -569,11 +569,13 @@ const { state: cartItemState } = store(
 			},
 
 			get isProductHiddenFromCatalog(): boolean {
+				const context = getContext< { isImageHidden: boolean } >();
 				const { catalog_visibility: catalogVisibility } =
 					cartItemState.cartItem;
 				return (
-					catalogVisibility === 'hidden' ||
-					catalogVisibility === 'search'
+					( catalogVisibility === 'hidden' ||
+						catalogVisibility === 'search' ) &&
+					! context.isImageHidden
 				);
 			},
 
@@ -665,8 +667,8 @@ const { state: cartItemState } = store(
 			},
 
 			hideImage() {
-				const context = getContext< { isHidden: boolean } >();
-				context.isHidden = true;
+				const context = getContext< { isImageHidden: boolean } >();
+				context.isImageHidden = true;
 			},
 		},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -663,6 +663,11 @@ const { state: cartItemState } = store(
 					quantity: cartItemState.cartItem.quantity - multipleOf,
 				} );
 			},
+
+			hideImage() {
+				const context = getContext< { isHidden: boolean } >();
+				context.isHidden = true;
+			},
 		},
 
 		callbacks: {

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -113,7 +113,6 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 					>
 						<tr class="wc-block-cart-items__row" data-wp-run="callbacks.filterCartItemClass" tabindex="-1">
 							<td data-wp-context='{ "isImageHidden": false }' class="wc-block-cart-item__image" aria-hidden="true">
-									
 								<img
 									data-wp-bind--hidden="!state.isProductHiddenFromCatalog"
 									data-wp-bind--src="state.itemThumbnail" 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -115,7 +115,13 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 							<td class="wc-block-cart-item__image" aria-hidden="true">
 								<img data-wp-bind--hidden="!state.isProductHiddenFromCatalog" data-wp-bind--src="state.itemThumbnail" data-wp-bind--alt="state.cartItemName">
 								<a data-wp-bind--hidden="state.isProductHiddenFromCatalog" data-wp-bind--href="state.cartItem.permalink" tabindex="-1">
-									<img data-wp-bind--src="state.itemThumbnail" data-wp-bind--alt="state.cartItemName">	
+									<img
+										data-wp-context='{ "isHidden": false }'
+										data-wp-bind--hidden="context.isHidden"
+										data-wp-bind--src="state.itemThumbnail"
+										data-wp-bind--alt="state.cartItemName"
+										data-wp-on--error="actions.hideImage"
+									>	
 								</a>
 							</td>
 							<td class="wc-block-cart-item__product">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -112,12 +112,17 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 						data-wp-each-key="state.cartItem.key"
 					>
 						<tr class="wc-block-cart-items__row" data-wp-run="callbacks.filterCartItemClass" tabindex="-1">
-							<td class="wc-block-cart-item__image" aria-hidden="true">
-								<img data-wp-bind--hidden="!state.isProductHiddenFromCatalog" data-wp-bind--src="state.itemThumbnail" data-wp-bind--alt="state.cartItemName">
+							<td data-wp-context='{ "isImageHidden": false }' class="wc-block-cart-item__image" aria-hidden="true">
+									
+								<img
+									data-wp-bind--hidden="!state.isProductHiddenFromCatalog"
+									data-wp-bind--src="state.itemThumbnail" 
+									data-wp-bind--alt="state.cartItemName"
+									data-wp-on--error="actions.hideImage"
+								>
 								<a data-wp-bind--hidden="state.isProductHiddenFromCatalog" data-wp-bind--href="state.cartItem.permalink" tabindex="-1">
 									<img
-										data-wp-context='{ "isHidden": false }'
-										data-wp-bind--hidden="context.isHidden"
+										data-wp-bind--hidden="context.isImageHidden"
 										data-wp-bind--src="state.itemThumbnail"
 										data-wp-bind--alt="state.cartItemName"
 										data-wp-on--error="actions.hideImage"


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This pull request addresses an issue in the new Interactivity API-powered Mini Cart where a broken image icon is displayed for products that do not have a featured image.

The proposed solution hides the `<img>` element if it fails to load, preventing the broken image icon from appearing. This is achieved by using the `data-wp-on--error` directive from the Interactivity API to set a state that hides the element. This change aligns the behavior of the new Mini Cart with the classic one, where missing images are not displayed.

Closes [#60488](https://github.com/woocommerce/woocommerce/issues/60488).

### Screenshots or screen recordings:

| Before | After |
| ------ | ----- |
| <img width="1046" height="644" alt="image" src="https://github.com/user-attachments/assets/87f92edf-34ec-4cae-93c5-ee5a7a6d6ffc" />|<img width="1046" height="644" alt="image" src="https://github.com/user-attachments/assets/71ac1a6e-dfdb-45d4-bca4-9c11be055bdf" />|

### How to test the changes in this Pull Request:

1. Start with a product that has no image.
2. Go to WooCommerce > Settings > Products > General > Placeholder image and add a non-existent image URL.
3. Open the mini cart. As the placeholder image points to a non-existent URL, no image should be seen.
4. Change the placeholder image option to add a non-existent image ID. For example, 0.
5. Reopen the mini cart. Now the default WooCommerce placeholder image should be seen.
6. Now use an existing image ID.
7. Reopen the mini cart. Now the selected placeholder image should be seen.
8. Now open the product and add an existing image.
9. Reopen the mini cart. Now that image should be shown.
10. Now, open the dev tools and block the URL of that image.
11. Reopen the mini cart. Now, no image should be shown.

### Testing that has already taken place:

Manual testing was performed following the steps above to confirm the fix.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Mini Cart: Hide product image if it does not exist.

</details>