### PR TITLE
Fix styles in the Classic Template block add to cart form

### DIFF
--- a/plugins/woocommerce/changelog/fix-classic-template-add-to-cart-form
+++ b/plugins/woocommerce/changelog/fix-classic-template-add-to-cart-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix styles in the Classic Template block add to cart form

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
@@ -1,5 +1,11 @@
-:where(div[data-block-name="woocommerce/legacy-template"]) {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: 1000px;
+/*
+ * We only want to apply these styles to the legacy template block.
+ * @see https://github.com/woocommerce/woocommerce/pull/57713
+ */
+.woocommerce :where(div[data-block-name="woocommerce/legacy-template"]) div.product form.cart div.quantity {
+	display: inline-block;
+
+	.input-text {
+		padding: 0.9rem 1.1rem;
+	}
 }

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
@@ -4,6 +4,7 @@
  */
 .woocommerce :where(div[data-block-name="woocommerce/legacy-template"]) div.product form.cart div.quantity {
 	display: inline-block;
+	vertical-align: middle;
 
 	.input-text {
 		padding: 0.9rem 1.1rem;

--- a/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
+++ b/plugins/woocommerce/client/blocks/assets/js/blocks/classic-template/style.scss
@@ -1,6 +1,6 @@
 /*
- * We only want to apply these styles to the legacy template block.
- * @see https://github.com/woocommerce/woocommerce/pull/57713
+ * We only want to apply these styles to the legacy template block, as other
+ * blocks have their own styles for this.
  */
 .woocommerce :where(div[data-block-name="woocommerce/legacy-template"]) div.product form.cart div.quantity {
 	display: inline-block;

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ClassicTemplate.php
@@ -438,13 +438,4 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		$pattern_get_class = '/(?<=class=\"|\')[^"|\']+(?=\"|\')/';
 		return preg_replace( $pattern_get_class, '$0 ' . $align_class_and_style['class'], $content, 1 );
 	}
-
-	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @return null
-	 */
-	protected function get_block_type_style() {
-		return null;
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes two regressions that affected the add to cart form inside the _Classic Template_ block:

1. The input and the button broke into two separate lines (introduced in https://github.com/woocommerce/woocommerce/pull/57713).
2. The input didn't have padding by default (https://github.com/woocommerce/woocommerce/pull/53521).

Instead of reverting the changes in `woocommerce-blocktheme.scss`, I think this is the perfect opportunity to move these styles to the block stylesheet, so they are encapsulated and don't load unnecessarily on every page.

Btw, when fixing this I also noticed that we already had a `classic-template/style.scss` file, but it was never being loaded. I removed the styles that were there.

### How to test the changes in this Pull Request:

1. Go to _Appearance_ > _Editor_ > _Templates_ > _Single Product_, remove all the blocks except the header and footer template parts and add the _Product (Classic)_ block.
2. Go to the frontend.
3. Verify the quantity input has padding and is in the same line as the button.

Before | After
--- | ---
<img width="1015" height="709" alt="imatge" src="https://github.com/user-attachments/assets/7df71768-bba9-45a6-8b94-8aa7615d4454" /> | <img width="1015" height="709" alt="imatge" src="https://github.com/user-attachments/assets/81aef651-e3aa-4979-9625-11c7605cb4ad" />
