### PR TITLE
dev: Update blocks e2e tests config to run all relevant jobs when tests are updated

### DIFF
--- a/plugins/woocommerce/changelog/dev-run-all-blocks-e2e-on-tests-updates
+++ b/plugins/woocommerce/changelog/dev-run-all-blocks-e2e-on-tests-updates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update CI config for blocks e2e tests
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -659,7 +659,8 @@
 					"changes": [
 						"src/Blocks/**",
 						"templates/**",
-						"patterns/**"
+						"patterns/**",
+						"client/blocks/tests/e2e/**"
 					],
 					"testEnv": {
 						"start": "env:start:blocks",
@@ -694,7 +695,9 @@
 						"--shard=9/10",
 						"--shard=10/10"
 					],
-					"changes": [],
+					"changes": [
+						"client/blocks/tests/e2e/**"
+					],
 					"testEnv": {
 						"start": "env:start:blocks",
 						"config": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the CI config for Blocks e2e jobs to run all of them when these tests are updated. Sometimes an update breaks them with the previous WP Core version which only runs on a daily basis.

### How to test the changes in this Pull Request:

Test should be to make an update in the blocks e2e tests and check the CI. It should run the Blocks e2e tests with WP L-1. But in this PR the package.json is updated so all tests will run anyway. 
This can be tested with a fork, or after merging.
