### PR TITLE
Immediately persist cart to draft order after updating customer in Store API

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-5341-investigate-empty-order-addresses-on-block-checkout
+++ b/plugins/woocommerce/changelog/wooplug-5341-investigate-empty-order-addresses-on-block-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Save customer immediately after update in StoreAPI

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -221,6 +221,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		// If no draft order exists yet, create one so the data is properly stored.
 		if ( ! $draft_order && ! WC()->cart->is_empty() ) {
 			$draft_order = $this->order_controller->create_order_from_cart();
+			wc_log_order_step( '[Store API - CartUpdateCustomer] Created draft order while updating customer', array( 'order_object' => $draft_order ) );
 			$this->set_draft_order_id( $draft_order->get_id() );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -213,6 +213,12 @@ class CartUpdateCustomer extends AbstractCartRoute {
 
 		$customer->save();
 
+		// Force immediate session persistence to database to prevent race conditions
+		// with subsequent requests that might read stale session data.
+		if ( WC()->session && WC()->session instanceof \WC_Session_Handler ) {
+			WC()->session->save_data();
+		}
+
 		$this->cart_controller->calculate_totals();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -220,8 +220,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 
 		// If no draft order exists yet, create one so the data is properly stored.
 		if ( ! $draft_order && ! WC()->cart->is_empty() ) {
-			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
-			$draft_order      = $order_controller->create_order_from_cart();
+			$draft_order = $this->order_controller->create_order_from_cart();
 			$this->set_draft_order_id( $draft_order->get_id() );
 		}
 

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -213,10 +213,23 @@ class CartUpdateCustomer extends AbstractCartRoute {
 
 		$customer->save();
 
-		// Force immediate session persistence to database to prevent race conditions
-		// with subsequent requests that might read stale session data.
-		if ( WC()->session && WC()->session instanceof \WC_Session_Handler ) {
-			WC()->session->save_data();
+		// Fix for race condition: Update the draft order directly with fresh customer data
+		// This prevents stale session data from overwriting recent updates when concurrent
+		// requests occur (e.g., batch POST followed immediately by GET checkout).
+		$draft_order = $this->get_draft_order();
+
+		// If no draft order exists yet, create one so the data is properly stored.
+		if ( ! $draft_order && ! WC()->cart->is_empty() ) {
+			$order_controller = new \Automattic\WooCommerce\StoreApi\Utilities\OrderController();
+			$draft_order      = $order_controller->create_order_from_cart();
+			$this->set_draft_order_id( $draft_order->get_id() );
+		}
+
+		if ( $draft_order ) {
+			$this->order_controller->update_order_from_cart( $draft_order, $customer );
+
+			// Save the draft order with fresh data immediately.
+			$draft_order->save();
 		}
 
 		$this->cart_controller->calculate_totals();

--- a/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/plugins/woocommerce/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -225,7 +225,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		}
 
 		if ( $draft_order ) {
-			$this->order_controller->update_order_from_cart( $draft_order, $customer );
+			$this->order_controller->update_order_from_cart( $draft_order, true, $customer );
 
 			// Save the draft order with fresh data immediately.
 			$draft_order->save();

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -848,6 +848,6 @@ class OrderController {
 				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
 			)
 		);
-		$this->additional_fields_controller->sync_order_additional_fields_with_customer( $order, wc()->customer );
+		$this->additional_fields_controller->sync_order_additional_fields_with_customer( $order, $customer_to_copy );
 	}
 }

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -824,12 +824,12 @@ class OrderController {
 	protected function update_addresses_from_cart( \WC_Order $order, ?\WC_Customer $customer = null ) {
 		// Determine which customer to use for copying address data.
 		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
-		
+
 		// If no valid customer context exists, return early to prevent fatals.
 		if ( ! $customer_to_copy instanceof \WC_Customer ) {
 			return;
 		}
-		
+
 		$order->set_props(
 			array(
 				'billing_first_name'  => $customer_to_copy->get_billing_first_name(),
@@ -855,7 +855,7 @@ class OrderController {
 				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
 			)
 		);
-		
+
 		// Only sync additional fields when we have a valid WC_Customer.
 		$this->additional_fields_controller->sync_order_additional_fields_with_customer( $order, $customer_to_copy );
 	}

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -110,16 +110,24 @@ class OrderController {
 			wc()->cart->calculate_totals();
 		}
 
+		// Determine which customer to use for operations.
+		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
+
+		// If no valid customer context exists, return early to prevent fatals.
+		if ( ! $customer_to_copy instanceof \WC_Customer ) {
+			return;
+		}
+
 		// Update the current order to match the current cart.
 		$this->update_line_items_from_cart( $order );
-		$this->update_addresses_from_cart( $order, $customer );
+		$this->update_addresses_from_cart( $order, $customer_to_copy );
 		$order->set_currency( get_woocommerce_currency() );
 		$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 		$order->set_customer_id( get_current_user_id() );
 		$order->set_customer_ip_address( \WC_Geolocation::get_ip_address() );
 		$order->set_customer_user_agent( wc_get_user_agent() );
 		$order->set_payment_method( PaymentUtils::get_default_payment_method() );
-		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( wc()->cart->get_customer()->get_is_vat_exempt() ) );
+		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( $customer_to_copy->get_is_vat_exempt() ) );
 		$order->calculate_totals();
 	}
 
@@ -821,38 +829,30 @@ class OrderController {
 	 * @param \WC_Order    $order    The order object to update.
 	 * @param \WC_Customer $customer The customer to copy the address data from.
 	 */
-	protected function update_addresses_from_cart( \WC_Order $order, ?\WC_Customer $customer = null ) {
-		// Determine which customer to use for copying address data.
-		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
-
-		// If no valid customer context exists, return early to prevent fatals.
-		if ( ! $customer_to_copy instanceof \WC_Customer ) {
-			return;
-		}
-
+	protected function update_addresses_from_cart( \WC_Order $order, \WC_Customer $customer ) {
 		$order->set_props(
 			array(
-				'billing_first_name'  => $customer_to_copy->get_billing_first_name(),
-				'billing_last_name'   => $customer_to_copy->get_billing_last_name(),
-				'billing_company'     => $customer_to_copy->get_billing_company(),
-				'billing_address_1'   => $customer_to_copy->get_billing_address_1(),
-				'billing_address_2'   => $customer_to_copy->get_billing_address_2(),
-				'billing_city'        => $customer_to_copy->get_billing_city(),
-				'billing_state'       => $customer_to_copy->get_billing_state(),
-				'billing_postcode'    => $customer_to_copy->get_billing_postcode(),
-				'billing_country'     => $customer_to_copy->get_billing_country(),
-				'billing_email'       => $customer_to_copy->get_billing_email(),
-				'billing_phone'       => $customer_to_copy->get_billing_phone(),
-				'shipping_first_name' => $customer_to_copy->get_shipping_first_name(),
-				'shipping_last_name'  => $customer_to_copy->get_shipping_last_name(),
-				'shipping_company'    => $customer_to_copy->get_shipping_company(),
-				'shipping_address_1'  => $customer_to_copy->get_shipping_address_1(),
-				'shipping_address_2'  => $customer_to_copy->get_shipping_address_2(),
-				'shipping_city'       => $customer_to_copy->get_shipping_city(),
-				'shipping_state'      => $customer_to_copy->get_shipping_state(),
-				'shipping_postcode'   => $customer_to_copy->get_shipping_postcode(),
-				'shipping_country'    => $customer_to_copy->get_shipping_country(),
-				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
+				'billing_first_name'  => $customer->get_billing_first_name(),
+				'billing_last_name'   => $customer->get_billing_last_name(),
+				'billing_company'     => $customer->get_billing_company(),
+				'billing_address_1'   => $customer->get_billing_address_1(),
+				'billing_address_2'   => $customer->get_billing_address_2(),
+				'billing_city'        => $customer->get_billing_city(),
+				'billing_state'       => $customer->get_billing_state(),
+				'billing_postcode'    => $customer->get_billing_postcode(),
+				'billing_country'     => $customer->get_billing_country(),
+				'billing_email'       => $customer->get_billing_email(),
+				'billing_phone'       => $customer->get_billing_phone(),
+				'shipping_first_name' => $customer->get_shipping_first_name(),
+				'shipping_last_name'  => $customer->get_shipping_last_name(),
+				'shipping_company'    => $customer->get_shipping_company(),
+				'shipping_address_1'  => $customer->get_shipping_address_1(),
+				'shipping_address_2'  => $customer->get_shipping_address_2(),
+				'shipping_city'       => $customer->get_shipping_city(),
+				'shipping_state'      => $customer->get_shipping_state(),
+				'shipping_postcode'   => $customer->get_shipping_postcode(),
+				'shipping_country'    => $customer->get_shipping_country(),
+				'shipping_phone'      => $customer->get_shipping_phone(),
 			)
 		);
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -817,32 +817,34 @@ class OrderController {
 	/**
 	 * Update address data from cart and/or customer session data.
 	 *
-	 * @param \WC_Order $order The order object to update.
+	 * @param \WC_Order    $order    The order object to update.
+	 * @param \WC_Customer $customer The customer to copy the address data from.
 	 */
-	protected function update_addresses_from_cart( \WC_Order $order ) {
+	protected function update_addresses_from_cart( \WC_Order $order, $customer = null ) {
+		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
 		$order->set_props(
 			array(
-				'billing_first_name'  => wc()->customer->get_billing_first_name(),
-				'billing_last_name'   => wc()->customer->get_billing_last_name(),
-				'billing_company'     => wc()->customer->get_billing_company(),
-				'billing_address_1'   => wc()->customer->get_billing_address_1(),
-				'billing_address_2'   => wc()->customer->get_billing_address_2(),
-				'billing_city'        => wc()->customer->get_billing_city(),
-				'billing_state'       => wc()->customer->get_billing_state(),
-				'billing_postcode'    => wc()->customer->get_billing_postcode(),
-				'billing_country'     => wc()->customer->get_billing_country(),
-				'billing_email'       => wc()->customer->get_billing_email(),
-				'billing_phone'       => wc()->customer->get_billing_phone(),
-				'shipping_first_name' => wc()->customer->get_shipping_first_name(),
-				'shipping_last_name'  => wc()->customer->get_shipping_last_name(),
-				'shipping_company'    => wc()->customer->get_shipping_company(),
-				'shipping_address_1'  => wc()->customer->get_shipping_address_1(),
-				'shipping_address_2'  => wc()->customer->get_shipping_address_2(),
-				'shipping_city'       => wc()->customer->get_shipping_city(),
-				'shipping_state'      => wc()->customer->get_shipping_state(),
-				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
-				'shipping_country'    => wc()->customer->get_shipping_country(),
-				'shipping_phone'      => wc()->customer->get_shipping_phone(),
+				'billing_first_name'  => $customer_to_copy->get_billing_first_name(),
+				'billing_last_name'   => $customer_to_copy->get_billing_last_name(),
+				'billing_company'     => $customer_to_copy->get_billing_company(),
+				'billing_address_1'   => $customer_to_copy->get_billing_address_1(),
+				'billing_address_2'   => $customer_to_copy->get_billing_address_2(),
+				'billing_city'        => $customer_to_copy->get_billing_city(),
+				'billing_state'       => $customer_to_copy->get_billing_state(),
+				'billing_postcode'    => $customer_to_copy->get_billing_postcode(),
+				'billing_country'     => $customer_to_copy->get_billing_country(),
+				'billing_email'       => $customer_to_copy->get_billing_email(),
+				'billing_phone'       => $customer_to_copy->get_billing_phone(),
+				'shipping_first_name' => $customer_to_copy->get_shipping_first_name(),
+				'shipping_last_name'  => $customer_to_copy->get_shipping_last_name(),
+				'shipping_company'    => $customer_to_copy->get_shipping_company(),
+				'shipping_address_1'  => $customer_to_copy->get_shipping_address_1(),
+				'shipping_address_2'  => $customer_to_copy->get_shipping_address_2(),
+				'shipping_city'       => $customer_to_copy->get_shipping_city(),
+				'shipping_state'      => $customer_to_copy->get_shipping_state(),
+				'shipping_postcode'   => $customer_to_copy->get_shipping_postcode(),
+				'shipping_country'    => $customer_to_copy->get_shipping_country(),
+				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
 			)
 		);
 		$this->additional_fields_controller->sync_order_additional_fields_with_customer( $order, wc()->customer );

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -110,24 +110,16 @@ class OrderController {
 			wc()->cart->calculate_totals();
 		}
 
-		// Determine which customer to use for operations.
-		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
-
-		// If no valid customer context exists, return early to prevent fatals.
-		if ( ! $customer_to_copy instanceof \WC_Customer ) {
-			return;
-		}
-
 		// Update the current order to match the current cart.
 		$this->update_line_items_from_cart( $order );
-		$this->update_addresses_from_cart( $order, $customer_to_copy );
+		$this->update_addresses_from_cart( $order, $customer );
 		$order->set_currency( get_woocommerce_currency() );
 		$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 		$order->set_customer_id( get_current_user_id() );
 		$order->set_customer_ip_address( \WC_Geolocation::get_ip_address() );
 		$order->set_customer_user_agent( wc_get_user_agent() );
 		$order->set_payment_method( PaymentUtils::get_default_payment_method() );
-		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( $customer_to_copy->get_is_vat_exempt() ) );
+		$order->update_meta_data( 'is_vat_exempt', wc_bool_to_string( wc()->cart->get_customer()->get_is_vat_exempt() ) );
 		$order->calculate_totals();
 	}
 
@@ -829,30 +821,38 @@ class OrderController {
 	 * @param \WC_Order    $order    The order object to update.
 	 * @param \WC_Customer $customer The customer to copy the address data from.
 	 */
-	protected function update_addresses_from_cart( \WC_Order $order, \WC_Customer $customer ) {
+	protected function update_addresses_from_cart( \WC_Order $order, ?\WC_Customer $customer = null ) {
+		// Determine which customer to use for copying address data.
+		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
+
+		// If no valid customer context exists, return early to prevent fatals.
+		if ( ! $customer_to_copy instanceof \WC_Customer ) {
+			return;
+		}
+
 		$order->set_props(
 			array(
-				'billing_first_name'  => $customer->get_billing_first_name(),
-				'billing_last_name'   => $customer->get_billing_last_name(),
-				'billing_company'     => $customer->get_billing_company(),
-				'billing_address_1'   => $customer->get_billing_address_1(),
-				'billing_address_2'   => $customer->get_billing_address_2(),
-				'billing_city'        => $customer->get_billing_city(),
-				'billing_state'       => $customer->get_billing_state(),
-				'billing_postcode'    => $customer->get_billing_postcode(),
-				'billing_country'     => $customer->get_billing_country(),
-				'billing_email'       => $customer->get_billing_email(),
-				'billing_phone'       => $customer->get_billing_phone(),
-				'shipping_first_name' => $customer->get_shipping_first_name(),
-				'shipping_last_name'  => $customer->get_shipping_last_name(),
-				'shipping_company'    => $customer->get_shipping_company(),
-				'shipping_address_1'  => $customer->get_shipping_address_1(),
-				'shipping_address_2'  => $customer->get_shipping_address_2(),
-				'shipping_city'       => $customer->get_shipping_city(),
-				'shipping_state'      => $customer->get_shipping_state(),
-				'shipping_postcode'   => $customer->get_shipping_postcode(),
-				'shipping_country'    => $customer->get_shipping_country(),
-				'shipping_phone'      => $customer->get_shipping_phone(),
+				'billing_first_name'  => $customer_to_copy->get_billing_first_name(),
+				'billing_last_name'   => $customer_to_copy->get_billing_last_name(),
+				'billing_company'     => $customer_to_copy->get_billing_company(),
+				'billing_address_1'   => $customer_to_copy->get_billing_address_1(),
+				'billing_address_2'   => $customer_to_copy->get_billing_address_2(),
+				'billing_city'        => $customer_to_copy->get_billing_city(),
+				'billing_state'       => $customer_to_copy->get_billing_state(),
+				'billing_postcode'    => $customer_to_copy->get_billing_postcode(),
+				'billing_country'     => $customer_to_copy->get_billing_country(),
+				'billing_email'       => $customer_to_copy->get_billing_email(),
+				'billing_phone'       => $customer_to_copy->get_billing_phone(),
+				'shipping_first_name' => $customer_to_copy->get_shipping_first_name(),
+				'shipping_last_name'  => $customer_to_copy->get_shipping_last_name(),
+				'shipping_company'    => $customer_to_copy->get_shipping_company(),
+				'shipping_address_1'  => $customer_to_copy->get_shipping_address_1(),
+				'shipping_address_2'  => $customer_to_copy->get_shipping_address_2(),
+				'shipping_city'       => $customer_to_copy->get_shipping_city(),
+				'shipping_state'      => $customer_to_copy->get_shipping_state(),
+				'shipping_postcode'   => $customer_to_copy->get_shipping_postcode(),
+				'shipping_country'    => $customer_to_copy->get_shipping_country(),
+				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
 			)
 		);
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -64,10 +64,11 @@ class OrderController {
 	/**
 	 * Update an order using data from the current cart.
 	 *
-	 * @param \WC_Order $order The order object to update.
-	 * @param boolean   $update_totals Whether to update totals or not.
+	 * @param \WC_Order         $order The order object to update.
+	 * @param boolean           $update_totals Whether to update totals or not.
+	 * @param \WC_Customer|null $customer A customer object to use as the source of billing and shipping addresses. If null, will use the current session customer.
 	 */
-	public function update_order_from_cart( \WC_Order $order, $update_totals = true ) {
+	public function update_order_from_cart( \WC_Order $order, $update_totals = true, \WC_Customer $customer = null ) {
 		/**
 		 * This filter ensures that local pickup locations are still used for order taxes by forcing the address used to
 		 * calculate tax for an order to match the current address of the customer.
@@ -111,7 +112,7 @@ class OrderController {
 
 		// Update the current order to match the current cart.
 		$this->update_line_items_from_cart( $order );
-		$this->update_addresses_from_cart( $order );
+		$this->update_addresses_from_cart( $order, $customer );
 		$order->set_currency( get_woocommerce_currency() );
 		$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 		$order->set_customer_id( get_current_user_id() );

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -68,7 +68,7 @@ class OrderController {
 	 * @param boolean           $update_totals Whether to update totals or not.
 	 * @param \WC_Customer|null $customer A customer object to use as the source of billing and shipping addresses. If null, will use the current session customer.
 	 */
-	public function update_order_from_cart( \WC_Order $order, $update_totals = true, \WC_Customer $customer = null ) {
+	public function update_order_from_cart( \WC_Order $order, $update_totals = true, ?\WC_Customer $customer = null ) {
 		/**
 		 * This filter ensures that local pickup locations are still used for order taxes by forcing the address used to
 		 * calculate tax for an order to match the current address of the customer.
@@ -821,7 +821,7 @@ class OrderController {
 	 * @param \WC_Order    $order    The order object to update.
 	 * @param \WC_Customer $customer The customer to copy the address data from.
 	 */
-	protected function update_addresses_from_cart( \WC_Order $order, $customer = null ) {
+	protected function update_addresses_from_cart( \WC_Order $order, ?\WC_Customer $customer = null ) {
 		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
 		$order->set_props(
 			array(

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -822,7 +822,14 @@ class OrderController {
 	 * @param \WC_Customer $customer The customer to copy the address data from.
 	 */
 	protected function update_addresses_from_cart( \WC_Order $order, ?\WC_Customer $customer = null ) {
+		// Determine which customer to use for copying address data.
 		$customer_to_copy = $customer instanceof \WC_Customer ? $customer : WC()->customer;
+		
+		// If no valid customer context exists, return early to prevent fatals.
+		if ( ! $customer_to_copy instanceof \WC_Customer ) {
+			return;
+		}
+		
 		$order->set_props(
 			array(
 				'billing_first_name'  => $customer_to_copy->get_billing_first_name(),
@@ -848,6 +855,8 @@ class OrderController {
 				'shipping_phone'      => $customer_to_copy->get_shipping_phone(),
 			)
 		);
+		
+		// Only sync additional fields when we have a valid WC_Customer.
 		$this->additional_fields_controller->sync_order_additional_fields_with_customer( $order, $customer_to_copy );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue with race conditions when updating customers. This occurs if a GET request is made to the `checkout` endpoint during another request to update the customer (`cart/udpate-customer`)

During the GET request, the customer session is synced to the draft order, which, if there's a parallel update request, will have "stale" data, due to the update request not completing and persisting the customer object.

To fix this, I propose _immediately_ writing customer data to the draft order during the update, rather than waiting for the shutdown hook.

The following changes were made:
- Allow a customer object to be passed to `update_addresses_from_cart`. If one is not passed, the existing behaviour will still occur, which writes the data from WC()->customer to the draft order.
- On the update customer route, run `update_addresses_from_cart` but pass the customer object that is being modified in this request.


Closes #60414
Closes WOOPLUG-5341

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add an item to your cart and go to the Checkout page.
2. Run this snippet in your console (update the checkoutUrl)

```js
(function() {
  const target = "/v1/batch";
  const checkoutUrl = "http://your-domain/checkout";

  const triggerCheckoutGet = () => {
    console.log("%cDetected POST to /v1/batch → pulling checkout page", "color: green");
    setTimeout(() => {
      fetch(checkoutUrl, {
        method: "GET",
        credentials: "include", // keep cookies/session
        headers: {
          "Referrer": window.location.href
        }
      })
      .then(res => res.text())
      .then(html => {
        console.log("%cCheckout HTML fetched:", "color: blue", html);
      })
      .catch(err => console.error("Checkout GET failed:", err));
    }, 50); // slight delay
  };

  // Intercept XHR
  const origOpen = XMLHttpRequest.prototype.open;
  XMLHttpRequest.prototype.open = function(method, url) {
    if (method.toUpperCase() === "POST" && url.includes(target)) {
      triggerCheckoutGet();
    }
    return origOpen.apply(this, arguments);
  };

  // Intercept fetch
  const origFetch = window.fetch;
  window.fetch = function(input, init) {
    const url = typeof input === "string" ? input : input.url;
    const method = (init && init.method) || "GET";

    if (method.toUpperCase() === "POST" && url.includes(target)) {
      triggerCheckoutGet();
    }
    return origFetch.apply(this, arguments);
  };

  console.log("%cWatcher active: Will GET checkout after POST /v1/batch", "color: orange; font-weight:bold;");
})();
```
3. Update the shipping and or billing addresses.
4. Reload the page and ensure the updates you made persisted.
5. Repeat and ensure checkout works and the correct address is saved in the order dashboard.

### Smoke testing/other tests (with and without the snippet from above)

1. Modify multiple fields several times without reloading. Check out and ensure the correct address information is saved.
2. Modify things like email, selected shipping option and payment options. Ensure the changes persist and that checkout works with the correct data saved.
3. Install the custom fields tester (https://github.com/woocommerce/additional-checkout-fields-tester) and ensure the fields modified here are saved and persisted too.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
