### PR TITLE
iAPI Mini Cart: Pass an empty string when there's no short description

### DIFF
--- a/plugins/woocommerce/changelog/60518-wooplug-5386-interactivity-api-powered-mini-cart-fix-adding-products
+++ b/plugins/woocommerce/changelog/60518-wooplug-5386-interactivity-api-powered-mini-cart-fix-adding-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini Cart - Avoid error when adding products without a description.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -674,17 +674,20 @@ const { state: cartItemState } = store(
 
 		callbacks: {
 			itemShortDescription() {
-				const el = getElement();
+				const { ref } = getElement();
 
-				if ( el.ref ) {
-					const innerEl = el.ref.querySelector(
+				if ( ref ) {
+					const innerEl = ref.querySelector(
 						'.wc-block-components-product-metadata__description'
 					);
+					const { short_description, description } =
+						cartItemState.cartItem;
 
-					// A workaround for the lack of dangerous set HTML directive in interactivity API
-					if ( innerEl ) {
+					// A workaround for the lack of dangerous set HTML directive
+					// in interactivity API.
+					if ( innerEl && ( short_description || description ) ) {
 						innerEl.innerHTML = trimWords(
-							cartItemState.cartItem.short_description || ''
+							short_description || description
 						);
 					}
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -680,14 +680,14 @@ const { state: cartItemState } = store(
 					const innerEl = ref.querySelector(
 						'.wc-block-components-product-metadata__description'
 					);
-					const { short_description, description } =
+					const { short_description: shortDescription, description } =
 						cartItemState.cartItem;
 
 					// A workaround for the lack of dangerous set HTML directive
 					// in interactivity API.
-					if ( innerEl && ( short_description || description ) ) {
+					if ( innerEl && ( shortDescription || description ) ) {
 						innerEl.innerHTML = trimWords(
-							short_description || description
+							shortDescription || description
 						);
 					}
 				}

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -684,7 +684,7 @@ const { state: cartItemState } = store(
 					// A workaround for the lack of dangerous set HTML directive in interactivity API
 					if ( innerEl ) {
 						innerEl.innerHTML = trimWords(
-							cartItemState.cartItem.short_description
+							cartItemState.cartItem.short_description || ''
 						);
 					}
 				}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses an issue where adding a product without a short description to the new Interactivity API-powered Mini Cart block would result in a JavaScript error in the browser console.

The change ensures that if `short_description` is not present on the cart item, it defaults to an empty string, preventing the error when `trimWords` is called.

Closes #60517.

### Screenshots or screen recordings:

This change fixes a console error and has no visual impact, so no screenshots are provided.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product and leave the "Product short description" field empty.
5. Go to your store's frontend and add the product you just created to the cart.
7. Open your browser's developer console.
8. **Verify:** There should be no JavaScript errors in the console.
9. Now, edit the same product and add a short description.
10. Go back to the frontend, clear the cart, and add the product again.
11. Open the Mini Cart.
12. **Verify:** The short description is displayed correctly in the Mini Cart.

<!-- End testing instructions -->

### Testing that has already taken place:

I have performed the testing steps above on my local environment and confirmed that the fix works as expected.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fix - Fixes an existing bug

#### Message

Mini Cart - Avoid error when adding products without a description.

</details>
