### PR TITLE
More robust link detection in email preview

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-link-detection
+++ b/plugins/woocommerce/changelog/enhancement-link-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: No visible change, just improving link detection in the background
+
+

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -254,16 +254,41 @@ class EmailPreview {
 	 * @return string
 	 */
 	public function ensure_links_open_in_new_tab( string $content ) {
-		return (string) preg_replace_callback(
-			'/<a\s+([^>]*?)(target=["\']?[^"\']*["\']?)?([^>]*)>/i',
-			function ( $matches ) {
-				$before = $matches[1];
-				$target = 'target="_blank"';
-				$after  = $matches[3];
-				return "<a $before $target $after>";
-			},
-			$content
-		);
+		if ( empty( $content ) || strpos( $content, '<a' ) === false ) {
+			return $content;
+		}
+
+		// Suppress libxml errors to prevent them from being displayed.
+		$previous_use_internal_errors = libxml_use_internal_errors( true );
+
+		try {
+			$dom = new \DOMDocument();
+
+			// Add UTF-8 encoding and load with error suppression flags.
+			$html_with_encoding = '<?xml encoding="UTF-8">' . $content;
+			$dom->loadHTML(
+				$html_with_encoding,
+				LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOWARNING | LIBXML_NOERROR
+			);
+
+			$links = $dom->getElementsByTagName( 'a' );
+			foreach ( $links as $link ) {
+				$link->setAttribute( 'target', '_blank' );
+				$link->setAttribute( 'rel', 'noopener' );
+			}
+
+			$result = $dom->saveHTML();
+
+			// Remove the XML declaration we added earlier, it's not meant to be used in an HTML document.
+			$result = preg_replace( '/<\?xml[^>]*>\s*/i', '', $result );
+
+			return $result;
+		} catch ( \Exception $e ) {
+			return $content;
+		} finally {
+			libxml_use_internal_errors( $previous_use_internal_errors );
+			libxml_clear_errors();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
+++ b/plugins/woocommerce/src/Internal/Admin/EmailPreview/EmailPreview.php
@@ -258,6 +258,10 @@ class EmailPreview {
 			return $content;
 		}
 
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			return $content;
+		}
+
 		// Suppress libxml errors to prevent them from being displayed.
 		$previous_use_internal_errors = libxml_use_internal_errors( true );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Email preview in **WooCommerce > Settings > Emails** is rendered in an iframe, so we have to ensure, that the links in the email open in a new tab and not in the iframe itself. As user can add their own links in **Additional content** field, this change ensures, that they are properly detected and updated to also open in a new tab. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Settings > Emails > New Order > Manage** (any email would work).
2. Test that all links in the email preview opens in a new tab, and not directly in the iframe.
3. Add a new link in **Additional content** and check, that it shows in the email preview, and link opens in the new tab.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->
