### PR TITLE
Migrate the product summary block to fetch product data via the `@wordpress/core-data` package

### DIFF
--- a/plugins/woocommerce/changelog/60494-feat-use-product-entity-for-product-summary-block
+++ b/plugins/woocommerce/changelog/60494-feat-use-product-entity-for-product-summary-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate the product summary block to fetch product data via the `@wordpress/core-data` package.

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/block.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Summary from '@woocommerce/base-components/summary';
 import { blocksConfig } from '@woocommerce/block-settings';
-import { isEmpty } from '@woocommerce/types';
+import { isEmpty, ProductResponseItem } from '@woocommerce/types';
 
 import {
 	useInnerBlockLayoutContext,
@@ -13,6 +13,7 @@ import {
 } from '@woocommerce/shared-context';
 import { useStyleProps } from '@woocommerce/base-hooks';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
+import { ProductEntityResponse } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ const isLegacyProductSummary = ( props: Partial< BlockProps > ) => {
 };
 
 const getSource = (
-	product: { short_description?: string; description?: string },
+	product: ProductResponseItem | ProductEntityResponse,
 	showDescriptionIfEmpty: boolean
 ) => {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -62,9 +63,14 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 		linkText,
 		isDescendantOfAllProducts,
 		isDescendentOfSingleProductTemplate,
+		product: productEntity,
+		isAdmin,
 	} = props;
 	const { parentClassName } = useInnerBlockLayoutContext();
-	const { product } = useProductDataContext();
+	const { product } = useProductDataContext( {
+		product: productEntity,
+		isAdmin,
+	} );
 	const styleProps = useStyleProps( props );
 
 	// The attributes of this block have been updated. There's migration
@@ -88,7 +94,7 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 		: showDescriptionIfEmptyAttr;
 	const showLink = isLegacy ? allProductsShowLink : showLinkAttr;
 
-	const source = getSource( product, showDescriptionIfEmpty );
+	const source = product ? getSource( product, showDescriptionIfEmpty ) : '';
 	const maxLength = summaryLength || Infinity;
 
 	const summaryClassName = 'wc-block-components-product-summary';
@@ -142,7 +148,10 @@ const Block = ( props: BlockProps ): JSX.Element | null => {
 				countType={ blocksConfig.wordCountType || 'words' }
 				style={ styleProps.style }
 			/>
-			{ isDescendantOfAllProducts && showLink && linkText ? (
+			{ isDescendantOfAllProducts &&
+			showLink &&
+			linkText &&
+			product?.permalink ? (
 				<a href={ `${ product.permalink }#tab-description` }>
 					{ linkText }
 				</a>

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
@@ -18,6 +18,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { useProduct } from '@woocommerce/entities';
 
 /**
  * Internal dependencies
@@ -186,9 +187,11 @@ const Edit = ( {
 		]
 	);
 
+	const { product } = useProduct( context.postId );
+
 	return (
 		<div { ...blockProps }>
-			<Block { ...attributes } />
+			<Block isAdmin={ true } { ...attributes } product={ product } />
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings', 'woocommerce' ) }

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/edit.tsx
@@ -8,6 +8,7 @@ import {
 	InspectorControls,
 	RichText,
 } from '@wordpress/block-editor';
+import { useProduct } from '@woocommerce/entities';
 import {
 	RangeControl,
 	ToggleControl,
@@ -18,7 +19,6 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { useProduct } from '@woocommerce/entities';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/types.ts
@@ -4,6 +4,7 @@
 import type { BlockEditProps } from '@wordpress/blocks';
 import type { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
 import type { CSSProperties } from '@wordpress/element';
+import { ProductEntityResponse } from '@woocommerce/entities';
 
 export interface Attributes {
 	productId: number;
@@ -30,4 +31,6 @@ export type ControlProps< T extends keyof Attributes > = Pick< Attributes, T > &
 export type BlockProps = Attributes & {
 	style?: CSSProperties;
 	className?: string;
+	product: ProductEntityResponse;
+	isAdmin: boolean;
 };

--- a/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/types.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/summary/types.ts
@@ -4,7 +4,7 @@
 import type { BlockEditProps } from '@wordpress/blocks';
 import type { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
 import type { CSSProperties } from '@wordpress/element';
-import { ProductEntityResponse } from '@woocommerce/entities';
+import type { ProductEntityResponse } from '@woocommerce/entities';
 
 export interface Attributes {
 	productId: number;
@@ -17,13 +17,14 @@ export interface Attributes {
 	summaryLength: number;
 	linkText: string;
 }
-
 export type SetAttributes = Pick<
 	BlockEditProps< Attributes >,
 	'setAttributes'
 >;
 
-export type EditProps = BlockEditProps< Attributes > & { context: Context };
+export type EditProps = BlockEditProps< Attributes > & {
+	context: Context & { postId?: number };
+};
 
 export type ControlProps< T extends keyof Attributes > = Pick< Attributes, T > &
 	SetAttributes;
@@ -31,6 +32,6 @@ export type ControlProps< T extends keyof Attributes > = Pick< Attributes, T > &
 export type BlockProps = Attributes & {
 	style?: CSSProperties;
 	className?: string;
-	product: ProductEntityResponse;
-	isAdmin: boolean;
+	product?: ProductEntityResponse | null | undefined;
+	isAdmin?: boolean;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Part of #60048 

This PR migrates the product summary block to fetch product data via the @wordpress/core-data package.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new post or page.
2. Add Product block to the page. Select one product.
3. See the Product Summary block displays summary data.
4. Edit the Single Product Template.
5. Add the Product Summary block.
6. Ensure that the placeholder is visible.
7. Edit the Product Catalog templates.
8. Add the Product Summary block.
9. Ensure that the Product Summary block display summary data.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Dev - Development related task

#### Message

Migrate the product summary block to fetch product data via the `@wordpress/core-data` package.

</details>