### PR TITLE
Revert delayed initial rendering for checkout blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-delayed-rendering-for-checkout-blocks
+++ b/plugins/woocommerce/changelog/fix-remove-delayed-rendering-for-checkout-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert delayed initial rendering for checkout blocks

--- a/plugins/woocommerce/client/blocks/assets/js/base/utils/render-frontend.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/base/utils/render-frontend.tsx
@@ -144,21 +144,6 @@ const renderBlockInContainers = <
 	const roots: ReactRootWithContainer[] = [];
 
 	containers.forEach( ( el, i ) => {
-		const isCheckoutBlock = el.classList.contains(
-			'wp-block-woocommerce-checkout'
-		);
-		const isCartBlock = el.classList.contains(
-			'wp-block-woocommerce-cart'
-		);
-		// Check for reduced motion preference with sensible fallback
-		// Default to reduced motion (safer for accessibility) when matchMedia is unavailable
-		const hasMotionReduced =
-			typeof window !== 'undefined' &&
-			typeof window.matchMedia === 'function'
-				? window.matchMedia( '(prefers-reduced-motion: reduce)' )
-						.matches
-				: true; // Fallback: assume reduced motion for better accessibility
-
 		const props = getProps( el, i );
 
 		const errorBoundaryProps = getErrorBoundaryProps( el, i );
@@ -167,38 +152,16 @@ const renderBlockInContainers = <
 			...( props.attributes || ( {} as TAttributes ) ),
 		};
 
-		// Determine rendering delay based on block type and user preferences.
-		// The cart and checkout blocks page placeholders should fade out if motion is not reduced.
-		const shouldAnimate =
-			( isCheckoutBlock || isCartBlock ) && ! hasMotionReduced;
-
-		const performRender = () => {
-			const root = renderBlock( {
+		roots.push( {
+			container: el,
+			root: renderBlock( {
 				Block,
 				container: el,
 				props,
 				attributes,
 				errorBoundaryProps,
-			} );
-
-			roots.push( {
-				container: el,
-				root,
-			} );
-
-			if ( shouldAnimate ) {
-				el.classList.remove( 'is-fading' );
-			}
-		};
-
-		if ( shouldAnimate ) {
-			// Apply fade-in animation for cart/checkout blocks when motion is not reduced
-			el.classList.add( 'is-fading' );
-			setTimeout( performRender, 200 );
-		} else {
-			// Render immediately for all other cases (non-cart/checkout blocks or reduced motion)
-			performRender();
-		}
+			} ),
+		} );
 	} );
 
 	return roots;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart/style.scss
@@ -214,23 +214,6 @@
 	}
 }
 
-// Fade out skeleton animation before content is loaded
-.wp-block-woocommerce-cart.is-loading.is-fading {
-	.wp-block-woocommerce-cart-order-summary-block,
-	.wp-block-woocommerce-cart-express-payment-block,
-	.wp-block-woocommerce-proceed-to-checkout-block,
-	.wp-block-woocommerce-cart-accepted-payment-methods-block,
-	.wp-block-woocommerce-cart-line-items-block {
-		background-color: transparent;
-		&::after {
-			background: transparent;
-		}
-	}
-	div.wp-block-woocommerce-cart-order-summary-totals-block {
-		border-top: none;
-	}
-}
-
 // Skeleton is shown before mobile classes are appended.
 @include cart-checkout-below-large-container {
 	.wp-block-woocommerce-cart.is-loading {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/styles/style.scss
@@ -138,19 +138,6 @@
 	}
 }
 
-.wp-block-woocommerce-checkout.is-loading.is-fading {
-	div.wp-block-woocommerce-checkout-totals-block,
-	div.wp-block-woocommerce-checkout-fields-block {
-		> div {
-			background-color: transparent;
-
-			&::after {
-				background: transparent;
-			}
-		}
-	}
-}
-
 // Skeleton is shown before mobile classes are appended.
 @media only screen and (max-width: 700px) {
 	.wp-block-woocommerce-checkout.is-loading {


### PR DESCRIPTION
This commit reverts the delay we add added https://github.com/woocommerce/woocommerce/pull/60020 because it broke the functionality of the interactivity api power product collection in the cart block. The iAPI gets initialized before the inner blocks render, which causes the iapi to no longer work for blocks added with a delay.

After this change, the checkout blocks will render immediately to the page without a fade-in delay

This needs to land in 10.2, as the initial PR is also set to land in 10.2.
It will also unblock https://github.com/woocommerce/woocommerce/pull/60278

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes # .




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Go to the Checkout page and add the Products collection under the Checkout block. Choose the On sale collection
1. Add a product to cart
2. Go to the Cart block and notice it's rendering successfully
3. Go to the Checkout block and notice it's rendering successfully
4. Click Add to cart on one of the products from the On sale collection
5. Notice it's appearing in the Order summary
6. Place your oder

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
