### PR TITLE
Validate quantities are valid in the Add to Cart + Options on setQuantity()

### DIFF
--- a/plugins/woocommerce/changelog/add-quantity-validation-on-input
+++ b/plugins/woocommerce/changelog/add-quantity-validation-on-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Validate quantities are valid in the Add to Cart + Options on every input change

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -188,7 +188,7 @@ export type AddToCartWithOptionsStore = {
 		handleQuantityInput: (
 			event: HTMLElementEvent< HTMLInputElement >
 		) => void;
-		handleQuantityChange: (
+		handleQuantityBlur: (
 			event: HTMLElementEvent< HTMLInputElement >
 		) => void;
 		handleQuantityCheckboxChange: (
@@ -463,7 +463,10 @@ const { actions, state } = store<
 
 				actions.setQuantity( currentValue );
 			},
-			handleQuantityChange: (
+			// We need to listen to blur events instead of change events because
+			// the change event isn't triggered in invalid numbers (ie: writting
+			// letters) if the current value is already invalid or an empty string.
+			handleQuantityBlur: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {
 				const {
@@ -474,14 +477,19 @@ const { actions, state } = store<
 					selectedAttributes,
 				} = getContext< Context >();
 
-				// In grouped products, we allow resetting the inputs to ''.
+				// In grouped products, we reset invalid inputs to ''.
 				if (
-					event.target.value.trim() === '' &&
+					( Number.isNaN( event.target.valueAsNumber ) ||
+						event.target.valueAsNumber === 0 ) &&
 					productType === 'grouped'
 				) {
+					actions.setQuantity( 0 );
+					if ( Number.isNaN( event.target.valueAsNumber ) ) {
+						event.target.value = '';
+					}
+					dispatchChangeEvent( event.target );
 					return;
 				}
-
 				const id = childProductId || productId;
 				const productObject = getProductData(
 					id,
@@ -494,12 +502,14 @@ const { actions, state } = store<
 					return;
 				}
 
+				// In other product types, we reset inputs to `min` if they are
+				// 0 or NaN.
 				const { min } = productObject;
 
 				const newValue =
-					event.target.value.trim() !== '' &&
-					isFinite( event.target.value )
-						? Number( event.target.value )
+					Number.isFinite( event.target.valueAsNumber ) &&
+					event.target.valueAsNumber > 0
+						? event.target.valueAsNumber
 						: min;
 
 				if ( event.target.value !== newValue.toString() ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { FormEvent, HTMLElementEvent } from 'react';
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, getConfig } from '@wordpress/interactivity';
 import type {
 	Store as WooCommerce,
 	SelectedAttributes,
@@ -66,16 +66,20 @@ const getInputElementFromEvent = (
 	return inputElement;
 };
 
-const getProductData = (
+export const getProductData = (
 	id: number,
 	productType: string,
-	availableVariations: AvailableVariation[],
-	selectedAttributes: SelectedAttributes[]
-): ( ProductData & { id: number } ) | null => {
+	availableVariations?: AvailableVariation[],
+	selectedAttributes?: SelectedAttributes[]
+) => {
 	let productId = id;
 	let productData: ProductData | undefined;
 
-	if ( productType === 'variable' ) {
+	if (
+		productType === 'variable' &&
+		availableVariations &&
+		selectedAttributes
+	) {
 		const matchedVariation = getMatchedVariation(
 			availableVariations,
 			selectedAttributes
@@ -171,6 +175,7 @@ export type AddToCartWithOptionsStore = {
 		validationErrors: AddToCartError[];
 	};
 	actions: {
+		validateQuantity: ( value: number ) => void;
 		setQuantity: ( value: number ) => void;
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
@@ -212,17 +217,10 @@ const { actions, state } = store<
 
 				return [];
 			},
-
 			get isFormValid(): boolean {
 				const context = getContext< Context >();
 				if ( ! context ) {
 					return true;
-				}
-
-				const { productType, quantity } = context;
-
-				if ( productType === 'grouped' ) {
-					return Object.values( quantity ).some( ( qty ) => qty > 0 );
 				}
 
 				return state.validationErrors.length === 0;
@@ -298,6 +296,30 @@ const { actions, state } = store<
 			},
 		},
 		actions: {
+			validateQuantity( value: number ) {
+				actions.clearErrors( 'invalid-quantities' );
+
+				const context = getContext< Context >();
+
+				// If selected quantity is invalid, add an error.
+				const { variationId } = state;
+				const id = variationId || context.productId;
+				const product = getProductData( id, 'grouped' );
+
+				if (
+					value === 0 ||
+					( product &&
+						( value < product.min || value > product.max ) )
+				) {
+					const { errorMessages } = getConfig();
+
+					actions.addError( {
+						code: 'invalidQuantities',
+						message: errorMessages?.invalidQuantities || '',
+						group: 'invalid-quantities',
+					} );
+				}
+			},
 			setQuantity( value: number ) {
 				const context = getContext< Context >();
 
@@ -319,6 +341,8 @@ const { actions, state } = store<
 						[ id ]: value,
 					};
 				}
+
+				actions.validateQuantity( value );
 			},
 			addError: ( error: AddToCartError ): string => {
 				const { validationErrors } = state;
@@ -461,20 +485,21 @@ const { actions, state } = store<
 			handleQuantityChange: (
 				event: HTMLElementEvent< HTMLInputElement >
 			) => {
-				const inputData = getInputData( event );
-				if ( ! inputData ) {
-					return;
-				}
-
-				const { childProductId } = getContext< Context >();
-				const { currentValue } = inputData;
-
 				const {
+					childProductId,
 					productType,
 					productId,
 					availableVariations,
 					selectedAttributes,
 				} = getContext< Context >();
+
+				// In grouped products, we allow resetting the inputs to ''.
+				if (
+					event.target.value.trim() === '' &&
+					productType === 'grouped'
+				) {
+					return;
+				}
 
 				const id = childProductId || productId;
 				const productObject = getProductData(
@@ -488,26 +513,13 @@ const { actions, state } = store<
 					return;
 				}
 
-				const { min, max, step } = productObject;
+				const { min } = productObject;
 
-				if (
-					typeof step !== 'number' ||
-					typeof min !== 'number' ||
-					typeof max !== 'number'
-				) {
-					return;
-				}
-
-				let newValue = Math.min(
-					max ?? Infinity,
-					Math.max( min, currentValue )
-				);
-
-				// In grouped product children, we allow decreasing the value
-				// down to 0, even if the minimum value is greater than 0.
-				if ( productType === 'grouped' && currentValue < min ) {
-					newValue = 0;
-				}
+				const newValue =
+					event.target.value.trim() !== '' &&
+					isFinite( event.target.value )
+						? event.target.value
+						: min;
 
 				if ( event.target.value !== newValue.toString() ) {
 					actions.setQuantity( newValue );

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -218,11 +218,6 @@ const { actions, state } = store<
 				return [];
 			},
 			get isFormValid(): boolean {
-				const context = getContext< Context >();
-				if ( ! context ) {
-					return true;
-				}
-
 				return state.validationErrors.length === 0;
 			},
 			get allowsDecrease() {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -124,7 +124,7 @@ const getInputData = (
 		return;
 	}
 
-	const parsedValue = parseInt( inputElement.value, 10 );
+	const parsedValue = Number( inputElement.value );
 	const currentValue = isNaN( parsedValue ) ? 0 : parsedValue;
 
 	return {
@@ -299,12 +299,13 @@ const { actions, state } = store<
 				// If selected quantity is invalid, add an error.
 				const { variationId } = state;
 				const id = variationId || context.productId;
-				const product = getProductData( id, 'grouped' );
+				const productObject = getProductData( id, context.productType );
 
 				if (
 					value === 0 ||
-					( product &&
-						( value < product.min || value > product.max ) )
+					( productObject &&
+						( value < productObject.min ||
+							value > productObject.max ) )
 				) {
 					const { errorMessages } = getConfig();
 
@@ -513,7 +514,7 @@ const { actions, state } = store<
 				const newValue =
 					event.target.value.trim() !== '' &&
 					isFinite( event.target.value )
-						? event.target.value
+						? Number( event.target.value )
 						: min;
 
 				if ( event.target.value !== newValue.toString() ) {

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -250,10 +250,6 @@ const { actions, state } = store<
 
 				const { id, min, step } = productObject;
 
-				if ( typeof step !== 'number' || typeof min !== 'number' ) {
-					return true;
-				}
-
 				const currentQuantity = quantity[ id ] || 0;
 
 				return currentQuantity - step >= min;
@@ -280,10 +276,6 @@ const { actions, state } = store<
 				}
 
 				const { id, max, step } = productObject;
-
-				if ( typeof step !== 'number' || typeof max !== 'number' ) {
-					return true;
-				}
 
 				const currentQuantity = quantity[ id ] || 0;
 
@@ -394,14 +386,6 @@ const { actions, state } = store<
 
 				const { max, min, step } = productObject;
 
-				if (
-					typeof step !== 'number' ||
-					typeof min !== 'number' ||
-					typeof max !== 'number'
-				) {
-					return;
-				}
-
 				const newValue = currentValue + step;
 
 				if ( newValue <= max ) {
@@ -439,15 +423,7 @@ const { actions, state } = store<
 					return;
 				}
 
-				const { min, max, step } = productObject;
-
-				if (
-					typeof step !== 'number' ||
-					typeof min !== 'number' ||
-					typeof max !== 'number'
-				) {
-					return;
-				}
+				const { min, step } = productObject;
 
 				let newValue = currentValue - step;
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -175,7 +175,7 @@ export type AddToCartWithOptionsStore = {
 		validationErrors: AddToCartError[];
 	};
 	actions: {
-		validateQuantity: ( value: number ) => void;
+		validateQuantity: ( value?: number ) => void;
 		setQuantity: ( value: number ) => void;
 		addError: ( error: AddToCartError ) => string;
 		clearErrors: ( group?: string ) => void;
@@ -283,8 +283,12 @@ const { actions, state } = store<
 			},
 		},
 		actions: {
-			validateQuantity( value: number ) {
+			validateQuantity( value?: number ) {
 				actions.clearErrors( 'invalid-quantities' );
+
+				if ( typeof value !== 'number' ) {
+					return;
+				}
 
 				const context = getContext< Context >();
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/frontend.ts
@@ -69,8 +69,8 @@ const getInputElementFromEvent = (
 export const getProductData = (
 	id: number,
 	productType: string,
-	availableVariations?: AvailableVariation[],
-	selectedAttributes?: SelectedAttributes[]
+	availableVariations: AvailableVariation[],
+	selectedAttributes: SelectedAttributes[]
 ) => {
 	let productId = id;
 	let productData: ProductData | undefined;
@@ -295,7 +295,12 @@ const { actions, state } = store<
 				// If selected quantity is invalid, add an error.
 				const { variationId } = state;
 				const id = variationId || context.productId;
-				const productObject = getProductData( id, context.productType );
+				const productObject = getProductData(
+					id,
+					context.productType,
+					context.availableVariations,
+					context.selectedAttributes
+				);
 
 				if (
 					value === 0 ||

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -11,8 +11,7 @@ import type {
 	AddToCartWithOptionsStore,
 	Context as AddToCartWithOptionsStoreContext,
 } from '../frontend';
-
-import { getNewQuantity } from '../frontend';
+import { getNewQuantity, getProductData } from '../frontend';
 
 // Stores are locked to prevent 3PD usage until the API is stable.
 const universalLock =
@@ -21,11 +20,11 @@ const universalLock =
 export type GroupedProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		actions: {
-			setQuantity: ( value: number ) => void;
+			validateQuantity: () => void;
 			addToCart: () => void;
 		};
 		callbacks: {
-			validateGrouped: () => void;
+			validateQuantities: () => void;
 		};
 	};
 
@@ -33,6 +32,50 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 	'woocommerce/add-to-cart-with-options',
 	{
 		actions: {
+			validateQuantity() {
+				actions.clearErrors( 'invalid-quantities' );
+
+				const { errorMessages } = getConfig();
+				const context =
+					getContext< AddToCartWithOptionsStoreContext >();
+
+				// Validate that at least one product quantity is above 0.
+				const hasNonZeroQuantity = Object.values(
+					context.quantity
+				).some( ( qty ) => qty > 0 );
+
+				if ( ! hasNonZeroQuantity ) {
+					actions.addError( {
+						code: 'groupedProductAddToCartMissingItems',
+						message:
+							errorMessages?.groupedProductAddToCartMissingItems ||
+							'',
+						group: 'invalid-quantities',
+					} );
+
+					return;
+				}
+
+				// Validate that all product quantities are within the min and max (or 0).
+				const hasInvalidQuantity = Object.entries(
+					context.quantity
+				).some( ( [ id, qty ] ) => {
+					const product = getProductData( Number( id ), 'grouped' );
+					return (
+						qty !== 0 &&
+						( qty < ( product?.min ?? 0 ) ||
+							qty > ( product?.max ?? Infinity ) )
+					);
+				} );
+
+				if ( hasInvalidQuantity ) {
+					actions.addError( {
+						code: 'invalidQuantities',
+						message: errorMessages?.invalidQuantities || '',
+						group: 'invalid-quantities',
+					} );
+				}
+			},
 			*addToCart() {
 				// Todo: Use the module exports instead of `store()` once the
 				// woocommerce store is public.
@@ -75,27 +118,8 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 			},
 		},
 		callbacks: {
-			validateGrouped: () => {
-				actions.clearErrors( 'grouped-product' );
-
-				const { errorMessages } = getConfig();
-
-				const { quantity } =
-					getContext< AddToCartWithOptionsStoreContext >();
-
-				const hasNonZeroQuantity = Object.values( quantity ).some(
-					( val ) => val > 0
-				);
-
-				if ( ! hasNonZeroQuantity ) {
-					actions.addError( {
-						code: 'groupedProductAddToCartMissingItems',
-						message:
-							errorMessages?.groupedProductAddToCartMissingItems ||
-							'',
-						group: 'grouped-product',
-					} );
-				}
+			validateQuantities() {
+				actions.validateQuantity();
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -23,7 +23,7 @@ const universalLock =
 export type GroupedProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		actions: {
-			validateQuantity: ( value: number ) => void;
+			validateQuantity: ( value?: number ) => void;
 			addToCart: () => void;
 		};
 		callbacks: {
@@ -35,11 +35,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 	'woocommerce/add-to-cart-with-options',
 	{
 		actions: {
-			// The `validateQuantity` action usually gets a `value` parameter,
-			// but we don't need it in Grouped products, as validation is done
-			// based on the quantities of all child products.
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			validateQuantity( _: number ) {
+			validateQuantity() {
 				actions.clearErrors( 'invalid-quantities' );
 
 				const { errorMessages } = getConfig();
@@ -129,7 +125,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 		},
 		callbacks: {
 			validateQuantities() {
-				actions.validateQuantity( 0 );
+				actions.validateQuantity();
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -65,7 +65,9 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 				).some( ( [ id, qty ] ) => {
 					const productObject = getProductData(
 						Number( id ),
-						context.productType
+						context.productType,
+						context.availableVariations,
+						context.selectedAttributes
 					);
 					return (
 						qty !== 0 &&

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { store, getContext, getConfig } from '@wordpress/interactivity';
-import type { ClientCartItem } from '@woocommerce/stores/woocommerce/cart';
+import type {
+	ClientCartItem,
+	Store as WooCommerce,
+} from '@woocommerce/stores/woocommerce/cart';
 
 /**
  * Internal dependencies
@@ -20,7 +23,7 @@ const universalLock =
 export type GroupedProductAddToCartWithOptionsStore =
 	AddToCartWithOptionsStore & {
 		actions: {
-			validateQuantity: () => void;
+			validateQuantity: ( value: number ) => void;
 			addToCart: () => void;
 		};
 		callbacks: {
@@ -32,7 +35,10 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 	'woocommerce/add-to-cart-with-options',
 	{
 		actions: {
-			validateQuantity() {
+			// The `validateQuantity` action usually gets a `value` parameter,
+			// but we don't need it in Grouped products, as validation is done
+			// based on the quantities of all child products.
+			validateQuantity( _: number ) {
 				actions.clearErrors( 'invalid-quantities' );
 
 				const { errorMessages } = getConfig();
@@ -60,11 +66,14 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 				const hasInvalidQuantity = Object.entries(
 					context.quantity
 				).some( ( [ id, qty ] ) => {
-					const product = getProductData( Number( id ), 'grouped' );
+					const productObject = getProductData(
+						Number( id ),
+						context.productType
+					);
 					return (
 						qty !== 0 &&
-						( qty < ( product?.min ?? 0 ) ||
-							qty > ( product?.max ?? Infinity ) )
+						( qty < ( productObject?.min ?? 0 ) ||
+							qty > ( productObject?.max ?? Infinity ) )
 					);
 				} );
 
@@ -119,7 +128,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 		},
 		callbacks: {
 			validateQuantities() {
-				actions.validateQuantity();
+				actions.validateQuantity( 0 );
 			},
 		},
 	},

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/add-to-cart-with-options/grouped-product-selector/frontend.ts
@@ -38,6 +38,7 @@ const { actions } = store< GroupedProductAddToCartWithOptionsStore >(
 			// The `validateQuantity` action usually gets a `value` parameter,
 			// but we don't need it in Grouped products, as validation is done
 			// based on the quantities of all child products.
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			validateQuantity( _: number ) {
 				actions.clearErrors( 'invalid-quantities' );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -355,6 +355,21 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await quantityInput.fill( '8' );
 
 			await expect( increaseQuantityButton ).toBeDisabled();
+
+			// Make sure quantities below min are not allowed even when manually filled.
+			const addToCartButton = page.getByRole( 'button', {
+				name: 'Add to cart: “T-Shirt”',
+			} );
+
+			await quantityInput.fill( '3' );
+			await expect( addToCartButton ).toHaveClass( /disabled/ );
+			await expect( reduceQuantityButton ).toBeDisabled();
+			await expect( increaseQuantityButton ).toBeEnabled();
+
+			// Verify setting the input to an empty string resets the value to the min.
+			await quantityInput.fill( '' );
+			await quantityInput.blur();
+			await expect( quantityInput ).toHaveValue( '4' );
 		} );
 
 		await test.step( 'in grouped products', async () => {
@@ -400,10 +415,19 @@ test.describe( 'Add to Cart + Options Block', () => {
 			await expect( reduceQuantityButton ).toBeDisabled();
 
 			// Make sure quantities below min are not allowed even when manually filled.
-			await quantityInput.fill( '3' );
-			await quantityInput.blur();
+			const addToCartButton = page.getByRole( 'button', {
+				name: 'Add to cart',
+			} );
 
-			await expect( quantityInput ).toHaveValue( '0' );
+			await quantityInput.fill( '3' );
+			await expect( addToCartButton ).toHaveClass( /disabled/ );
+			await expect( reduceQuantityButton ).toBeEnabled();
+			await expect( increaseQuantityButton ).toBeEnabled();
+
+			// Verify empty strings are not reset in grouped products.
+			await quantityInput.fill( '' );
+			await quantityInput.blur();
+			await expect( quantityInput ).toHaveValue( '' );
 		} );
 	} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -356,23 +356,53 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await expect( increaseQuantityButton ).toBeDisabled();
 
-			// Make sure quantities below min are not allowed even when manually filled.
 			const addToCartButton = page.getByRole( 'button', {
 				name: 'Add to cart: “T-Shirt”',
 			} );
 
-			await quantityInput.fill( '3' );
-			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
-			await expect( reduceQuantityButton ).toBeDisabled();
-			await expect( increaseQuantityButton ).toBeEnabled();
-			await quantityInput.blur();
-			await expect( quantityInput ).toHaveValue( '3' );
+			await test.step( 'make sure quantities below min are not allowed even when manually filled but they persist in the input field', async () => {
+				await quantityInput.fill( '3' );
+				await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+				await expect( reduceQuantityButton ).toBeDisabled();
+				await expect( increaseQuantityButton ).toBeEnabled();
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '3' );
+			} );
 
-			// Verify setting the input to an empty string resets the value to the min.
-			await quantityInput.fill( '' );
-			await quantityInput.blur();
-			await expect( quantityInput ).toHaveValue( '4' );
-			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
+			await test.step( 'verify 0 is reset in simple products', async () => {
+				await quantityInput.fill( '0' );
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '4' );
+				await expect( addToCartButton ).not.toHaveClass(
+					/\bdisabled\b/
+				);
+			} );
+
+			await test.step( 'verify setting the input to an empty string resets the value to the min', async () => {
+				await quantityInput.fill( '' );
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '4' );
+				await expect( addToCartButton ).not.toHaveClass(
+					/\bdisabled\b/
+				);
+			} );
+
+			await test.step( 'verify letters are reset to min value in simple products', async () => {
+				// Playwright doesn't support filling a numeric input with a
+				// string, but we still want to test this case as users are able
+				// to type letters directly in the input field.
+				await quantityInput.evaluate( ( element: HTMLInputElement ) => {
+					element.value = 'abc';
+					element.focus();
+					requestAnimationFrame( () => {
+						element.blur();
+					} );
+				} );
+				await expect( quantityInput ).toHaveValue( '4' );
+				await expect( addToCartButton ).not.toHaveClass(
+					/\bdisabled\b/
+				);
+			} );
 		} );
 
 		await test.step( 'in grouped products', async () => {
@@ -417,23 +447,47 @@ test.describe( 'Add to Cart + Options Block', () => {
 
 			await expect( reduceQuantityButton ).toBeDisabled();
 
-			// Make sure quantities below min are not allowed even when manually filled.
 			const addToCartButton = page.getByRole( 'button', {
 				name: 'Add to cart',
 			} );
 
-			await quantityInput.fill( '3' );
-			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
-			await expect( reduceQuantityButton ).toBeEnabled();
-			await expect( increaseQuantityButton ).toBeEnabled();
-			await quantityInput.blur();
-			await expect( quantityInput ).toHaveValue( '3' );
+			await test.step( 'make sure quantities below min are not allowed even when manually filled but they persist in the input field', async () => {
+				await quantityInput.fill( '3' );
+				await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+				await expect( reduceQuantityButton ).toBeEnabled();
+				await expect( increaseQuantityButton ).toBeEnabled();
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '3' );
+			} );
 
-			// Verify empty strings are not reset in grouped products.
-			await quantityInput.fill( '' );
-			await quantityInput.blur();
-			await expect( quantityInput ).toHaveValue( '' );
-			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+			await test.step( 'verify 0 is not reset in grouped products', async () => {
+				await quantityInput.fill( '0' );
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '0' );
+				await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+			} );
+
+			await test.step( 'verify empty strings are not reset in grouped products', async () => {
+				await quantityInput.fill( '' );
+				await quantityInput.blur();
+				await expect( quantityInput ).toHaveValue( '' );
+				await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+			} );
+
+			await test.step( 'verify letters are reset to an empty string in grouped products', async () => {
+				// Playwright doesn't support filling a numeric input with a
+				// string, but we still want to test this case as users are able
+				// to type letters directly in the input field.
+				await quantityInput.evaluate( ( element: HTMLInputElement ) => {
+					element.value = 'abc';
+					element.focus();
+					requestAnimationFrame( () => {
+						element.blur();
+					} );
+				} );
+				await expect( quantityInput ).toHaveValue( '' );
+				await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
+			} );
 		} );
 	} );
 

--- a/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
+++ b/plugins/woocommerce/client/blocks/tests/e2e/tests/add-to-cart-with-options/add-to-cart-with-options.block_theme.spec.ts
@@ -164,7 +164,7 @@ test.describe( 'Add to Cart + Options Block', () => {
 			// Note: The button is always enabled for accessibility reasons.
 			// Instead, we check directly for the "disabled" class, which grays
 			// out the button.
-			await expect( addToCartButton ).not.toHaveClass( /disabled/ );
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 
 			await addToCartButton.click();
 
@@ -362,14 +362,17 @@ test.describe( 'Add to Cart + Options Block', () => {
 			} );
 
 			await quantityInput.fill( '3' );
-			await expect( addToCartButton ).toHaveClass( /disabled/ );
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 			await expect( reduceQuantityButton ).toBeDisabled();
 			await expect( increaseQuantityButton ).toBeEnabled();
+			await quantityInput.blur();
+			await expect( quantityInput ).toHaveValue( '3' );
 
 			// Verify setting the input to an empty string resets the value to the min.
 			await quantityInput.fill( '' );
 			await quantityInput.blur();
 			await expect( quantityInput ).toHaveValue( '4' );
+			await expect( addToCartButton ).not.toHaveClass( /\bdisabled\b/ );
 		} );
 
 		await test.step( 'in grouped products', async () => {
@@ -420,14 +423,17 @@ test.describe( 'Add to Cart + Options Block', () => {
 			} );
 
 			await quantityInput.fill( '3' );
-			await expect( addToCartButton ).toHaveClass( /disabled/ );
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 			await expect( reduceQuantityButton ).toBeEnabled();
 			await expect( increaseQuantityButton ).toBeEnabled();
+			await quantityInput.blur();
+			await expect( quantityInput ).toHaveValue( '3' );
 
 			// Verify empty strings are not reset in grouped products.
 			await quantityInput.fill( '' );
 			await quantityInput.blur();
 			await expect( quantityInput ).toHaveValue( '' );
+			await expect( addToCartButton ).toHaveClass( /\bdisabled\b/ );
 		} );
 	} );
 

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/AddToCartWithOptions.php
@@ -200,6 +200,10 @@ class AddToCartWithOptions extends AbstractBlock {
 				'woocommerce/add-to-cart-with-options',
 				array(
 					'errorMessages' => array(
+						'invalidQuantities'                => esc_html__(
+							'Please select a valid quantity to add to the cart.',
+							'woocommerce'
+						),
 						'groupedProductAddToCartMissingItems' => esc_html__(
 							'Please select some products to add to the cart.',
 							'woocommerce'

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelector.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/GroupedProductSelector.php
@@ -36,7 +36,7 @@ class GroupedProductSelector extends AbstractBlock {
 			$p = new \WP_HTML_Tag_Processor( $content );
 
 			if ( $p->next_tag( array( 'class_name' => 'wp-block-woocommerce-add-to-cart-with-options-grouped-product-selector' ) ) ) {
-				$p->set_attribute( 'data-wp-watch--validate', 'callbacks.validateGrouped' );
+				$p->set_attribute( 'data-wp-init', 'callbacks.validateQuantities' );
 			}
 
 			return $p->get_updated_html();

--- a/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/AddToCartWithOptions/Utils.php
@@ -71,7 +71,7 @@ class Utils {
 			strpos( $processor->get_attribute( 'name' ), 'quantity' ) !== false
 		) {
 			$processor->set_attribute( 'data-wp-on--input', 'actions.handleQuantityInput' );
-			$processor->set_attribute( 'data-wp-on--change', 'actions.handleQuantityChange' );
+			$processor->set_attribute( 'data-wp-on--blur', 'actions.handleQuantityBlur' );
 		}
 
 		$quantity_html = $processor->get_updated_html();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

_(Issue originally highlighted by @kmanijak in https://github.com/woocommerce/woocommerce/pull/60543#pullrequestreview-3143424300)_

This PR implements some changes to how quantity validation is handled in the _Add to Cart + Options_ block:

* Now, we validate quantities inside `setQuantity()`, this has the advantage that the _Add to Cart_ button can change its styles from disabled/enabled instantly, instead of having to wait until the inputs are unfocused.
* When introducing a value below the minimum allowed quantity, we don't automatically update it to min. For example, if the minimum quantity accepted for a product is `4` and the shopper introduces `2`, we don't change it to `4`. That's to avoid the case that the shopper introduces `2` and, without unfocusing the input, clicks on the button, which would unexpectedly add 4 items. This is also aligned with how things behave in classic templates.

### How to test the changes in this Pull Request:

1. Add this code snippet to modify the `min`, `max` and `step` quantities of one of the simple products (you will need to change `110` with the product id):

```PHP
add_filter( 'woocommerce_quantity_input_min', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 4;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_step', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 2;
	}
	return $default;
}, 10, 2 );

add_filter( 'woocommerce_quantity_input_max', function( $default, $product ) {
	if ( $product->get_id() === 110 ) {
		return 8;
	}
	return $default;
}, 10, 2 );
```
2. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_.
3. Click on the _Add to Cart with Options_ block and update to the blockified version.
4. Go to the frontend of the simple product that you added the quantity constraints to. In another tab, go to the frontend of a grouped product containing the simple product with quantity constraints.
5. Verify that:
  * If you leave the input to an empty string, a space or a random string, it gets automatically updated to the min product value (or 0 in grouped product children).
  * If you set a numeric value smaller than min, it doesn't auto-update, but the _Add to Cart_ button looks disabled.
  * In simple products, you can't set the value to 0.
  * In grouped products, if all products are set to 0, the _Add to Cart_ button looks disabled. It only gets enabled if at least one of the products get a quantity value higher than its minimum.
  * You can still use the reduce and increase quantity buttons as usual.
  
Before | After
--- | ---
<img width="1515" height="976" alt="imatge" src="https://github.com/user-attachments/assets/8c0fc389-0501-473e-9499-af7e59289fb5" /> | <img width="1515" height="976" alt="imatge" src="https://github.com/user-attachments/assets/b925d3e0-be01-46f2-9d1c-6fdb36f60b8a" />