### PR TITLE
Enhance changelog workflow to honor plugin version and determine append/replace logic automatically

### DIFF
--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -166,13 +166,6 @@ jobs:
           echo "Using branch: $SELECTED_BRANCH"
           echo "Generating changelog for version: $VERSION"
 
-          # Normalize version for use with changelog command.
-          VERSION=$(echo "$VERSION" | grep -oP '\d+\.\d+\.\d+')
-
-          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
-            VERSION=${VERSION%.0}
-          fi
-
           APPEND_CHANGELOG=""
           if [[ "${{ github.event.inputs.append_changelog }}" == "true" ]]; then
             APPEND_CHANGELOG="--append-changelog"

--- a/.github/workflows/release-compile-changelog.yml
+++ b/.github/workflows/release-compile-changelog.yml
@@ -6,10 +6,14 @@ on:
         description: 'Version (in X.Y or X.Y.Z format). Branch "release/{x.y.z}" or "release/{x.y}" should already exist.'
         required: true
       append_changelog:
-        description: 'Append changelog entries to the existing changelog file instead of replacing it.'
-        type: boolean
+        description: 'Append or replace entries in changelog?'
+        type: choice
+        options:
+          - auto
+          - replace
+          - append
         required: false
-        default: false
+        default: auto
       release_date:
         description: 'Release date in YYYY-MM-DD format. If not provided, the current date will be used.'
         required: false
@@ -166,8 +170,24 @@ jobs:
           echo "Using branch: $SELECTED_BRANCH"
           echo "Generating changelog for version: $VERSION"
 
+          # Determine whether to replace or append.
           APPEND_CHANGELOG=""
-          if [[ "${{ github.event.inputs.append_changelog }}" == "true" ]]; then
+
+          # append_changelog: auto.
+          if [[ -z "${{ github.event.inputs.append_changelog }}" || "${{ github.event.inputs.append_changelog }}" == "auto" ]]; then
+            # If a prerelease, append if there's already content in the changelog.
+            if [[ "$VERSION" == *"-"* || "$VERSION" =~ \.0$ ]]; then
+              git checkout ${SELECTED_BRANCH}
+
+              if sed -n '/== Changelog ==/,$p' plugins/woocommerce/readme.txt | grep -Fq '**WooCommerce**'; then
+                APPEND_CHANGELOG="--append-changelog"
+              fi
+
+              # Go back to trunk to run the tools.
+              git checkout trunk
+            fi
+          elif [[ "${{ github.event.inputs.append_changelog }}" == "append" ]]; then
+            # append_changelog: append.
             APPEND_CHANGELOG="--append-changelog"
           fi
 

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
@@ -38,7 +38,7 @@ export const changelogCommand = new Command( 'changelog' )
 		false
 	)
 	.option(
-		'-o, --override <override>',
+		'-t, --override <override>',
 		"Time Override: The time to use in checking whether the action should run (default: 'now').",
 		'now'
 	)

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/index.ts
@@ -82,7 +82,8 @@ export const changelogCommand = new Command( 'changelog' )
 			} );
 		}
 
-		const releaseBranch = branch || `release/${ version }`;
+		const releaseBranch =
+			branch || `release/${ version.replace( /\.\d+(-.*)?$/, '' ) }`;
 
 		// Update the release branch.
 		const releaseBranchChanges = await updateReleaseBranchChangelogs(

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -49,7 +49,7 @@ const updateReleaseChangelogs = async (
 		'NEXT_CHANGELOG.md'
 	);
 
-	var readme  = await readFile( readmeFile, 'utf-8' );
+	let readme = await readFile( readmeFile, 'utf-8' );
 	let nextLog = await readFile( nextLogFile, 'utf-8' );
 
 	nextLog = nextLog.replace(
@@ -84,7 +84,9 @@ const updateReleaseChangelogs = async (
 	}
 
 	// Ensure there are exactly two empty lines between entries and 'See changelog for all versions'.
-	readme = readme.trim().replace( /\n+(\[See changelog for all versions\])/, `\n\n\n$1` );
+	readme = readme
+		.trim()
+		.replace( /\n+(\[See changelog for all versions\])/, `\n\n\n$1` );
 
 	await writeFile( readmeFile, readme );
 };

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -22,11 +22,13 @@ import { getToday } from '../../get-version/lib';
 /**
  * Perform changelog adjustments after Jetpack Changelogger has run.
  *
+ * @param {string}  version         The original plugin version in the branch.
  * @param {string}  override        Time override.
  * @param {boolean} appendChangelog Whether to append the changelog or replace it.
  * @param {string}  tmpRepoPath     Path where the temporary repo is cloned.
  */
 const updateReleaseChangelogs = async (
+	version: string,
 	override: string,
 	appendChangelog: boolean,
 	tmpRepoPath: string
@@ -47,12 +49,12 @@ const updateReleaseChangelogs = async (
 		'NEXT_CHANGELOG.md'
 	);
 
-	let readme = await readFile( readmeFile, 'utf-8' );
+	var readme  = await readFile( readmeFile, 'utf-8' );
 	let nextLog = await readFile( nextLogFile, 'utf-8' );
 
 	nextLog = nextLog.replace(
 		/= (\d+\.\d+\.\d+) YYYY-mm-dd =/,
-		`= $1 ${ releaseDate } =`
+		`= ${ version } ${ releaseDate } =`
 	);
 
 	// Convert PR number to markdown link.
@@ -65,13 +67,13 @@ const updateReleaseChangelogs = async (
 		// Append: Insert new changelog after "== Changelog ==" but before existing entries
 		const changelogEntries = nextLog
 			.replace(
-				/^= \d+\.\d+\.\d+ \d{4}-\d{2}-\d{2} =\n\n\*\*WooCommerce\*\*\n\n/,
+				/^= \d+\.\d+\.\d+(-.*?)? \d{4}-\d{2}-\d{2} =\n\n\*\*WooCommerce\*\*\n\n/,
 				''
 			)
 			.trim();
 		readme = readme.replace(
 			/\n+(\[See changelog for all versions\])/,
-			`\n${ changelogEntries }\n\n$1`
+			`\n${ changelogEntries }\n\n\n$1`
 		);
 	} else {
 		// Replace: Replace all existing changelog content with the new changelog
@@ -80,6 +82,9 @@ const updateReleaseChangelogs = async (
 			`== Changelog ==\n\n${ nextLog }\n\n[See changelog for all versions]`
 		);
 	}
+
+	// Ensure there are exactly two empty lines between entries and 'See changelog for all versions'.
+	readme = readme.trim().replace( /\n+(\[See changelog for all versions\])/, `\n\n\n$1` );
 
 	await writeFile( readmeFile, readme );
 };
@@ -98,6 +103,8 @@ export const updateReleaseBranchChangelogs = async (
 	releaseBranch: string
 ): Promise< { deletionCommitHash: string; prNumber: number } > => {
 	const { owner, name, version, commitDirectToBase } = options;
+	const mainVersion = version.replace( /\.\d+(-.*)?$/, '' ); // For compatibility with Jetpack changelogger which expects X.Y as version.
+
 	try {
 		// Do a full checkout so that we can find the correct PR numbers for changelog entries.
 		await checkoutRemoteBranch( tmpRepoPath, releaseBranch, false );
@@ -128,7 +135,7 @@ export const updateReleaseBranchChangelogs = async (
 		Logger.notice( `Running the changelog script in ${ tmpRepoPath }` );
 
 		execSync(
-			`pnpm --filter=@woocommerce/plugin-woocommerce changelog write --add-pr-num -n -vvv --use-version ${ version }`,
+			`pnpm --filter=@woocommerce/plugin-woocommerce changelog write --add-pr-num -n -vvv --use-version ${ mainVersion }`,
 			{
 				cwd: tmpRepoPath,
 				stdio: 'inherit',
@@ -144,6 +151,7 @@ export const updateReleaseBranchChangelogs = async (
 
 		Logger.notice( `Updating readme.txt in ${ tmpRepoPath }` );
 		await updateReleaseChangelogs(
+			version,
 			options.override,
 			options.appendChangelog,
 			tmpRepoPath


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->
The Jetpack changelogger we use under the hood for compiling the changelog doesn't like prerelease versions. We previously sanitized the versions so that the generated changelog always used the next stable (even during the prerelease cycle), but this can be confusing. Since #60356 we want exact version information to be displayed, and so this PR works around the changelogger limitation by restoring the version number after changelog is generated but before the PR is produced.

This PR also introduces a new `auto` mode for deciding whether the new entries should be appended to the existing changelog or replace it entirely. The way it works it'll replace the section if there aren't any entries or if we're releasing a stable version after the initial `.0`. For any other prerelease and up to the first stable it'll instead _append_ the entries, ensuring the changelog for the final stable contains everything.

When required, specific `append` and `replace` options remain available.

Closes #60549.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->


0. Download the attached ZIP ([changelog-entries.zip](https://github.com/user-attachments/files/21933712/changelog-entries.zip)) and uncompress to a location in your hard drive. The file contains example changelog entries which will be useful during testing.
1. Fork this repo.
1. In your fork, go to **Code > Branches** and create a new branch off `trunk` named `release/10.2`.
1. **Test 'auto' mode for the first release in cycle:**
   1. Go to **Actions > Release: Bump version number** and run against the `release/10.2` branch with option `beta`. Merge the PR updating the version numbers to `10.2.0-beta.1`.
   1. Go to **Actions > Release: Compile changelog** and run with `10.2` as version. Leave the append/replace option as `auto`.
   1. Confirm that the generated PR looks correct and the version (`10.2.0-beta.1`) was preserved in the header.
   1. Merge this PR (as well as the `trunk` one).
1. In your fork, go to `https://github.com/<username>/woocommerce/tree/release/10.2/plugins/woocommerce/changelog`, click **Add file > Upload files** and upload the entries from the ZIP file. Commit the changes directly to `release/10.2`.
1. **Test 'auto' mode for a prerelease in cycle:**
   1. Run **Actions > Release: Bump version number** again against the `release/10.2` branch with option `rc`. Merge the PR updating the version numbers to `10.2.0-rc.1`.
   1. Go to **Actions > Release: Compile changelog** and run with `10.2` as version. Leave the append/replace option as `auto`. Confirm that the new entries have been **appended** to the existing changelog and no other changes were performed.
   1. **Do not** merge this PR. We'll reuse the entries on the branch for further testing.
1. **Test 'auto' mode for the first stable:**
   Repeat step **5**, this time with bump type `stable`. Ensure versions are updated to `10.2.0` everywhere (including the readme.txt changelog header). Confirm that the 'new' changelog entries are **appended** and do not replace the changelog section entirely.
1. **Test 'auto' mode during a patch release:**
   Repeat step **5**, this time with bump type `stable`. Confirm that versions are updated to `10.2.1` and that the 'new' changelog entries **replace** the existing section (are not appended).

<!-- End testing instructions -->