### PR TITLE
WPS Migration: Note PayPal debug ID

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -150,7 +150,7 @@ class WC_Gateway_Paypal_Request {
 			$response_data = json_decode( $body, true );
 
 			if ( ! in_array( $http_code, array( 200, 201 ), true ) ) {
-				$paypal_debug_id = isset( $response_data['data']['debug_id'] ) ? $response_data['data']['debug_id'] : null;
+				$paypal_debug_id = isset( $response_data['debug_id'] ) ? $response_data['debug_id'] : null;
 				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -188,6 +188,7 @@ class WC_Gateway_Paypal_Request {
 	 */
 	public function authorize_or_capture_payment( $order, $action_url, $action = 'capture' ) {
 		$paypal_order_id = $order->get_meta( '_paypal_order_id' );
+		$paypal_debug_id = null;
 		if ( ! $paypal_order_id ) {
 			WC_Gateway_Paypal::log( 'PayPal order ID not found. Cannot ' . $action . ' payment.' );
 			return;
@@ -229,20 +230,31 @@ class WC_Gateway_Paypal_Request {
 
 			$http_code = wp_remote_retrieve_response_code( $response );
 			$body      = wp_remote_retrieve_body( $response );
+			$response_data = json_decode( $body, true );
 
 			if ( 200 !== $http_code && 201 !== $http_code ) {
+				$paypal_debug_id = isset( $response_data['debug_id'] ) ? $response_data['debug_id'] : null;
 				throw new Exception( 'PayPal ' . $action . ' payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
-			$order->add_order_note(
-				sprintf(
-					/* translators: %1$s: Action, %2$s: PayPal order ID */
-					__( 'PayPal %1$s payment failed. PayPal Order ID: %2$s', 'woocommerce' ),
-					$action,
-					$paypal_order_id
-				)
+			$note_message = sprintf(
+				/* translators: %1$s: Action, %2$s: PayPal order ID */
+				__( 'PayPal %1$s payment failed. PayPal Order ID: %2$s', 'woocommerce' ),
+				$action,
+				$paypal_order_id
 			);
+
+			// Add debug ID to the note if available.
+			if ( $paypal_debug_id ) {
+				$note_message .= sprintf(
+					/* translators: %s: PayPal debug ID */
+					__( '. PayPal debug ID: %s', 'woocommerce' ),
+					$paypal_debug_id
+				);
+			}
+
+			$order->add_order_note( $note_message );
 			$order->update_status( OrderStatus::FAILED );
 			$order->save();
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -273,7 +273,8 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		// Skip if the payment is already captured.
-		if ( 'completed' === $order->get_meta( '_paypal_status', true ) ) {
+		$paypal_status = $order->get_meta( '_paypal_status', true );
+		if ( 'captured' === $paypal_status || 'completed' === $paypal_status ) {
 			WC_Gateway_Paypal::log( 'PayPal payment is already captured. Skipping capture. Order ID: ' . $order->get_id() );
 			return;
 		}
@@ -301,10 +302,9 @@ class WC_Gateway_Paypal_Request {
 				WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 
-			if ( isset( $response_data['status'] ) ) {
-				$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
-				$order->save();
-			}
+			// set custom status for successful capture response.
+			$order->update_meta_data( '_paypal_status', 'captured' );
+			$order->save();
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			$note_message = sprintf(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -265,6 +265,7 @@ class WC_Gateway_Paypal_Request {
 	 *
 	 * @param WC_Order $order Order object.
 	 * @return void
+	 * @throws Exception If the PayPal payment capture fails.
 	 */
 	public function capture_authorized_payment( $order ) {
 		if ( ! $order || ! $order->get_transaction_id() ) {

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -228,8 +228,8 @@ class WC_Gateway_Paypal_Request {
 				throw new Exception( 'PayPal ' . $action . ' payment request failed. Response error: ' . $response->get_error_message() );
 			}
 
-			$http_code = wp_remote_retrieve_response_code( $response );
-			$body      = wp_remote_retrieve_body( $response );
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$body          = wp_remote_retrieve_body( $response );
 			$response_data = json_decode( $body, true );
 
 			if ( 200 !== $http_code && 201 !== $http_code ) {
@@ -289,8 +289,7 @@ class WC_Gateway_Paypal_Request {
 			$response     = $this->send_wpcom_proxy_request( 'POST', self::WPCOM_PROXY_PAYMENT_CAPTURE_AUTH_ENDPOINT, $request_body );
 
 			if ( is_wp_error( $response ) ) {
-				WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
-				return;
+				throw new Exception( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
 			}
 
 			$http_code     = wp_remote_retrieve_response_code( $response );
@@ -299,7 +298,7 @@ class WC_Gateway_Paypal_Request {
 
 			if ( 200 !== $http_code && 201 !== $http_code ) {
 				$paypal_debug_id = isset( $response_data['debug_id'] ) ? $response_data['debug_id'] : null;
-				WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
+				throw new Exception( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 
 			// set custom status for successful capture response.
@@ -308,7 +307,7 @@ class WC_Gateway_Paypal_Request {
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
 			$note_message = sprintf(
-				__( 'PayPal capture payment failed', 'woocommerce' ),
+				__( 'PayPal capture authorized payment failed', 'woocommerce' ),
 			);
 			if ( $paypal_debug_id ) {
 				$note_message .= sprintf(

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -133,6 +133,7 @@ class WC_Gateway_Paypal_Request {
 	 * @throws Exception If the PayPal order creation fails.
 	 */
 	public function create_paypal_order( $order ) {
+		$paypal_debug_id = null;
 		try {
 			$request_body = array(
 				'test_mode' => $this->gateway->testmode,
@@ -149,6 +150,7 @@ class WC_Gateway_Paypal_Request {
 			$response_data = json_decode( $body, true );
 
 			if ( ! in_array( $http_code, array( 200, 201 ), true ) ) {
+				$paypal_debug_id = isset( $response_data['data']['debug_id'] ) ? $response_data['data']['debug_id'] : null;
 				throw new Exception( 'PayPal order creation failed. Response status: ' . $http_code . '. Response body: ' . $body );
 			}
 
@@ -160,6 +162,15 @@ class WC_Gateway_Paypal_Request {
 			);
 		} catch ( Exception $e ) {
 			WC_Gateway_Paypal::log( $e->getMessage() );
+			if ( $paypal_debug_id ) {
+				$order->add_order_note(
+					sprintf(
+						/* translators: %1$s: PayPal debug ID */
+						__( 'PayPal order creation failed. PayPal debug ID: %1$s', 'woocommerce' ),
+						$paypal_debug_id
+					)
+				);
+			}
 			return null;
 		}
 	}

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -266,28 +266,46 @@ class WC_Gateway_Paypal_Request {
 			return;
 		}
 
-		$request_body = array(
-			'test_mode'        => $this->gateway->testmode,
-			'authorization_id' => $order->get_transaction_id(),
-		);
-		$response     = $this->send_wpcom_proxy_request( 'POST', self::WPCOM_PROXY_PAYMENT_CAPTURE_AUTH_ENDPOINT, $request_body );
+		$paypal_debug_id = null;
 
-		if ( is_wp_error( $response ) ) {
-			WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
-			return;
-		}
+		try {
+			$request_body = array(
+				'test_mode'        => $this->gateway->testmode,
+				'authorization_id' => $order->get_transaction_id(),
+			);
+			$response     = $this->send_wpcom_proxy_request( 'POST', self::WPCOM_PROXY_PAYMENT_CAPTURE_AUTH_ENDPOINT, $request_body );
 
-		$http_code     = wp_remote_retrieve_response_code( $response );
-		$body          = wp_remote_retrieve_body( $response );
-		$response_data = json_decode( $body, true );
+			if ( is_wp_error( $response ) ) {
+				WC_Gateway_Paypal::log( 'PayPal capture payment request failed. Response error: ' . $response->get_error_message() );
+				return;
+			}
 
-		if ( 200 !== $http_code && 201 !== $http_code ) {
-			WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
-		}
+			$http_code     = wp_remote_retrieve_response_code( $response );
+			$body          = wp_remote_retrieve_body( $response );
+			$response_data = json_decode( $body, true );
 
-		if ( isset( $response_data['status'] ) ) {
-			$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
-			$order->save();
+			if ( 200 !== $http_code && 201 !== $http_code ) {
+				$paypal_debug_id = isset( $response_data['debug_id'] ) ? $response_data['debug_id'] : null;
+				WC_Gateway_Paypal::log( 'PayPal capture payment failed. Response status: ' . $http_code . '. Response body: ' . $body );
+			}
+
+			if ( isset( $response_data['status'] ) ) {
+				$order->update_meta_data( '_paypal_status', strtolower( $response_data['status'] ) );
+				$order->save();
+			}
+		} catch ( Exception $e ) {
+			WC_Gateway_Paypal::log( $e->getMessage() );
+			$note_message = sprintf(
+				__( 'PayPal capture payment failed', 'woocommerce' ),
+			);
+			if ( $paypal_debug_id ) {
+				$note_message .= sprintf(
+					/* translators: %s: PayPal debug ID */
+					__( '. PayPal debug ID: %s', 'woocommerce' ),
+					$paypal_debug_id
+				);
+			}
+			$order->add_order_note( $note_message );
 		}
 	}
 

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php
@@ -63,6 +63,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			return;
 		}
 
+		// Skip if the payment is already processed.
+		if ( 'completed' === $order->get_meta( '_paypal_status', true ) ) {
+			return;
+		}
+
 		$status          = $event['resource']['status'] ?? null;
 		$paypal_order_id = $event['resource']['id'] ?? null;
 		if ( 'APPROVED' === $status ) {
@@ -107,6 +112,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
 			return;
 		}
 
+		// Skip if the payment is already processed.
+		if ( 'completed' === $order->get_meta( '_paypal_status', true ) ) {
+			return;
+		}
+
 		$order->set_transaction_id( $event['resource']['id'] );
 		$order->update_meta_data( '_paypal_status', strtolower( $event['resource']['status'] ) );
 		$order->payment_complete();
@@ -130,6 +140,11 @@ class WC_Gateway_Paypal_Webhook_Handler {
 		$order     = $this->get_wc_order( $custom_id );
 		if ( ! $order ) {
 			WC_Gateway_Paypal::log( 'Invalid order. Custom ID: ' . wc_print_r( $custom_id, true ) );
+			return;
+		}
+
+		// Skip if the payment is already processed.
+		if ( 'completed' === $order->get_meta( '_paypal_status', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Added the PayPal debug ID in order notes.

### How to test the changes in this Pull Request:

1. Add this option to enable PayPal standard `wp option patch update woocommerce_paypal_settings _should_load 'yes'`
2. Setup the proxy server or use the temporary proxy available in the feature branch.
3. Remove the `currency` data from [get_paypal_create_order_request_params method](https://github.com/woocommerce/woocommerce/blob/feature/paypal-wps-migration/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php#L336) to simulate a failed create order request.
4. As a shopper, try to place an order with PayPal standard.
5. The checkout should fail.
6. Check the order as an admin. The PayPal debug ID should be present in the order note.
7. Undo step 3. 
8. From `plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-webhook-handler.php` in this branch, remove the check below `// Skip if the payment is already processed.` comment to allow duplicate webhook processing to simulate failed capture.
9. As a shopper place an order using PayPal.
10. Wait a few minutes for the payment to be completed. 
11. Once the order is in `processing` state, go to the developer.paypal.com > Events > Events of your App. Resend the order approval event.
12. Wait for a while and refresh the order edit page as an admin. There should be a order note with debug ID.
13. Undo step 8 and confirm that with the checks present, there is no duplicate webhook processing.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
