### PR TITLE
Fix Single Product DB templates not showing the compatibility layer

### DIFF
--- a/plugins/woocommerce/changelog/fix-single-product-compatibility-layer-in-all-results
+++ b/plugins/woocommerce/changelog/fix-single-product-compatibility-layer-in-all-results
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix Single Product template compatibility layer not loaded if there were several results of the same template
+
+

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplate.php
@@ -143,9 +143,6 @@ class SingleProductTemplate extends AbstractTemplate {
 			$query_result
 		);
 
-		// Let's make sure we only run the filter once.
-		remove_filter( 'get_block_templates', array( $this, 'update_single_product_content' ), 11 );
-
 		return $query_result;
 	}
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -262,9 +262,8 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @return string
 	 */
 	public static function add_compatibility_layer( $template_content ) {
-		// Check if we have already run the compatibility layer. In that case,
-		// return early.
-		if ( str_contains( $template_content, self::IS_FIRST_BLOCK ) ) {
+		// Return early if we've already applied the compatibility layer.
+		if ( false !== strpos( $template_content, self::IS_FIRST_BLOCK ) ) {
 			return $template_content;
 		}
 

--- a/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
+++ b/plugins/woocommerce/src/Blocks/Templates/SingleProductTemplateCompatibility.php
@@ -262,6 +262,12 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @return string
 	 */
 	public static function add_compatibility_layer( $template_content ) {
+		// Check if we have already run the compatibility layer. In that case,
+		// return early.
+		if ( str_contains( $template_content, self::IS_FIRST_BLOCK ) ) {
+			return $template_content;
+		}
+
 		$blocks = parse_blocks( $template_content );
 		if ( self::has_single_product_template_blocks( $blocks ) ) {
 			$blocks = self::wrap_single_product_template( $template_content );

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
@@ -1,8 +1,9 @@
 <?php
+declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\Tests\Blocks\Templates;
 
-use \WP_UnitTestCase;
+use WP_UnitTestCase;
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
 
 /**
@@ -435,10 +436,10 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
 	}
 
-		/**
-		 *  @group failing
-		 * Test that the Single Product Template doesn't remove any blocks if those aren't grouped in a a core/group block
-		 */
+	/**
+	 * @group failing
+	 * Test that the Single Product Template doesn't remove any blocks if those aren't grouped in a a core/group block
+	 */
 	public function test_add_compatibility_layer_if_contains_blocks_not_related_to_the_single_product_template_and_not_grouped() {
 		$default_single_product_template = '
 		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
@@ -467,6 +468,43 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
 
 		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
+
+		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
+		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
+
+		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+	}
+
+	/**
+	 * Test that the Single Product Template has the compatibility layer when queried using the `get_templates()` function.
+	 */
+	public function test_add_compatibility_layer_only_once() {
+		$templates                       = get_block_templates();
+		$default_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+		<div class="wp-block-group">
+		   <!-- wp:woocommerce/product-image-gallery /-->
+		</div>
+		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$expected_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<!-- wp:group {"className":"woocommerce product", "__wooCommerceIsFirstBlock":true,"__wooCommerceIsLastBlock":true} -->
+		<div class="wp-block-group woocommerce product">
+		   <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+		   <div class="wp-block-group">
+			  <!-- wp:woocommerce/product-image-gallery /-->
+		   </div>
+		   <!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		// Run `add_compatibility_layer` twice to make sure we only add it once.
+		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
+		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $result );
 
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );

--- a/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/Templates/SingleProductTemplateCompatibilityTests.php
@@ -41,7 +41,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -159,7 +159,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -194,7 +194,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -229,7 +229,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -296,7 +296,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -325,7 +325,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 
@@ -355,7 +355,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -396,7 +396,7 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
@@ -433,12 +433,11 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
-	 * @group failing
-	 * Test that the Single Product Template doesn't remove any blocks if those aren't grouped in a a core/group block
+	 * Test that the Single Product Template doesn't remove any blocks if those aren't grouped in a core/group block
 	 */
 	public function test_add_compatibility_layer_if_contains_blocks_not_related_to_the_single_product_template_and_not_grouped() {
 		$default_single_product_template = '
@@ -472,14 +471,13 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 
 	/**
 	 * Test that the Single Product Template has the compatibility layer when queried using the `get_templates()` function.
 	 */
 	public function test_add_compatibility_layer_only_once() {
-		$templates                       = get_block_templates();
 		$default_single_product_template = '
 		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
 		<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
@@ -509,6 +507,6 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 		$result_without_whitespace                           = preg_replace( '/\s+/', '', $result );
 		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
 
-		$this->assertEquals( $result_without_whitespace, $expected_single_product_template_without_whitespace, '' );
+		$this->assertEquals( $expected_single_product_template_without_whitespace, $result_without_whitespace, '' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR refactors the logic that prevented the compatibility layer logic from being run twice on the same template. Instead of removing the filter, we check the template contents and return early.

The previous approach had the issue that if there were multiple queries, only the first one would run the compatibility layer logic. That made it so if the site had customized the _Single Product_ template, the compatibility layer wouldn't be applied to it.

Kudos to @kmanijak for catching this issue! :raised_hands: 

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
2. Make any edits if you hadn't customized the template before.
3. Load the Single Product template in the frontend.
4. Verify the magnifier icon is rendered on top of the gallery images:

Before | After
--- | ---
<img width="1539" height="766" alt="imatge" src="https://github.com/user-attachments/assets/e0ec543e-6afd-4031-b826-7d796b728c73" /> | <img width="1539" height="766" alt="imatge" src="https://github.com/user-attachments/assets/0d904fe3-6668-42b8-ba84-729b32516e09" />