### PR TITLE
Fix missing padding for checkout actions block

### DIFF
--- a/plugins/woocommerce/changelog/lstr-fix-no-padding-for-checkout-actions-block
+++ b/plugins/woocommerce/changelog/lstr-fix-no-padding-for-checkout-actions-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing padding for checkout actions block

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -1,57 +1,55 @@
-.wp-block-woocommerce-checkout-actions-block {
-	.wc-block-checkout__actions {
-		&_row {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
+.wc-block-checkout__actions {
+	.wc-block-checkout__actions_row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
 
-			.wc-block-components-checkout-place-order-button {
-				width: 50%;
-				padding: 1em;
-				height: auto;
+		.wc-block-components-checkout-place-order-button {
+			width: 50%;
+			padding: 1em;
+			height: auto;
 
-				&--full-width {
-					width: 100%;
-				}
+			&--full-width {
+				width: 100%;
+			}
 
-				// Hides labels when the spinner is shown.
-				&--loading {
-					.wc-block-components-button__text {
-						visibility: hidden;
-					}
-					.wc-block-components-spinner,
-					.wc-block-components-checkout-place-order-button__icon {
-						visibility: visible;
-					}
-				}
-
-				.wc-block-components-checkout-place-order-button__text {
-					display: flex;
-					align-items: center;
-				}
-
-				.wc-block-components-checkout-place-order-button__separator {
-					margin: 0 20px;
-				}
-
+			// Hides labels when the spinner is shown.
+			&--loading {
 				.wc-block-components-button__text {
-					> svg {
-						fill: $white;
-						vertical-align: top;
-						position: absolute;
-						top: 50%;
-						left: 50%;
-						transform: translate(-50%, -50%);
-					}
+					visibility: hidden;
+				}
+				.wc-block-components-spinner,
+				.wc-block-components-checkout-place-order-button__icon {
+					visibility: visible;
+				}
+			}
+
+			.wc-block-components-checkout-place-order-button__text {
+				display: flex;
+				align-items: center;
+			}
+
+			.wc-block-components-checkout-place-order-button__separator {
+				margin: 0 20px;
+			}
+
+			.wc-block-components-button__text {
+				> svg {
+					fill: $white;
+					vertical-align: top;
+					position: absolute;
+					top: 50%;
+					left: 50%;
+					transform: translate(-50%, -50%);
 				}
 			}
 		}
 	}
+}
 
-	@include cart-checkout-large-container {
-		.wc-block-checkout__actions {
-			padding: 0 0 $gap-largest 0;
-		}
+@include cart-checkout-large-container {
+	.wc-block-checkout__actions {
+		padding: 0 0 $gap-largest 0;
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

See p1755859451797029-slack-C8X6Q7XQU

Apart from fixing the issue I also:
- picked a top-level class that is more discoverable (as it is defined in the sibling file `Block.tsx`)
- removed clever nesting in SCSS to improve readability

### Screenshots or screen recordings:

| Before | After |
|--------|-------|
| <img width="1682" height="432" alt="CleanShot 2025-08-22 at 16 07 45@2x" src="https://github.com/user-attachments/assets/5ab4da4c-eaf0-46be-8d3c-fe8b634ec639" /> | <img width="1702" height="514" alt="CleanShot 2025-08-22 at 16 07 21@2x" src="https://github.com/user-attachments/assets/e716c502-d48c-4457-ad39-1e94dc58f163" /> |

### How to test the changes in this Pull Request:

1. Open checkout page in the editor
2. For "Terms and Conditions" block make sure to enable "Show separator" in "Display options"
3. Make sure that "Terms and Conditions" block is placed right after "Actions" block
4. Make sure that the spacing between "Actions" and "Terms and Conditions" block is correct, please test both the editor and the frontend of your store

### Testing that has already taken place:

The above.

### Changelog entry

Changelog was added manually