### PR TITLE
Refactor EmailContent block rendering in editor

### DIFF
--- a/packages/php/email-editor/changelog/wooplug-4686-apply-email-styles-to-woo-email-content-block-in-the-editor
+++ b/packages/php/email-editor/changelog/wooplug-4686-apply-email-styles-to-woo-email-content-block-in-the-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove `block_preview_url` from `WooCommerceEmailEditor` object

--- a/packages/php/email-editor/src/Engine/class-assets-manager.php
+++ b/packages/php/email-editor/src/Engine/class-assets-manager.php
@@ -214,7 +214,6 @@ class Assets_Manager {
 				'send'     => admin_url( 'admin.php?page=wc-settings&tab=email' ),
 				'back'     => admin_url( 'admin.php?page=wc-settings&tab=email' ),
 			),
-			'block_preview_url'     => esc_url( wp_nonce_url( admin_url( '?preview_woocommerce_mail_editor_content=true' ), 'preview-mail' ) ),
 		);
 
 		wp_localize_script(

--- a/plugins/woocommerce/changelog/wooplug-4686-apply-email-styles-to-woo-email-content-block-in-the-editor
+++ b/plugins/woocommerce/changelog/wooplug-4686-apply-email-styles-to-woo-email-content-block-in-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Refactor EmailContent block rendering in the editor to use `<ServerSideRender />` instead of iframe

--- a/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
+++ b/plugins/woocommerce/client/admin/client/wp-admin-scripts/email-editor-integration/global.d.ts
@@ -7,7 +7,6 @@ interface Window {
 			label: string;
 			id: string;
 		}[];
-		block_preview_url: string;
 		sender_settings: {
 			from_name: string;
 			from_address: string;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/block.json
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/block.json
@@ -8,7 +8,11 @@
 		"inserter": false,
 		"email": true
 	},
-	"attributes": {},
+	"attributes": {
+		"emailType": {
+			"type": "string"
+		}
+	},
 	"apiVersion": 3,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/edit.tsx
@@ -82,10 +82,7 @@ export default function Edit() {
 		>
 			<ServerSideRender
 				block={ metadata.name }
-				attributes={ {
-					...blockProps,
-					emailType,
-				} }
+				attributes={ { emailType } }
 			></ServerSideRender>
 
 			{ isHovered && (

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/edit.tsx
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/email-content/edit.tsx
@@ -2,13 +2,20 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
 import {
 	__experimentalText as Text, // eslint-disable-line
 } from '@wordpress/components';
 // eslint-disable-next-line @woocommerce/dependency-group
 import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
 
 declare global {
 	interface Window {
@@ -18,7 +25,6 @@ declare global {
 				value: string;
 				id: string;
 			} >;
-			block_preview_url?: string;
 		};
 	}
 }
@@ -42,101 +48,60 @@ function HoverContent() {
 	);
 }
 
-const updateIFrameBackgroundColor = (
-	iframeRef: React.RefObject< HTMLIFrameElement >,
-	isHovered: boolean
-) => {
-	if ( iframeRef?.current?.contentWindow?.document.body ) {
-		iframeRef.current.contentWindow.document.body.style.overflow = 'hidden';
-		iframeRef.current.contentWindow.document.body.style.pointerEvents =
-			'none';
-		iframeRef.current.contentWindow.document.body.style.backgroundColor =
-			isHovered
-				? '#00000059'
-				: iframeRef.current.contentWindow?.document?.bgColor;
-	}
-};
-
 const getEmailType = ( value: string ) => {
 	return window.WooCommerceEmailEditor?.email_types?.find(
 		( emailType ) => emailType.value === value
 	)?.id;
 };
 
-const updateiFrameSource = (
-	iframeRef: React.RefObject< HTMLIFrameElement >,
-	url: string
-) => {
-	// Update iframe src using replace to avoid polluting browser history
-	iframeRef?.current?.contentWindow?.location.replace( url );
-};
-
 const DEFAULT_EMAIL_TYPE = 'WC_Email_Customer_Processing_Order';
 
 export default function Edit() {
+	const [ isHovered, setIsHovered ] = useState( false );
+	const blockProps = useBlockProps();
 	const { postSlug } = useSelect(
 		( select ) => ( {
 			postSlug: select( editorStore ).getCurrentPost?.()?.slug,
 		} ),
 		[]
 	);
-
-	const iframeRef = useRef< HTMLIFrameElement | null >( null );
-	const [ isHovered, setIsHovered ] = useState( false );
-
-	const previewUrlBase = window.WooCommerceEmailEditor?.block_preview_url;
-
-	useEffect( () => {
-		if ( ! postSlug ) {
-			return;
-		}
-
-		// current email type
-		const currentEmailType = getEmailType( postSlug || '' );
-		if ( currentEmailType && iframeRef.current ) {
-			updateiFrameSource(
-				iframeRef,
-				`${ previewUrlBase }&type=${ currentEmailType }`
-			);
-		}
-	}, [ postSlug, iframeRef, previewUrlBase ] );
+	const emailType = getEmailType( postSlug || '' ) || DEFAULT_EMAIL_TYPE;
 
 	return (
 		<div
+			{ ...blockProps }
+			onMouseEnter={ () => {
+				setIsHovered( true );
+			} }
+			onMouseLeave={ () => {
+				setIsHovered( false );
+			} }
 			style={ {
 				position: 'relative',
 			} }
 		>
-			<iframe
-				style={ {
-					width: '100%',
-					height:
-						iframeRef?.current?.contentWindow?.document?.body
-							?.clientHeight || '750px',
-					backgroundColor: 'initial',
-					minHeight: '100px',
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ {
+					...blockProps,
+					emailType,
 				} }
-				ref={ iframeRef }
-				src={ `${ previewUrlBase }&type=${ DEFAULT_EMAIL_TYPE }` }
-				title={ __( 'Email preview frame', 'woocommerce' ) }
-				onMouseEnter={ () => {
-					setIsHovered( true );
-					updateIFrameBackgroundColor( iframeRef, true );
-				} }
-				onMouseLeave={ () => {
-					setIsHovered( false );
-					updateIFrameBackgroundColor( iframeRef, false );
-				} }
-			/>
+			></ServerSideRender>
+
 			{ isHovered && (
 				<div
 					style={ {
 						position: 'absolute',
-						top: '50%',
-						left: '50%',
-						transform: 'translate(-50%, -50%)',
 						zIndex: 1000,
-						pointerEvents: 'none', // This ensures hover events pass through to the iframe
+						left: 0,
+						top: 0,
+						width: '100%',
+						height: '100%',
+						background: 'rgba(0,0,0,0.5)',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						pointerEvents: 'none', // This ensures hover events pass through to ServerSideRender elements
 					} }
 				>
 					<HoverContent />

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -37,7 +37,6 @@ class WC_Admin {
 		add_action( 'current_screen', array( $this, 'conditional_includes' ) );
 		add_action( 'admin_init', array( $this, 'buffer' ), 1 );
 		add_action( 'admin_init', array( $this, 'preview_emails' ) );
-		add_action( 'admin_init', array( $this, 'preview_email_editor_dummy_content' ) );
 		add_action( 'admin_init', array( $this, 'prevent_admin_access' ) );
 		add_action( 'admin_init', array( $this, 'admin_redirects' ) );
 		add_action( 'admin_footer', 'wc_print_js', 25 );
@@ -265,44 +264,6 @@ class WC_Admin {
 			// phpcs:enable
 			exit;
 		}
-	}
-
-	/**
-	 * Preview email editor placeholder dummy content.
-	 */
-	public function preview_email_editor_dummy_content() {
-		$message = '';
-		if ( ! isset( $_GET['preview_woocommerce_mail_editor_content'] ) ) {
-			return;
-		}
-
-		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'preview-mail' ) ) {
-			die( 'Security check' );
-		}
-
-		/**
-		 * Email preview instance for rendering dummy content.
-		 *
-		 * @var EmailPreview $email_preview - email preview instance
-		 */
-		$email_preview = wc_get_container()->get( EmailPreview::class );
-
-		$type_param = EmailPreview::DEFAULT_EMAIL_TYPE;
-		if ( isset( $_GET['type'] ) ) {
-			$type_param = sanitize_text_field( wp_unslash( $_GET['type'] ) );
-		}
-
-		try {
-			$message = $email_preview->generate_placeholder_content( $type_param );
-		} catch ( \Exception $e ) {
-			// Catch other potential errors during content generation.
-			wp_die( esc_html__( 'There was an error rendering the email preview.', 'woocommerce' ), 404 );
-		}
-
-		// Print the placeholder content.
-		// phpcs:ignore WordPress.Security.EscapeOutput
-		echo $message;
-		exit;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmailContent.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmailContent.php
@@ -78,9 +78,10 @@ class EmailContent extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $_GET['context'] ) && $_GET['context'] === 'edit' ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $_GET['context'] ) && 'edit' === sanitize_text_field( wp_unslash( $_GET['context'] ) ) ) {
 			// Block is being rendered for ServerSideRender editor preview.
-			return $this->render_preview( $attributes, $content, $block );
+			return $this->render_preview( $attributes );
 		}
 
 		return BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/EmailContent.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/EmailContent.php
@@ -4,6 +4,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
 use Automattic\WooCommerce\Internal\EmailEditor\BlockEmailRenderer;
+use Automattic\WooCommerce\Internal\EmailEditor\WooContentProcessor;
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
 
 /**
  * EmailContent class.
@@ -41,6 +43,33 @@ class EmailContent extends AbstractBlock {
 	}
 
 	/**
+	 * Renders the block preview for the editor.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered block output.
+	 */
+	protected function render_preview( $attributes ) {
+		/**
+		 * Email preview instance for rendering dummy content.
+		 *
+		 * @var EmailPreview $email_preview - email preview instance
+		 */
+		$email_preview = wc_get_container()->get( EmailPreview::class );
+
+		$type_param = EmailPreview::DEFAULT_EMAIL_TYPE;
+		if ( isset( $attributes['emailType'] ) ) {
+			$type_param = sanitize_text_field( wp_unslash( $attributes['emailType'] ) );
+		}
+
+		try {
+			return $email_preview->generate_placeholder_content( $type_param );
+		} catch ( \Exception $e ) {
+			// Catch other potential errors during content generation.
+			return esc_html__( 'There was an error rendering the email preview.', 'woocommerce' );
+		}
+	}
+
+	/**
 	 * Renders Woo content placeholder to be replaced by content during sending.
 	 *
 	 * @param array     $attributes Block attributes.
@@ -49,6 +78,11 @@ class EmailContent extends AbstractBlock {
 	 * @return string Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST && isset( $_GET['context'] ) && $_GET['context'] === 'edit' ) {
+			// Block is being rendered for ServerSideRender editor preview.
+			return $this->render_preview( $attributes, $content, $block );
+		}
+
 		return BlockEmailRenderer::WOO_EMAIL_CONTENT_PLACEHOLDER;
 	}
 }

--- a/plugins/woocommerce/tests/e2e-pw/tests/email/editor-tracking-selectors.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/email/editor-tracking-selectors.spec.js
@@ -134,6 +134,7 @@ test.describe( 'WooCommerce Email Editor Tracking Selectors', () => {
 		await page
 			.frameLocator( 'iframe[name="editor-canvas"]' )
 			.locator( '.wp-block-heading' )
+			.first()
 			.click();
 		await expect(
 			editorLocator.locator( '.editor-collapsible-block-toolbar__toggle' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR refactors the edit component of the `woocommerce/email-content` block to use `<ServerSideRender />` instead of an iframe that renders the block preview so that the email content inherits the styles from the editor. This change improves the visual consistency between the editor and the rendered email.

Closes [WOOPLUG-4686](https://linear.app/a8c/issue/WOOPLUG-4686/apply-email-styles-to-woo-email-content-block-in-the-editor).

### Screenshots or screen recordings:

<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1197" height="804" alt="XeR1IY5cyFeRS0hi" src="https://github.com/user-attachments/assets/c1b2cb5d-2805-4a67-a887-81236390d58c" /> | <img width="1197" height="804" alt="zqPZGhhMRYFvl7Hl" src="https://github.com/user-attachments/assets/9f25aa1d-deda-4d0c-b680-2227939bdd24" /> |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based email editor from WooCommerce → Settings → Advanced → Features → **Block Email Editor (alpha)**
`woocommerce/email-content`, or refresh your instance so that the emails are created with the correct block name.
2. Open an email in the editor WooCommerce → Settings → **Emails**
3. Change the email styles - e.g. Typography, Color, etc.
4. Confirm the styles are now being applied to the email content elements as well.
5. Confirm the editor styles match the email preview and the email notifications.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Refactor EmailContent block rendering in the editor to use `<ServerSideRender />` instead of iframe
</details>
