### PR TITLE
Ensure workflows support new db updates versioning

### DIFF
--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           script: |
             const { run } = require( './checkout-trunk/.github/workflows/scripts/release-check-db-updates' );
-            run( `${{ inputs.branch }}`, { github, context } );
+            await run( `${{ inputs.branch }}`, { github, context } );
 
   build:
     name: Build release zip file

--- a/.github/workflows/release-build-zip-file.yml
+++ b/.github/workflows/release-build-zip-file.yml
@@ -62,6 +62,18 @@ jobs:
               echo "::error::Verification can not be skipped when building for a release."
               exit 1
           fi
+
+        # Checkout trunk.
+      - uses: actions/checkout@v4
+        with:
+          ref: trunk
+          path: checkout-trunk
+          sparse-checkout: |
+            /.github/workflows/scripts/release-check-db-updates.js
+          sparse-checkout-cone-mode: false
+        if: ${{ ! inputs.skip_verify }}
+
+        # Checkout branch.
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}
@@ -73,6 +85,7 @@ jobs:
         if: ${{ ! inputs.skip_verify }}
 
       - name: 'Pre-build verification'
+        id: pre-build-verification
         if: ${{ ! inputs.skip_verify }}
         env:
           BRANCH: ${{ inputs.branch || github.ref }}
@@ -136,6 +149,16 @@ jobs:
                 echo "::error::Pre-build verification: there are PRs with milestone '$milestone' still open."
                 exit 1
             fi
+
+            echo "release_version=$branch_plugin_version" >> $GITHUB_OUTPUT
+
+      - name: 'Pre-build verification: db updates'
+        if: ${{ ! inputs.skip_verify && ! contains( steps.pre-build-verification.outputs.release_version, '-dev' ) && ! contains( steps.pre-build-verification.outputs.release_version, '-beta.1' ) }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          script: |
+            const { run } = require( './checkout-trunk/.github/workflows/scripts/release-check-db-updates' );
+            run( `${{ inputs.branch }}`, { github, context } );
 
   build:
     name: Build release zip file

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -198,6 +198,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: release/${{ needs.extract-versions.outputs.current_version }}
           fetch-depth: 0
 
       - name: Check for database updates
@@ -227,24 +228,22 @@ jobs:
               // Check if the version exists as a key in the array
               // This regex looks for the version as a string key with the format X.Y.Z
               const escapedVersion = version.replace('.', '\\.');
-              const versionPattern = new RegExp(`['"]${escapedVersion}(?:\\.\\d+)?['"]\\s*=>\\s*array\\s*\\((.*?)\\)`, 's');
-              const versionMatch = dbUpdatesContent.match(versionPattern);
+              const versionPattern = new RegExp( `['"]${escapedVersion}\\.\\d+(?:-.*?)?['"]\\s*=>\\s*array\\s*\\((.*?)\\)`, 'gs' );
+              const versionMatch = [...dbUpdatesContent.matchAll(versionPattern)];
 
-              if (versionMatch) {
+              if ( versionMatch && versionMatch.length > 0 ) {
                 console.log(`✅ Found database updates for version ${version}`);
                 core.setOutput('has_updates', 'true');
 
-                const updatesContent = versionMatch[1];
+                // Split by comma and clean up each update function.
+                const updates = versionMatch
+                  .flatMap( m => m[1].split( ',' ) )
+                  .map( u => u.replace( /['"]/g, '' ).trim() )
+                  .filter( u => u.length > 0 )
 
-                // Split by comma and clean up each update function
-                const updates = updatesContent
-                  .split(',')
-                  .map(update => update.trim().replace(/['"]/g, ''))
-                  .filter(update => update.length > 0);
 
                 // Store updates for the PR finding step
                 core.setOutput('updates_list', updates.join(','));
-
               } else {
                 console.log(`⛔ No database updates found for version ${version}`);
                 core.setOutput('has_updates', 'false');

--- a/.github/workflows/release-commits-and-contributors.yml
+++ b/.github/workflows/release-commits-and-contributors.yml
@@ -195,10 +195,20 @@ jobs:
       updates_list: ${{ steps.check-db-updates.outputs.updates_list }}
       formatted_updates: ${{ steps.find-pr.outputs.formatted_updates }}
     steps:
+      - name: Checkout utilities
+        uses: actions/checkout@v4
+        with:
+          ref: trunk
+          path: checkout-trunk
+          sparse-checkout: |
+            /.github/workflows/scripts/release-check-db-updates.js
+          sparse-checkout-cone-mode: false
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: release/${{ needs.extract-versions.outputs.current_version }}
+          path: checkout-release
           fetch-depth: 0
 
       - name: Check for database updates
@@ -207,50 +217,45 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = 'plugins/woocommerce/includes/class-wc-install.php';
+            const { readDbUpdatesFromString } = require( './checkout-trunk/.github/workflows/scripts/release-check-db-updates' );
+            const path = 'checkout-release/plugins/woocommerce/includes/class-wc-install.php';
             const version = '${{ needs.extract-versions.outputs.current_version }}';
 
             console.log(`Checking for database updates for version: ${version}`);
 
             try {
               const fileContent = fs.readFileSync(path, 'utf8');
+              const dbUpdates   = readDbUpdatesFromString( fileContent );
 
-              const dbUpdatesMatch = fileContent.match(/\$db_updates\s*=\s*array\s*\((.*?)\);/s);
-
-              if (!dbUpdatesMatch) {
-                console.log('Could not find `$db_updates` array in the file');
+              if ( ! dbUpdates || 0 === dbUpdates.size ) {
+                console.log('Could not find `$db_updates` array in the file.');
                 core.setOutput('has_updates', 'false');
                 return;
               }
 
-              const dbUpdatesContent = dbUpdatesMatch[1];
+              // Group all db updates for this version.
+              const updates = [];
 
-              // Check if the version exists as a key in the array
-              // This regex looks for the version as a string key with the format X.Y.Z
-              const escapedVersion = version.replace('.', '\\.');
-              const versionPattern = new RegExp( `['"]${escapedVersion}\\.\\d+(?:-.*?)?['"]\\s*=>\\s*array\\s*\\((.*?)\\)`, 'gs' );
-              const versionMatch = [...dbUpdatesContent.matchAll(versionPattern)];
+              const fullVersion = version + '.0';
+              for ( const [ key, value ] of dbUpdates ) {
+                if ( key.replace( /-.*$/, '' ) !== fullVersion ) {
+                  continue;
+                }
 
-              if ( versionMatch && versionMatch.length > 0 ) {
-                console.log(`✅ Found database updates for version ${version}`);
-                core.setOutput('has_updates', 'true');
-
-                // Split by comma and clean up each update function.
-                const updates = versionMatch
-                  .flatMap( m => m[1].split( ',' ) )
-                  .map( u => u.replace( /['"]/g, '' ).trim() )
-                  .filter( u => u.length > 0 )
-
-
-                // Store updates for the PR finding step
-                core.setOutput('updates_list', updates.join(','));
-              } else {
-                console.log(`⛔ No database updates found for version ${version}`);
-                core.setOutput('has_updates', 'false');
-                core.setOutput('updates_list', '');
+                updates.push( ...value );
               }
+
+              if ( updates.length > 0 ) {
+                console.log( `✅ Found database updates for version ${version}` );
+
+                core.setOutput( 'has_updates', 'true' );
+                core.setOutput( 'updates_list', updates.join( ',' ) );
+              } else {
+                console.log( `⛔ No database updates found for version ${version}` );
+                core.setOutput( 'has_updates', 'false' );
+                core.setOutput( 'updates_list', '' );
+               }
             } catch (error) {
-              console.error(`Error reading file: ${error.message}`);
               core.setFailed(`Failed to check database updates: ${error.message}`);
             }
 
@@ -260,6 +265,8 @@ jobs:
         run: |
           FILE_PATH="plugins/woocommerce/includes/class-wc-install.php"
           UPDATES="${{ steps.check-db-updates.outputs.updates_list }}"
+
+          cd checkout-release
 
           echo "Searching for PRs that introduced database updates"
 

--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -148,7 +148,7 @@ const dbUpdateKeyGreaterThan = ( key1, key2 ) => {
 };
 
 /**
- * Performs a check to ensure db udpates are correct in a given ref.
+ * Performs a check to ensure db updates are correct in a given ref.
  *
  * @param {string} currentRef
  * @param {{ github: Octokit, context: { repo: { owner: string, repo: string } } }} options

--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -48,8 +48,6 @@ const findPreviousVersion = async ( version, { github, context } ) => {
     allTags.push( version );
   }
 
-  console.log( allTags );
-
   // Sort tags.
   allTags.sort( (a, b) => Number( a.split( '.' ).at( -1 ) ) - Number( b.split( '.' ).at( -1 ) ) );
 
@@ -108,6 +106,48 @@ const readFileFromRef = async ( ref, path, { github, context } ) => {
 };
 
 /**
+ * Parses a db update key into its components.
+ *
+ * @param {string} key
+ * @returns {{ mainVersion: number, patch: number, suffix: number }}
+ */
+const parseDbUpdateKey = ( key ) => {
+  const m = key.match( /(?<main>\d+\.\d+)\.(?<patch>\d+)(-(?<suffix>\d+))?/ );
+
+  if ( ! m ) {
+    throw new Error( `Could not parse db update key '${ key }'.` );
+  }
+
+  return {
+    mainVersion: Number( m.groups['main'] ),
+    patch: parseInt( m.groups['patch'] || 0 ),
+    suffix: parseInt( m.groups['suffix'] || 0 ),
+  };
+};
+
+/**
+ * Checks if a db update key is greater than another.
+ *
+ * @param {string} key1
+ * @param {string} key2
+ * @returns {boolean} True if key1 is greater than key2.
+ */
+const dbUpdateKeyGreaterThan = ( key1, key2 ) => {
+  const v1 = parseDbUpdateKey( key1 );
+  const v2 = parseDbUpdateKey( key2 );
+
+  if ( v1.mainVersion !== v2.mainVersion ) {
+    return v1.mainVersion > v2.mainVersion;
+  }
+
+  if ( v1.patch !== v2.patch ) {
+    return v1.patch > v2.patch;
+  }
+
+  return v1.suffix > v2.suffix;
+};
+
+/**
  * Performs a check to ensure db udpates are correct in a given ref.
  *
  * @param {string} currentRef
@@ -138,15 +178,20 @@ const run = async ( currentRef, { github, context } ) => {
 
   // Compare db updates.
   const key1 = Array.from( previousDbUpdates.keys() ).pop();
-  const [ base1, suffix1 ] = key1.split( '-' );
-
   const key2 = Array.from( currentDbUpdates.keys() ).pop();
-  const [ base2, suffix2 ] = key2.split( '-' );
+
+  // key2 shouldn't be truly ahead of version.
+  if ( dbUpdateKeyGreaterThan( key2.replace( /-.*$/, '' ), version.replace( /-.*$/, '' ) ) ) {
+    throw new Error(
+      `DB update key '${ key2 }' is ahead of the plugin version '${ version.replace( /-.*$/, '' ) }'.`
+    );
+  }
 
   // If the keys are identical, ensure no new callback was added. Removing callbacks is allowed.
   if ( key1 === key2 ) {
     const updates1 = previousDbUpdates.get( key1 );
-    const updates2 = currentDbUpdates.get( key2 );
+    const updates2 = currentDbUpdates.get( key2 )
+    const [ base1, suffix1 ] = key1.split( '-' );
 
     updates2.forEach(
       ( e ) => {
@@ -159,17 +204,13 @@ const run = async ( currentRef, { github, context } ) => {
     return;
   }
 
-  // If the basis are different, the new one must have a higher patch number.
-  if ( base1 !== base2 && ( Number( base2.split( '.' ).at( -1 )  ) > Number( base1.split( '.' ).at( -1 ) ) ) ) {
-    return;
+  // If the keys are different, key2 must be > key1.
+  if ( ! dbUpdateKeyGreaterThan( key2, key1 ) ) {
+    throw new Error(
+      `In order to preserve the correct order of db updates, an update key greater than '${ key1 }' is required in version '${ version }'. Found '${ key2 }' instead. An empty array is allowed to skip removed db updates.`
+    );
   }
 
-  // If the basis are equal, the new one must have a higher suffix.
-  if ( base1 === base2 && ( Number( suffix2 || 0 ) > Number( suffix1 || 0 ) ) ) {
-    return;
-  }
-
-  throw new Error( `DB update callbacks under key '${ key1 }' were removed in version '${ version }'. Use an empty array if necessary to maintain the correct order.` );
 };
 
 module.exports = { readDbUpdatesFromString, run };

--- a/.github/workflows/scripts/release-check-db-updates.js
+++ b/.github/workflows/scripts/release-check-db-updates.js
@@ -1,0 +1,175 @@
+/**
+ * Uses the GitHub API to find the previous version of a given version.
+ *
+ * @param {string} version
+ * @param {{ github: Octokit, context: { repo: { owner: string, repo: string } } }} options
+ * @returns {Promise<string>} The previous version.
+ */
+const findPreviousVersion = async ( version, { github, context } ) => {
+  if ( version.endsWith( '-dev' ) || version.endsWith( '-beta.1' ) ) {
+    throw new Error( `Version '${ version }' is the first version in the cycle.` );
+  }
+
+  // Match all versions in cycle.
+  const matchingRef = version.replace( /\.\d+(-.*)?$/, '' );
+  var allTags = (
+    await github.request(
+      'GET /repos/{owner}/{repo}/git/matching-refs/tags/{ref}', {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: matchingRef,
+      }
+    )
+  ).data.map( ( t ) => t.ref.replace( 'refs/tags/', '' ) );
+
+  // Filter out unnecessary tags.
+  allTags = allTags.filter(
+    ( t ) => {
+      // If version is -rc.1 or a beta we want betas.
+      if ( version.endsWith( '-rc.1' ) || version.includes( '-beta' ) ) {
+        return t.includes( '-beta' );
+      }
+
+      // If version is .0 (stable) or an RC we want RCs.
+      if ( version.endsWith( '.0' ) || version.includes( '-rc' ) ) {
+        return t.includes( '-rc' );
+      }
+
+      return ! t.includes( '-' );
+    }
+  );
+
+  if ( 0 === allTags.length) {
+    throw new Error( `Cannot determine previous version for '${ version }'.` );
+  }
+
+  // Insert current version in array when necessary.
+  if ( ! version.endsWith( '-rc.1' ) && ! version.endsWith( '.0' ) && ! allTags.includes( version ) ) {
+    allTags.push( version );
+  }
+
+  console.log( allTags );
+
+  // Sort tags.
+  allTags.sort( (a, b) => Number( a.split( '.' ).at( -1 ) ) - Number( b.split( '.' ).at( -1 ) ) );
+
+  return ( version.endsWith( '-rc.1' ) || version.endsWith( '.0' ) )
+    ? allTags.at( -1 )
+    : allTags.at( allTags.indexOf( version ) - 1 );
+};
+
+/**
+ * Reads the `$db_updates` array from a file.
+ * @param {string} path
+ * @returns {Map<string, string[]>} The `$db_updates` array with version as key and set of callbacks.
+ */
+const readDbUpdatesFromString = ( fileContent ) => {
+    const dbUpdatesMatch = fileContent.match( /\$db_updates\s*=\s*array\s*\((.*?)\);/s );
+    const dbUpdatesContent = dbUpdatesMatch[1];
+
+    const versionPattern = new RegExp( `['"](?<version>\\d+\\.\\d+\\.\\d+(?:-.*?)?)['"]\\s*=>\\s*array\\s*\\((?<callbacks>.*?)\\)`, 'gs' );
+    const versionMatch = [ ...dbUpdatesContent.matchAll( versionPattern ) ];
+
+    const dbUpdates = new Map();
+    for ( const m of versionMatch ) {
+        dbUpdates.set(
+          m.groups.version,
+          m.groups.callbacks
+            .split( ',' )
+            .map( c => c.replace( /['"]/g, '' ) )
+            .map( c => c.trim() )
+            .filter( c => c.length > 0 )
+            .sort()
+        );
+    }
+
+    return dbUpdates;
+};
+
+/**
+ * Reads a file from a given ref.
+ *
+ * @param {string} ref
+ * @param {string} path
+ * @param {{ github: Octokit, context: { repo: { owner: string, repo: string } } }} options
+ * @returns {Promise<string>} The file content.
+ */
+const readFileFromRef = async ( ref, path, { github, context } ) => {
+    const file = await github.rest.repos.getContent(
+        {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            path,
+            ref
+        }
+    );
+
+    return Buffer.from( file.data.content, 'base64' ).toString();
+};
+
+/**
+ * Performs a check to ensure db udpates are correct in a given ref.
+ *
+ * @param {string} currentRef
+ * @param {{ github: Octokit, context: { repo: { owner: string, repo: string } } }} options
+ * @returns {Promise<void>}
+ */
+const run = async ( currentRef, { github, context } ) => {
+  // Find version number in ref.
+  const version = (
+    await readFileFromRef( currentRef, 'plugins/woocommerce/woocommerce.php', { github, context } )
+  ).match( /(?<=Version: )(.+)/ )[0];
+
+  if ( version.endsWith( '-dev' ) || version.endsWith( '-beta.1' ) ) {
+    console.log( `Skipping db updates check for '-dev' or '-beta.1'.` );
+    return;
+  }
+
+  // Previous version.
+  const previousRef = await findPreviousVersion( version, { github, context } );
+  const previousFile = await readFileFromRef( previousRef, 'plugins/woocommerce/includes/class-wc-install.php', { github, context } );
+  const previousDbUpdates = readDbUpdatesFromString( previousFile );
+
+  // Read current wc-install.php.
+  const currentFile = await readFileFromRef( currentRef, 'plugins/woocommerce/includes/class-wc-install.php', { github, context } );
+  const currentDbUpdates = readDbUpdatesFromString( currentFile );
+
+  console.log( `Comparing versions '${ previousRef }' and '${ version }'  (ref: '${ currentRef }').` );
+
+  // Compare db updates.
+  const key1 = Array.from( previousDbUpdates.keys() ).pop();
+  const [ base1, suffix1 ] = key1.split( '-' );
+
+  const key2 = Array.from( currentDbUpdates.keys() ).pop();
+  const [ base2, suffix2 ] = key2.split( '-' );
+
+  // If the keys are identical, ensure no new callback was added. Removing callbacks is allowed.
+  if ( key1 === key2 ) {
+    const updates1 = previousDbUpdates.get( key1 );
+    const updates2 = currentDbUpdates.get( key2 );
+
+    updates2.forEach(
+      ( e ) => {
+        if ( ! updates1.includes( e ) ) {
+          throw new Error( `A new db update callback was added under key '${ key1 }' in version '${ version }'. Add them under a new key instead (e.g. '${ base1 }-${ Number( suffix1 || 0 ) + 1 }').` );
+        }
+      }
+    );
+
+    return;
+  }
+
+  // If the basis are different, the new one must have a higher patch number.
+  if ( base1 !== base2 && ( Number( base2.split( '.' ).at( -1 )  ) > Number( base1.split( '.' ).at( -1 ) ) ) ) {
+    return;
+  }
+
+  // If the basis are equal, the new one must have a higher suffix.
+  if ( base1 === base2 && ( Number( suffix2 || 0 ) > Number( suffix1 || 0 ) ) ) {
+    return;
+  }
+
+  throw new Error( `DB update callbacks under key '${ key1 }' were removed in version '${ version }'. Use an empty array if necessary to maintain the correct order.` );
+};
+
+module.exports = { readDbUpdatesFromString, run };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
In the past, we've used the stable version as key [in the `$db_updates` array](https://github.com/woocommerce/woocommerce/blob/50509ae41a43d211097831fe074c9f20b96d7ee4/plugins/woocommerce/includes/class-wc-install.php#L41) throughout the prerelease cycle. This means that if anyone installs a prerelease, the `woocommerce_db_option` in their database is set to the stable version, thus upgrading to any other prerelease in that same cycle or even the final stable wouldn't trigger any new db updates (if added).

#60356 and #60400 make sure db updates can be added to the array even between prereleases as long as we create a new key (say `X.Y.0-1`, `X.Y.0-2`, and so on) to ensure they compare as higher in PHP's `version_compare()`.

While uncommon for db updates to be added this late in the cycle, we want to make sure that:

- DB updates added after the first beta get their own key so that they are not skipped for anyone using beta or RC versions or upgrading from such version to the final stable. We're enforcing this as a pre-build check which compares the `$db_updates` array with the previous release/tag.
- Our `'Release: Generate Number of Commits and Contributors'` which produces a list of db updates for Dev Advocacy takes into account the new naming scheme where all `X.Y.0`, `X.Y.0-1`, ... keys all refer to release `X.Y.0`.

Related to #60345.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

> [!NOTE]
> Testing is a bit complex in this case. Please be patient and keep hydrated! 🚰 

1. Fork this repo, including `trunk` and `release/10.1` (this is required for one workflow, but we won't be using it).
1. Run **Actions > Release: Bump version number** with release branch `release/10.2` and bump type `beta`. Merge the resulting PR, which should bump versions to `10.2.0-beta.1`.
1. Run **Actions > Release: Generate Number of Commits and Contributors** with version `10.2`. It's ok if the overall workflow fails (there's one step that runs against the WC repo), but ensure that **Check for database updates** step does succeed and reports no database updates:
   <img width="614" height="112" alt="Screenshot 2025-08-22 at 14 58 39" src="https://github.com/user-attachments/assets/2dea0958-9cdd-4e25-9742-1c4cf1b009ff" />
1. Using the GH UI, edit `plugins/woocommerce/includes/class-wc-install.php` on `release/10.2` and add the following to the end of the `$db_updates` array:
   ```php
		'10.2.0' => array(
			'foobar',
		),
   ```
1. Run **Actions > Release: Generate Number of Commits and Contributors** with version `10.2` and confirm that the **Check for database updates** step reports the new database update:
   <img width="638" height="306" alt="Screenshot 2025-08-22 at 11 53 12" src="https://github.com/user-attachments/assets/ee962d5d-bb3b-4450-b4a7-442cb5701cc5" />
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.2` and with the option to create a GH release checked. Once the process completes, **publish** the `10.2.-beta.1` tag in **Code > Releases**.
1. Once again, use the GH UI to edit `plugins/woocommerce/includes/class-wc-install.php` on your `release/10.2` branch and add this at the end of the `$db_updates` array:
   ```php
		'10.2.0-1' => array(
			'foobaz',
		),
   ```
1. Run **Actions > Release: Generate Number of Commits and Contributors** with version `10.2` and confirm that the **Check for database updates** step reports the combined `10.2.0` updates:
   <img width="411" height="419" alt="Screenshot 2025-08-22 at 15 16 15" src="https://github.com/user-attachments/assets/dcd1801b-0fae-434e-9a1d-bf1e4551a9f8" />
1. Run **Actions > Release: Bump version number** with release branch `release/10.2` and bump type `beta`. Merge the resulting PR, which should bump versions to `10.2.0-beta.2`.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.2` and with the option to create a GH release checked. Once the process completes, **publish** the `10.2.-beta.2` tag in **Code > Releases**.
1. Now, we're going to simulate a new db update added _after_ a prerelease was published, which should not be allowed because the update wouldn't be triggered for someone updating from `-beta.1`.
   Use the GH UI to edit `plugins/woocommerce/includes/class-wc-install.php` on your `release/10.2` branch and replace the existing key `10.2.0-1` in `$db_updates` to
   ```php
		'10.2.0-1' => array(
			'foobaz',
			'quux',
		),
   ```

   That is, we're adding `quux`.
1. Run **Actions > Release: Bump version number** with release branch `release/10.2` and bump type `rc`. Merge the resulting PR, which should bump versions to `10.2.0-rc.1`.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.2`. The verification should fail indicating that a new db update was added under an existing key:

   <img width="1059" height="66" alt="Screenshot 2025-08-22 at 15 36 22" src="https://github.com/user-attachments/assets/ac4b4fee-5481-4ad4-a7be-956d23c29e99" />

1. Edit `plugins/woocommerce/includes/class-wc-install.php` on your `release/10.2` branch via the GH UI and either remove `quux` from the array under the `10.2.0-1` key in `$db_updates` or add it to a new `10.2.0-2` key as the error above suggests.
1. Run **Actions > Release: Build ZIP file** with release branch `release/10.2`. Verification should pass. Feel free to cancel the run after the _Pre-build verification_ step completes (successfully).

<!-- End testing instructions -->