### PR TITLE
Interactivity API powered Mini Cart - show variations and custom data

### DIFF
--- a/plugins/woocommerce/changelog/60596-wooplug-5390-interactivity-api-powered-mini-cart-show-variations
+++ b/plugins/woocommerce/changelog/60596-wooplug-5390-interactivity-api-powered-mini-cart-show-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support variations and custom data in iAPI-powered minicart

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -653,8 +653,9 @@ const { state: cartItemState } = store(
 					dataProperty: DataProperty;
 				} >();
 				return (
-					dataProperty === 'variation' &&
-					cartItemState.cartItem.type !== 'variation'
+					cartItemState.cartItem[ dataProperty ].length === 0 ||
+					( dataProperty === 'variation' &&
+						cartItemState.cartItem.type !== 'variation' )
 				);
 			},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -77,6 +77,17 @@ type CartItemContext = {
 	cartItem: CartItem;
 };
 
+type CartItemData = {
+	name: string;
+	value: string;
+};
+
+type CartItemVariationAttr = {
+	attribute: string;
+	raw_attribute: string;
+	value: string;
+};
+
 const trimWords = ( html: string, maxWords = 15 ): string => {
 	const words = html.trim().split( /\s+/ );
 	if ( words.length <= maxWords ) {
@@ -612,14 +623,27 @@ const { state: cartItemState } = store(
 					.toLowerCase() }`;
 			},
 
-			get cartItemDataName(): string {
+			get cartItemData(): CartItemData {
 				const context = getContext< {
-					itemData: { attribute: string };
+					itemData: CartItemVariationAttr;
 				} >();
-				return context.itemData.attribute + ':';
+
+				// Use the context if it is in a loop, otherwise use the unique variation if it exists.
+				const variationAttr: CartItemVariationAttr =
+					context.itemData || cartItemState.cartItem.variation[ 0 ];
+
+				return {
+					name: variationAttr.attribute,
+					value: variationAttr.value,
+				};
 			},
 
-			get variationHasMultipleAttrs(): boolean {
+			get cartItemDataName(): string {
+				// TODO: Not sure why this is not displayed when there is only one attribute.
+				return cartItemState.cartItemData.name + ':';
+			},
+
+			get itemDataHasMultipleAttributes(): boolean {
 				const { variation = [] } = cartItemState.cartItem;
 				return variation.length > 1;
 			},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -641,6 +641,30 @@ const { state: cartItemState } = store(
 				} >();
 				return cartItemState.cartItem[ dataProperty ]?.length > 1;
 			},
+
+			get shouldHideProductDetails(): boolean {
+				const { dataProperty } = getContext< {
+					dataProperty: 'item_data' | 'variation';
+				} >();
+				return (
+					dataProperty === 'variation' &&
+					cartItemState.cartItem.type !== 'variation'
+				);
+			},
+
+			get shouldHideSingleProductDetails(): boolean {
+				return (
+					cartItemState.shouldHideProductDetails ||
+					cartItemState.itemDataHasMultipleAttributes
+				);
+			},
+
+			get shouldHideMultipleProductDetails(): boolean {
+				return (
+					cartItemState.shouldHideProductDetails ||
+					! cartItemState.itemDataHasMultipleAttributes
+				);
+			},
 		},
 
 		actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -619,10 +619,15 @@ const { state: cartItemState } = store(
 
 				const dataItemAttrKey =
 					dataItemAttr.key || dataItemAttr.attribute;
+				// Decode entities.
+				const nameTxt = document.createElement( 'textarea' );
+				nameTxt.innerHTML = dataItemAttrKey + ':';
+				const valueTxt = document.createElement( 'textarea' );
+				valueTxt.innerHTML = dataItemAttr.value;
 
 				return {
-					name: dataItemAttrKey + ':',
-					value: dataItemAttr.value,
+					name: nameTxt.value,
+					value: valueTxt.value,
 					className: `wc-block-components-product-details__${ dataItemAttrKey
 						.replace( /([a-z])([A-Z])/g, '$1-$2' )
 						.replace( /[\s_]+/g, '-' )

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -78,9 +78,10 @@ type CartItemContext = {
 };
 
 type CartItemDataAttr = {
-	name: string;
-	value: string;
-	className: string;
+	name?: string;
+	value?: string;
+	className?: string;
+	hidden?: boolean;
 };
 
 type DataProperty = 'item_data' | 'variation';
@@ -611,7 +612,12 @@ const { state: cartItemState } = store(
 
 			get cartItemDataAttr(): CartItemDataAttr | null {
 				const { itemData, dataProperty } = getContext< {
-					itemData: { key: string; attribute: string; value: string };
+					itemData: {
+						key: string;
+						attribute: string;
+						value: string;
+						hidden: string;
+					};
 					dataProperty: DataProperty;
 				} >();
 
@@ -620,7 +626,7 @@ const { state: cartItemState } = store(
 					itemData || cartItemState.cartItem[ dataProperty ]?.[ 0 ];
 
 				if ( ! dataItemAttr ) {
-					return null;
+					return { hidden: true };
 				}
 
 				const dataItemAttrKey =
@@ -638,6 +644,7 @@ const { state: cartItemState } = store(
 						.replace( /([a-z])([A-Z])/g, '$1-$2' )
 						.replace( /[\s_]+/g, '-' )
 						.toLowerCase() }`,
+					hidden: dataItemAttr.hidden === '1' ? true : false,
 				};
 			},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -643,14 +643,14 @@ const { state: cartItemState } = store(
 
 			get itemDataHasMultipleAttributes(): boolean {
 				const { dataProperty } = getContext< {
-					dataProperty: 'item_data' | 'variation';
+					dataProperty: DataProperty;
 				} >();
 				return cartItemState.cartItem[ dataProperty ]?.length > 1;
 			},
 
 			get shouldHideProductDetails(): boolean {
 				const { dataProperty } = getContext< {
-					dataProperty: 'item_data' | 'variation';
+					dataProperty: DataProperty;
 				} >();
 				return (
 					dataProperty === 'variation' &&

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -600,6 +600,29 @@ const { state: cartItemState } = store(
 					  } )
 					: true;
 			},
+
+			get productAttributeClass(): string {
+				const context = getContext< {
+					itemData: { attribute: string };
+				} >();
+				// Transform attribute name to a valid CSS class name.
+				return `wc-block-components-product-details__${ context.itemData.attribute
+					.replace( /([a-z])([A-Z])/g, '$1-$2' )
+					.replace( /[\s_]+/g, '-' )
+					.toLowerCase() }`;
+			},
+
+			get cartItemDataName(): string {
+				const context = getContext< {
+					itemData: { attribute: string };
+				} >();
+				return context.itemData.attribute + ':';
+			},
+
+			get variationHasMultipleAttrs(): boolean {
+				const { variation = [] } = cartItemState.cartItem;
+				return variation.length > 1;
+			},
 		},
 
 		actions: {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -613,7 +613,7 @@ const { state: cartItemState } = store(
 					dataProperty: 'item_data' | 'variation';
 				} >();
 
-				// Use the context if it is in a loop, otherwise use the unique variation if it exists.
+				// Use the context if it is in a loop, otherwise use the unique item if it exists.
 				const dataItemAttr =
 					itemData || cartItemState.cartItem[ dataProperty ]?.[ 0 ];
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -77,15 +77,10 @@ type CartItemContext = {
 	cartItem: CartItem;
 };
 
-type CartItemData = {
+type CartItemDataAttr = {
 	name: string;
 	value: string;
-};
-
-type CartItemVariationAttr = {
-	attribute: string;
-	raw_attribute: string;
-	value: string;
+	className: string;
 };
 
 const trimWords = ( html: string, maxWords = 15 ): string => {
@@ -612,40 +607,34 @@ const { state: cartItemState } = store(
 					: true;
 			},
 
-			get productAttributeClass(): string {
-				const context = getContext< {
-					itemData: { attribute: string };
-				} >();
-				// Transform attribute name to a valid CSS class name.
-				return `wc-block-components-product-details__${ context.itemData.attribute
-					.replace( /([a-z])([A-Z])/g, '$1-$2' )
-					.replace( /[\s_]+/g, '-' )
-					.toLowerCase() }`;
-			},
-
-			get cartItemData(): CartItemData {
-				const context = getContext< {
-					itemData: CartItemVariationAttr;
+			get cartItemDataAttr(): CartItemDataAttr {
+				const { itemData, dataProperty } = getContext< {
+					itemData: { key: string; attribute: string; value: string };
+					dataProperty: 'item_data' | 'variation';
 				} >();
 
 				// Use the context if it is in a loop, otherwise use the unique variation if it exists.
-				const variationAttr: CartItemVariationAttr =
-					context?.itemData || cartItemState.cartItem.variation[ 0 ];
+				const dataItemAttr =
+					itemData || cartItemState.cartItem[ dataProperty ]?.[ 0 ];
+
+				const dataItemAttrKey =
+					dataItemAttr.key || dataItemAttr.attribute;
 
 				return {
-					name: variationAttr.attribute,
-					value: variationAttr.value,
+					name: dataItemAttrKey + ':',
+					value: dataItemAttr.value,
+					className: `wc-block-components-product-details__${ dataItemAttrKey
+						.replace( /([a-z])([A-Z])/g, '$1-$2' )
+						.replace( /[\s_]+/g, '-' )
+						.toLowerCase() }`,
 				};
 			},
 
-			get cartItemDataName(): string {
-				// TODO: Not sure why this is not displayed when there is only one attribute.
-				return cartItemState.cartItemData.name + ':';
-			},
-
 			get itemDataHasMultipleAttributes(): boolean {
-				const { variation = [] } = cartItemState.cartItem;
-				return variation.length > 1;
+				const { dataProperty } = getContext< {
+					dataProperty: 'item_data' | 'variation';
+				} >();
+				return cartItemState.cartItem[ dataProperty ]?.length > 1;
 			},
 		},
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -630,7 +630,7 @@ const { state: cartItemState } = store(
 
 				// Use the context if it is in a loop, otherwise use the unique variation if it exists.
 				const variationAttr: CartItemVariationAttr =
-					context.itemData || cartItemState.cartItem.variation[ 0 ];
+					context?.itemData || cartItemState.cartItem.variation[ 0 ];
 
 				return {
 					name: variationAttr.attribute,

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/mini-cart/iapi-frontend.ts
@@ -83,6 +83,8 @@ type CartItemDataAttr = {
 	className: string;
 };
 
+type DataProperty = 'item_data' | 'variation';
+
 const trimWords = ( html: string, maxWords = 15 ): string => {
 	const words = html.trim().split( /\s+/ );
 	if ( words.length <= maxWords ) {
@@ -607,15 +609,19 @@ const { state: cartItemState } = store(
 					: true;
 			},
 
-			get cartItemDataAttr(): CartItemDataAttr {
+			get cartItemDataAttr(): CartItemDataAttr | null {
 				const { itemData, dataProperty } = getContext< {
 					itemData: { key: string; attribute: string; value: string };
-					dataProperty: 'item_data' | 'variation';
+					dataProperty: DataProperty;
 				} >();
 
 				// Use the context if it is in a loop, otherwise use the unique item if it exists.
 				const dataItemAttr =
 					itemData || cartItemState.cartItem[ dataProperty ]?.[ 0 ];
+
+				if ( ! dataItemAttr ) {
+					return null;
+				}
 
 				const dataItemAttrKey =
 					dataItemAttr.key || dataItemAttr.attribute;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -264,14 +264,14 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 		<div
 			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			class="wc-block-components-product-details"
-			data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
+			data-wp-bind--hidden="state.shouldHideSingleProductDetails"
 		>
 			<?php echo $this->render_experimental_iapi_product_details_item_markup( 'div' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<ul
 			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			class="wc-block-components-product-details"
-			data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
+			data-wp-bind--hidden="state.shouldHideMultipleProductDetails"
 		>
 			<template
 				data-wp-each--item-data="state.cartItem.<?php echo esc_attr( $property ); ?>"

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -262,14 +262,14 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 		ob_start();
 		?>
 		<div
-			<?php wp_interactivity_data_wp_context( $context ); ?>
+			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			class="wc-block-components-product-details"
 			data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
 		>
 			<?php echo $this->render_experimental_iapi_product_details_item_markup( 'div' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<ul
-			<?php wp_interactivity_data_wp_context( $context ); ?>
+			<?php echo wp_interactivity_data_wp_context( $context ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			class="wc-block-components-product-details"
 			data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
 		>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -174,20 +174,53 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
-										<div class="wc-block-components-product-details" data-wp-bind--hidden="state.itemDataHasMultipleAttributes">
-											<div data-wp-bind--class="state.productAttributeClass">
-												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataName"></span>
-												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemData.value"></span>
+										<div
+											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'variation' ) ); ?>
+											class="wc-block-components-product-details"
+											data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
+										>
+											<div data-wp-bind--class="state.cartItemDataAttr.className">
+												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
 											</div>
 										</div>
-										<ul class="wc-block-components-product-details" data-wp-bind--hidden="!state.itemDataHasMultipleAttributes">
+										<ul
+											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'variation' ) ); ?>
+											class="wc-block-components-product-details"
+											data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
+										>
 											<template
 												data-wp-each--item-data="state.cartItem.variation"
 												data-wp-each-key="context.itemData.raw_attribute"
 											>
-												<li data-wp-bind--class="state.productAttributeClass">
-													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataName"></span>
-													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemData.value"></span>
+												<li data-wp-bind--class="state.cartItemDataAttr.className">
+													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
+												</li>
+											</template>
+										</ul>
+										<div
+											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'item_data' ) ); ?>
+											class="wc-block-components-product-details"
+											data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
+										>
+											<div data-wp-bind--class="state.cartItemDataAttr.className">
+												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
+											</div>
+										</div>
+										<ul
+											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'item_data' ) ); ?>
+											class="wc-block-components-product-details"
+											data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
+										>
+											<template
+												data-wp-each--item-data="state.cartItem.item_data"
+												data-wp-each-key="context.itemData.key"
+											>
+												<li data-wp-bind--class="state.cartItemDataAttr.className">
+													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
 												</li>
 											</template>
 										</ul>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -174,6 +174,17 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
+										<ul class="wc-block-components-product-details">
+											<template
+												data-wp-each--item-data="state.cartItem.variation"
+												data-wp-each-key="context.itemData.raw_attribute"
+											>
+												<li data-wp-bind--class="state.productAttributeClass">
+													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataName"></span>
+													<span class="wc-block-components-product-details__value" data-wp-text="context.itemData.value"></span>
+												</li>
+											</template>
+										</ul>
 									</div>
 									<div class="wc-block-cart-item__quantity">
 										<div class="wc-block-components-quantity-selector" data-wp-bind--hidden="state.cartItem.sold_individually">

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -174,56 +174,8 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
-										<div
-											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'variation' ) ); ?>
-											class="wc-block-components-product-details"
-											data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
-										>
-											<div data-wp-bind--class="state.cartItemDataAttr.className">
-												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-											</div>
-										</div>
-										<ul
-											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'variation' ) ); ?>
-											class="wc-block-components-product-details"
-											data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
-										>
-											<template
-												data-wp-each--item-data="state.cartItem.variation"
-												data-wp-each-key="context.itemData.raw_attribute"
-											>
-												<li data-wp-bind--class="state.cartItemDataAttr.className">
-													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-												</li>
-											</template>
-										</ul>
-										<div
-											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'item_data' ) ); ?>
-											class="wc-block-components-product-details"
-											data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
-										>
-											<div data-wp-bind--class="state.cartItemDataAttr.className">
-												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-											</div>
-										</div>
-										<ul
-											<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => 'item_data' ) ); ?>
-											class="wc-block-components-product-details"
-											data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
-										>
-											<template
-												data-wp-each--item-data="state.cartItem.item_data"
-												data-wp-each-key="context.itemData.key"
-											>
-												<li data-wp-bind--class="state.cartItemDataAttr.className">
-													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-												</li>
-											</template>
-										</ul>
+										<?php echo $this->render_experimental_iapi_product_details_markup( 'variation' ); ?>
+										<?php echo $this->render_experimental_iapi_product_details_markup( 'item_data' ); ?>
 									</div>
 									<div class="wc-block-cart-item__quantity">
 										<div class="wc-block-components-quantity-selector" data-wp-bind--hidden="state.cartItem.sold_individually">
@@ -294,6 +246,44 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 				</tbody>
 			</table>
 		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render markup for product details.
+	 *
+	 * @param string $property The property to render in the product details markup.
+	 * @return string Rendered product details output.
+	 */
+	protected function render_experimental_iapi_product_details_markup( $property ) {
+		ob_start();
+		?>
+		<div
+			<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => $property ) ); ?>
+			class="wc-block-components-product-details"
+			data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
+		>
+			<div data-wp-bind--class="state.cartItemDataAttr.className">
+				<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+				<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
+			</div>
+		</div>
+		<ul
+			<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => $property ) ); ?>
+			class="wc-block-components-product-details"
+			data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
+		>
+			<template
+				data-wp-each--item-data="state.cartItem.<?php echo esc_attr( $property ); ?>"
+				data-wp-each-key="context.itemData.raw_attribute"
+			>
+				<li data-wp-bind--class="state.cartItemDataAttr.className">
+					<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+					<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
+				</li>
+			</template>
+		</ul>
 		<?php
 		return ob_get_clean();
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -174,14 +174,20 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
-										<ul class="wc-block-components-product-details">
+										<div class="wc-block-components-product-details" data-wp-bind--hidden="state.itemDataHasMultipleAttributes">
+											<div data-wp-bind--class="state.productAttributeClass">
+												<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataName"></span>
+												<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemData.value"></span>
+											</div>
+										</div>
+										<ul class="wc-block-components-product-details" data-wp-bind--hidden="!state.itemDataHasMultipleAttributes">
 											<template
 												data-wp-each--item-data="state.cartItem.variation"
 												data-wp-each-key="context.itemData.raw_attribute"
 											>
 												<li data-wp-bind--class="state.productAttributeClass">
 													<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataName"></span>
-													<span class="wc-block-components-product-details__value" data-wp-text="context.itemData.value"></span>
+													<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemData.value"></span>
 												</li>
 											</template>
 										</ul>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -293,7 +293,10 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 	private function render_experimental_iapi_product_details_item_markup( $tag_name ) {
 		ob_start();
 		?>
-		<<?php echo tag_escape( $tag_name ); ?> data-wp-bind--class="state.cartItemDataAttr.className">
+		<<?php echo tag_escape( $tag_name ); ?>
+			data-wp-bind--hidden="state.cartItemDataAttr.hidden"
+			data-wp-bind--class="state.cartItemDataAttr.className"
+		>
 			<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
 			<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
 		</<?php echo tag_escape( $tag_name ); ?>>

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -257,20 +257,19 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 	 * @return string Rendered product details output.
 	 */
 	protected function render_experimental_iapi_product_details_markup( $property ) {
+		$context = array( 'dataProperty' => $property );
+
 		ob_start();
 		?>
 		<div
-			<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => $property ) ); ?>
+			<?php wp_interactivity_data_wp_context( $context ); ?>
 			class="wc-block-components-product-details"
 			data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
 		>
-			<div data-wp-bind--class="state.cartItemDataAttr.className">
-				<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-				<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-			</div>
+			<?php echo $this->render_experimental_iapi_product_details_item_markup( 'div' ); ?>
 		</div>
 		<ul
-			<?php echo wp_interactivity_data_wp_context( array( 'dataProperty' => $property ) ); ?>
+			<?php wp_interactivity_data_wp_context( $context ); ?>
 			class="wc-block-components-product-details"
 			data-wp-bind--hidden="!state.itemDataHasMultipleAttributes"
 		>
@@ -278,12 +277,26 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 				data-wp-each--item-data="state.cartItem.<?php echo esc_attr( $property ); ?>"
 				data-wp-each-key="context.itemData.raw_attribute"
 			>
-				<li data-wp-bind--class="state.cartItemDataAttr.className">
-					<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
-					<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-				</li>
+				<?php echo $this->render_experimental_iapi_product_details_item_markup( 'li' ); ?>
 			</template>
 		</ul>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render markup for a single product detail item.
+	 *
+	 * @param string $tag_name The HTML tag to use for the item.
+	 * @return string Rendered product detail item output.
+	 */
+	private function render_experimental_iapi_product_details_item_markup( $tag_name ) {
+		ob_start();
+		?>
+		<<?php echo $tag_name; ?> data-wp-bind--class="state.cartItemDataAttr.className">
+			<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
+			<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
+		</<?php echo $tag_name; ?>>
 		<?php
 		return ob_get_clean();
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/MiniCartProductsTableBlock.php
@@ -174,8 +174,8 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 										<div data-wp-watch="callbacks.itemShortDescription" >
 											<div class="wc-block-components-product-metadata__description"></div>
 										</div>
-										<?php echo $this->render_experimental_iapi_product_details_markup( 'variation' ); ?>
-										<?php echo $this->render_experimental_iapi_product_details_markup( 'item_data' ); ?>
+										<?php echo $this->render_experimental_iapi_product_details_markup( 'variation' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+										<?php echo $this->render_experimental_iapi_product_details_markup( 'item_data' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 									</div>
 									<div class="wc-block-cart-item__quantity">
 										<div class="wc-block-components-quantity-selector" data-wp-bind--hidden="state.cartItem.sold_individually">
@@ -266,7 +266,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 			class="wc-block-components-product-details"
 			data-wp-bind--hidden="state.itemDataHasMultipleAttributes"
 		>
-			<?php echo $this->render_experimental_iapi_product_details_item_markup( 'div' ); ?>
+			<?php echo $this->render_experimental_iapi_product_details_item_markup( 'div' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 		<ul
 			<?php wp_interactivity_data_wp_context( $context ); ?>
@@ -277,7 +277,7 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 				data-wp-each--item-data="state.cartItem.<?php echo esc_attr( $property ); ?>"
 				data-wp-each-key="context.itemData.raw_attribute"
 			>
-				<?php echo $this->render_experimental_iapi_product_details_item_markup( 'li' ); ?>
+				<?php echo $this->render_experimental_iapi_product_details_item_markup( 'li' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</template>
 		</ul>
 		<?php
@@ -293,10 +293,10 @@ class MiniCartProductsTableBlock extends AbstractInnerBlock {
 	private function render_experimental_iapi_product_details_item_markup( $tag_name ) {
 		ob_start();
 		?>
-		<<?php echo $tag_name; ?> data-wp-bind--class="state.cartItemDataAttr.className">
+		<<?php echo tag_escape( $tag_name ); ?> data-wp-bind--class="state.cartItemDataAttr.className">
 			<span class="wc-block-components-product-details__name" data-wp-text="state.cartItemDataAttr.name"></span>
 			<span class="wc-block-components-product-details__value" data-wp-text="state.cartItemDataAttr.value"></span>
-		</<?php echo $tag_name; ?>>
+		</<?php echo tag_escape( $tag_name ); ?>>
 		<?php
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this pull request I'm adding support to minicart items variations and custom data, which is currently not showing.

I've replicated the current behavior included in the React version:
- There are two `ProductDetails` components ([link](https://github.com/woocommerce/woocommerce/blob/ce2a35c6c04dc3f9bf7e1aa7d9a187559688e4d0/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-metadata/index.tsx#L33-L39)): One for the variations and another one for custom data plugins can add.
- The markup will vary depending on the number of items in the array ([link](https://github.com/woocommerce/woocommerce/blob/ce2a35c6c04dc3f9bf7e1aa7d9a187559688e4d0/plugins/woocommerce/client/blocks/assets/js/base/components/cart-checkout/product-details/index.tsx)).

Closes #60527.

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="475" height="479" alt="Screenshot 2025-08-25 at 14 02 25" src="https://github.com/user-attachments/assets/b36eaf74-a7e2-4214-9275-276c9f7ffa07" />   |  <img width="477" height="590" alt="Screenshot 2025-08-25 at 14 01 01" src="https://github.com/user-attachments/assets/165f873c-ad16-49d1-9e77-ca8245704499" />   |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**_Test variations with one attribute_**

1. Add a variable product with just one attribute. Color, in the example.
2. Add it to the cart with any option selected. Blue, in the example.
3. Open the minicart and check that the selected attribute is shown as expected inside a `<div>` and not a `<ul>`.

**_Test variations with multiple attributes_**

1. Add a variable product with just multiple attributes. Logo & Color, in the example.
2. Add it to the cart with any options selected. No & Blue, in the example.
3. Open the minicart and check that the selected attribute is shown as expected inside a `<ul>` and not a `<div>`.

**_Test custom data with one element_**

1. Add a code snippet to add custom data for the product with just one element. This is what I'm using:
```php
function test_get_item_data( $cart_item_data, $cart_item ) {
	$cart_item_data[] = array(
		'key'    => 'Test Name',
		'value'  => 'Test Value',
		'hidden' => false,
	);

	return $cart_item_data;
}
add_filter( 'woocommerce_get_item_data', 'test_get_item_data', 10, 2 );
```
2. Check that it shows in the minicart inside a `<div>` and not a `<ul>`.

**_Test custom data with multiple elements_**

1. Add a code snippet to add custom data for the product with multiple elements. This is what I'm using:
```php
function test_get_item_data( $cart_item_data, $cart_item ) {
	$cart_item_data[] = array(
		'key'    => 'Test Name',
		'value'  => 'Test Value',
		'hidden' => false,
	);

	$cart_item_data[] = array(
		'key'    => 'Test Name 2',
		'value'  => 'Test Value 2',
		'hidden' => false,
	);

	return $cart_item_data;
}
add_filter( 'woocommerce_get_item_data', 'test_get_item_data', 10, 2 );
```
2. Check that it shows in the minicart inside a `<ul>` and not a `<div>`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Support variations and custom data in iAPI-powered minicart

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
