### PR TITLE
Fix a TypeScript error in addCartItem()

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-cart-item
+++ b/plugins/woocommerce/changelog/fix-add-cart-item
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix a TypeScript error in addCartItem()
+
+

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -27,7 +27,6 @@ export type OptimisticCartItem = {
 	id: number;
 	quantity: number;
 	variation?: CartVariationItem[];
-	name: string;
 	type: string;
 	updateOptimistically?: boolean;
 };
@@ -95,6 +94,11 @@ type BatchResponse = {
 	responses: ApiResponse< Cart >[];
 };
 
+// Guard to distinguish between optimistic and cart items.
+function isCartItem( item: OptimisticCartItem | CartItem ): item is CartItem {
+	return 'name' in item;
+}
+
 function isApiErrorResponse(
 	res: Response,
 	json: unknown
@@ -137,11 +141,15 @@ const getInfoNoticesFromCartUpdates = (
 	const autoDeletedToNotify = oldItems.filter(
 		( old ) =>
 			old.key &&
+			! isCartItem( old ) &&
 			! newItems.some( ( item ) => old.key === item.key ) &&
 			! pendingDelete.includes( old.key )
 	);
 
 	const autoUpdatedToNotify = newItems.filter( ( item ) => {
+		if ( ! isCartItem( item ) ) {
+			return false;
+		}
 		const old = oldItems.find( ( o ) => o.key === item.key );
 		return old
 			? ! pendingQuantity.includes( item.key ) &&

--- a/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/base/stores/woocommerce/cart.ts
@@ -141,7 +141,7 @@ const getInfoNoticesFromCartUpdates = (
 	const autoDeletedToNotify = oldItems.filter(
 		( old ) =>
 			old.key &&
-			! isCartItem( old ) &&
+			isCartItem( old ) &&
 			! newItems.some( ( item ) => old.key === item.key ) &&
 			! pendingDelete.includes( old.key )
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a TypeScript error that appeared after `name` was introduced as a required prop in `OptimisticCartItem` in https://github.com/woocommerce/woocommerce/pull/59683.

### How to test the changes in this Pull Request:

1. In your code editor, open these files:
  * `/plugins/woocommerce/client/blocks/assets/js/atomic/blocks/product-elements/button/frontend.ts`
  * `/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts`
  * `/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts`
2. Search for calls to `addCartItem` and `batchAddCartItems`. Verify there isn't a TypeScript error about items missing a `name` property.
3. Smoke testing adding to cart in the frontend from the _Product Collection_ block and the _Add to Cart + Options_ block to make sure there are no obvious regressions.
4. Go through the testing steps in https://github.com/woocommerce/woocommerce/pull/59683 to make sure there are no regressions.