### PR TITLE
Add to Cart + Options: allow setting grouped product children quantity to 0

### DIFF
--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-products-0
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-products-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add to Cart + Options: allow setting grouped product childreantity to 0
+Add to Cart + Options: allow setting grouped product children quantity to 0

--- a/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-products-0
+++ b/plugins/woocommerce/changelog/fix-add-to-cart-with-options-grouped-products-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add to Cart + Options: allow setting grouped product childreantity to 0

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -95,7 +95,7 @@ const getProductData = (
 		return null;
 	}
 
-	const min = typeof productData.min === 'number' ? productData.min : 0;
+	const min = typeof productData.min === 'number' ? productData.min : 1;
 	const max =
 		typeof productData.max === 'number' && productData.max >= 1
 			? productData.max

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -95,10 +95,7 @@ const getProductData = (
 		return null;
 	}
 
-	// Add default quantity constraint values.
-	const defaultMinValue = productType === 'grouped' ? 0 : 1;
-	const min =
-		typeof productData.min === 'number' ? productData.min : defaultMinValue;
+	const min = typeof productData.min === 'number' ? productData.min : 0;
 	const max =
 		typeof productData.max === 'number' && productData.max >= 1
 			? productData.max
@@ -239,6 +236,13 @@ const { actions, state } = store<
 					availableVariations,
 					selectedAttributes,
 				} = getContext< Context >();
+
+				if (
+					productType === 'grouped' &&
+					quantity[ childProductId ] > 0
+				) {
+					return true;
+				}
 
 				const productObject = getProductData(
 					childProductId || productId,
@@ -425,12 +429,21 @@ const { actions, state } = store<
 					return;
 				}
 
-				const newValue = currentValue - step;
+				let newValue = currentValue - step;
 
-				if ( newValue >= min ) {
-					const updatedValue = Math.min( max ?? Infinity, newValue );
-					actions.setQuantity( updatedValue );
-					inputElement.value = updatedValue.toString();
+				// In grouped product children, we allow decreasing the value
+				// down to 0, even if the minimum value is greater than 0.
+				if ( productType === 'grouped' && newValue < min ) {
+					if ( currentValue > min ) {
+						newValue = min;
+					} else {
+						newValue = 0;
+					}
+				}
+
+				if ( newValue !== currentValue ) {
+					actions.setQuantity( newValue );
+					inputElement.value = newValue.toString();
 					dispatchChangeEvent( inputElement );
 				}
 			},
@@ -485,10 +498,16 @@ const { actions, state } = store<
 					return;
 				}
 
-				const newValue = Math.min(
+				let newValue = Math.min(
 					max ?? Infinity,
 					Math.max( min, currentValue )
 				);
+
+				// In grouped product children, we allow decreasing the value
+				// down to 0, even if the minimum value is greater than 0.
+				if ( productType === 'grouped' && currentValue < min ) {
+					newValue = 0;
+				}
 
 				if ( event.target.value !== newValue.toString() ) {
 					actions.setQuantity( newValue );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -33,17 +33,6 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 	'woocommerce/add-to-cart-with-options',
 	{
 		actions: {
-			setQuantity( value: number ) {
-				const context =
-					getContext< AddToCartWithOptionsStoreContext >();
-
-				const id = context.childProductId;
-
-				context.quantity = {
-					...context.quantity,
-					[ id ]: value,
-				};
-			},
 			*addToCart() {
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -224,18 +224,20 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
 		} );
 
-		await test.step( 'child simple product values can be decreased down to 0', async () => {
-			const decreaseQuantityButton = page.getByLabel(
+		await test.step( 'child simple product quantities can be decreased down to 0', async () => {
+			const reduceQuantityButton = page.getByLabel(
 				'Reduce quantity of Beanie'
 			);
-			await decreaseQuantityButton.click();
-			await decreaseQuantityButton.click();
+			await reduceQuantityButton.click();
+			await reduceQuantityButton.click();
 
 			const quantityInput = page.getByRole( 'spinbutton', {
 				name: 'Beanie',
 			} );
 
 			await expect( quantityInput ).toHaveValue( '0' );
+
+			await expect( reduceQuantityButton ).toBeDisabled();
 		} );
 	} );
 
@@ -377,21 +379,29 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( increaseQuantityButton ).toBeDisabled();
 
 			// Values can be decreased down to 0.
-			const decreaseQuantityButton = page.getByLabel(
+			const reduceQuantityButton = page.getByLabel(
 				'Reduce quantity of T-Shirt'
 			);
 
-			await decreaseQuantityButton.click();
+			await reduceQuantityButton.click();
 
 			await expect( quantityInput ).toHaveValue( '6' );
 
 			await quantityInput.fill( '5' );
 
-			await decreaseQuantityButton.click();
+			await reduceQuantityButton.click();
 
 			await expect( quantityInput ).toHaveValue( '4' );
 
-			await decreaseQuantityButton.click();
+			await reduceQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '0' );
+
+			await expect( reduceQuantityButton ).toBeDisabled();
+
+			// Make sure quantities below min are not allowed even when manually filled.
+			await quantityInput.fill( '3' );
+			await quantityInput.blur();
 
 			await expect( quantityInput ).toHaveValue( '0' );
 		} );

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -223,6 +223,18 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await expect( page.getByLabel( '2 items in cart' ) ).toBeVisible();
 		} );
+
+		await test.step( 'child simple product values can be decreased down to 0', async () => {
+			const decreaseQuantityButton = page.getByLabel(
+				'Decrease quantity of Beanie'
+			);
+			await decreaseQuantityButton.click();
+			await decreaseQuantityButton.click();
+
+			const quantityInput = page.getByLabel( 'Product quantity' );
+
+			await expect( quantityInput ).toHaveValue( '0' );
+		} );
 	} );
 
 	test( "doesn't allow selecting invalid variations in pills mode", async ( {
@@ -365,6 +377,25 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await quantityInput.fill( '8' );
 
 			await expect( increaseQuantityButton ).toBeDisabled();
+
+			// Values can be decreased down to 0.
+			const decreaseQuantityButton = page.getByLabel(
+				'Decrease quantity of T-Shirt'
+			);
+
+			await decreaseQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '6' );
+
+			await quantityInput.fill( '5' );
+
+			await decreaseQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '4' );
+
+			await decreaseQuantityButton.click();
+
+			await expect( quantityInput ).toHaveValue( '0' );
 		} );
 	} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -226,12 +226,14 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 		await test.step( 'child simple product values can be decreased down to 0', async () => {
 			const decreaseQuantityButton = page.getByLabel(
-				'Decrease quantity of Beanie'
+				'Reduce quantity of Beanie'
 			);
 			await decreaseQuantityButton.click();
 			await decreaseQuantityButton.click();
 
-			const quantityInput = page.getByLabel( 'Product quantity' );
+			const quantityInput = page.getByRole( 'spinbutton', {
+				name: 'Beanie',
+			} );
 
 			await expect( quantityInput ).toHaveValue( '0' );
 		} );
@@ -368,10 +370,6 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await expect( quantityInput ).toHaveValue( '4' );
 
-			const reduceQuantityButton = page.getByLabel(
-				'Reduce quantity of T-Shirt'
-			);
-			await expect( reduceQuantityButton ).toBeDisabled();
 			await increaseQuantityButton.click();
 
 			await quantityInput.fill( '8' );
@@ -380,7 +378,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			// Values can be decreased down to 0.
 			const decreaseQuantityButton = page.getByLabel(
-				'Decrease quantity of T-Shirt'
+				'Reduce quantity of T-Shirt'
 			);
 
 			await decreaseQuantityButton.click();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductItemSelector.php
@@ -45,15 +45,6 @@ class GroupedProductItemSelector extends AbstractBlock {
 		$min_value = $product->get_min_purchase_quantity();
 		$max_value = $product->get_max_purchase_quantity();
 
-		// By default, products have a min value of 1. In that case, we can
-		// safely override it to 0 when they are a child of a grouped product.
-		// The main benefit is that the the decrease quantity button will be
-		// enabled even when the quantity is 1, which is a small quality of life
-		// enhancement for shoppers.
-		if ( 1 === $min_value ) {
-			$min_value = 0;
-		}
-
 		if ( $min_value === $max_value && $min_value > 0 ) {
 			add_filter( 'woocommerce_quantity_input_type', array( $this, 'set_quantity_input_type' ) );
 		}
@@ -63,7 +54,7 @@ class GroupedProductItemSelector extends AbstractBlock {
 				'input_name'  => 'quantity[' . $product->get_id() . ']',
 				'input_id'    => 'quantity_' . $product->get_id(),
 				'input_value' => isset( $_POST['quantity'][ $product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $product->get_id() ] ) ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				'min_value'   => $min_value,
+				'min_value'   => 0,
 				'max_value'   => $max_value,
 				/**
 				 * Filter the placeholder value allowed for the product.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60525.

This PR makes it so shoppers can set the minimum quantities of grouped products children to `0` using the minus button.

### How to test the changes in this Pull Request:

1. Create a grouped product with two simple products as children (or use an existing one if you already have this set up in your store).
2. Add this code snippet to modify the `min`, `max` and `step` quantities of one of the simple products (you will need to change `110` with the product id):

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 4;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_step', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 2;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 8;
	}
	return $default;
}, 10, 2 );
```

3. Visit the grouped product in the frontend, making sure it's using the _Add to Cart + Options_ block.
4. Increase and decrease the quantity of the simple products and verify you can set the quantities to `0` but you are not allowed to set the quantities to something between `0` and `min`.

https://github.com/user-attachments/assets/ccd9745a-1054-4b93-bcef-7cd9ca497f65