### PR TITLE
iAPI Mini Cart: Support Including Tax option in Display prices during cart

### DIFF
--- a/plugins/woocommerce/changelog/60540-wooplug-5378-interactivity-api-powered-mini-cart-support-including-tax
+++ b/plugins/woocommerce/changelog/60540-wooplug-5378-interactivity-api-powered-mini-cart-support-including-tax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Mini Cart - Respect "Including tax" option in "Display prices during cart and checkout"

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -63,6 +63,7 @@ type MiniCart = {
 		drawerRole: string | null;
 		drawerTabIndex: string | null;
 		buttonAriaLabel: string;
+		shouldShowTaxLabel: boolean;
 	};
 	callbacks: {
 		openDrawer: () => void;
@@ -171,6 +172,15 @@ store< MiniCart >(
 					.replace( '%d', state.totalItemsInCart )
 					.replace( '%1$d', state.totalItemsInCart )
 					.replace( '%2$s', state.formattedSubtotal );
+			},
+
+			get shouldShowTaxLabel(): boolean {
+				return (
+					parseInt(
+						woocommerceState.cart.totals.total_items_tax,
+						10
+					) > 0
+				);
 			},
 		},
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -541,7 +541,7 @@ class MiniCart extends AbstractBlock {
 				array(
 					'isOpen'             => false,
 					'totalItemsInCart'   => $cart_item_count,
-					'shouldShowTaxLabel' => ! $cart->is_empty(),
+					'shouldShowTaxLabel' => $cart->get_cart_contents_tax() > 0,
 					'badgeIsVisible'     => $badge_is_visible,
 					'formattedSubtotal'  => $formatted_subtotal,
 					'drawerOverlayClass' => 'wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -613,7 +613,7 @@ class MiniCart extends AbstractBlock {
 						</span>
 						<?php if ( ! empty( $this->tax_label ) ) : ?>
 							<small
-								data-wp-bind--hidden="state.cartIsEmpty"
+								data-wp-bind--hidden="!state.shouldShowTaxLabel"
 								class="wc-block-mini-cart__tax-label"
 								style="color:'<?php echo esc_attr( $price_color ); ?>'"
 							>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -615,7 +615,7 @@ class MiniCart extends AbstractBlock {
 							<small
 								data-wp-bind--hidden="!state.shouldShowTaxLabel"
 								class="wc-block-mini-cart__tax-label"
-								style="color:'<?php echo esc_attr( $price_color ); ?>'"
+								style="color:<?php echo esc_attr( $price_color ); ?>"
 							>
 								<?php echo esc_html( $this->tax_label ); ?>
 							</small>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -541,6 +541,7 @@ class MiniCart extends AbstractBlock {
 				array(
 					'isOpen'             => false,
 					'totalItemsInCart'   => $cart_item_count,
+					'cartIsEmpty'        => $cart->is_empty(),
 					'badgeIsVisible'     => $badge_is_visible,
 					'formattedSubtotal'  => $formatted_subtotal,
 					'drawerOverlayClass' => 'wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden',
@@ -554,17 +555,17 @@ class MiniCart extends AbstractBlock {
 			);
 
 			$context = array(
-				'productCountVisibility'       => $product_count_visibility,
-				'displayCartPriceIncludingTax' => $display_cart_price_including_tax,
+				'productCountVisibility' => $product_count_visibility,
 			);
 
 			wp_interactivity_config(
 				$this->get_full_block_name(),
 				array(
-					'addToCartBehaviour'      => $attributes['addToCartBehaviour'],
-					'onCartClickBehaviour'    => $on_cart_click_behaviour,
-					'checkoutUrl'             => wc_get_checkout_url(),
-					'buttonAriaLabelTemplate' => $button_aria_label_template,
+					'displayCartPriceIncludingTax' => $display_cart_price_including_tax,
+					'addToCartBehaviour'           => $attributes['addToCartBehaviour'],
+					'onCartClickBehaviour'         => $on_cart_click_behaviour,
+					'checkoutUrl'                  => wc_get_checkout_url(),
+					'buttonAriaLabelTemplate'      => $button_aria_label_template,
 				)
 			);
 
@@ -610,10 +611,15 @@ class MiniCart extends AbstractBlock {
 					<?php if ( $cart_always_shows_price ) : ?>
 						<span data-wp-text="state.formattedSubtotal" class="wc-block-mini-cart__amount" style="<?php echo 'color:' . esc_attr( $price_color ); ?>">
 						</span>
-						<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							echo $this->get_include_tax_label_markup( $attributes );
-						?>
+						<?php if ( ! empty( $this->tax_label ) ) : ?>
+							<small
+								data-wp-bind--hidden="state.cartIsEmpty"
+								class="wc-block-mini-cart__tax-label"
+								style="color:'<?php echo esc_attr( $price_color ); ?>'"
+							>
+								<?php echo esc_html( $this->tax_label ); ?>
+							</small>
+						<?php endif; ?>
 					<?php endif; ?>
 				</button>
 			</div>
@@ -621,14 +627,14 @@ class MiniCart extends AbstractBlock {
 			return ob_get_clean();
 		}
 
-		return '';
+			return '';
 	}
 
-	/**
-	 * Echoes the Interactivity API Mini Cart overlay markup.
-	 *
-	 * @return void
-	 */
+			/**
+			 * Echoes the Interactivity API Mini Cart overlay markup.
+			 *
+			 * @return void
+			 */
 	public function render_experimental_iapi_mini_cart_overlay() {
 		$template_part_contents = $this->get_template_part_contents( false );
 		$template_part_contents = do_blocks( $this->process_template_contents( $template_part_contents ) );
@@ -650,30 +656,30 @@ class MiniCart extends AbstractBlock {
 			>
 				<div class="wc-block-components-drawer__content">
 					<div class="wc-block-mini-cart__template-part">
-						<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							echo $template_part_contents;
-						?>
+				<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $template_part_contents;
+				?>
 					</div>
 				</div>
 			</div>
 		</div>				
-		<?php
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo wp_interactivity_process_directives( ob_get_clean() );
+				<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo wp_interactivity_process_directives( ob_get_clean() );
 	}
 
-	/**
-	 * Process template contents to remove unwanted div wrappers.
-	 *
-	 * The old Mini Cart template had extra divs nested within the block tags
-	 * that are no longer necessary since we don't render the Mini Cart with
-	 * React anymore. To maintain compatibility with user saved templates that
-	 * have these wrapper divs, we must remove them.
-	 *
-	 * @param string $template_contents The template contents to process.
-	 * @return string The processed template contents.
-	 */
+			/**
+			 * Process template contents to remove unwanted div wrappers.
+			 *
+			 * The old Mini Cart template had extra divs nested within the block tags
+			 * that are no longer necessary since we don't render the Mini Cart with
+			 * React anymore. To maintain compatibility with user saved templates that
+			 * have these wrapper divs, we must remove them.
+			 *
+			 * @param string $template_contents The template contents to process.
+			 * @return string The processed template contents.
+			 */
 	protected function process_template_contents( $template_contents ) {
 		$p               = new \WP_HTML_Tag_Processor( $template_contents );
 		$is_old_template = $p->next_tag(
@@ -722,12 +728,12 @@ class MiniCart extends AbstractBlock {
 		return $output;
 	}
 
-	/**
-	 * Get the mini cart template part contents to render inside the drawer.
-	 *
-	 * @param bool $do_blocks Whether to apply do_blocks() to the template part contents.
-	 * @return string The contents of the template part.
-	 */
+			/**
+			 * Get the mini cart template part contents to render inside the drawer.
+			 *
+			 * @param bool $do_blocks Whether to apply do_blocks() to the template part contents.
+			 * @return string The contents of the template part.
+			 */
 	protected function get_template_part_contents( $do_blocks = true ) {
 		$template_name          = 'mini-cart';
 		$template_part_contents = '';
@@ -765,13 +771,13 @@ class MiniCart extends AbstractBlock {
 		return $template_part_contents;
 	}
 
-	/**
-	 * Render the markup for the Mini-Cart block.
-	 *
-	 * @param array $attributes Block attributes.
-	 *
-	 * @return string The HTML markup.
-	 */
+			/**
+			 * Render the markup for the Mini-Cart block.
+			 *
+			 * @param array $attributes Block attributes.
+			 *
+			 * @return string The HTML markup.
+			 */
 	protected function get_markup( $attributes ) {
 		if ( is_admin() || WC()->is_rest_api_request() ) {
 			// In the editor we will display the placeholder, so no need to load
@@ -815,19 +821,19 @@ class MiniCart extends AbstractBlock {
 				<div class="wc-block-mini-cart__drawer wc-block-components-drawer">
 					<div class="wc-block-components-drawer__content">
 						<div class="wc-block-mini-cart__template-part">'
-					. wp_kses_post( $template_part_contents ) .
-					'</div>
+			. wp_kses_post( $template_part_contents ) .
+			'</div>
 					</div>
 				</div>
 			</div>
 		</div>';
 	}
 
-	/**
-	 * Return the main instance of WC_Cart class.
-	 *
-	 * @return \WC_Cart CartController class instance.
-	 */
+			/**
+			 * Return the main instance of WC_Cart class.
+			 *
+			 * @return \WC_Cart CartController class instance.
+			 */
 	protected function get_cart_instance() {
 		$cart = WC()->cart;
 
@@ -838,13 +844,13 @@ class MiniCart extends AbstractBlock {
 		return null;
 	}
 
-	/**
-	 * Get array with data for handle the tax label.
-	 * the entire logic of this function is was taken from:
-	 * https://github.com/woocommerce/woocommerce/blob/e730f7463c25b50258e97bf56e31e9d7d3bc7ae7/includes/class-wc-cart.php#L1582
-	 *
-	 * @return array;
-	 */
+			/**
+			 * Get array with data for handle the tax label.
+			 * the entire logic of this function is was taken from:
+			 * https://github.com/woocommerce/woocommerce/blob/e730f7463c25b50258e97bf56e31e9d7d3bc7ae7/includes/class-wc-cart.php#L1582
+			 *
+			 * @return array;
+			 */
 	protected function get_tax_label() {
 		$cart = $this->get_cart_instance();
 
@@ -877,9 +883,9 @@ class MiniCart extends AbstractBlock {
 		);
 	}
 
-	/**
-	 * Prepare translations for inner blocks and dependencies.
-	 */
+			/**
+			 * Prepare translations for inner blocks and dependencies.
+			 */
 	protected function get_inner_blocks_translations() {
 		$wp_scripts   = wp_scripts();
 		$translations = array();
@@ -900,9 +906,9 @@ class MiniCart extends AbstractBlock {
 		return implode( '', $translations );
 	}
 
-	/**
-	 * Register block pattern for Empty Cart Message to make it translatable.
-	 */
+			/**
+			 * Register block pattern for Empty Cart Message to make it translatable.
+			 */
 	public function register_empty_cart_message_block_pattern() {
 		register_block_pattern(
 			'woocommerce/mini-cart-empty-cart-message',
@@ -914,13 +920,13 @@ class MiniCart extends AbstractBlock {
 		);
 	}
 
-	/**
-	 * Returns whether the Mini-Cart should be rendered or not.
-	 *
-	 * @param array $attributes Block attributes.
-	 *
-	 * @return bool
-	 */
+			/**
+			 * Returns whether the Mini-Cart should be rendered or not.
+			 *
+			 * @param array $attributes Block attributes.
+			 *
+			 * @return bool
+			 */
 	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -541,7 +541,7 @@ class MiniCart extends AbstractBlock {
 				array(
 					'isOpen'             => false,
 					'totalItemsInCart'   => $cart_item_count,
-					'cartIsEmpty'        => $cart->is_empty(),
+					'shouldShowTaxLabel' => ! $cart->is_empty(),
 					'badgeIsVisible'     => $badge_is_visible,
 					'formattedSubtotal'  => $formatted_subtotal,
 					'drawerOverlayClass' => 'wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--with-slide-out wc-block-components-drawer__screen-overlay--is-hidden',

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCart.php
@@ -627,14 +627,14 @@ class MiniCart extends AbstractBlock {
 			return ob_get_clean();
 		}
 
-			return '';
+		return '';
 	}
 
-			/**
-			 * Echoes the Interactivity API Mini Cart overlay markup.
-			 *
-			 * @return void
-			 */
+	/**
+	 * Echoes the Interactivity API Mini Cart overlay markup.
+	 *
+	 * @return void
+	 */
 	public function render_experimental_iapi_mini_cart_overlay() {
 		$template_part_contents = $this->get_template_part_contents( false );
 		$template_part_contents = do_blocks( $this->process_template_contents( $template_part_contents ) );
@@ -656,30 +656,30 @@ class MiniCart extends AbstractBlock {
 			>
 				<div class="wc-block-components-drawer__content">
 					<div class="wc-block-mini-cart__template-part">
-				<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $template_part_contents;
-				?>
+						<?php
+							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							echo $template_part_contents;
+						?>
 					</div>
 				</div>
 			</div>
 		</div>				
-				<?php
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo wp_interactivity_process_directives( ob_get_clean() );
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_interactivity_process_directives( ob_get_clean() );
 	}
 
-			/**
-			 * Process template contents to remove unwanted div wrappers.
-			 *
-			 * The old Mini Cart template had extra divs nested within the block tags
-			 * that are no longer necessary since we don't render the Mini Cart with
-			 * React anymore. To maintain compatibility with user saved templates that
-			 * have these wrapper divs, we must remove them.
-			 *
-			 * @param string $template_contents The template contents to process.
-			 * @return string The processed template contents.
-			 */
+	/**
+	 * Process template contents to remove unwanted div wrappers.
+	 *
+	 * The old Mini Cart template had extra divs nested within the block tags
+	 * that are no longer necessary since we don't render the Mini Cart with
+	 * React anymore. To maintain compatibility with user saved templates that
+	 * have these wrapper divs, we must remove them.
+	 *
+	 * @param string $template_contents The template contents to process.
+	 * @return string The processed template contents.
+	 */
 	protected function process_template_contents( $template_contents ) {
 		$p               = new \WP_HTML_Tag_Processor( $template_contents );
 		$is_old_template = $p->next_tag(
@@ -728,12 +728,12 @@ class MiniCart extends AbstractBlock {
 		return $output;
 	}
 
-			/**
-			 * Get the mini cart template part contents to render inside the drawer.
-			 *
-			 * @param bool $do_blocks Whether to apply do_blocks() to the template part contents.
-			 * @return string The contents of the template part.
-			 */
+	/**
+	 * Get the mini cart template part contents to render inside the drawer.
+	 *
+	 * @param bool $do_blocks Whether to apply do_blocks() to the template part contents.
+	 * @return string The contents of the template part.
+	 */
 	protected function get_template_part_contents( $do_blocks = true ) {
 		$template_name          = 'mini-cart';
 		$template_part_contents = '';
@@ -771,13 +771,13 @@ class MiniCart extends AbstractBlock {
 		return $template_part_contents;
 	}
 
-			/**
-			 * Render the markup for the Mini-Cart block.
-			 *
-			 * @param array $attributes Block attributes.
-			 *
-			 * @return string The HTML markup.
-			 */
+	/**
+	 * Render the markup for the Mini-Cart block.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string The HTML markup.
+	 */
 	protected function get_markup( $attributes ) {
 		if ( is_admin() || WC()->is_rest_api_request() ) {
 			// In the editor we will display the placeholder, so no need to load
@@ -821,19 +821,19 @@ class MiniCart extends AbstractBlock {
 				<div class="wc-block-mini-cart__drawer wc-block-components-drawer">
 					<div class="wc-block-components-drawer__content">
 						<div class="wc-block-mini-cart__template-part">'
-			. wp_kses_post( $template_part_contents ) .
-			'</div>
+					. wp_kses_post( $template_part_contents ) .
+					'</div>
 					</div>
 				</div>
 			</div>
 		</div>';
 	}
 
-			/**
-			 * Return the main instance of WC_Cart class.
-			 *
-			 * @return \WC_Cart CartController class instance.
-			 */
+	/**
+	 * Return the main instance of WC_Cart class.
+	 *
+	 * @return \WC_Cart CartController class instance.
+	 */
 	protected function get_cart_instance() {
 		$cart = WC()->cart;
 
@@ -844,13 +844,13 @@ class MiniCart extends AbstractBlock {
 		return null;
 	}
 
-			/**
-			 * Get array with data for handle the tax label.
-			 * the entire logic of this function is was taken from:
-			 * https://github.com/woocommerce/woocommerce/blob/e730f7463c25b50258e97bf56e31e9d7d3bc7ae7/includes/class-wc-cart.php#L1582
-			 *
-			 * @return array;
-			 */
+	/**
+	 * Get array with data for handle the tax label.
+	 * the entire logic of this function is was taken from:
+	 * https://github.com/woocommerce/woocommerce/blob/e730f7463c25b50258e97bf56e31e9d7d3bc7ae7/includes/class-wc-cart.php#L1582
+	 *
+	 * @return array;
+	 */
 	protected function get_tax_label() {
 		$cart = $this->get_cart_instance();
 
@@ -883,9 +883,9 @@ class MiniCart extends AbstractBlock {
 		);
 	}
 
-			/**
-			 * Prepare translations for inner blocks and dependencies.
-			 */
+	/**
+	 * Prepare translations for inner blocks and dependencies.
+	 */
 	protected function get_inner_blocks_translations() {
 		$wp_scripts   = wp_scripts();
 		$translations = array();
@@ -906,9 +906,9 @@ class MiniCart extends AbstractBlock {
 		return implode( '', $translations );
 	}
 
-			/**
-			 * Register block pattern for Empty Cart Message to make it translatable.
-			 */
+	/**
+	 * Register block pattern for Empty Cart Message to make it translatable.
+	 */
 	public function register_empty_cart_message_block_pattern() {
 		register_block_pattern(
 			'woocommerce/mini-cart-empty-cart-message',
@@ -920,13 +920,13 @@ class MiniCart extends AbstractBlock {
 		);
 	}
 
-			/**
-			 * Returns whether the Mini-Cart should be rendered or not.
-			 *
-			 * @param array $attributes Block attributes.
-			 *
-			 * @return bool
-			 */
+	/**
+	 * Returns whether the Mini-Cart should be rendered or not.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return bool
+	 */
 	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request fixes a bug in the new Interactivity API-powered Mini Cart where the "Display prices during cart and checkout" setting for including tax was not being respected. This resulted in prices being displayed without tax, even when they should have been.

The fix involves passing the `displayCartPriceIncludingTax` setting from the server to the frontend Interactivity API store. The frontend logic has been updated to use this setting to conditionally and reactively display the tax label next to prices, ensuring that the total price in the badge, the item totals, and the subtotal in the footer all correctly reflect whether tax should be included.

Closes #60487.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="128" height="80" alt="Screenshot 2025-08-21 at 13 59 56" src="https://github.com/user-attachments/assets/19f7268d-e275-4e78-b8d9-ff2730e95ac3" />    |   <img width="195" height="69" alt="Screenshot 2025-08-21 at 13 58 43" src="https://github.com/user-attachments/assets/f37b5816-201f-43e6-a3f6-e693346a4f9b" />    |
|    <img width="531" height="311" alt="Screenshot 2025-08-21 at 14 00 14" src="https://github.com/user-attachments/assets/6162f298-071b-4687-b46c-1f88f1960527" />    |   <img width="528" height="278" alt="Screenshot 2025-08-21 at 13 59 21" src="https://github.com/user-attachments/assets/c4f8777d-6b69-4f28-8fab-4ea877816d96" />    |
| <img width="531" height="79" alt="Screenshot 2025-08-21 at 14 00 45" src="https://github.com/user-attachments/assets/fb6dd055-1362-4918-8559-d741b8c2f476" />  | <img width="531" height="79" alt="Screenshot 2025-08-21 at 14 01 17" src="https://github.com/user-attachments/assets/10563702-a35f-40ad-9e5c-25204423b28e" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Go to `WooCommerce > Settings > General` and activate `Enable taxes`.
2.  Then, go to `WooCommerce > Settings > Tax > Standard rates` and add a row with a tax percentage for all locations.
3.  Go to `WooCommerce > Settings > Tax > Tax options` and set `Display prices during cart and checkout` to `Including tax`.
4.  Navigate to a page that has the Mini Cart block and ensure the `Display total price` option is enabled in the block settings.
5.  Add a product to the cart and observe the Mini Cart.
6.  Confirm the following:
    - The total price displayed in the Mini Cart badge includes tax.
    - The item total inside the Mini Cart drawer includes tax.
    - The subtotal in the Mini Cart footer includes tax.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Mini Cart - Respect "Including tax" option in "Display prices during cart and checkout"

</details>

