### PR TITLE
Ensure `woocommerce_cancel_unpaid_orders` job is requeued after running

### DIFF
--- a/plugins/woocommerce/changelog/fix-cancel-unpaid-orders-job
+++ b/plugins/woocommerce/changelog/fix-cancel-unpaid-orders-job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent woocommerce_cancel_unpaid_orders being queued as unique so it recurs after the stock hold limit

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1098,6 +1098,11 @@ function wc_cancel_unpaid_orders() {
 	 */
 	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
 
+	// Don't reschedule if the interval is 0 to prevent endless loops.
+	if ( $cancel_unpaid_interval < 1 ) {
+		return;
+	}
+
 	// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
 	if ( function_exists( 'as_schedule_single_action' ) ) {
 		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', false );

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1097,7 +1097,7 @@ function wc_cancel_unpaid_orders() {
 
 	// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
 	if ( function_exists( 'as_schedule_single_action' ) ) {
-		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', true );
+		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', false );
 	} else {
 		wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 	}

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1077,8 +1077,18 @@ add_action( 'woocommerce_trash_order', 'wc_update_coupon_usage_counts' );
 function wc_cancel_unpaid_orders() {
 	$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
 
-	// Re-schedule the event before cancelling orders
-	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry.
+	// Clear existing scheduled events (both Action Scheduler and WP-Cron).
+	if ( function_exists( 'as_unschedule_all_actions' ) ) {
+		as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+	}
+	// Always clear WP-Cron events as well in case they exist.
+	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+
+	// Check if we should reschedule. Don't reschedule if stock management is disabled or hold duration is not set.
+	if ( $held_duration < 1 || 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
+		return;
+	}
+
 	/**
 	 * Filters the interval at which to cancel unpaid orders in minutes.
 	 *
@@ -1088,22 +1098,11 @@ function wc_cancel_unpaid_orders() {
 	 */
 	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
 
-	// Clear existing scheduled events.
-	if ( function_exists( 'as_unschedule_all_actions' ) ) {
-		as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
-	} else {
-		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
-	}
-
 	// Schedule the next event using Action Scheduler if available, otherwise fall back to WordPress cron.
 	if ( function_exists( 'as_schedule_single_action' ) ) {
 		as_schedule_single_action( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce', false );
 	} else {
 		wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
-	}
-
-	if ( $held_duration < 1 || 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
-		return;
 	}
 
 	$data_store    = WC_Data_Store::load( 'order' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -35,7 +35,7 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		parent::setUp();
 
 		// Don't allow actual order cancellations during tests.
-		add_filter( 'woocommerce_cancel_unpaid_orders', '__return_false', 10, 0 );
+		add_filter( 'woocommerce_cancel_unpaid_order', '__return_false', 10, 0 );
 		$this->original_hold_stock_minutes  = get_option( 'woocommerce_hold_stock_minutes', 0 );
 		$this->original_manage_stock_option = get_option( 'woocommerce_manage_stock', 'yes' );
 	}
@@ -204,5 +204,6 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		// Remove any filters that might have been added.
 		remove_all_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes' );
 		remove_all_filters( 'woocommerce_cancel_unpaid_orders' );
+		remove_all_filters( 'woocommerce_cancel_unpaid_order' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -48,11 +48,6 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 	 * fixed in PR #60607).
 	 */
 	public function test_cancel_unpaid_orders_reschedules_itself() {
-		// Skip if Action Scheduler is not available.
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			$this->markTestSkipped( 'Action Scheduler not available' );
-		}
-
 		// Enable hold stock functionality with a short interval (1 minute).
 		update_option( 'woocommerce_hold_stock_minutes', 1 );
 		update_option( 'woocommerce_manage_stock', 'yes' );
@@ -101,11 +96,6 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 	 * Test that existing actions are cleared before scheduling new ones.
 	 */
 	public function test_cancel_unpaid_orders_clears_existing_actions() {
-		// Skip if Action Scheduler is not available.
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			$this->markTestSkipped( 'Action Scheduler not available' );
-		}
-
 		// Enable hold stock functionality.
 		update_option( 'woocommerce_hold_stock_minutes', 60 );
 		update_option( 'woocommerce_manage_stock', 'yes' );
@@ -144,11 +134,6 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 	 * Test that the woocommerce_cancel_unpaid_orders_interval_minutes filter works.
 	 */
 	public function test_cancel_unpaid_orders_respects_interval_filter() {
-		// Skip if Action Scheduler is not available.
-		if ( ! function_exists( 'as_schedule_single_action' ) ) {
-			$this->markTestSkipped( 'Action Scheduler not available' );
-		}
-
 		// Set up test conditions.
 		update_option( 'woocommerce_hold_stock_minutes', 60 );
 		update_option( 'woocommerce_manage_stock', 'yes' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -78,7 +78,6 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 
 		// Verify the scheduled time is approximately correct (1 minute + 30 seconds buffer).
 		$expected_time = $now + ( 1 * MINUTE_IN_SECONDS );
-		$expected_time = $now + ( 1 * MINUTE_IN_SECONDS );
 		$this->assertGreaterThanOrEqual(
 			$expected_time - 30,
 			$next_scheduled,

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -1,10 +1,12 @@
 <?php
-declare(strict_types=1);
 /**
  * Tests for WC Cancel Unpaid Orders functionality.
  *
  * @package WooCommerce\Tests\Core
  */
+
+declare(strict_types=1);
+
 
 /**
  * Class WC_Tests_Cancel_Unpaid_Orders.

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -173,6 +173,153 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that no rescheduling happens when hold stock minutes is 0.
+	 */
+	public function test_cancel_unpaid_orders_no_reschedule_when_hold_stock_zero() {
+		// Set hold stock minutes to 0.
+		update_option( 'woocommerce_hold_stock_minutes', 0 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Clear existing actions.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+
+		// Run the function.
+		wc_cancel_unpaid_orders();
+
+		// Verify no action is scheduled.
+		$this->assertFalse(
+			as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+			'No action should be scheduled when hold stock minutes is 0'
+		);
+
+		// Also check WordPress cron.
+		$this->assertFalse(
+			wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+			'No WP cron event should be scheduled when hold stock minutes is 0'
+		);
+	}
+
+	/**
+	 * Test that no rescheduling happens when stock management is disabled.
+	 */
+	public function test_cancel_unpaid_orders_no_reschedule_when_stock_management_disabled() {
+		// Disable stock management.
+		update_option( 'woocommerce_hold_stock_minutes', 60 );
+		update_option( 'woocommerce_manage_stock', 'no' );
+
+		// Clear existing actions.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+
+		// Run the function.
+		wc_cancel_unpaid_orders();
+
+		// Verify no action is scheduled.
+		$this->assertFalse(
+			as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+			'No action should be scheduled when stock management is disabled'
+		);
+
+		// Also check WordPress cron.
+		$this->assertFalse(
+			wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+			'No WP cron event should be scheduled when stock management is disabled'
+		);
+	}
+
+	/**
+	 * Test that no rescheduling happens when interval is filtered to 0 to prevent endless loops.
+	 */
+	public function test_cancel_unpaid_orders_no_reschedule_when_interval_zero() {
+		// Set up test conditions.
+		update_option( 'woocommerce_hold_stock_minutes', 1 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Clear existing actions.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+
+		// Add filter to force interval to 0 (which should prevent rescheduling).
+		add_filter(
+			'woocommerce_cancel_unpaid_orders_interval_minutes',
+			function () {
+				return 0;
+			}
+		);
+
+		// Run the function.
+		wc_cancel_unpaid_orders();
+
+		// Verify no action is scheduled when interval is 0.
+		$this->assertFalse(
+			as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+			'No action should be scheduled when interval is filtered to 0 to prevent endless loops'
+		);
+
+		// Also check WordPress cron.
+		$this->assertFalse(
+			wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+			'No WP cron event should be scheduled when interval is filtered to 0'
+		);
+	}
+
+	/**
+	 * Test that both Action Scheduler and WP-Cron events are cleared.
+	 */
+	public function test_cancel_unpaid_orders_clears_both_as_and_wp_cron() {
+		// Set up test conditions.
+		update_option( 'woocommerce_hold_stock_minutes', 60 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Schedule both types of events.
+		if ( function_exists( 'as_schedule_single_action' ) ) {
+			as_schedule_single_action( time() + 3600, 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+		}
+		wp_schedule_single_event( time() + 7200, 'woocommerce_cancel_unpaid_orders' );
+
+		// Verify both are scheduled.
+		if ( function_exists( 'as_next_scheduled_action' ) ) {
+			$this->assertIsInt(
+				as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+				'Action Scheduler event should be scheduled initially'
+			);
+		}
+		$this->assertIsInt(
+			wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+			'WP-Cron event should be scheduled initially'
+		);
+
+		// Run the function which should clear both and reschedule only one.
+		wc_cancel_unpaid_orders();
+
+		// If Action Scheduler is available, it should be the only one scheduled.
+		if ( function_exists( 'as_next_scheduled_action' ) ) {
+			$this->assertIsInt(
+				as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+				'Action Scheduler event should be scheduled'
+			);
+			// WP-Cron should be cleared.
+			$this->assertFalse(
+				wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+				'WP-Cron event should be cleared when Action Scheduler is used'
+			);
+		} else {
+			// If Action Scheduler is not available, only WP-Cron should be scheduled.
+			$this->assertIsInt(
+				wp_next_scheduled( 'woocommerce_cancel_unpaid_orders' ),
+				'WP-Cron event should be scheduled when Action Scheduler is not available'
+			);
+		}
+	}
+
+	/**
 	 * Clean up after tests.
 	 */
 	public function tearDown(): void {

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -12,6 +12,33 @@ declare(strict_types=1);
 class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 
 	/**
+	 * Original hold stock minutes option value.
+	 *
+	 * @var int
+	 */
+	public $original_hold_stock_minutes = 0;
+
+	/**
+	 * Original manage stock option value.
+	 *
+	 * @var int
+	 */
+	public $original_manage_stock_option = 0;
+
+	/**
+	 * Set up test environment.
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Don't allow actual order cancellations during tests.
+		add_filter( 'woocommerce_cancel_unpaid_orders', '__return_false' );
+		$this->original_hold_stock_minutes  = get_option( 'woocommerce_hold_stock_minutes', 0 );
+		$this->original_manage_stock_option = get_option( 'woocommerce_manage_stock', 'yes' );
+	}
+
+	/**
 	 * Test that wc_cancel_unpaid_orders reschedules itself after running.
 	 *
 	 * This test protects against the regression where the action was marked as unique,
@@ -159,10 +186,11 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
 		}
-		delete_option( 'woocommerce_hold_stock_minutes' );
-		delete_option( 'woocommerce_manage_stock' );
+		update_option( 'woocommerce_hold_stock_minutes', $this->original_hold_stock_minutes );
+		update_option( 'woocommerce_manage_stock', $this->original_manage_stock_option );
 
 		// Remove any filters that might have been added.
 		remove_all_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes' );
+		remove_all_filters( 'woocommerce_cancel_unpaid_orders' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -23,9 +23,9 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 	/**
 	 * Original manage stock option value.
 	 *
-	 * @var int
+	 * @var string
 	 */
-	public $original_manage_stock_option = 0;
+	public $original_manage_stock_option = 'yes';
 
 	/**
 	 * Set up test environment.
@@ -35,7 +35,7 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		parent::setUp();
 
 		// Don't allow actual order cancellations during tests.
-		add_filter( 'woocommerce_cancel_unpaid_orders', '__return_false' );
+		add_filter( 'woocommerce_cancel_unpaid_orders', '__return_false', 10, 0 );
 		$this->original_hold_stock_minutes  = get_option( 'woocommerce_hold_stock_minutes', 0 );
 		$this->original_manage_stock_option = get_option( 'woocommerce_manage_stock', 'yes' );
 	}
@@ -69,19 +69,27 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		);
 
 		// Invoke the function that should schedule the action.
+		$now = time();
 		wc_cancel_unpaid_orders();
 
 		// Assert that the action is now scheduled for the future.
 		$next_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
 		$this->assertIsInt( $next_scheduled, 'Action should be scheduled and return a timestamp' );
-		$this->assertGreaterThan(
-			time(),
+		$this->assertGreaterThanOrEqual(
+			$now,
 			$next_scheduled,
 			'Action should be scheduled for a future time'
 		);
 
 		// Verify the scheduled time is approximately correct (1 minute + 30 seconds buffer).
-		$expected_time = time() + ( 1 * MINUTE_IN_SECONDS );
+		$expected_time = $now + ( 1 * MINUTE_IN_SECONDS );
+		$expected_time = $now + ( 1 * MINUTE_IN_SECONDS );
+		$this->assertGreaterThanOrEqual(
+			$expected_time - 30,
+			$next_scheduled,
+			'Action should not be scheduled too early'
+		);
+
 		$this->assertLessThan(
 			$expected_time + 30,
 			$next_scheduled,
@@ -110,6 +118,7 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		$this->assertIsInt( $old_scheduled, 'Initial action should be scheduled' );
 
 		// Run the function which should clear and reschedule.
+		$now = time();
 		wc_cancel_unpaid_orders();
 
 		// Verify action is still scheduled but at a different time.
@@ -118,7 +127,7 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		$this->assertNotEquals( $old_scheduled, $new_scheduled, 'New scheduled time should be different from the old one' );
 
 		// The new scheduled time should be based on current time + 60 minutes.
-		$expected_time = time() + ( 60 * MINUTE_IN_SECONDS );
+		$expected_time = $now + ( 60 * MINUTE_IN_SECONDS );
 		$this->assertLessThan(
 			$expected_time + 60,
 			$new_scheduled,
@@ -159,13 +168,14 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		);
 
 		// Run the function.
+		$now = time();
 		wc_cancel_unpaid_orders();
 
 		// Verify the scheduled time reflects the filtered interval.
 		$next_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
 		$this->assertIsInt( $next_scheduled );
 
-		$expected_time = time() + ( $custom_interval * MINUTE_IN_SECONDS );
+		$expected_time = $now + ( $custom_interval * MINUTE_IN_SECONDS );
 		$this->assertLessThan(
 			$expected_time + 60,
 			$next_scheduled,

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -148,7 +148,9 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 			'woocommerce_cancel_unpaid_orders_interval_minutes',
 			function () use ( $custom_interval ) {
 				return $custom_interval;
-			}
+			},
+			10,
+			0
 		);
 
 		// Run the function.
@@ -251,7 +253,9 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 			'woocommerce_cancel_unpaid_orders_interval_minutes',
 			function () {
 				return 0;
-			}
+			},
+			10,
+			0
 		);
 
 		// Run the function.
@@ -329,6 +333,8 @@ class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
 		if ( function_exists( 'as_unschedule_all_actions' ) ) {
 			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
 		}
+		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+
 		update_option( 'woocommerce_hold_stock_minutes', $this->original_hold_stock_minutes );
 		update_option( 'woocommerce_manage_stock', $this->original_manage_stock_option );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/test-wc-cancel-unpaid-orders.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+/**
+ * Tests for WC Cancel Unpaid Orders functionality.
+ *
+ * @package WooCommerce\Tests\Core
+ */
+
+/**
+ * Class WC_Tests_Cancel_Unpaid_Orders.
+ */
+class WC_Tests_Cancel_Unpaid_Orders extends WC_Unit_Test_Case {
+
+	/**
+	 * Test that wc_cancel_unpaid_orders reschedules itself after running.
+	 *
+	 * This test protects against the regression where the action was marked as unique,
+	 * preventing it from re-queuing itself while still running (introduced in PR #59325,
+	 * fixed in PR #60607).
+	 */
+	public function test_cancel_unpaid_orders_reschedules_itself() {
+		// Skip if Action Scheduler is not available.
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available' );
+		}
+
+		// Enable hold stock functionality with a short interval (1 minute).
+		update_option( 'woocommerce_hold_stock_minutes', 1 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Clear any existing scheduled actions to start clean.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+
+		// Verify no action is currently scheduled.
+		$this->assertFalse(
+			as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' ),
+			'No cancel unpaid orders action should be scheduled initially'
+		);
+
+		// Invoke the function that should schedule the action.
+		wc_cancel_unpaid_orders();
+
+		// Assert that the action is now scheduled for the future.
+		$next_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+		$this->assertIsInt( $next_scheduled, 'Action should be scheduled and return a timestamp' );
+		$this->assertGreaterThan(
+			time(),
+			$next_scheduled,
+			'Action should be scheduled for a future time'
+		);
+
+		// Verify the scheduled time is approximately correct (1 minute + 30 seconds buffer).
+		$expected_time = time() + ( 1 * MINUTE_IN_SECONDS );
+		$this->assertLessThan(
+			$expected_time + 30,
+			$next_scheduled,
+			'Action should be scheduled within the expected time range'
+		);
+	}
+
+	/**
+	 * Test that existing actions are cleared before scheduling new ones.
+	 */
+	public function test_cancel_unpaid_orders_clears_existing_actions() {
+		// Skip if Action Scheduler is not available.
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available' );
+		}
+
+		// Enable hold stock functionality.
+		update_option( 'woocommerce_hold_stock_minutes', 60 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Manually schedule an action first, in the past so it is "past-due" - this prevents race conditions in the test.
+		as_schedule_single_action( time() - 3600, 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+
+		// Verify action is scheduled.
+		$old_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+		$this->assertIsInt( $old_scheduled, 'Initial action should be scheduled' );
+
+		// Run the function which should clear and reschedule.
+		wc_cancel_unpaid_orders();
+
+		// Verify action is still scheduled but at a different time.
+		$new_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+		$this->assertIsInt( $new_scheduled, 'Action should still be scheduled after clearing and rescheduling' );
+		$this->assertNotEquals( $old_scheduled, $new_scheduled, 'New scheduled time should be different from the old one' );
+
+		// The new scheduled time should be based on current time + 60 minutes.
+		$expected_time = time() + ( 60 * MINUTE_IN_SECONDS );
+		$this->assertLessThan(
+			$expected_time + 60,
+			$new_scheduled,
+			'New scheduled action should be based on current settings'
+		);
+		$this->assertGreaterThan(
+			$expected_time - 60,
+			$new_scheduled,
+			'New scheduled action should be approximately at the expected time'
+		);
+	}
+
+	/**
+	 * Test that the woocommerce_cancel_unpaid_orders_interval_minutes filter works.
+	 */
+	public function test_cancel_unpaid_orders_respects_interval_filter() {
+		// Skip if Action Scheduler is not available.
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available' );
+		}
+
+		// Set up test conditions.
+		update_option( 'woocommerce_hold_stock_minutes', 60 );
+		update_option( 'woocommerce_manage_stock', 'yes' );
+
+		// Clear existing actions.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+
+		// Add filter to change the interval.
+		$custom_interval = 30; // 30 minutes instead of 60.
+		add_filter(
+			'woocommerce_cancel_unpaid_orders_interval_minutes',
+			function () use ( $custom_interval ) {
+				return $custom_interval;
+			}
+		);
+
+		// Run the function.
+		wc_cancel_unpaid_orders();
+
+		// Verify the scheduled time reflects the filtered interval.
+		$next_scheduled = as_next_scheduled_action( 'woocommerce_cancel_unpaid_orders', array(), 'woocommerce' );
+		$this->assertIsInt( $next_scheduled );
+
+		$expected_time = time() + ( $custom_interval * MINUTE_IN_SECONDS );
+		$this->assertLessThan(
+			$expected_time + 60,
+			$next_scheduled,
+			'Action should be scheduled based on filtered interval'
+		);
+		$this->assertGreaterThan(
+			$expected_time - 60,
+			$next_scheduled,
+			'Action should be scheduled approximately at the filtered interval time'
+		);
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Clean up scheduled actions and settings.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cancel_unpaid_orders' );
+		}
+		delete_option( 'woocommerce_hold_stock_minutes' );
+		delete_option( 'woocommerce_manage_stock' );
+
+		// Remove any filters that might have been added.
+		remove_all_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `woocommerce_cancel_unpaid_orders` is not scheduled as recurring, but the job itself handles re-adding the action. The action was listed as unique, and because the action had not finished running yet, trying to re-add itself as unique would fail.

This PR adds the order as non-unique to allow it to be re-queued.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- For bug fixes: If known, please provide links to help with traceability and escape analysis. -->
<!-- Please include a link to the issue of the bug being fixed, if one doesn't exist please create it. -->
<!-- If the PR that introduced the bug is known, please also add its link below. -->

Closes #60375 

(For Bug Fixes) Bug introduced in PR #59325

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up the "Hold stock (minutes)" option in WooCommerce -> Settings -> Products -> Inventory
2. Go to WooCommerce -> Status -> Scheduled Actions -> Pending
3. Check if `woocommerce_cancel_unpaid_orders` is listed
4. If not, find `action_scheduler_run_recurring_actions_schedule_hook` and run it.
5. Check if `woocommerce_cancel_unpaid_orders` is scheduled now.
6. Run it and ensure it's re-added to the pending list when finished running.

<!-- End testing instructions -->

### Testing that has already taken place:

<!-- Detail any testing that has already been conducted. -->
<!-- Include environment details such as hosting type, plugins, theme, store size, store age, and relevant settings. -->
<!-- Mention any analysis performed, such as assessing potential impacts on environment attributes and other plugins, performance profiling, or LLM/AI-based analysis. -->
<!-- Within the testing details you provide, please ensure that no sensitive information (such as API keys, passwords, user data, etc.) is included in this public pull request. -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
