### PR TITLE
Ensure customer country gets reset to a valid option

### DIFF
--- a/plugins/woocommerce/changelog/wooplug-4321-checkout-can-get-into-an-invalid-state-if-ship-to-specific
+++ b/plugins/woocommerce/changelog/wooplug-4321-checkout-can-get-into-an-invalid-state-if-ship-to-specific
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure customer country gets reset to a valid option when allowed countries changes

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -94,12 +94,15 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	public function get_item_response( $address ) {
 		$validation_util = new ValidationUtils();
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
-			$billing_country = $address->get_billing_country();
-			$billing_state   = $address->get_billing_state();
+			// Validate and correct country/state if needed.
+			$validated_address = $validation_util->validate_and_correct_country(
+				$address->get_billing_country(),
+				$address->get_billing_state(),
+				'billing'
+			);
 
-			if ( ! $validation_util->validate_state( $billing_state, $billing_country ) ) {
-				$billing_state = '';
-			}
+			$billing_country = $validated_address['country'];
+			$billing_state   = $validated_address['state'];
 
 			$additional_address_fields = $this->additional_fields_controller->get_all_fields_from_object( $address, 'billing' );
 

--- a/plugins/woocommerce/src/StoreApi/Schemas/V1/ShippingAddressSchema.php
+++ b/plugins/woocommerce/src/StoreApi/Schemas/V1/ShippingAddressSchema.php
@@ -35,12 +35,15 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 	public function get_item_response( $address ) {
 		$validation_util = new ValidationUtils();
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
-			$shipping_country = $address->get_shipping_country();
-			$shipping_state   = $address->get_shipping_state();
+			// Validate and correct country/state if needed.
+			$validated_address = $validation_util->validate_and_correct_country(
+				$address->get_shipping_country(),
+				$address->get_shipping_state(),
+				'shipping'
+			);
 
-			if ( ! $validation_util->validate_state( $shipping_state, $shipping_country ) ) {
-				$shipping_state = '';
-			}
+			$shipping_country = $validated_address['country'];
+			$shipping_state   = $validated_address['state'];
 
 			$additional_address_fields = $this->additional_fields_controller->get_all_fields_from_object( $address, 'shipping' );
 

--- a/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/OrderController.php
@@ -174,8 +174,8 @@ class OrderController {
 
 		$this->validate_coupons( $order );
 		$this->validate_email( $order );
-		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order, $needs_shipping );
+		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 
 		// Perform custom validations.
 		$this->perform_custom_order_validation( $order );

--- a/plugins/woocommerce/src/StoreApi/Utilities/ValidationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ValidationUtils.php
@@ -81,8 +81,11 @@ class ValidationUtils {
 		// Check if the current country is in the allowed countries list.
 		if ( $country && ! array_key_exists( $country, $allowed_countries ) ) {
 			// Reset to first available country if current country is not allowed.
-			$country = array_key_first( $allowed_countries );
-			$state   = ''; // Reset state when country changes.
+			$first_available = array_key_first( $allowed_countries );
+			if ( $first_available ) {
+				$country = $first_available;
+				$state   = ''; // Reset state when country changes.
+			}
 		}
 
 		// Validate the state for the (possibly corrected) country.

--- a/plugins/woocommerce/src/StoreApi/Utilities/ValidationUtils.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/ValidationUtils.php
@@ -58,4 +58,41 @@ class ValidationUtils {
 
 		return $state;
 	}
+
+	/**
+	 * Validate and correct country and state values based on allowed countries.
+	 *
+	 * If the provided country is not in the allowed countries list, it will be replaced
+	 * with the first available country and the state will be reset.
+	 *
+	 * @param string $country Current country code.
+	 * @param string $state Current state code.
+	 * @param string $address_type Address type: 'billing' or 'shipping'.
+	 * @return array Array with 'country' and 'state' keys containing validated values.
+	 */
+	public function validate_and_correct_country( $country, $state, $address_type = 'billing' ) {
+		// Determine which countries list to use based on address type.
+		if ( 'shipping' === $address_type ) {
+			$allowed_countries = \WC()->countries->get_shipping_countries();
+		} else {
+			$allowed_countries = \WC()->countries->get_allowed_countries();
+		}
+
+		// Check if the current country is in the allowed countries list.
+		if ( $country && ! array_key_exists( $country, $allowed_countries ) ) {
+			// Reset to first available country if current country is not allowed.
+			$country = array_key_first( $allowed_countries );
+			$state   = ''; // Reset state when country changes.
+		}
+
+		// Validate the state for the (possibly corrected) country.
+		if ( ! $this->validate_state( $state, $country ) ) {
+			$state = '';
+		}
+
+		return [
+			'country' => $country,
+			'state'   => $state,
+		];
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ValidationUtilsTest.php
+++ b/plugins/woocommerce/tests/php/src/Blocks/StoreApi/Utilities/ValidationUtilsTest.php
@@ -1,0 +1,365 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Blocks\StoreApi\Utilities;
+
+use Automattic\WooCommerce\StoreApi\Utilities\ValidationUtils;
+
+/**
+ * A collection of tests for the ValidationUtils class.
+ */
+class ValidationUtilsTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * ValidationUtils instance.
+	 *
+	 * @var ValidationUtils
+	 */
+	private $validation_utils;
+
+	/**
+	 * Original WC countries instance for restoration.
+	 *
+	 * @var \WC_Countries
+	 */
+	private $original_wc_countries;
+
+	/**
+	 * Setup test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->validation_utils = new ValidationUtils();
+
+		// Store original countries instance.
+		$this->original_wc_countries = WC()->countries;
+	}
+
+	/**
+	 * Teardown test.
+	 */
+	public function tearDown(): void {
+		// Restore original countries instance.
+		WC()->countries = $this->original_wc_countries;
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should return the same country and state when they are valid for billing addresses.
+	 */
+	public function test_validate_and_correct_country_valid_billing_address() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[
+				'US' => 'United States',
+				'CA' => 'Canada',
+			],
+			[ 'US' => 'United States' ]
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'CA', 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( 'CA', $result['state'] );
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should return the same country and state when they are valid for shipping addresses.
+	 */
+	public function test_validate_and_correct_country_valid_shipping_address() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[ 'US' => 'United States' ],
+			[
+				'US' => 'United States',
+				'CA' => 'Canada',
+			]
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( 'CA', 'BC', 'shipping' );
+
+		$this->assertEquals( 'CA', $result['country'] );
+		$this->assertEquals( 'BC', $result['state'] );
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should correct invalid billing country to first available.
+	 */
+	public function test_validate_and_correct_country_invalid_billing_country() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[
+				'US' => 'United States',
+				'CA' => 'Canada',
+			],
+			[ 'US' => 'United States' ]
+		);
+
+		// Test with invalid billing country 'GB'.
+		$result = $this->validation_utils->validate_and_correct_country( 'GB', 'London', 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] ); // Should be corrected to first available.
+		$this->assertEquals( '', $result['state'] ); // State should be reset.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should correct invalid shipping country to first available.
+	 */
+	public function test_validate_and_correct_country_invalid_shipping_country() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[ 'US' => 'United States' ],
+			[
+				'CA' => 'Canada',
+				'AU' => 'Australia',
+			]
+		);
+
+		// Test with invalid shipping country 'GB'.
+		$result = $this->validation_utils->validate_and_correct_country( 'GB', 'London', 'shipping' );
+
+		$this->assertEquals( 'CA', $result['country'] ); // Should be corrected to first available shipping country.
+		$this->assertEquals( '', $result['state'] ); // State should be reset.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle empty country gracefully.
+	 */
+	public function test_validate_and_correct_country_empty_country() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[
+				'US' => 'United States',
+				'CA' => 'Canada',
+			],
+			[ 'US' => 'United States' ]
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( '', 'CA', 'billing' );
+
+		$this->assertEquals( '', $result['country'] );
+		// State validation for empty country usually passes, so state may be preserved.
+		// This is actually correct behavior - we don't want to modify valid state if country is just empty.
+		$this->assertEquals( 'CA', $result['state'] );
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should reset invalid state for valid country.
+	 */
+	public function test_validate_and_correct_country_invalid_state() {
+		// Set up a country with no states to simulate invalid state validation.
+		$this->mock_wc_countries( [ 'US' => 'United States' ], [ 'US' => 'United States' ] );
+
+		// Mock WC_Countries to return empty states for US (so any state will be invalid).
+		$countries_mock = $this->getMockBuilder( \WC_Countries::class )
+			->onlyMethods( [ 'get_allowed_countries', 'get_shipping_countries', 'get_states' ] )
+			->getMock();
+
+		$countries_mock->method( 'get_allowed_countries' )
+			->willReturn( [ 'US' => 'United States' ] );
+		$countries_mock->method( 'get_shipping_countries' )
+			->willReturn( [ 'US' => 'United States' ] );
+		$countries_mock->method( 'get_states' )
+			->with( 'US' )
+			->willReturn( [ 'NY' => 'New York' ] ); // Only NY is valid.
+
+		WC()->countries = $countries_mock;
+
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'INVALID_STATE', 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( '', $result['state'] ); // Invalid state should be reset.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should default to billing when no address type specified.
+	 */
+	public function test_validate_and_correct_country_defaults_to_billing() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries( [ 'US' => 'United States' ], [ 'CA' => 'Canada' ] );
+
+		// Test with country that's only valid for shipping, should fail for billing (default).
+		$result = $this->validation_utils->validate_and_correct_country( 'CA', 'BC' ); // No address_type specified.
+
+		$this->assertEquals( 'US', $result['country'] ); // Should be corrected using billing countries.
+		$this->assertEquals( '', $result['state'] ); // State should be reset.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle null state gracefully.
+	 */
+	public function test_validate_and_correct_country_null_state() {
+		// Mock WC()->countries to return specific allowed countries.
+		$this->mock_wc_countries(
+			[
+				'US' => 'United States',
+				'CA' => 'Canada',
+			],
+			[ 'US' => 'United States' ]
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( 'US', null, 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( '', $result['state'] ); // Null state should be converted to empty string.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should preserve valid states.
+	 */
+	public function test_validate_and_correct_country_preserves_valid_state() {
+		// Use standardized mocking approach.
+		$this->mock_wc_countries_with_states(
+			[ 'US' => 'United States' ],
+			[ 'US' => 'United States' ],
+			[
+				'US' => [
+					'NY' => 'New York',
+					'CA' => 'California',
+				],
+			]
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'NY', 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( 'NY', $result['state'] ); // Valid state should be preserved.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle empty allowed countries gracefully.
+	 */
+	public function test_validate_and_correct_country_no_allowed_countries() {
+		// Test with no allowed countries - should handle gracefully.
+		$this->mock_wc_countries( [], [] );
+
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'CA', 'billing' );
+
+		// When no countries are available, should preserve original country since no correction is possible.
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( 'CA', $result['state'] ); // State should be preserved when no validation is possible.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle both country and state being empty.
+	 */
+	public function test_validate_and_correct_country_both_empty() {
+		$this->mock_wc_countries( [ 'US' => 'United States' ], [ 'US' => 'United States' ] );
+
+		$result = $this->validation_utils->validate_and_correct_country( '', '', 'billing' );
+
+		$this->assertEquals( '', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should validate states properly for countries with states.
+	 */
+	public function test_validate_and_correct_country_realistic_state_validation() {
+		// Use realistic US state validation.
+		$this->mock_wc_countries_with_states(
+			[ 'US' => 'United States' ],
+			[ 'US' => 'United States' ],
+			[
+				'US' => [
+					'CA' => 'California',
+					'NY' => 'New York',
+					'TX' => 'Texas',
+				],
+			]
+		);
+
+		// Test valid state code.
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'CA', 'billing' );
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( 'CA', $result['state'] );
+
+		// Test invalid state.
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'INVALID', 'billing' );
+		$this->assertEquals( 'US', $result['country'] );
+		$this->assertEquals( '', $result['state'] );
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle countries without states.
+	 */
+	public function test_validate_and_correct_country_no_states() {
+		// Test with a country that has no states (like many European countries).
+		$this->mock_wc_countries_with_states(
+			[ 'DE' => 'Germany' ],
+			[ 'DE' => 'Germany' ],
+			[ 'DE' => [] ] // No states for Germany.
+		);
+
+		$result = $this->validation_utils->validate_and_correct_country( 'DE', 'Berlin', 'billing' );
+
+		$this->assertEquals( 'DE', $result['country'] );
+		$this->assertEquals( 'Berlin', $result['state'] ); // Should preserve any state value for countries without states.
+	}
+
+	/**
+	 * @testdox `validate_and_correct_country` should handle edge cases with special characters.
+	 */
+	public function test_validate_and_correct_country_special_characters() {
+		$this->mock_wc_countries( [ 'US' => 'United States' ], [ 'US' => 'United States' ] );
+
+		// Test with special characters in state.
+		$result = $this->validation_utils->validate_and_correct_country( 'US', 'St. John\'s', 'billing' );
+
+		$this->assertEquals( 'US', $result['country'] );
+		// State validation may clear special characters, but method should not crash.
+		$this->assertIsString( $result['state'] );
+	}
+
+	/**
+	 * Mock WC()->countries methods for testing.
+	 *
+	 * @param array $allowed_countries Billing countries.
+	 * @param array $shipping_countries Shipping countries.
+	 */
+	private function mock_wc_countries( $allowed_countries, $shipping_countries ) {
+		// Create a mock for WC_Countries.
+		$countries_mock = $this->getMockBuilder( \WC_Countries::class )
+			->onlyMethods( [ 'get_allowed_countries', 'get_shipping_countries' ] )
+			->getMock();
+
+		$countries_mock->method( 'get_allowed_countries' )
+			->willReturn( $allowed_countries );
+
+		$countries_mock->method( 'get_shipping_countries' )
+			->willReturn( $shipping_countries );
+
+		// Replace WC()->countries with our mock.
+		WC()->countries = $countries_mock;
+	}
+
+	/**
+	 * Mock WC()->countries methods including states for more comprehensive testing.
+	 *
+	 * @param array $allowed_countries Billing countries.
+	 * @param array $shipping_countries Shipping countries.
+	 * @param array $states States per country.
+	 */
+	private function mock_wc_countries_with_states( $allowed_countries, $shipping_countries, $states ) {
+		// Create a mock for WC_Countries.
+		$countries_mock = $this->getMockBuilder( \WC_Countries::class )
+			->onlyMethods( [ 'get_allowed_countries', 'get_shipping_countries', 'get_states' ] )
+			->getMock();
+
+		$countries_mock->method( 'get_allowed_countries' )
+			->willReturn( $allowed_countries );
+
+		$countries_mock->method( 'get_shipping_countries' )
+			->willReturn( $shipping_countries );
+
+		// Set up get_states to return different states per country.
+		foreach ( $states as $country => $country_states ) {
+			$countries_mock->method( 'get_states' )
+				->with( $country )
+				->willReturn( $country_states );
+		}
+
+		// Replace WC()->countries with our mock.
+		WC()->countries = $countries_mock;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Create a `validate_and_correct_country` util which takes the country, state, and address type. This util will ensure the country is available in the list of allowed selling countries in the case of billing, and allowed shipping countries in the case of shipping. It also resets the state if it's not a valid option for the current country.
- Make Billing Address and Shipping Address schemas run the currently selected country through this util before returning them. This ensures the checkout loads in a usable state.
- Changed the order in which addresses and shipping methods are validated. It is better to block checkout for an invalid country (makes more sense to the user) than an invalid shipping method (they won't understand why in certain edge cases)

Note that the list of allowed countries is defined on page load, and does not update without reloading the page. Doing so increases complexity and is an over-optimisation for such an edge case.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes WOOPLUG-4321

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> General and then find the Selling location(s) and Shipping location(s) options.
2. In a new incognito tab, add an item to your cart and go to the Checkout.
3. Enter a UK address, e.g. 123 Test Street, Liverpool, L10BP. Ensure the address is valid and synced to the server.
4. Go to the dashboard tab and change Selling location(s) to be "Sell to specific countries" then choose United States. Save the page.
5. Reload the Checkout page from step 2. Ensure the country has changed to United States. Note, it may have switched you to Local Pickup if this is the case due to an invalid address. I think for the scope of this PR and how much of an edge case this is, we can skip addressing this.
6. Reset the option on the dashboard to "Sell to all countries" and reload the checkout page. Ensure all countries are available, go back to the UK address from step 3 and ensure the address saves.
7. Repeat step 3.
8. Without reloading the checkout tab, try to place the order. Ensure it doesn't let you.
9. Next, change part of the address, e.g. the postcode.
10. Ensure you are still unable to check out.
11. Test with various combos of the Selling location(s) and Shipping location(s) options. (Note, billing address will allow you to _select_ incorrect countries, but will show a validation error).

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
