### PR TITLE
Add to Cart + Options: Don't make Product Price block interactive if all variations have the same price

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-price-interactivity
+++ b/plugins/woocommerce/changelog/fix-product-price-interactivity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't make Product Price block interactive if all variations have the same price

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -85,34 +85,45 @@ class ProductPrice extends AbstractBlock {
 			if ( $is_interactive ) {
 				$variations_data           = $product->get_available_variations();
 				$formatted_variations_data = array();
+				$is_price_html_different   = false;
+				$last_price_html           = '';
 				foreach ( $variations_data as $variation ) {
 					if ( ! isset( $variation['variation_id'] ) || ! isset( $variation['price_html'] ) ) {
 							continue;
+					}
+					if ( $variation['price_html'] !== $last_price_html ) {
+						$is_price_html_different = true;
+					} else {
+						$last_price_html = $variation['price_html'];
 					}
 					$formatted_variations_data[ $variation['variation_id'] ] = array(
 						'price_html' => $variation['price_html'],
 					);
 				}
 
-				wp_interactivity_state(
-					'woocommerce',
-					array(
-						'products' => array(
-							$product->get_id() => array(
-								'price_html' => $product->get_price_html(),
-								'variations' => $formatted_variations_data,
+				if ( ! $is_price_html_different ) {
+					$is_interactive = false;
+				} else {
+					wp_interactivity_state(
+						'woocommerce',
+						array(
+							'products' => array(
+								$product->get_id() => array(
+									'price_html' => $product->get_price_html(),
+									'variations' => $formatted_variations_data,
+								),
 							),
-						),
-					)
-				);
+						)
+					);
 
-				wp_enqueue_script_module( 'woocommerce/product-elements' );
-				$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
-				$context                                   = array(
-					'productElementKey' => 'price_html',
-				);
-				$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
-				$watch_attribute                           = 'data-wp-watch="callbacks.updateValue"';
+					wp_enqueue_script_module( 'woocommerce/product-elements' );
+					$wrapper_attributes['data-wp-interactive'] = 'woocommerce/product-elements';
+					$context                                   = array(
+						'productElementKey' => 'price_html',
+					);
+					$wrapper_attributes['data-wp-context']     = wp_json_encode( $context, JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
+					$watch_attribute                           = 'data-wp-watch="callbacks.updateValue"';
+				}
 			}
 
 			return sprintf(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -85,23 +85,20 @@ class ProductPrice extends AbstractBlock {
 			if ( $is_interactive ) {
 				$variations_data           = $product->get_available_variations();
 				$formatted_variations_data = array();
-				$is_price_html_different   = false;
-				$last_price_html           = '';
+				$has_variation_price_html  = false;
 				foreach ( $variations_data as $variation ) {
-					if ( ! isset( $variation['variation_id'] ) || ! isset( $variation['price_html'] ) ) {
+					if ( ! isset( $variation['variation_id'] ) || ! isset( $variation['price_html'] ) || empty( $variation['price_html'] ) ) {
 							continue;
 					}
-					if ( $variation['price_html'] !== $last_price_html ) {
-						$is_price_html_different = true;
-					} else {
-						$last_price_html = $variation['price_html'];
-					}
+					// Core behavior: variation['price_html'] is empty iff all variation prices are identical.
+					// Therefore, any non-empty price_html indicates differences that warrant interactivity.
+					$has_variation_price_html                                = true;
 					$formatted_variations_data[ $variation['variation_id'] ] = array(
 						'price_html' => $variation['price_html'],
 					);
 				}
 
-				if ( ! $is_price_html_different ) {
+				if ( ! $has_variation_price_html ) {
 					$is_interactive = false;
 				} else {
 					wp_interactivity_state(

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductPrice.php
@@ -87,11 +87,15 @@ class ProductPrice extends AbstractBlock {
 				$formatted_variations_data = array();
 				$has_variation_price_html  = false;
 				foreach ( $variations_data as $variation ) {
-					if ( ! isset( $variation['variation_id'] ) || ! isset( $variation['price_html'] ) || empty( $variation['price_html'] ) ) {
-							continue;
+					if (
+						empty( $variation['variation_id'] )
+						|| ! array_key_exists( 'price_html', $variation )
+						|| '' === $variation['price_html']
+					) {
+						continue;
 					}
-					// Core behavior: variation['price_html'] is empty iff all variation prices are identical.
-					// Therefore, any non-empty price_html indicates differences that warrant interactivity.
+					// Core behavior: when all variation prices are identical, Core returns '' for variation['price_html'].
+					// Therefore, the presence of any non-empty price_html implies price differences and warrants interactivity.
 					$has_variation_price_html                                = true;
 					$formatted_variations_data[ $variation['variation_id'] ] = array(
 						'price_html' => $variation['price_html'],

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -369,6 +369,9 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			)
 		);
 
+		// Sync again so the variable product reflects the new variation.
+		\WC_Product_Variable::sync( $product_id );
+
 		// Assert that Product Price block has a `data-wp-watch` attribute.
 		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-price /--><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
 

--- a/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/BlockTypes/AddToCartWithOptions.php
@@ -314,4 +314,68 @@ class AddToCartWithOptions extends \WP_UnitTestCase {
 			'The "small" size option should be checked when set as the default attribute.'
 		);
 	}
+
+	/**
+	 * Tests that the Product Price block is only interactive when some variations have different prices.
+	 */
+	public function test_variable_product_price_interactivity() {
+		global $product;
+
+		$fixtures = new FixtureData();
+
+		$product = $fixtures->get_variable_product(
+			array(),
+			array(
+				$fixtures->get_product_attribute( 'color', array( 'red', 'green', 'blue' ) ),
+				$fixtures->get_product_attribute( 'size', array( 'small', 'medium', 'large' ) ),
+			)
+		);
+
+		$product_id = $product->get_id();
+
+		$fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'red-slug',
+				'pa_size'  => 'small-slug',
+			),
+			array(
+				'regular_price' => 10,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		// Sync the variable product to update its children list.
+		\WC_Product_Variable::sync( $product_id );
+
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-price /--><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		// Assert that Product Price block doesn't have a `data-wp-watch` attribute.
+		$this->assertDoesNotMatchRegularExpression(
+			'/<div[^>]*class="wc-block-components-product-price[^>]*data-wp-watch=[^>]*>/',
+			$markup,
+			'The Product Price block should not be interactive when all variations have the same price.'
+		);
+
+		$fixtures->get_variation_product(
+			$product_id,
+			array(
+				'pa_color' => 'red-slug',
+				'pa_size'  => 'medium-slug',
+			),
+			array(
+				'regular_price' => 15,
+				'stock_status'  => ProductStockStatus::IN_STOCK,
+			)
+		);
+
+		// Assert that Product Price block has a `data-wp-watch` attribute.
+		$markup = do_blocks( '<!-- wp:woocommerce/single-product {"productId":' . $product_id . '} --><!-- wp:woocommerce/product-price /--><!-- wp:woocommerce/add-to-cart-with-options /--><!-- /wp:woocommerce/single-product -->' );
+
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*class="wc-block-components-product-price[^>]*data-wp-watch=[^>]*>/',
+			$markup,
+			'The Product Price block should be interactive when some variations have different prices.'
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/60532.

If all variation prices are the same, WC core returns an empty string as the variation `price_html`. That caused the product price to disappear when selecting a variation.

This PR makes it so if we detect all prices are the same, we don't make the block interactive at all, so it doesn't react to variations being selected.

### How to test the changes in this Pull Request:

1. Create a variable product making sure all variations have the same price.
2. In the frontend, using the _Add to Cart + Options_ block, select the variations.
3. Make sure the price persists and it doesn't disappear.

https://github.com/user-attachments/assets/44da667e-8212-4b5b-bc32-c2d438375263