### PR TITLE
[NOX] Fix missing background on Take offline payments section when reordering

### DIFF
--- a/plugins/woocommerce/changelog/enhance-WOOPLUG-5415-take-offline-payments-background-on-reorder
+++ b/plugins/woocommerce/changelog/enhance-WOOPLUG-5415-take-offline-payments-background-on-reorder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fixed missing background on Take offline payments section when reordering on Settings > Payments page.

--- a/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
+++ b/plugins/woocommerce/client/admin/client/settings-payments/components/payment-gateway-list/payment-gateway-list.scss
@@ -8,7 +8,7 @@
 		border-bottom: 1px solid $gray-200;
 
 		&.clickable-list-item:hover {
-			background-color: rgba(0, 0, 0, 0.02); /* Light overlay effect */
+			background-color: $button-hover;
 			cursor: pointer;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR resolves a styling issue on the NOX Payments page where the Take offline payments section lost its background when being reordered. Without the background, the section appeared merged with adjacent sections, causing visual inconsistency.

Closes WOOPLUG-5415

### Screenshots or screen recordings:

Before

https://github.com/user-attachments/assets/3ee92843-fdfd-4bc5-a457-d5f3b80d5610


After

https://github.com/user-attachments/assets/cd0b08ba-75b4-4a82-a3fb-8b0b4facaab7




### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN store with WooCommerce on this PR's branch (here is [a direct create link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments&woocommerce-payments-dev-tools&branches.woocommerce=enhance/WOOPLUG-5415-take-offline-payments-background-on-reorder)).
2. Go to the new store's dashboard, click on WooCommerce > Home to trigger the core profiler, skip it, and set your store's location to Austria.
3. Click on the "Payments" main menu item, and you should see the Payments Settings page.
4. Drag the Take offline payments section and verify the background is not transparent while dragging it over the above and below sections.

<!-- End testing instructions -->

### Testing that has already taken place:

Check above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
