### PR TITLE
[NOX in context] Resolve persistence issue with combined Apple Pay & Google Pay toggle state

### DIFF
--- a/plugins/woocommerce/changelog/fix-WOOPLUG-5399-apple-google-pay-not-persisted
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-5399-apple-google-pay-not-persisted
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: fix
 
-Resolved Apple Pay & Google Pay combined toggle state not persisting when disabled by users.
+Comment: Resolve an issue where the combined Apple Pay & Google Pay toggle state did not persist when disabled.

--- a/plugins/woocommerce/changelog/fix-WOOPLUG-5399-apple-google-pay-not-persisted
+++ b/plugins/woocommerce/changelog/fix-WOOPLUG-5399-apple-google-pay-not-persisted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Resolved Apple Pay & Google Pay combined toggle state not persisting when disabled by users.

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -2361,9 +2361,14 @@ class WooPaymentsService {
 		}
 
 		// Combine Apple Pay and Google Pay into a single `apple_google` entry.
-		$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
+		// First check if apple_google is explicitly stored, otherwise fallback to combining individual states
+		if ( isset( $step_pms_data['apple_google'] ) ) {
+			$apple_google_enabled = wc_string_to_bool( $step_pms_data['apple_google'] );
+		} else {
+			// Fallback to OR logic for backward compatibility
+			$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
+		}
 
-		// Optionally also respect stored state or forced requirements if needed here.
 		$payment_methods_state['apple_google'] = $apple_google_enabled;
 
 		return $payment_methods_state;

--- a/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsService.php
@@ -2361,11 +2361,11 @@ class WooPaymentsService {
 		}
 
 		// Combine Apple Pay and Google Pay into a single `apple_google` entry.
-		// First check if apple_google is explicitly stored, otherwise fallback to combining individual states
+		// First check if apple_google is explicitly stored, otherwise fallback to combining individual states.
 		if ( isset( $step_pms_data['apple_google'] ) ) {
 			$apple_google_enabled = wc_string_to_bool( $step_pms_data['apple_google'] );
 		} else {
-			// Fallback to OR logic for backward compatibility
+			// Fallback to OR logic for backward compatibility.
 			$apple_google_enabled = $apple_pay_enabled || $google_pay_enabled;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8441,7 +8441,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test get_onboarding_payment_methods_state respects stored apple_pay and google_pay states.
+	 * Test get_onboarding_payment_methods_state respects stored apple_pay and google_pay states (no explicit apple_google present).
 	 *
 	 * @return void
 	 */
@@ -8465,29 +8465,26 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$stored_step_data = array(
-			'payment_methods' => array(
-				'apple_pay'  => 'false',
-				'google_pay' => 'false',
-				'card'       => 'true',
+		// Create NOX profile data structure with stored payment method states.
+		$nox_profile_data = array(
+			'onboarding' => array(
+				$location => array(
+					'steps' => array(
+						'payment_methods' => array(
+							'data' => array(
+								'payment_methods' => array(
+									'apple_pay'  => 'false',
+									'google_pay' => 'false',
+									'card'       => 'true',
+								),
+							),
+						),
+					),
+				),
 			),
 		);
 
-		$this->mockable_proxy->register_static_mocks(
-			array(
-				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
-						// Avoid unused parameter warnings in static analysis.
-						unset( $step_id, $location );
-
-						if ( isset( $stored_step_data[ $entry ] ) ) {
-							return $stored_step_data[ $entry ];
-						}
-						return $default_value;
-					},
-				),
-			)
-		);
+		$this->mock_nox_profile_option( $nox_profile_data );
 
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 		$this->assertArrayHasKey( 'apple_google', $result );
@@ -8514,29 +8511,26 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$stored_step_data = array(
-			'payment_methods' => array(
-				'apple_pay'  => 'true',
-				'google_pay' => 'false',
-				// No apple_google key - should fall back to OR logic.
+		// Create NOX profile data structure with apple_pay and google_pay but no apple_google key.
+		$nox_profile_data = array(
+			'onboarding' => array(
+				$location => array(
+					'steps' => array(
+						'payment_methods' => array(
+							'data' => array(
+								'payment_methods' => array(
+									'apple_pay'  => 'true',
+									'google_pay' => 'false',
+									// No apple_google key - should fall back to OR logic.
+								),
+							),
+						),
+					),
+				),
 			),
 		);
 
-		$this->mockable_proxy->register_static_mocks(
-			array(
-				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
-						// Avoid unused parameter warnings in static analysis.
-						unset( $step_id, $location );
-
-						if ( isset( $stored_step_data[ $entry ] ) ) {
-							return $stored_step_data[ $entry ];
-						}
-						return $default_value;
-					},
-				),
-			)
-		);
+		$this->mock_nox_profile_option( $nox_profile_data );
 
 		// Mock the provider to return recommended payment methods.
 		$this->mock_provider
@@ -8571,23 +8565,10 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		$stored_step_data = array();
+		// Create empty NOX profile data structure (no stored state).
+		$nox_profile_data = array();
 
-		$this->mockable_proxy->register_static_mocks(
-			array(
-				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
-						// Avoid unused parameter warnings in static analysis.
-						unset( $step_id, $location );
-
-						if ( isset( $stored_step_data[ $entry ] ) ) {
-							return $stored_step_data[ $entry ];
-						}
-						return $default_value;
-					},
-				),
-			)
-		);
+		$this->mock_nox_profile_option( $nox_profile_data );
 
 		$this->mock_provider
 			->expects( $this->once() )
@@ -8601,6 +8582,36 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using recommended values with OR logic (true || false = true)' );
 	}
 
+	public function test_get_onboarding_payment_methods_state_prefers_explicit_apple_google() {
+		$location        = 'US';
+		$recommended_pms = array(
+			array( 'id' => 'apple_pay',  'enabled' => true,  'required' => false ),
+			array( 'id' => 'google_pay', 'enabled' => true,  'required' => false ),
+		);
+		// Create NOX profile data structure with explicit apple_google override.
+		$nox_profile_data = array(
+			'onboarding' => array(
+				$location => array(
+					'steps' => array(
+						'payment_methods' => array(
+							'data' => array(
+								'payment_methods' => array(
+									'apple_google' => 'false',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->mock_nox_profile_option( $nox_profile_data );
+
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+		$this->assertArrayHasKey( 'apple_google', $result );
+		$this->assertFalse( $result['apple_google'], 'Explicit stored apple_google should take precedence over OR/recommended.' );
+	}
+
 	/**
 	 * Helper method to invoke private methods for testing.
 	 *
@@ -8610,8 +8621,30 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 */
 	private function invoke_private_method( string $method_name, array $args = array() ) {
 		$reflection = new \ReflectionClass( $this->sut );
-		$method     = $reflection->getMethod( $method_name );
+		if ( ! $reflection->hasMethod( $method_name ) ) {
+			$this->fail( sprintf( 'Method %s not found on %s', $method_name, get_class( $this->sut ) ) );
+		}
+		$method = $reflection->getMethod( $method_name );
 		$method->setAccessible( true );
 		return $method->invokeArgs( $this->sut, $args );
+	}
+
+	/**
+	 * Helper method to mock data entry in the NOX profile.
+	 *
+	 * @param array $stored_data The step data to mock.
+	 * @return void
+	 */
+	private function mock_nox_profile_option( array $stored_data ): void {
+		$this->mockable_proxy->register_function_mocks(
+			array(
+				'get_option' => function ( $option_name, $default = false ) use ( $stored_data ) {
+					if ( 'woocommerce_woopayments_nox_profile' === $option_name ) {
+						return $stored_data;
+					}
+					return $default;
+				},
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8477,6 +8477,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			array(
 				Utils::class => array(
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						// Avoid unused parameter warnings in static analysis.
+						unset( $step_id, $location );
+						
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}
@@ -8523,6 +8526,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			array(
 				Utils::class => array(
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						// Avoid unused parameter warnings in static analysis.
+						unset( $step_id, $location );
+						
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}
@@ -8571,6 +8577,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			array(
 				Utils::class => array(
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						// Avoid unused parameter warnings in static analysis.
+						unset( $step_id, $location );
+						
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8441,57 +8441,6 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test get_onboarding_payment_methods_state respects stored apple_pay and google_pay states (no explicit apple_google present).
-	 *
-	 * @return void
-	 */
-	public function test_get_onboarding_payment_methods_state_respects_stored_apple_google_states() {
-		$location        = 'US';
-		$recommended_pms = array(
-			array(
-				'id'       => 'card',
-				'enabled'  => true,
-				'required' => true,
-			),
-			array(
-				'id'       => 'apple_pay',
-				'enabled'  => false,
-				'required' => false,
-			),
-			array(
-				'id'       => 'google_pay',
-				'enabled'  => false,
-				'required' => false,
-			),
-		);
-
-		// Create NOX profile data structure with stored payment method states.
-		$nox_profile_data = array(
-			'onboarding' => array(
-				$location => array(
-					'steps' => array(
-						'payment_methods' => array(
-							'data' => array(
-								'payment_methods' => array(
-									'apple_pay'  => 'false',
-									'google_pay' => 'false',
-									'card'       => 'true',
-								),
-							),
-						),
-					),
-				),
-			),
-		);
-
-		$this->mock_nox_profile_option( $nox_profile_data );
-
-		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
-		$this->assertArrayHasKey( 'apple_google', $result );
-		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled in recommended PMs' );
-	}
-
-	/**
 	 * Test get_onboarding_payment_methods_state falls back to OR logic when no explicit apple_google stored.
 	 *
 	 * @return void
@@ -8519,7 +8468,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 						'payment_methods' => array(
 							'data' => array(
 								'payment_methods' => array(
-									'apple_pay'  => 'true',
+									'apple_pay'  => 'false',
 									'google_pay' => 'false',
 									// No apple_google key - should fall back to OR logic.
 								),
@@ -8582,11 +8531,24 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using recommended values with OR logic (true || false = true)' );
 	}
 
+	/**
+	 * Test get_onboarding_payment_methods_state prefers explicit stored apple_google over OR logic.
+	 *
+	 * @return void
+	 */
 	public function test_get_onboarding_payment_methods_state_prefers_explicit_apple_google() {
 		$location        = 'US';
 		$recommended_pms = array(
-			array( 'id' => 'apple_pay',  'enabled' => true,  'required' => false ),
-			array( 'id' => 'google_pay', 'enabled' => true,  'required' => false ),
+			array(
+				'id' => 'apple_pay',
+				'enabled' => true,
+				'required' => false
+			),
+			array(
+				'id' => 'google_pay',
+				'enabled' => true,
+				'required' => false
+			),
 		);
 		// Create NOX profile data structure with explicit apple_google override.
 		$nox_profile_data = array(
@@ -8638,11 +8600,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	private function mock_nox_profile_option( array $stored_data ): void {
 		$this->mockable_proxy->register_function_mocks(
 			array(
-				'get_option' => function ( $option_name, $default = false ) use ( $stored_data ) {
-					if ( 'woocommerce_woopayments_nox_profile' === $option_name ) {
+				'get_option' => function ( $option_name, $fallback = false ) use ( $stored_data ) {
+					if ( WooPaymentsService::NOX_PROFILE_OPTION_KEY === $option_name ) {
 						return $stored_data;
 					}
-					return $default;
+					return $fallback;
 				},
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8479,7 +8479,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
 						// Avoid unused parameter warnings in static analysis.
 						unset( $step_id, $location );
-						
+
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}
@@ -8528,7 +8528,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
 						// Avoid unused parameter warnings in static analysis.
 						unset( $step_id, $location );
-						
+
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}
@@ -8579,7 +8579,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
 						// Avoid unused parameter warnings in static analysis.
 						unset( $step_id, $location );
-						
+
 						if ( isset( $stored_step_data[ $entry ] ) ) {
 							return $stored_step_data[ $entry ];
 						}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8439,4 +8439,229 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			'PR' => 'Puerto Rico',
 		);
 	}
+
+	/**
+	 * Test get_onboarding_payment_methods_state respects stored apple_pay and google_pay states.
+	 *
+	 * @return void
+	 */
+	public function test_get_onboarding_payment_methods_state_respects_stored_apple_google_states() {
+		$location = 'US';
+		$recommended_pms = array(
+			array(
+				'id'       => 'card',
+				'enabled'  => true,
+				'required' => true,
+			),
+			array(
+				'id'       => 'apple_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+			array(
+				'id'       => 'google_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+		);
+
+		// Mock the NOX profile data with stored apple_pay and google_pay states
+		$stored_step_data = array(
+			'apple_pay'   => false,
+			'google_pay'  => false,
+			'card'        => true,
+		);
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+						return $stored_step_data;
+					},
+				),
+			)
+		);
+
+		// Mock the provider to return recommended payment methods
+		$this->mock_provider
+			->expects( $this->once() )
+			->method( 'get_recommended_payment_methods' )
+			->with( $location )
+			->willReturn( $recommended_pms );
+
+		// Act
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+
+		// Assert: apple_google should be false since both individual states are false
+		$this->assertArrayHasKey( 'apple_google', $result );
+		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled' );
+		$this->assertFalse( $result['apple_pay'] ?? true, 'apple_pay should be false from stored state' );
+		$this->assertFalse( $result['google_pay'] ?? true, 'google_pay should be false from stored state' );
+	}
+
+	/**
+	 * Test get_onboarding_payment_methods_state respects explicitly stored apple_google value.
+	 *
+	 * @return void
+	 */
+	public function test_get_onboarding_payment_methods_state_respects_explicit_apple_google_state() {
+		$location = 'US';
+		$recommended_pms = array(
+			array(
+				'id'       => 'apple_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+			array(
+				'id'       => 'google_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+		);
+
+		// Mock the NOX profile data with explicit apple_google state
+		$stored_step_data = array(
+			'apple_pay'    => true,
+			'google_pay'   => true,
+			'apple_google' => false, // Explicitly disabled despite individual states being true
+		);
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+						return $stored_step_data;
+					},
+				),
+			)
+		);
+
+		// Mock the provider to return recommended payment methods
+		$this->mock_provider
+			->expects( $this->once() )
+			->method( 'get_recommended_payment_methods' )
+			->with( $location )
+			->willReturn( $recommended_pms );
+
+		// Act
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+
+		// Assert: apple_google should respect the explicit false value
+		$this->assertArrayHasKey( 'apple_google', $result );
+		$this->assertFalse( $result['apple_google'], 'apple_google should respect explicit stored value of false' );
+	}
+
+	/**
+	 * Test get_onboarding_payment_methods_state falls back to OR logic when no explicit apple_google stored.
+	 *
+	 * @return void
+	 */
+	public function test_get_onboarding_payment_methods_state_fallback_or_logic() {
+		$location = 'US';
+		$recommended_pms = array(
+			array(
+				'id'       => 'apple_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+			array(
+				'id'       => 'google_pay',
+				'enabled'  => false,
+				'required' => false,
+			),
+		);
+
+		// Mock the NOX profile data without explicit apple_google state
+		$stored_step_data = array(
+			'apple_pay'  => true,
+			'google_pay' => false,
+			// No apple_google key - should fall back to OR logic
+		);
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+						return $stored_step_data;
+					},
+				),
+			)
+		);
+
+		// Mock the provider to return recommended payment methods
+		$this->mock_provider
+			->expects( $this->once() )
+			->method( 'get_recommended_payment_methods' )
+			->with( $location )
+			->willReturn( $recommended_pms );
+
+		// Act
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+
+		// Assert: apple_google should be true due to OR logic (true || false = true)
+		$this->assertArrayHasKey( 'apple_google', $result );
+		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using OR fallback logic (apple_pay=true || google_pay=false)' );
+	}
+
+	/**
+	 * Test get_onboarding_payment_methods_state uses recommended values when no stored state.
+	 *
+	 * @return void
+	 */
+	public function test_get_onboarding_payment_methods_state_uses_recommended_when_no_stored_state() {
+		$location = 'US';
+		$recommended_pms = array(
+			array(
+				'id'       => 'apple_pay',
+				'enabled'  => true,
+				'required' => false,
+			),
+			array(
+				'id'       => 'google_pay',
+				'enabled'  => false,
+				'required' => false,
+			),
+		);
+
+		// Mock the NOX profile data as empty (no stored state)
+		$stored_step_data = array();
+
+		$this->mockable_proxy->register_static_mocks(
+			array(
+				Utils::class => array(
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+						return $stored_step_data;
+					},
+				),
+			)
+		);
+
+		// Mock the provider to return recommended payment methods
+		$this->mock_provider
+			->expects( $this->once() )
+			->method( 'get_recommended_payment_methods' )
+			->with( $location )
+			->willReturn( $recommended_pms );
+
+		// Act
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+
+		// Assert: should use recommended values with OR logic
+		$this->assertArrayHasKey( 'apple_google', $result );
+		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using recommended values with OR logic (true || false = true)' );
+	}
+
+	/**
+	 * Helper method to invoke private methods for testing.
+	 *
+	 * @param string $method_name The name of the private method.
+	 * @param array  $args        The arguments to pass to the method.
+	 * @return mixed The result of the method call.
+	 */
+	private function invoke_private_method( string $method_name, array $args = array() ) {
+		$reflection = new \ReflectionClass( $this->sut );
+		$method = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+		return $method->invokeArgs( $this->sut, $args );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8540,14 +8540,14 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$location        = 'US';
 		$recommended_pms = array(
 			array(
-				'id' => 'apple_pay',
-				'enabled' => true,
-				'required' => false
+				'id'       => 'apple_pay',
+				'enabled'  => true,
+				'required' => false,
 			),
 			array(
-				'id' => 'google_pay',
-				'enabled' => true,
-				'required' => false
+				'id'       => 'google_pay',
+				'enabled'  => true,
+				'required' => false,
 			),
 		);
 		// Create NOX profile data structure with explicit apple_google override.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8446,7 +8446,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_onboarding_payment_methods_state_respects_stored_apple_google_states() {
-		$location = 'US';
+		$location        = 'US';
 		$recommended_pms = array(
 			array(
 				'id'       => 'card',
@@ -8455,48 +8455,42 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 			array(
 				'id'       => 'apple_pay',
-				'enabled'  => true,
+				'enabled'  => false,
 				'required' => false,
 			),
 			array(
 				'id'       => 'google_pay',
-				'enabled'  => true,
+				'enabled'  => false,
 				'required' => false,
 			),
 		);
 
-		// Mock the NOX profile data with stored apple_pay and google_pay states
 		$stored_step_data = array(
-			'apple_pay'   => false,
-			'google_pay'  => false,
-			'card'        => true,
+			'apple_pay'  => 'false',
+			'google_pay' => 'false',
+			'card'       => 'true',
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
 						return $stored_step_data;
 					},
 				),
 			)
 		);
 
-		// Mock the provider to return recommended payment methods
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
 			->with( $location )
 			->willReturn( $recommended_pms );
 
-		// Act
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 
-		// Assert: apple_google should be false since both individual states are false
 		$this->assertArrayHasKey( 'apple_google', $result );
-		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled' );
-		$this->assertFalse( $result['apple_pay'] ?? true, 'apple_pay should be false from stored state' );
-		$this->assertFalse( $result['google_pay'] ?? true, 'google_pay should be false from stored state' );
+		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled in recommended PMs' );
 	}
 
 	/**
@@ -8519,34 +8513,30 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		// Mock the NOX profile data with explicit apple_google state
 		$stored_step_data = array(
-			'apple_pay'    => true,
-			'google_pay'   => true,
-			'apple_google' => false, // Explicitly disabled despite individual states being true
+			'apple_pay'    => 'true',
+			'google_pay'   => 'true',
+			'apple_google' => 'false', // Explicitly disabled despite individual states being true.
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
 						return $stored_step_data;
 					},
 				),
 			)
 		);
 
-		// Mock the provider to return recommended payment methods
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
 			->with( $location )
 			->willReturn( $recommended_pms );
 
-		// Act
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 
-		// Assert: apple_google should respect the explicit false value
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'apple_google should respect explicit stored value of false' );
 	}
@@ -8571,34 +8561,31 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		// Mock the NOX profile data without explicit apple_google state
 		$stored_step_data = array(
-			'apple_pay'  => true,
-			'google_pay' => false,
-			// No apple_google key - should fall back to OR logic
+			'apple_pay'  => 'true',
+			'google_pay' => 'false',
+			// No apple_google key - should fall back to OR logic.
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
 						return $stored_step_data;
 					},
 				),
 			)
 		);
 
-		// Mock the provider to return recommended payment methods
+		// Mock the provider to return recommended payment methods.
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
 			->with( $location )
 			->willReturn( $recommended_pms );
 
-		// Act
-		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, null ) );
 
-		// Assert: apple_google should be true due to OR logic (true || false = true)
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using OR fallback logic (apple_pay=true || google_pay=false)' );
 	}
@@ -8623,30 +8610,26 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			),
 		);
 
-		// Mock the NOX profile data as empty (no stored state)
 		$stored_step_data = array();
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location ) use ( $stored_step_data ) {
+					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
 						return $stored_step_data;
 					},
 				),
 			)
 		);
 
-		// Mock the provider to return recommended payment methods
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
 			->with( $location )
 			->willReturn( $recommended_pms );
 
-		// Act
-		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
+		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, null ) );
 
-		// Assert: should use recommended values with OR logic
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertTrue( $result['apple_google'], 'apple_google should be true when using recommended values with OR logic (true || false = true)' );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8466,29 +8466,30 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		);
 
 		$stored_step_data = array(
-			'apple_pay'  => 'false',
-			'google_pay' => 'false',
-			'card'       => 'true',
+			'payment_methods' => array(
+				'apple_pay'  => 'false',
+				'google_pay' => 'false',
+				'card'       => 'true',
+			),
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
-						return $stored_step_data;
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						if ( isset( $stored_step_data[ $entry ] ) ) {
+							return $stored_step_data[ $entry ];
+						}
+						return $default_value;
 					},
 				),
 			)
 		);
 
-		$this->mock_provider
-			->expects( $this->once() )
-			->method( 'get_recommended_payment_methods' )
-			->with( $location )
-			->willReturn( $recommended_pms );
-
+		// Act: Call method directly with recommended PMs (no provider call needed)
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 
+		// Assert: apple_google should be false since both recommended states are false
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled in recommended PMs' );
 	}
@@ -8499,7 +8500,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_onboarding_payment_methods_state_respects_explicit_apple_google_state() {
-		$location = 'US';
+		$location        = 'US';
 		$recommended_pms = array(
 			array(
 				'id'       => 'apple_pay',
@@ -8514,29 +8515,30 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		);
 
 		$stored_step_data = array(
-			'apple_pay'    => 'true',
-			'google_pay'   => 'true',
-			'apple_google' => 'false', // Explicitly disabled despite individual states being true.
+			'payment_methods' => array(
+				'apple_pay'    => 'true',
+				'google_pay'   => 'true',
+				'apple_google' => 'false', // Explicitly disabled despite individual states being true.
+			),
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
-						return $stored_step_data;
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						if ( isset( $stored_step_data[ $entry ] ) ) {
+							return $stored_step_data[ $entry ];
+						}
+						return $default_value;
 					},
 				),
 			)
 		);
 
-		$this->mock_provider
-			->expects( $this->once() )
-			->method( 'get_recommended_payment_methods' )
-			->with( $location )
-			->willReturn( $recommended_pms );
-
+		// Act: Call method directly with recommended PMs (no provider call needed)
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
 
+		// Assert: apple_google should respect the explicit false value
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'apple_google should respect explicit stored value of false' );
 	}
@@ -8547,7 +8549,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_onboarding_payment_methods_state_fallback_or_logic() {
-		$location = 'US';
+		$location        = 'US';
 		$recommended_pms = array(
 			array(
 				'id'       => 'apple_pay',
@@ -8562,16 +8564,21 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		);
 
 		$stored_step_data = array(
-			'apple_pay'  => 'true',
-			'google_pay' => 'false',
-			// No apple_google key - should fall back to OR logic.
+			'payment_methods' => array(
+				'apple_pay'  => 'true',
+				'google_pay' => 'false',
+				// No apple_google key - should fall back to OR logic.
+			),
 		);
 
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
-						return $stored_step_data;
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						if ( isset( $stored_step_data[ $entry ] ) ) {
+							return $stored_step_data[ $entry ];
+						}
+						return $default_value;
 					},
 				),
 			)
@@ -8596,7 +8603,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_onboarding_payment_methods_state_uses_recommended_when_no_stored_state() {
-		$location = 'US';
+		$location        = 'US';
 		$recommended_pms = array(
 			array(
 				'id'       => 'apple_pay',
@@ -8615,8 +8622,11 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mockable_proxy->register_static_mocks(
 			array(
 				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function () use ( $stored_step_data ) {
-						return $stored_step_data;
+					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
+						if ( isset( $stored_step_data[ $entry ] ) ) {
+							return $stored_step_data[ $entry ];
+						}
+						return $default_value;
 					},
 				),
 			)
@@ -8643,7 +8653,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 	 */
 	private function invoke_private_method( string $method_name, array $args = array() ) {
 		$reflection = new \ReflectionClass( $this->sut );
-		$method = $reflection->getMethod( $method_name );
+		$method     = $reflection->getMethod( $method_name );
 		$method->setAccessible( true );
 		return $method->invokeArgs( $this->sut, $args );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Settings/PaymentsProviders/WooPayments/WooPaymentsServiceTest.php
@@ -8486,61 +8486,9 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Act: Call method directly with recommended PMs (no provider call needed)
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
-
-		// Assert: apple_google should be false since both recommended states are false
 		$this->assertArrayHasKey( 'apple_google', $result );
 		$this->assertFalse( $result['apple_google'], 'apple_google should be false when both apple_pay and google_pay are disabled in recommended PMs' );
-	}
-
-	/**
-	 * Test get_onboarding_payment_methods_state respects explicitly stored apple_google value.
-	 *
-	 * @return void
-	 */
-	public function test_get_onboarding_payment_methods_state_respects_explicit_apple_google_state() {
-		$location        = 'US';
-		$recommended_pms = array(
-			array(
-				'id'       => 'apple_pay',
-				'enabled'  => true,
-				'required' => false,
-			),
-			array(
-				'id'       => 'google_pay',
-				'enabled'  => true,
-				'required' => false,
-			),
-		);
-
-		$stored_step_data = array(
-			'payment_methods' => array(
-				'apple_pay'    => 'true',
-				'google_pay'   => 'true',
-				'apple_google' => 'false', // Explicitly disabled despite individual states being true.
-			),
-		);
-
-		$this->mockable_proxy->register_static_mocks(
-			array(
-				Utils::class => array(
-					'get_nox_profile_onboarding_step_data_entry' => function ( $step_id, $location, $entry = null, $default_value = false ) use ( $stored_step_data ) {
-						if ( isset( $stored_step_data[ $entry ] ) ) {
-							return $stored_step_data[ $entry ];
-						}
-						return $default_value;
-					},
-				),
-			)
-		);
-
-		// Act: Call method directly with recommended PMs (no provider call needed)
-		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, $recommended_pms ) );
-
-		// Assert: apple_google should respect the explicit false value
-		$this->assertArrayHasKey( 'apple_google', $result );
-		$this->assertFalse( $result['apple_google'], 'apple_google should respect explicit stored value of false' );
 	}
 
 	/**
@@ -8588,7 +8536,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
-			->with( $location )
+			->with( $this->isInstanceOf( FakePaymentGateway::class ), $location )
 			->willReturn( $recommended_pms );
 
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, null ) );
@@ -8635,7 +8583,7 @@ class WooPaymentsServiceTest extends WC_Unit_Test_Case {
 		$this->mock_provider
 			->expects( $this->once() )
 			->method( 'get_recommended_payment_methods' )
-			->with( $location )
+			->with( $this->isInstanceOf( FakePaymentGateway::class ), $location )
 			->willReturn( $recommended_pms );
 
 		$result = $this->invoke_private_method( 'get_onboarding_payment_methods_state', array( $location, null ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR resolves an issue where the combined Apple Pay & Google Pay toggle remained enabled in the UI even after users disabled it. The problem was caused by inconsistent state management between the frontend and backend, preventing the toggle state from persisting correctly.

Closes WOOPLUG-5399

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1642" height="831" alt="Screenshot 2025-08-22 at 17 28 07" src="https://github.com/user-attachments/assets/0319c358-c96e-45b3-9204-b5ce9d4e1dcc" /> | <img width="1645" height="834" alt="Screenshot 2025-08-22 at 17 28 25" src="https://github.com/user-attachments/assets/560a47db-d536-41f7-970d-81bb85703557" /> |

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN store with WooCommerce on this PR's branch (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=fix/WOOPLUG-5399-apple-google-pay-not-persisted)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Click on the "Payments" main menu item, and you should see the Payments Settings page.
4. Click the "Install" button next to the WooPayments gateway.
5. When the modal opens, confirm that it lands on the recommended payment methods selection screen.
6. Disable Apple Pay / Google Pay toggle and close the modal.
7. Click on the Complete setup button and verify the Apple Pay / Google Pay toggle is still disabled.
8. Enable Apple Pay / Google Pay toggle and close the modal again.
9. Click on the Complete setup button and verify the Apple Pay / Google Pay toggle is still enabled.
10. Click on the Continue button and proceed with Jetpack connection setup, then onboard a test account.
11. Navigate to Payments > Settings and verify that Apple Pay / Google Pay is payment method is enabled.
12. Navigate to Payments > Overview and reset the account.
13. Go to the Payments menu again and click the Complete setup button.
14. This time, disable the Apple Pay / Google Pay toggle and click the Continue button.
15. Onboard a test account again.
16. Navigate to Payments > Settings and verify that Apple Pay / Google Pay is payment method is disabled.

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
