### PR TITLE
WPS migration: fix onboarding plugin update trigger

### DIFF
--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -180,26 +180,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			add_action( 'woocommerce_paypal_show_legacy_settings', array( $this, 'should_show_legacy_settings' ) );
 
 			// Hook for plugin upgrades.
-			add_action( 'upgrader_process_complete', array( $this, 'maybe_onboard_on_upgrade' ), 10, 2 );
-		}
-	}
-
-	/**
-	 * Handle onboarding on plugin upgrade.
-	 *
-	 * @param WP_Upgrader $upgrader_object WP_Upgrader instance.
-	 * @param array       $options Array of bulk item update data.
-	 *
-	 * @return void
-	 */
-	public function maybe_onboard_on_upgrade( $upgrader_object, $options ) {
-		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
-			foreach ( $options['plugins'] as $plugin ) {
-				if ( str_contains( $plugin, 'woocommerce.php' ) ) {
-					$this->maybe_onboard_with_transact();
-					break;
-				}
-			}
+			add_action( 'woocommerce_updated', array( $this, 'maybe_onboard_with_transact' ) );
 		}
 	}
 
@@ -208,7 +189,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 *
 	 * @return void
 	 */
-	private function maybe_onboard_with_transact() {
+	public function maybe_onboard_with_transact() {
 		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -195,7 +195,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		// Do not run if PayPal Standard is not enabled.
-		if ( ! $this->enabled ) {
+		if ( 'yes' !== $this->enabled ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Part of PAYPAL-62

We want to trigger Transact onboarding when WooCommerce is updated. This changes the action from `upgrader_process_complete` to `woocommerce_updated`.

Why we can't use `upgrader_process_complete`: https://developer.wordpress.org/reference/hooks/upgrader_process_complete/#more-information

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Reset onbarding flag: `wp option patch delete woocommerce_paypal_settings transact_onboarding_complete`
2. Set WC to a previous version: `wp option update woocommerce_version 10.1.0` 
3. Reload wp-admin to trigger the action.
4. `wp option pluck woocommerce_paypal_settings transact_onboarding_complete` should give you a `yes`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger the 'Add changelog to PR' CI job to create and push the entry into the branch. -->

<!-- Due to org permissions, the job might fail for PRs crated from a fork under GitHub organizations. Possible solutions: -->
<!-- * Create entry manually with `pnpm --filter='@woocommerce/plugin-woocommerce' changelog add` and push it into the branch (replace `@woocommerce/plugin-woocommerce` with package name from nearest `package.json` file) -->
<!-- * Create entry from supplied PR data and push it automatically `pnpm utils changefile pr-number-here -o github-org-name-here` -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Merges into a feature branch.

</details>
