### PR TITLE
Use store's locale when rendering email preview in settings

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4894-email-previews-use-admins-language-on-monolingual-stores
+++ b/plugins/woocommerce/changelog/wooplug-4894-email-previews-use-admins-language-on-monolingual-stores
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use store's locale when rendering email preview in settings

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -175,6 +175,8 @@ class EmailPreview {
 	 * @throws \InvalidArgumentException When the email type is invalid.
 	 */
 	public function set_email_type( string $email_type ) {
+		$this->switch_to_site_locale();
+
 		$wc_emails = WC()->mailer()->get_emails();
 		$emails    = array_combine(
 			array_map( 'get_class', $wc_emails ),
@@ -232,6 +234,8 @@ class EmailPreview {
 		 * @since 9.6.0
 		 */
 		$this->email = apply_filters( 'woocommerce_prepare_email_for_preview', $this->email );
+
+		$this->restore_locale();
 	}
 
 	/**
@@ -306,11 +310,11 @@ class EmailPreview {
 	 * @return string
 	 */
 	private function render_preview_email() {
-		$this->set_up_filters();
-
 		if ( ! $this->email_type ) {
 			$this->set_email_type( self::DEFAULT_EMAIL_TYPE );
 		}
+
+		$this->set_up_filters();
 
 		if ( 'plain' === $this->email->get_email_type() ) {
 			$content  = '<pre style="word-wrap: break-word; white-space: pre-wrap; text-align: ' . ( is_rtl() ? 'right' : 'left' ) . ';">';
@@ -489,12 +493,7 @@ class EmailPreview {
 	 * Set up filters for email preview.
 	 */
 	public function set_up_filters() {
-		// This is to ensure the email is displayed in the store's language,
-		// as the customer would see it, not the admin's language.
-		if ( ! $this->locale_switched ) {
-			wc_switch_to_site_locale();
-			$this->locale_switched = true;
-		}
+		$this->switch_to_site_locale();
 		// Always show shipping address in the preview email.
 		add_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		// Email templates fetch product from the database to show additional information, which are not
@@ -514,11 +513,7 @@ class EmailPreview {
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
 		remove_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 		remove_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
-		// Restore the original locale after email preview.
-		if ( $this->locale_switched ) {
-			wc_restore_locale();
-			$this->locale_switched = false;
-		}
+		$this->restore_locale();
 	}
 
 	/**
@@ -600,5 +595,26 @@ class EmailPreview {
 		}
 
 		return $message;
+	}
+
+	/**
+	 * Switch to the site locale. This is to ensure the email is displayed
+	 * in the store's language, as the customer would see it, not the admin's language.
+	 */
+	private function switch_to_site_locale() {
+		if ( ! $this->locale_switched ) {
+			wc_switch_to_site_locale();
+			$this->locale_switched = true;
+		}
+	}
+
+	/**
+	 * Restore the original locale.
+	 */
+	private function restore_locale() {
+		if ( $this->locale_switched ) {
+			wc_restore_locale();
+			$this->locale_switched = false;
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -8,7 +8,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\Internal\Admin\EmailPreview;
 
 use Automattic\WooCommerce\Internal\EmailEditor\WooContentProcessor;
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Throwable;
 use WC_Email;
 use WC_Order;
@@ -85,6 +84,13 @@ class EmailPreview {
 	 * @var object
 	 */
 	protected static $instance = null;
+
+	/**
+	 * Whether the locale has been switched when rendering the preview.
+	 *
+	 * @var bool
+	 */
+	private bool $locale_switched = false;
 
 	/**
 	 * Get class instance.
@@ -483,6 +489,12 @@ class EmailPreview {
 	 * Set up filters for email preview.
 	 */
 	public function set_up_filters() {
+		// This is to ensure the email is displayed in the store's language,
+		// as the customer would see it, not the admin's language.
+		if ( ! $this->locale_switched ) {
+			wc_switch_to_site_locale();
+			$this->locale_switched = true;
+		}
 		// Always show shipping address in the preview email.
 		add_filter( 'woocommerce_order_needs_shipping_address', array( $this, 'enable_shipping_address' ) );
 		// Email templates fetch product from the database to show additional information, which are not
@@ -502,6 +514,11 @@ class EmailPreview {
 		remove_filter( 'woocommerce_order_item_product', array( $this, 'get_dummy_product_when_not_set' ), 10 );
 		remove_filter( 'woocommerce_is_email_preview', array( $this, 'enable_preview_mode' ) );
 		remove_filter( 'woocommerce_order_item_thumbnail', array( $this, 'get_placeholder_image' ) );
+		// Restore the original locale after email preview.
+		if ( $this->locale_switched ) {
+			wc_restore_locale();
+			$this->locale_switched = false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Email preview in **WooCommerce > Settings > Emails** used user's language, which was misleading, because the customers would receive emails in the store's language. This PR changes that, so the email preview is rendered in store's language. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #59420, closes WOOPLUG-4894.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="699" height="979" alt="Screenshot 2025-08-20 at 12 57 04" src="https://github.com/user-attachments/assets/650c3ea1-9020-439d-af1b-f509cfd9e54e" />     |    <img width="703" height="977" alt="Screenshot 2025-08-21 at 15 29 46" src="https://github.com/user-attachments/assets/4e45fce6-4dee-4d2b-b738-1a9eec36f6ce" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set the store language (`/wp-admin/options-general.php`) to English.
2. Set the admin language (`/wp-admin/profile.php`) to anything else.
3. Update translations (`/wp-admin/update-core.php`).
4. Go to **WooCommerce > Settings > Emails** and check that the UI of the settings is in the admin's language, but the email preview content is in the store's language (English). 

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
