### PR TITLE
e2e tests blocks: Update Search reset button locator to fix strict mode violation

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-classic-template-strict-mode-reset-button
+++ b/plugins/woocommerce/changelog/e2e-fix-classic-template-strict-mode-reset-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E tests: fixed blocks e2e test
+
+

--- a/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/utils/editor/editor-utils.page.ts
@@ -122,7 +122,7 @@ export class Editor extends CoreEditor {
 
 		// Wait for the search to finish.
 		await expect(
-			this.page.getByRole( 'button', { name: 'Reset' } )
+			this.page.getByRole( 'button', { name: 'Reset Search' } )
 		).toBeVisible();
 		await expect( this.page.getByLabel( 'No results' ) ).toBeHidden();
 	}

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -659,7 +659,8 @@
 					"changes": [
 						"src/Blocks/**",
 						"templates/**",
-						"patterns/**"
+						"patterns/**",
+						"client/blocks/tests/e2e/**"
 					],
 					"testEnv": {
 						"start": "env:start:blocks",
@@ -694,7 +695,9 @@
 						"--shard=9/10",
 						"--shard=10/10"
 					],
-					"changes": [],
+					"changes": [
+						"client/blocks/tests/e2e/**"
+					],
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -669,6 +669,7 @@
 						}
 					},
 					"events": [
+						"pull_request",
 						"nightly-checks",
 						"release-checks",
 						"blocks-e2e-wp-pre-release"
@@ -705,6 +706,7 @@
 						}
 					},
 					"events": [
+						"pull_request",
 						"nightly-checks",
 						"release-checks",
 						"blocks-e2e-wp-latest-1"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a strict mode violation error breaking a blocks test with WordPress L-1.

See p1756093333362559-slack-C03CPM3UXDJ

### How to test the changes in this Pull Request:

Check CI which should run with both WP Core versions.

Locally, run the failing test with WP Core latest (currently 6.8.2) and with the previous version (currently 6.7.3)

```
pnpm test:e2e classic-template/classic-template.block_theme.spec.ts
```