### PR TITLE
A11y: Modify default credit card styles to avoid cropping text.

### DIFF
--- a/plugins/woocommerce/changelog/60609-fix-60516-a11y-credit-card-labels-cropped
+++ b/plugins/woocommerce/changelog/60609-fix-60516-a11y-credit-card-labels-cropped
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Improve accessibility of default credit card form available to gateway extensions.

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -1,5 +1,6 @@
 .wc-block-card-elements {
 	display: flex;
+	flex-wrap: wrap;
 	width: 100%;
 
 	.wc-block-components-validation-error {
@@ -14,21 +15,22 @@
 	white-space: nowrap;
 
 	&.wc-card-number-element {
-		flex-basis: 15em;
+		flex-basis: 100%;
 		flex-grow: 1;
 		// Currently, min() CSS function calls need to be wrapped with unquote.
 		min-width: string.unquote("min(15em, 60%)");
 	}
 
 	&.wc-card-expiry-element {
-		flex-basis: 7em;
-		margin-left: $gap-small;
+		flex-basis: calc(50% - #{$gap-smaller});
+		margin-left: 0;
+		margin-right: $gap-smaller;
 		min-width: string.unquote("min(7em, calc(24% - #{$gap-small}))");
 	}
 
 	&.wc-card-cvc-element {
-		flex-basis: 7em;
-		margin-left: $gap-small;
+		flex-basis: calc(50% - #{$gap-smaller});
+		margin-left: $gap-smaller;
 		// Notice the min width ems value is smaller than flex-basis. That's because
 		// by default we want it to have the same width as `expiry-element`, but
 		// if available space is scarce, `cvc-element` should get smaller faster.
@@ -149,31 +151,15 @@
 		}
 	}
 
-	.wc-block-card-elements {
-		flex-wrap: wrap;
-	}
-
-	.wc-block-gateway-container.wc-card-number-element {
-		flex-basis: 100%;
-	}
-
-	.wc-block-gateway-container.wc-card-expiry-element {
-		flex-basis: calc(50% - #{$gap-smaller});
-		margin-left: 0;
-		margin-right: $gap-smaller;
-	}
-
+	.wc-block-gateway-container.wc-card-expiry-element,
 	.wc-block-gateway-container.wc-card-cvc-element {
-		flex-basis: calc(50% - #{$gap-smaller});
-		margin-left: $gap-smaller;
+		flex-basis: 100%;
+		margin-left: 0;
+		margin-right: 0;
 	}
 }
 
-@include cart-checkout-small-container {
-	@include small-mobile-styles;
-}
-
-@include cart-checkout-mobile-container {
+@include cart-checkout-below-medium-container {
 	@include small-mobile-styles;
 }
 

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -159,6 +159,15 @@
 	}
 }
 
+/*
+ * Non standard container query for narrow viewports.
+ *
+ * A non-standard container query is required here for accessibility.
+ * Ems are used in order to prevent text being cropped in the credit
+ * card form based on the font size set for the element.
+ *
+ * See: https://github.com/woocommerce/woocommerce/issues/60516
+ */
 @container (max-width: 32em) {
 	@include small-mobile-styles;
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -159,7 +159,7 @@
 	}
 }
 
-@include cart-checkout-below-medium-container {
+@container (max-width: 32em) {
 	@include small-mobile-styles;
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This modifies the default styles for the credit card form to avoid cropping text when using faux-standard labels. The labels tested for are:

* Card Number
* Expiry Date
* Security Code

The changes to the styles are:

* on small screens: credit card form is one field per row
* on medium and larger screens: credit card form is two rows, card number on top of expiry date and security code

These changes use the existing `cart-checkout-below-medium-container` mixin for the container query as the value was within 10% of where the accessibility issues came in to affect.

Closes #60516
Closes WOOPYBR-74
Closes WOOPYBR-75

(For Bug Fixes) Bug introduced in PR # .

### Screenshots or screen recordings:

| Description | Before | After |
| ---- | ------ | ----- |
| Narrow screen       |    <img width="251" height="638" alt="before-narrow" src="https://github.com/user-attachments/assets/21df7195-7904-4a67-8285-f21ccf052ba7" />   | <img width="258" height="728" alt="after-narrow" src="https://github.com/user-attachments/assets/5e533fbe-7556-4fa8-9bc9-91364866b43c" /> |
| Wide screen | <img width="824" height="479" alt="before-wide" src="https://github.com/user-attachments/assets/897585fb-19c1-4a7e-aef2-254ebe2337a5" /> | <img width="692" height="602" alt="after-wide" src="https://github.com/user-attachments/assets/459cb069-494b-4c1d-8d31-dc795bb6cd24" /> |
| Narrow, increased letter spacing |  <img width="379" height="571" alt="before-small-letter-spacing" src="https://github.com/user-attachments/assets/95de4d26-0cbf-4dee-bc45-3882c0f6cf31" />  |  <img width="379" height="661" alt="after-small-letter-spacing" src="https://github.com/user-attachments/assets/bb385cca-59ba-4d51-812d-a5d347a666e8" />  |








<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and compile the Braintree gateway using the [branch for this pull request](https://github.com/woocommerce/woocommerce-gateway-paypal-powered-by-braintree/pull/705). This uses the somewhat standard labels described above.
2. Configure API keys/oAuth for the plugin as required
3. Configure the site to use a default block theme, eg 2025
4. Configure the site to use the block checkout
5. Add a product to the cart
6. Proceed to the checkout page
7. Begin testing 100% zoom
   1. Configure your browser to show a somewhat standard desktop size
   2. Ensure the label text is not cropped for the credit card form
   3. Narrow your browser to something about the width of a mobile device
   4. Ensure the label text is not cropped for the credit card form
8. Begin testing 200% zoom
   1. Zoom your browser to 200% by pressing command + a number of times
   2. Configure your browser to show a somewhat standard desktop size
   3. Ensure the label text is not cropped for the credit card form
   4. Narrow your browser to something about the width of a mobile device
   5. Ensure the label text is not cropped for the credit card form
   6. Return your browser's zoom to 100%
9. Begin testing increased letter spacing
   1. Set the letter spacing of the labels to 0.12em; you can do this in both Firefox and Chrome's dev tools by running `$$('.wc-block-card-elements label').forEach( (e) => { e.style.letterSpacing='0.12em';} ); ` in the console.
   2. Configure your browser to show a somewhat standard desktop size
   3. Ensure the label text is not cropped for the credit card form
   4. Narrow your browser to something about the width of a mobile device
   5. Ensure the label text is not cropped for the credit card form



<!-- End testing instructions -->

### Testing that has already taken place:

My tests have been using TT5 with a block checkout and the Braintree for WooCommerce Payment Gateway. The gateway uses the default WooCommerce Core styles for the credit card form.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Improve accessibility of default credit card form available to gateway extensions.

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>
